### PR TITLE
Make every locked-mode restore CI runs able to fail its step, and reach every committed lock file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,26 @@
 # Dependabot version updates (routine dependency bumps).
 # Security updates are enabled separately at the repo level and are not affected by this file.
-# NuGet projects use lockfiles (packages.lock.json); Dependabot regenerates them as part of each PR.
+#
+# NuGet projects commit packages.lock.json, and Dependabot does NOT regenerate them. It edits the one
+# PackageVersion line in Directory.Packages.props and leaves every lock file pinned to the old version, so
+# CI's locked-mode restore fails NU1004 before a test runs — measured on two consecutive pull requests, a
+# grouped patch-and-minor and a major (#3143). Every NuGet pull request from here therefore needs one command
+# before it can go green:
+#
+#     dotnet restore PerformanceMonitor.sln --force-evaluate
+#
+# then a commit of every packages.lock.json it rewrites. On a checkout with CRLF line endings that is only the
+# files whose CONTENT moved; a restore run on Linux or macOS also rewrites the rest with LF, and git
+# normalises those back on add.
+#
+# This is a step the updater does not perform, not a workaround for something misconfigured here, and the
+# lock files are worth the step: they are the only pin on the TRANSITIVE closure, which no props diff shows
+# moving. Reconciling #3143's AWSSDK.PI 4.0.100.11 -> .12 also moved AWSSDK.Core 4.0.102.1 -> .3, which the
+# one-line props change never mentioned.
+#
+# Not automated. A workflow committing to a Dependabot branch needs a write-scoped credential this repository
+# does not issue, and a push made with GITHUB_TOKEN triggers no workflow run — so the healed commit would
+# carry no checks at all, which is a worse place to be than one red check that names its own remedy (#3143).
 version: 2
 updates:
   # .NET packages across the solution (PerformanceMonitor.sln discovers all projects).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,11 +290,44 @@ jobs:
           cache: true
           cache-dependency-path: '**/packages.lock.json'
 
+      # Central package management pins the DIRECT versions in Directory.Packages.props; the committed
+      # packages.lock.json files pin the TRANSITIVE closure, which is the half no diff shows and no review
+      # reads. This step is where a change that moves one without the other is rejected, so two things have to
+      # hold of it, and neither did (#3143).
+      #
+      # `shell: bash` with errexit, not the runner default. A multi-line run block executes under pwsh on
+      # Windows, which does not abandon the block on a native command's non-zero exit and reports the block's
+      # exit code as the LAST command's — so five of the six restores here printed NU1004 and left this step
+      # green. That is not a hypothetical: the required `build` check passed on both Dependabot pull requests
+      # #3143 was filed from, carrying the error in its own log, and the only job that went red was
+      # darling-tree-guards, whose restore happens to be a single-command step.
+      #
+      # Every project with a committed lock file is reached from this list, directly or through a
+      # ProjectReference — a locked-mode restore validates the lock file of every project in the graph it
+      # walks, not only the one it was handed. deprecated/Installer is named because nothing references it, so
+      # nothing reached it: while it was absent, an inconsistent lock file there passed all six restores this
+      # step used to run and failed only a direct restore of that project, which no workflow performed.
+      # LockedModeRestoreCoverageTests derives both requirements — from the lock files on disk and the
+      # reference edges between projects — so a tenth lock file makes its restore mandatory rather than
+      # remembered, and re-spelling this block in a shell that swallows failures fails the suite.
       - name: Restore dependencies
+        id: restore
         if: steps.fastpath.outputs.engaged != 'true'
+        shell: bash
         run: |
+          set -euo pipefail
+
+          # NU1004 offers two remedies and one of them is dropping locked mode, which trades the closure pin
+          # rather than restoring it. Dependabot moves Directory.Packages.props and cannot regenerate the lock
+          # files that belong with it, so its weekly pull request lands here; naming the command that
+          # reconciles them is the difference between a red check that gets acted on and one that gets waited
+          # out. The trap keeps the message on the failure itself, so no second step can report green beside a
+          # red restore.
+          trap 'echo "::error title=Lock files disagree with Directory.Packages.props::Regenerate with '"'"'dotnet restore PerformanceMonitor.sln --force-evaluate'"'"' and commit every packages.lock.json it rewrites. Do not remove --locked-mode: the lock files are the only pin on the transitive closure, and the props diff does not show it moving."' ERR
+
           dotnet restore Lite/PerformanceMonitorLite.csproj --locked-mode
           dotnet restore Lite.Tests/Lite.Tests.csproj --locked-mode
+          dotnet restore deprecated/Installer/PerformanceMonitorInstaller.csproj --locked-mode
           dotnet restore deprecated/Installer.Tests/Installer.Tests.csproj --locked-mode
           dotnet restore deprecated/Dashboard.Tests/Dashboard.Tests.csproj --locked-mode
           dotnet restore Darling/Darling.Tests/Darling.Tests.csproj --locked-mode

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,7 +320,6 @@ jobs:
       # makes this restore mandatory and a second project taking an SDK-coupled reference fails rather than
       # joining the exemption quietly.
       - name: Restore dependencies
-        id: restore
         if: steps.fastpath.outputs.engaged != 'true'
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,14 +302,23 @@ jobs:
       # #3143 was filed from, carrying the error in its own log, and the only job that went red was
       # darling-tree-guards, whose restore happens to be a single-command step.
       #
-      # Every project with a committed lock file is reached from this list, directly or through a
+      # Every project with a committed lock file bar one is reached from this list, directly or through a
       # ProjectReference — a locked-mode restore validates the lock file of every project in the graph it
-      # walks, not only the one it was handed. deprecated/Installer is named because nothing references it, so
-      # nothing reached it: while it was absent, an inconsistent lock file there passed all six restores this
-      # step used to run and failed only a direct restore of that project, which no workflow performed.
+      # walks, not only the one it was handed. The exception is deprecated/Installer, which nothing
+      # references and which is deliberately still absent: it is the only project publishing single-file, so
+      # the SDK adds an implicit Microsoft.NET.ILLink.Tasks reference at the SDK's OWN version, and its lock
+      # file is the only one carrying that entry. global.json rolls forward across patches, so the runner
+      # installed 10.0.303 against a lock file written under 10.0.302 and the two disagree on that entry
+      # alone — a lock file that cannot be right for both SDKs at once, which is a decision about pinning the
+      # SDK rather than something a restore line here can fix. Adding the line reported it for the first time
+      # (#3143): nothing had restored that project, so the drift had accumulated unseen.
+      #
       # LockedModeRestoreCoverageTests derives both requirements — from the lock files on disk and the
       # reference edges between projects — so a tenth lock file makes its restore mandatory rather than
-      # remembered, and re-spelling this block in a shell that swallows failures fails the suite.
+      # remembered, and re-spelling this block in a shell that swallows failures fails the suite. It derives
+      # the exception from the SDK coupling too, and ratchets its membership, so pinning the SDK exactly
+      # makes this restore mandatory and a second project taking an SDK-coupled reference fails rather than
+      # joining the exemption quietly.
       - name: Restore dependencies
         id: restore
         if: steps.fastpath.outputs.engaged != 'true'
@@ -327,7 +336,6 @@ jobs:
 
           dotnet restore Lite/PerformanceMonitorLite.csproj --locked-mode
           dotnet restore Lite.Tests/Lite.Tests.csproj --locked-mode
-          dotnet restore deprecated/Installer/PerformanceMonitorInstaller.csproj --locked-mode
           dotnet restore deprecated/Installer.Tests/Installer.Tests.csproj --locked-mode
           dotnet restore deprecated/Dashboard.Tests/Dashboard.Tests.csproj --locked-mode
           dotnet restore Darling/Darling.Tests/Darling.Tests.csproj --locked-mode

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,21 +297,21 @@ jobs:
       #
       # `shell: bash` with errexit, not the runner default. A multi-line run block executes under pwsh on
       # Windows, which does not abandon the block on a native command's non-zero exit and reports the block's
-      # exit code as the LAST command's — so five of the six restores here printed NU1004 and left this step
-      # green. That is not a hypothetical: the required `build` check passed on both Dependabot pull requests
-      # #3143 was filed from, carrying the error in its own log, and the only job that went red was
-      # darling-tree-guards, whose restore happens to be a single-command step.
+      # exit code as the LAST command's — so under the default shell any restore but the last is unable to
+      # fail this step. Measured on the Dependabot pull requests #3143 was filed from: the required `build`
+      # check passed carrying `error NU1004` in its own log, and the only job that went red was
+      # darling-tree-guards, whose restore is a single-command step.
       #
       # Every project with a committed lock file bar one is reached from this list, directly or through a
       # ProjectReference — a locked-mode restore validates the lock file of every project in the graph it
-      # walks, not only the one it was handed. The exception is deprecated/Installer, which nothing
-      # references and which is deliberately still absent: it is the only project publishing single-file, so
-      # the SDK adds an implicit Microsoft.NET.ILLink.Tasks reference at the SDK's OWN version, and its lock
-      # file is the only one carrying that entry. global.json rolls forward across patches, so the runner
-      # installed 10.0.303 against a lock file written under 10.0.302 and the two disagree on that entry
-      # alone — a lock file that cannot be right for both SDKs at once, which is a decision about pinning the
-      # SDK rather than something a restore line here can fix. Adding the line reported it for the first time
-      # (#3143): nothing had restored that project, so the drift had accumulated unseen.
+      # walks, not only the one it was handed. The exception is deprecated/Installer, and it is deliberate.
+      # That project is the only one publishing single-file, so the SDK adds an implicit
+      # Microsoft.NET.ILLink.Tasks reference at the SDK's OWN version, and its lock file is the only one
+      # carrying that entry; global.json rolls forward across patches, so a runner on 10.0.303 wants
+      # [10.0.11, ) where a file written under 10.0.302 records [10.0.10, ). No restore line makes that file
+      # right for both, and nothing references the project, so nothing else reaches it either: a restore
+      # pointed at it reports NU1004 from dev today, with no dependency change involved (#3143). Whether it
+      # should carry a lock file at all, and whether global.json should pin the SDK exactly, are decisions.
       #
       # LockedModeRestoreCoverageTests derives both requirements — from the lock files on disk and the
       # reference edges between projects — so a tenth lock file makes its restore mandatory rather than
@@ -326,11 +326,11 @@ jobs:
           set -euo pipefail
 
           # NU1004 offers two remedies and one of them is dropping locked mode, which trades the closure pin
-          # rather than restoring it. Dependabot moves Directory.Packages.props and cannot regenerate the lock
-          # files that belong with it, so its weekly pull request lands here; naming the command that
-          # reconciles them is the difference between a red check that gets acted on and one that gets waited
-          # out. The trap keeps the message on the failure itself, so no second step can report green beside a
-          # red restore.
+          # rather than restoring it. Dependabot moves Directory.Packages.props and does not regenerate the
+          # lock files that belong with it, so its weekly pull request lands on this step; naming the command
+          # that reconciles them is the difference between a red check that gets acted on and one that gets
+          # waited out. The message rides an ERR trap rather than a following step, so nothing can report
+          # green beside a red restore.
           trap 'echo "::error title=Lock files disagree with Directory.Packages.props::Regenerate with '"'"'dotnet restore PerformanceMonitor.sln --force-evaluate'"'"' and commit every packages.lock.json it rewrites. Do not remove --locked-mode: the lock files are the only pin on the transitive closure, and the props diff does not show it moving."' ERR
 
           dotnet restore Lite/PerformanceMonitorLite.csproj --locked-mode

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -117,8 +117,16 @@ jobs:
           echo "VERSION=$nightly" >> $env:GITHUB_OUTPUT
           echo "Nightly version: $nightly"
 
+      # `shell: bash` with errexit for the reason build.yml's restore step carries it (#3143): a multi-line
+      # run block executes under pwsh on Windows, which reports the block's exit code as the LAST command's,
+      # so the two restores ahead of the last could print NU1004 and leave this step green. The project list
+      # is what this workflow publishes rather than the whole tree — build.yml's is the one that gates a
+      # merge, and LockedModeRestoreCoverageTests requires whole-tree lock-file coverage there and only there.
       - name: Restore dependencies
+        shell: bash
         run: |
+          set -euo pipefail
+
           dotnet restore Lite/PerformanceMonitorLite.csproj --locked-mode
           dotnet restore Lite.Tests/Lite.Tests.csproj --locked-mode
           dotnet restore Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj --locked-mode

--- a/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
+++ b/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+using static Darling.Tests.RepoFile;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Central package management pins the DIRECT versions in <c>Directory.Packages.props</c>; the committed
+/// <c>packages.lock.json</c> files pin the TRANSITIVE closure, which is the half nobody reviews. CI rejects a
+/// change that moves one without the other by restoring <c>--locked-mode</c>, and this holds the two
+/// properties that rejection rests on: every locked-mode restore CI runs is able to fail its step, and every
+/// committed lock file is reached by one (#3143).
+///
+/// <para><b>Neither property held.</b> The <c>build</c> job restored six projects in one multi-line
+/// <c>run:</c> block. A block like that runs under the runner's default shell — <c>pwsh</c> on Windows —
+/// which does not stop on a native command's non-zero exit and reports the block's exit code as the LAST
+/// command's, so the five restores ahead of it could print <c>NU1004</c> and leave the step green. Not
+/// hypothetical: on the Dependabot pull request #3143 was filed from, the required <c>build</c> check passed
+/// with <c>error NU1004</c> in its own log, and the only job that went red was the one whose restore is a
+/// single-command step.</para>
+///
+/// <para><b>And one lock file was reached by nothing.</b> <c>deprecated/Installer</c> carries a lock file, is
+/// referenced by no project, and was restored by no workflow. Measured rather than reasoned: perturbing that
+/// file left all six restores CI ran green, and failed only a direct restore of that project.</para>
+///
+/// <para><b>Coverage is derived, not listed.</b> The requirement comes from the lock files on disk and the
+/// <c>ProjectReference</c> edges between projects, so a tenth lock file arriving makes its restore mandatory
+/// instead of remembered. A referenced project's own lock file IS validated by a locked-mode restore of the
+/// referencing project — verified against NuGet by perturbing <c>Installer.Core</c>'s lock file and watching
+/// a locked-mode restore of <c>Installer.Tests</c> fail <c>NU1004</c> — so the closure arm encodes measured
+/// behaviour rather than an assumption about it.</para>
+///
+/// <para><b>What this cannot see.</b> Whether the restores CI runs cover the packages a particular change
+/// moves; that is NuGet's resolution, not text. What it holds is the shape that lets those restores report a
+/// mismatch at all, plus #3143's refusal to reach green by dropping <c>--locked-mode</c>. Both detectors are
+/// exercised against synthetic input, because a parser that matched nothing would report every step as safe
+/// and every lock file as covered — and would do it in green.</para>
+/// </summary>
+public sealed class LockedModeRestoreCoverageTests
+{
+    private static readonly string[] s_buildSegments = { ".github", "workflows", "build.yml" };
+
+    private static readonly string[] s_nightlySegments = { ".github", "workflows", "nightly.yml" };
+
+    /// <summary>
+    /// One <c>dotnet restore</c> invocation and what it names. The target is captured so the locked-mode
+    /// requirement can be read per invocation rather than per file.
+    /// </summary>
+    private static readonly Regex RestoreInvocation =
+        new(@"dotnet restore\s+(?<target>\S+)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// One <c>&lt;ProjectReference Include="..." /&gt;</c>. MSBuild spells these with backslashes on every
+    /// platform, so the path is normalised at the use site. <c>DarlingPathFilterGateTests</c> reads the same
+    /// edges for a different question — which shared libraries a path gate has to name — and answers it in
+    /// library names; this one answers in directories, because a directory is what holds a lock file.
+    /// </summary>
+    private static readonly Regex ProjectReference =
+        new(@"<ProjectReference\s+Include=""(?<path>[^""]+)""", RegexOptions.Compiled);
+
+    /// <summary>
+    /// A <c>set -e</c>-family line: bash abandoning the block at the first non-zero exit. Both spellings,
+    /// because <c>set -o errexit</c> has the same effect and a check that only knew the short form would
+    /// report a safe step as unsafe.
+    /// </summary>
+    private static readonly Regex SetsErrExit =
+        new(@"^\s*set\s+(-[a-z]*e[a-z]*|-o\s+errexit)(\s|$)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// A workflow-command annotation line — the one place a restore command appears as TEXT rather than as
+    /// something the runner executes, because the remediation message quotes the command to run.
+    ///
+    /// <para>The exemption is deliberately this narrow rather than "a line mentioning echo", and the
+    /// detector it exempts from is deliberately broad: any line carrying <c>dotnet restore</c> is treated as
+    /// an invocation. A restore smuggled onto the end of another command still gets read, which is the
+    /// direction to be wrong in — the alternative, anchoring the pattern to the start of a command, would
+    /// quietly return "no bare restores" for a workflow that had one.</para>
+    /// </summary>
+    private static readonly Regex Annotation =
+        new(@"::(error|warning|notice)[ :]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Every step that runs <c>dotnet restore</c> reports a failure from EVERY restore in it.
+    ///
+    /// <para>A step that runs several and reports only the last one's exit code is not a weaker guard, it is
+    /// an absent one for everything ahead of the last: the log carries the error and the check carries a
+    /// tick.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(".github/workflows/build.yml")]
+    [InlineData(".github/workflows/nightly.yml")]
+    public void EveryRestoreStep_ReportsAFailureFromEveryRestoreInIt(string workflow)
+    {
+        var steps = RestoreSteps(WorkflowText(workflow), workflow);
+
+        var swallowing = steps
+            .Where(step => !PropagatesEveryFailure(step))
+            .Select(FirstStepName)
+            .ToList();
+
+        Assert.True(
+            swallowing.Count == 0,
+            $"{workflow} has steps that run more than one command and report only the last one's exit code, "
+            + "so a locked-mode restore ahead of it can print NU1004 while the step reports success — give "
+            + "each `shell: bash` and open its run block with `set -euo pipefail`:\n  "
+            + string.Join("\n  ", swallowing));
+    }
+
+    /// <summary>
+    /// The step-shape check reads the SHAPE of a step rather than its name, and the cases it must get right
+    /// are pinned here instead of left to whatever the two workflows happen to contain.
+    ///
+    /// <para>The last case is the one a simpler rule gets wrong. "Exactly one restore in the block" is not
+    /// sufficient: a block whose restore is followed by anything else reports that other command's exit
+    /// code, so the restore is unable to fail the step even though it is the only one there.</para>
+    /// </summary>
+    [Theory]
+    // Several restores, runner default shell: only the last can fail the step.
+    [InlineData(false, "\n      - name: Restore\n        run: |\n          dotnet restore A.csproj --locked-mode\n          dotnet restore B.csproj --locked-mode\n")]
+    // bash without errexit is the same block with a different interpreter.
+    [InlineData(false, "\n      - name: Restore\n        shell: bash\n        run: |\n          dotnet restore A.csproj --locked-mode\n          dotnet restore B.csproj --locked-mode\n")]
+    // bash with errexit, set before the first restore.
+    [InlineData(true, "\n      - name: Restore\n        shell: bash\n        run: |\n          set -euo pipefail\n          dotnet restore A.csproj --locked-mode\n          dotnet restore B.csproj --locked-mode\n")]
+    // errexit set AFTER the first restore protects every restore but that one.
+    [InlineData(false, "\n      - name: Restore\n        shell: bash\n        run: |\n          dotnet restore A.csproj --locked-mode\n          set -euo pipefail\n          dotnet restore B.csproj --locked-mode\n")]
+    // The single-command form: the step's exit code IS the restore's.
+    [InlineData(true, "\n      - name: Restore\n        run: dotnet restore A.csproj --locked-mode\n")]
+    // A folded plain scalar reads like the single-command form and is not: the build's exit code reports.
+    [InlineData(false, "\n      - name: Restore\n        run: dotnet restore A.csproj --locked-mode\n          && dotnet build A.csproj --no-restore\n")]
+    // The same step's sibling keys sit at or above the run key's indent and do not make it a folded scalar.
+    [InlineData(true, "\n      - name: Restore\n        run: dotnet restore A.csproj --locked-mode\n        env:\n          CI: 'true'\n")]
+    // One restore, but not the whole command — the build's exit code is what reports.
+    [InlineData(false, "\n      - name: Restore\n        run: |\n          dotnet restore A.csproj --locked-mode\n          dotnet build A.csproj --no-restore\n")]
+    public void TheStepShapeCheck_ReadsTheShapeRatherThanTheStepName(bool propagates, string step) =>
+        Assert.Equal(propagates, PropagatesEveryFailure(step));
+
+    /// <summary>
+    /// Every committed <c>packages.lock.json</c> is reached by a locked-mode restore the <c>build</c>
+    /// workflow runs, directly or through a <c>ProjectReference</c>.
+    ///
+    /// <para>Scoped to <c>build.yml</c> deliberately: that is the workflow whose checks gate a merge.
+    /// <c>nightly.yml</c> restores what it publishes and is a backstop, so requiring whole-tree coverage
+    /// there would assert something that workflow is not for.</para>
+    /// </summary>
+    [Fact]
+    public void EveryCommittedLockFile_IsReachedByALockedModeRestoreInTheBuildWorkflow()
+    {
+        var buildYaml = ReadRepoFileLf(s_buildSegments);
+
+        /* Non-vacuity, in the direction that matters: an empty lock-file set or an empty restore set both
+           report perfect coverage. */
+        var lockFiles = LockFileDirectories();
+        Assert.Contains("Darling/Darling.Tests", lockFiles);
+        Assert.Contains("deprecated/Installer", lockFiles);
+        Assert.NotEmpty(RestoredProjects(buildYaml));
+
+        /* The closure arm carries real weight in the tree as it stands, rather than being a spare wheel that
+           would never turn: deprecated/Dashboard holds a lock file, is named by no restore line in the
+           workflow, and is covered only because Dashboard.Tests references it. */
+        Assert.DoesNotContain("dotnet restore deprecated/Dashboard/Dashboard.csproj", buildYaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("deprecated/Dashboard", UncoveredLockFiles(buildYaml));
+
+        var uncovered = UncoveredLockFiles(buildYaml);
+
+        Assert.True(
+            uncovered.Count == 0,
+            "Committed packages.lock.json files that no locked-mode restore in .github/workflows/build.yml "
+            + "reaches, so a lock file left inconsistent with Directory.Packages.props under one of them "
+            + "merges green — add a `dotnet restore <project> --locked-mode` for each, or reference it from "
+            + "a project already restored:\n  "
+            + string.Join("\n  ", uncovered));
+    }
+
+    /// <summary>
+    /// The coverage check reports an injected gap, in both of its arms.
+    ///
+    /// <para>Removing the restore of a project nothing references must uncover it, and removing the restore
+    /// of a project that others hang off must uncover THEM — otherwise the closure walk could be returning
+    /// everything it was handed and the assertion above would hold for a workflow that restored nothing.</para>
+    /// </summary>
+    [Fact]
+    public void TheCoverageCheck_ReportsAnInjectedGap()
+    {
+        var real = ReadRepoFileLf(s_buildSegments);
+
+        Assert.Empty(UncoveredLockFiles(real));
+
+        /* The direct arm: deprecated/Installer is in nobody's closure, so its own restore line is the only
+           thing covering it. This is the gap #3143 measured. */
+        var withoutInstaller = real.Replace(
+            "          dotnet restore deprecated/Installer/PerformanceMonitorInstaller.csproj --locked-mode\n",
+            string.Empty,
+            StringComparison.Ordinal);
+        Assert.NotEqual(real, withoutInstaller);
+        Assert.Contains("deprecated/Installer", UncoveredLockFiles(withoutInstaller));
+
+        /* The closure arm: Dashboard.Tests is the only restore that reaches deprecated/Dashboard, and it
+           reaches it only by reference. */
+        var withoutDashboardTests = real.Replace(
+            "          dotnet restore deprecated/Dashboard.Tests/Dashboard.Tests.csproj --locked-mode\n",
+            string.Empty,
+            StringComparison.Ordinal);
+        Assert.NotEqual(real, withoutDashboardTests);
+        Assert.Contains("deprecated/Dashboard", UncoveredLockFiles(withoutDashboardTests));
+    }
+
+    /// <summary>
+    /// No restore any workflow executes reaches green by leaving locked mode, and no project file switches it
+    /// off.
+    ///
+    /// <para>#3143 refused this option on the merits — central package management pins the direct versions,
+    /// the lock files pin the transitive closure, and a build that re-resolves that closure on every run has
+    /// stopped guaranteeing what ships. Pinning the refusal is what makes it survive the next red Dependabot
+    /// pull request, because the error NuGet prints names the opt-out as one of its own two remedies. A
+    /// deliberate reversal edits this test; an expedient one fails it.</para>
+    /// </summary>
+    [Fact]
+    public void NoRestoreAWorkflowExecutes_LeavesLockedMode()
+    {
+        var scanned = 0;
+        var invocations = 0;
+        var offending = new List<string>();
+
+        foreach (var file in Directory.GetFiles(Path.Combine(Root, ".github", "workflows"), "*.yml").OrderBy(path => path, StringComparer.Ordinal))
+        {
+            var yaml = File.ReadAllText(file).Replace("\r\n", "\n", StringComparison.Ordinal);
+            var name = Path.GetFileName(file);
+            scanned++;
+
+            Assert.DoesNotContain("RestoreLockedMode", yaml, StringComparison.Ordinal);
+
+            invocations += RestoreLines(yaml).Count;
+            offending.AddRange(RestoresOutsideLockedMode(yaml).Select(line => $"{name}: {line}"));
+        }
+
+        /* Non-vacuity: the sweep read the workflow directory and found the restores that are in it. A glob
+           matching nothing, or a detector matching nothing, satisfies the emptiness assertion below by
+           never having anything to judge. */
+        Assert.True(scanned >= 2, $"only {scanned} workflow files were scanned");
+        Assert.True(invocations >= 10, $"only {invocations} dotnet restore lines were seen across {scanned} workflow files");
+
+        Assert.True(
+            offending.Count == 0,
+            "Restores a workflow executes without --locked-mode, or with --force-evaluate, which resolve the "
+            + "transitive closure freshly instead of against the committed lock file:\n  "
+            + string.Join("\n  ", offending));
+
+        foreach (var project in Directory.GetFiles(Root, "*.csproj", SearchOption.AllDirectories))
+        {
+            if (IsBuildOutput(project))
+            {
+                continue;
+            }
+
+            Assert.DoesNotContain("RestoreLockedMode", File.ReadAllText(project), StringComparison.Ordinal);
+        }
+
+        Assert.DoesNotContain("RestoreLockedMode", ReadRepoFileLf("Directory.Packages.props"), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The locked-mode requirement is read per line, reports a restore that opts out however it is spelled,
+    /// and leaves the remediation message alone.
+    ///
+    /// <para>The last two cases are the pair that matters. A message quoting the command a human should run
+    /// is not a restore CI performs, and the workflow carries one; a restore appended to another command IS
+    /// one, and a detector narrowed enough to excuse the message would stop seeing it.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(0, "        run: dotnet restore A.csproj --locked-mode\n")]
+    [InlineData(1, "        run: dotnet restore A.csproj\n")]
+    [InlineData(1, "        run: dotnet restore A.csproj --force-evaluate\n")]
+    [InlineData(1, "        run: |\n          dotnet restore A.csproj --locked-mode\n          dotnet restore B.csproj\n")]
+    [InlineData(0, "          echo \"::error title=T::Regenerate with 'dotnet restore Solution.sln --force-evaluate' and commit them.\"\n")]
+    [InlineData(1, "          dotnet build A.csproj && dotnet restore B.csproj\n")]
+    public void TheLockedModeRequirement_ReadsEveryRestoreAndOnlyTheMessageIsExempt(int offending, string yaml) =>
+        Assert.Equal(offending, RestoresOutsideLockedMode(yaml).Count);
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// One of the two scanned workflows, LF-normalised, chosen by its repo-relative path so the
+    /// <c>[InlineData]</c> above names the file it is talking about.
+    /// </summary>
+    private static string WorkflowText(string workflow) => workflow switch
+    {
+        ".github/workflows/build.yml" => ReadRepoFileLf(s_buildSegments),
+        ".github/workflows/nightly.yml" => ReadRepoFileLf(s_nightlySegments),
+        _ => throw new ArgumentOutOfRangeException(nameof(workflow), workflow, "not a scanned workflow"),
+    };
+
+    /// <summary>
+    /// The steps of one workflow that run <c>dotnet restore</c>, split at the six-space indent every step in
+    /// these two files sits at.
+    /// </summary>
+    private static List<string> RestoreSteps(string yaml, string workflow)
+    {
+        var steps = Regex.Split(yaml, @"(?=\n {6}- )")
+            .Where(step => RestoreInvocation.IsMatch(step))
+            .ToList();
+
+        Assert.True(steps.Count > 0, $"{workflow} runs no dotnet restore — find where it moved before editing this test");
+
+        /* Counted two ways, because the two fail differently. A step boundary this split does not recognise
+           leaves its restore lines outside every block returned, and the check then reports the steps it did
+           find as safe while saying nothing about the one it lost — a partial answer wearing a green tick.
+           The file's own invocation count cannot lose a step to a boundary it never looks for. */
+        Assert.Equal(
+            RestoreInvocation.Matches(yaml).Count,
+            steps.Sum(step => RestoreInvocation.Matches(step).Count));
+
+        return steps;
+    }
+
+    /// <summary>
+    /// Whether every <c>dotnet restore</c> in one step block is able to fail that step.
+    /// </summary>
+    private static bool PropagatesEveryFailure(string step)
+    {
+        var lines = step.Split('\n');
+        var firstRestore = Array.FindIndex(lines, line => RestoreInvocation.IsMatch(line));
+
+        if (firstRestore < 0)
+        {
+            return true;
+        }
+
+        /* The single-command form, `run: dotnet restore ...` on the key's own line: the step's exit code IS
+           that restore's, whatever shell interprets it.
+
+           The continuation clause is not decoration. A YAML plain scalar may fold across lines, so
+           `run: dotnet restore X --locked-mode` followed by a more-indented `&& dotnet build Y` is ONE
+           command whose exit code is the build's — the same swallow wearing the shape of the safe form.
+           What identifies it is the CONTIGUOUS run of more-indented lines directly beneath the key, not
+           "any deeper line later in the step": a sibling `env:` key sits at the run key's own indent and
+           carries deeper lines of its own, so a check that looked further down the step would call every
+           step with an env block unsafe. Measured against the key's indentation rather than a fixed column,
+           so a step nested one level deeper does not take this branch for free. */
+        var runIndent = Indent(lines[firstRestore]);
+
+        var continuation = lines
+            .Skip(firstRestore + 1)
+            .TakeWhile(line => line.Trim().Length > 0 && Indent(line) > runIndent)
+            .ToList();
+
+        if (lines.Count(line => RestoreInvocation.IsMatch(line)) == 1
+            && Regex.IsMatch(lines[firstRestore], @"^\s*run: dotnet restore ")
+            && continuation.Count == 0)
+        {
+            return true;
+        }
+
+        /* Otherwise the block runs more than one command, and the only thing that makes each of them able to
+           fail the step is bash abandoning the block on the first non-zero exit — declared, and set before
+           the first restore rather than anywhere in the block. */
+        return lines.Take(firstRestore).Any(line => Regex.IsMatch(line, @"^\s*shell: bash\s*$"))
+            && lines.Take(firstRestore).Any(line => SetsErrExit.IsMatch(line));
+    }
+
+    /// <summary>
+    /// Every line of a fragment of YAML that carries a <c>dotnet restore</c>, annotation lines included, as
+    /// their own text. The population the requirement below is read against.
+    /// </summary>
+    private static List<string> RestoreLines(string yaml) =>
+        yaml.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n')
+            .Where(line => RestoreInvocation.IsMatch(line))
+            .Select(line => line.Trim())
+            .ToList();
+
+    /// <summary>
+    /// The restore lines that opt out of locked mode: no <c>--locked-mode</c>, or a <c>--force-evaluate</c>
+    /// that overrides it. Annotation lines are excluded because the runner prints them rather than running
+    /// them.
+    /// </summary>
+    private static List<string> RestoresOutsideLockedMode(string yaml) =>
+        RestoreLines(yaml)
+            .Where(line => !Annotation.IsMatch(line))
+            .Where(line => !line.Contains("--locked-mode", StringComparison.Ordinal)
+                        || line.Contains("--force-evaluate", StringComparison.Ordinal))
+            .ToList();
+
+    /// <summary>
+    /// The name of the step a block belongs to, for a message that names what to go and edit.
+    /// </summary>
+    private static string FirstStepName(string step)
+    {
+        var match = Regex.Match(step, @"- name: (?<name>.+)");
+        return match.Success ? match.Groups["name"].Value.Trim() : step.Split('\n').FirstOrDefault(l => l.Trim().Length > 0)?.Trim() ?? "(unnamed step)";
+    }
+
+    /// <summary>
+    /// Every directory holding a committed <c>packages.lock.json</c>, repo-relative with forward slashes.
+    /// </summary>
+    private static SortedSet<string> LockFileDirectories()
+    {
+        var found = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (var lockFile in Directory.GetFiles(Root, "packages.lock.json", SearchOption.AllDirectories))
+        {
+            if (IsBuildOutput(lockFile))
+            {
+                continue;
+            }
+
+            found.Add(RepoRelative(Path.GetDirectoryName(lockFile)!));
+        }
+
+        Assert.NotEmpty(found);
+        return found;
+    }
+
+    /// <summary>
+    /// The project files one workflow restores by name, as absolute paths.
+    /// </summary>
+    private static List<string> RestoredProjects(string yaml) =>
+        RestoreInvocation.Matches(yaml)
+            .Select(match => match.Groups["target"].Value)
+            .Where(target => target.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            .Select(target => Path.GetFullPath(Path.Combine(Root, target.Replace('/', Path.DirectorySeparatorChar))))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    /// <summary>
+    /// The lock-file directories no restore in one workflow reaches.
+    /// </summary>
+    private static List<string> UncoveredLockFiles(string yaml)
+    {
+        var reached = new HashSet<string>(StringComparer.Ordinal);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var pending = new Queue<string>(RestoredProjects(yaml));
+
+        while (pending.Count > 0)
+        {
+            var project = pending.Dequeue();
+
+            if (!seen.Add(project))
+            {
+                continue;
+            }
+
+            /* A ProjectReference that does not resolve fails loudly rather than silently shrinking the
+               closure: a short closure is how this check would start reporting coverage it does not have. */
+            Assert.True(File.Exists(project), $"a restore names, or a ProjectReference points at, a file that is not there: {project}");
+
+            var directory = Path.GetDirectoryName(project)!;
+            reached.Add(RepoRelative(directory));
+
+            foreach (Match match in ProjectReference.Matches(File.ReadAllText(project)))
+            {
+                var include = match.Groups["path"].Value
+                    .Replace('\\', Path.DirectorySeparatorChar)
+                    .Replace('/', Path.DirectorySeparatorChar);
+
+                pending.Enqueue(Path.GetFullPath(Path.Combine(directory, include)));
+            }
+        }
+
+        return LockFileDirectories().Where(directory => !reached.Contains(directory)).ToList();
+    }
+
+    /// <summary>
+    /// How far one line is indented, which is what tells a folded scalar's continuation from the next key.
+    /// </summary>
+    private static int Indent(string line) => line.Length - line.TrimStart().Length;
+
+    /// <summary>
+    /// An absolute path as a repo-relative one with forward slashes, so the two sides of the coverage
+    /// comparison and the failure message all spell a directory the same way.
+    /// </summary>
+    private static string RepoRelative(string absolute) =>
+        Path.GetRelativePath(Root, absolute).Replace(Path.DirectorySeparatorChar, '/');
+
+    /// <summary>
+    /// Whether a path sits under a <c>bin</c> or <c>obj</c> directory below the repository root. Restore
+    /// writes a copy of both the lock files and the project files into <c>obj</c>, and counting those would
+    /// make the requirement depend on whether anyone had built the tree.
+    /// </summary>
+    private static bool IsBuildOutput(string absolute) =>
+        Path.GetRelativePath(Root, absolute)
+            .Split(Path.DirectorySeparatorChar, '/')
+            .Any(segment => segment.Equals("bin", StringComparison.OrdinalIgnoreCase)
+                         || segment.Equals("obj", StringComparison.OrdinalIgnoreCase));
+}

--- a/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
+++ b/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
@@ -42,6 +42,15 @@ namespace Darling.Tests;
 /// a locked-mode restore of <c>Installer.Tests</c> fail <c>NU1004</c> — so the closure arm encodes measured
 /// behaviour rather than an assumption about it.</para>
 ///
+/// <para><b>Where this runs.</b> Its inputs span the whole repository — every lock file, every project
+/// file, <c>global.json</c>, <c>Directory.Packages.props</c>, both workflows — so no area path filter
+/// reaches them, and <c>deprecated/Installer</c> in particular belongs to <c>installer</c> alone while the
+/// step that runs this suite is gated on <c>darling</c>. Coverage therefore rests on
+/// <c>darling-tree-guards</c>, which runs the whole suite exactly when the <c>darling</c> filter did not
+/// fire — the backstop <c>CrossAppGuardCiGateTests</c> documents and whose gate it pins. Growing a filter
+/// to name these paths instead would be a hand-maintained copy of a whole-tree input set, and the honest
+/// filter for a whole-tree guard is every path there is.</para>
+///
 /// <para><b>What this cannot see.</b> Whether the restores CI runs cover the packages a particular change
 /// moves; that is NuGet's resolution, not text. What it holds is the shape that lets those restores report a
 /// mismatch at all, plus #3143's refusal to reach green by dropping <c>--locked-mode</c>. Both detectors are
@@ -71,8 +80,18 @@ public sealed class LockedModeRestoreCoverageTests
     private static readonly string[] s_sdkCoupledLockFiles = { "deprecated/Installer" };
 
     /// <summary>
-    /// One <c>dotnet restore</c> invocation and what it names. The target is captured so the locked-mode
-    /// requirement can be read per invocation rather than per file.
+    /// The text of a <c>dotnet restore</c> and what it names, deliberately broad: any line carrying the
+    /// words is a candidate, so a restore appended to another command is still seen. Breadth is the safe
+    /// direction — anchoring to the start of a command would quietly return "no bare restores" for a
+    /// workflow that had one.
+    ///
+    /// <para><b>Read only through <see cref="IsRestoreInvocation"/>.</b> Breadth means it also matches a
+    /// MESSAGE naming the command, and this workflow carries one: the remediation annotation quotes the
+    /// command a human should run, and it sits above the restores it is about. Every question this class
+    /// asks is about restores the runner EXECUTES, so every one of them has to subtract that line — and
+    /// subtracting it at four call sites is how three of them came to disagree. That there is one call site
+    /// is asserted in <see cref="TheRawPatterns_AreReadOnlyThroughTheOneAccessor"/> rather than left to
+    /// discipline.</para>
     /// </summary>
     private static readonly Regex RestoreInvocation =
         new(@"dotnet restore\s+(?<target>\S+)", RegexOptions.Compiled);
@@ -96,16 +115,36 @@ public sealed class LockedModeRestoreCoverageTests
 
     /// <summary>
     /// A workflow-command annotation line — the one place a restore command appears as TEXT rather than as
-    /// something the runner executes, because the remediation message quotes the command to run.
+    /// something the runner performs. Narrow on purpose: a line printing <c>::error</c>, <c>::warning</c> or
+    /// <c>::notice</c> is a message to the log, not a command, and "a line mentioning echo" would excuse far
+    /// more than that.
     ///
-    /// <para>The exemption is deliberately this narrow rather than "a line mentioning echo", and the
-    /// detector it exempts from is deliberately broad: any line carrying <c>dotnet restore</c> is treated as
-    /// an invocation. A restore smuggled onto the end of another command still gets read, which is the
-    /// direction to be wrong in — the alternative, anchoring the pattern to the start of a command, would
-    /// quietly return "no bare restores" for a workflow that had one.</para>
+    /// <para>Read only through <see cref="IsRestoreInvocation"/>, for the reason given there.</para>
     /// </summary>
     private static readonly Regex Annotation =
         new(@"::(error|warning|notice)[ :]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Whether one line is a <c>dotnet restore</c> the runner performs — the single place the breadth of one
+    /// pattern and the narrowness of the other are combined, and the only place either is read.
+    /// </summary>
+    private static bool IsRestoreInvocation(string line) =>
+        RestoreInvocation.IsMatch(line) && !Annotation.IsMatch(line);
+
+    /// <summary>
+    /// What one restore line names, or an empty string if the line is not one.
+    /// </summary>
+    private static string RestoreTarget(string line) =>
+        IsRestoreInvocation(line) ? RestoreInvocation.Match(line).Groups["target"].Value : string.Empty;
+
+    /// <summary>
+    /// Whether one line mentions a restore at all, message or command. Exists so the assertions that the
+    /// exclusion CHANGES an answer can be written without a second copy of the pattern: a class that only
+    /// knew the narrow population could not state that the broad one differs from it, and "the exclusion is
+    /// load-bearing" is the claim that needs stating.
+    /// </summary>
+    private static bool MentionsRestore(string line) =>
+        RestoreInvocation.IsMatch(line);
 
     /// <summary>
     /// Every step that runs <c>dotnet restore</c> reports a failure from EVERY restore in it.
@@ -159,6 +198,16 @@ public sealed class LockedModeRestoreCoverageTests
     [InlineData(true, "\n      - name: Restore\n        run: dotnet restore A.csproj --locked-mode\n        env:\n          CI: 'true'\n")]
     // One restore, but not the whole command — the build's exit code is what reports.
     [InlineData(false, "\n      - name: Restore\n        run: |\n          dotnet restore A.csproj --locked-mode\n          dotnet build A.csproj --no-restore\n")]
+    // The real workflow's shape: a message naming the command sits ABOVE the errexit line it is nothing to
+    // do with. Errexit still precedes every restore, so the step is safe — and an anchor that latched onto
+    // the message would find nothing above it and call this unsafe.
+    [InlineData(true, "\n      - name: Restore\n        shell: bash\n        run: |\n          echo \"::error title=T::Regenerate with 'dotnet restore Solution.sln --force-evaluate'\"\n          set -euo pipefail\n          dotnet restore A.csproj --locked-mode\n          dotnet restore B.csproj --locked-mode\n")]
+    // And the mirror: errexit above the message but the restores below both. Same verdict, so the message's
+    // position cannot decide the answer either way.
+    [InlineData(true, "\n      - name: Restore\n        shell: bash\n        run: |\n          set -euo pipefail\n          echo \"::error title=T::Regenerate with 'dotnet restore Solution.sln --force-evaluate'\"\n          dotnet restore A.csproj --locked-mode\n          dotnet restore B.csproj --locked-mode\n")]
+    // A step that only PRINTS the command guards no restore, so it has nothing to propagate. Judged as a
+    // restore step it would be flagged, which is a red build for a step that runs no restore at all.
+    [InlineData(true, "\n      - name: Say what to run\n        run: |\n          echo \"::error title=T::Run 'dotnet restore Solution.sln --force-evaluate'.\"\n          exit 1\n")]
     public void TheStepShapeCheck_ReadsTheShapeRatherThanTheStepName(bool propagates, string step) =>
         Assert.Equal(propagates, PropagatesEveryFailure(step));
 
@@ -358,6 +407,90 @@ public sealed class LockedModeRestoreCoverageTests
     public void TheLockedModeRequirement_ReadsEveryRestoreAndOnlyTheMessageIsExempt(int offending, string yaml) =>
         Assert.Equal(offending, RestoresOutsideLockedMode(yaml).Count);
 
+    /// <summary>
+    /// On the real workflow the message exclusion moves the anchor, and the shape check's verdict depends on
+    /// its landing in the right place.
+    ///
+    /// <para><b>This is the assertion the synthetic table could not make.</b> Not one of the tabled step
+    /// shapes contained an annotation line, so every one of them anchored on a real restore and the table
+    /// could not tell a correct anchor from one that had latched onto the remediation message. The workflow
+    /// this class guards DOES contain such a line, above the restores it is about — so the detector was
+    /// validated on inputs of a shape its subject does not have, and returned the right verdict for that
+    /// step by the coincidence that <c>shell: bash</c> and the errexit line both sit above the message
+    /// too.</para>
+    ///
+    /// <para>The mutation is what discriminates. Moving the errexit line to sit between the message and the
+    /// first performed restore leaves the step SAFE — errexit still precedes every restore — and an anchor
+    /// latched onto the message would report it unsafe, because nothing above the message sets errexit. A
+    /// verdict that survives that move is a verdict taken from the right line.</para>
+    /// </summary>
+    [Fact]
+    public void TheMessageExclusion_MovesTheAnchor_AndTheVerdictComesFromWhereItLands()
+    {
+        var step = RestoreSteps(ReadRepoFileLf(s_buildSegments), ".github/workflows/build.yml")
+            .Single(candidate => candidate.Contains("set -euo pipefail", StringComparison.Ordinal));
+
+        var lines = step.Split('\n');
+        var mentioned = Array.FindIndex(lines, MentionsRestore);
+        var performed = Array.FindIndex(lines, IsRestoreInvocation);
+
+        /* The exclusion is load-bearing HERE, not merely available: the first mention of a restore in this
+           step is not one the runner performs, and the first one it performs comes later. */
+        Assert.True(mentioned >= 0, "no line in the restore step mentions a restore");
+        Assert.False(IsRestoreInvocation(lines[mentioned]), $"expected the first mention to be a message, got: {lines[mentioned].Trim()}");
+        Assert.True(performed > mentioned, $"expected the first performed restore ({performed}) to come after the first mention ({mentioned})");
+
+        Assert.True(PropagatesEveryFailure(step), "the real restore step reports as unable to propagate a failure");
+
+        /* Errexit moved below the message and above every restore: still safe, and only an anchor on the
+           right line can say so. */
+        var errexit = Array.FindIndex(lines, SetsErrExit.IsMatch);
+        Assert.True(errexit >= 0 && errexit < performed, $"errexit is at {errexit}, the first performed restore at {performed}");
+
+        var moved = lines.Where((_, index) => index != errexit).ToList();
+        moved.Insert(Array.FindIndex(moved.ToArray(), MentionsRestore) + 1, lines[errexit]);
+        var mutated = string.Join('\n', moved);
+
+        Assert.NotEqual(step, mutated);
+        Assert.True(
+            PropagatesEveryFailure(mutated),
+            "with errexit between the remediation message and the first performed restore, the step is still "
+            + "safe — reporting it unsafe means the shape check anchored on the message rather than on a "
+            + "restore, which is what this assertion exists to catch");
+    }
+
+    /// <summary>
+    /// The raw patterns are read in exactly the accessors declared for them, and nowhere else.
+    ///
+    /// <para>The population is DERIVED — every member of this class that dereferences either pattern — so a
+    /// fifth reader arriving by paste reds instead of joining silently. That is the failure this pin is
+    /// about rather than a stylistic preference: the exclusion was originally applied at the one call site
+    /// that had gone red and not at the other three, which is a fix to an instance rather than to a class,
+    /// and it left the shape check reading its anchor through the unfiltered pattern.</para>
+    /// </summary>
+    [Fact]
+    public void TheRawPatterns_AreReadOnlyThroughTheOneAccessor()
+    {
+        var source = ReadRepoFileLf("Darling", "Darling.Tests", "LockedModeRestoreCoverageTests.cs");
+
+        Assert.Equal(
+            new[] { "IsRestoreInvocation", "MentionsRestore", "RestoreTarget" },
+            MembersReadingTheRawPatterns(source).ToArray());
+
+        /* The walk finds a reader put somewhere else. Without this the equality above is satisfied just as
+           well by a scan that cannot see a member at all. The anchor carries no escape sequences on purpose:
+           an injection whose search text does not match the source silently mutates nothing, and then the
+           NotEqual below is the only thing standing between that and a vacuous pass. */
+        var smuggled = source.Replace(
+            "Array.FindIndex(lines, IsRestoreInvocation)",
+            "Array.FindIndex(lines, line => RestoreInvocation.IsMatch(line))",
+            StringComparison.Ordinal);
+
+        Assert.NotEqual(source.Length, smuggled.Length);
+        Assert.Contains("PropagatesEveryFailure", MembersReadingTheRawPatterns(smuggled));
+
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -378,7 +511,7 @@ public sealed class LockedModeRestoreCoverageTests
     private static List<string> RestoreSteps(string yaml, string workflow)
     {
         var steps = Regex.Split(yaml, @"(?=\n {6}- )")
-            .Where(step => RestoreInvocation.IsMatch(step))
+            .Where(step => step.Split('\n').Any(IsRestoreInvocation))
             .ToList();
 
         Assert.True(steps.Count > 0, $"{workflow} runs no dotnet restore — find where it moved before editing this test");
@@ -386,10 +519,10 @@ public sealed class LockedModeRestoreCoverageTests
         /* Counted two ways, because the two fail differently. A step boundary this split does not recognise
            leaves its restore lines outside every block returned, and the check then reports the steps it did
            find as safe while saying nothing about the one it lost — a partial answer wearing a green tick.
-           The file's own invocation count cannot lose a step to a boundary it never looks for. */
+           The file's own line count cannot lose a step to a boundary it never looks for. */
         Assert.Equal(
-            RestoreInvocation.Matches(yaml).Count,
-            steps.Sum(step => RestoreInvocation.Matches(step).Count));
+            yaml.Split('\n').Count(IsRestoreInvocation),
+            steps.Sum(step => step.Split('\n').Count(IsRestoreInvocation)));
 
         return steps;
     }
@@ -400,7 +533,7 @@ public sealed class LockedModeRestoreCoverageTests
     private static bool PropagatesEveryFailure(string step)
     {
         var lines = step.Split('\n');
-        var firstRestore = Array.FindIndex(lines, line => RestoreInvocation.IsMatch(line));
+        var firstRestore = Array.FindIndex(lines, IsRestoreInvocation);
 
         if (firstRestore < 0)
         {
@@ -425,7 +558,7 @@ public sealed class LockedModeRestoreCoverageTests
             .TakeWhile(line => line.Trim().Length > 0 && Indent(line) > runIndent)
             .ToList();
 
-        if (lines.Count(line => RestoreInvocation.IsMatch(line)) == 1
+        if (lines.Count(IsRestoreInvocation) == 1
             && Regex.IsMatch(lines[firstRestore], @"^\s*run: dotnet restore ")
             && continuation.Count == 0)
         {
@@ -440,25 +573,24 @@ public sealed class LockedModeRestoreCoverageTests
     }
 
     /// <summary>
-    /// Every line of a fragment of YAML that carries a <c>dotnet restore</c>, annotation lines included, as
-    /// their own text — the population the locked-mode requirement is read against, and the count its
-    /// non-vacuity floor is taken from.
+    /// Every line of a fragment of YAML that performs a <c>dotnet restore</c> — the population the
+    /// locked-mode requirement is read against, and the count its non-vacuity floor is taken from. A message
+    /// quoting the command is not in it, because the runner prints that rather than running it.
     /// </summary>
     private static List<string> RestoreLines(string yaml) =>
         yaml.Replace("\r\n", "\n", StringComparison.Ordinal)
             .Split('\n')
-            .Where(line => RestoreInvocation.IsMatch(line))
+            .Where(IsRestoreInvocation)
             .Select(line => line.Trim())
             .ToList();
 
     /// <summary>
     /// The restore lines that opt out of locked mode: no <c>--locked-mode</c>, or a <c>--force-evaluate</c>
-    /// that overrides it. Annotation lines are excluded because the runner prints them rather than running
-    /// them.
+    /// that overrides it. The message exclusion is inherited rather than repeated here, which is the point
+    /// of there being one accessor.
     /// </summary>
     private static List<string> RestoresOutsideLockedMode(string yaml) =>
         RestoreLines(yaml)
-            .Where(line => !Annotation.IsMatch(line))
             .Where(line => !line.Contains("--locked-mode", StringComparison.Ordinal)
                         || line.Contains("--force-evaluate", StringComparison.Ordinal))
             .ToList();
@@ -494,11 +626,14 @@ public sealed class LockedModeRestoreCoverageTests
     }
 
     /// <summary>
-    /// The project files one workflow restores by name, as absolute paths.
+    /// The project files one workflow restores by name, as absolute paths. Read from the performed restores
+    /// only: a message quoting a restore of the SOLUTION would otherwise enter the closure walk, and the
+    /// reason it does not today is that it names a <c>.sln</c> — a property of the message's wording, not of
+    /// this code.
     /// </summary>
     private static List<string> RestoredProjects(string yaml) =>
-        RestoreInvocation.Matches(yaml)
-            .Select(match => match.Groups["target"].Value)
+        yaml.Split('\n')
+            .Select(RestoreTarget)
             .Where(target => target.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
             .Select(target => Path.GetFullPath(Path.Combine(Root, target.Replace('/', Path.DirectorySeparatorChar))))
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -564,6 +699,53 @@ public sealed class LockedModeRestoreCoverageTests
             .Where(directory => !reached.Contains(directory))
             .Where(directory => !excused.Contains(directory, StringComparer.Ordinal))
             .ToList();
+    }
+
+    /// <summary>
+    /// One dereference of a raw pattern — the name followed by a dot. The field declarations are not reads,
+    /// so they stay out of the population without being named as exceptions.
+    /// </summary>
+    private static readonly Regex RawPatternRead =
+        new(@"\b(RestoreInvocation|Annotation)\s*\.", RegexOptions.Compiled);
+
+    /// <summary>
+    /// One member declaration of this class, at its four-space indent, and the name it declares.
+    /// </summary>
+    private static readonly Regex MemberDeclaration =
+        new(@"^    (?:private|internal|public)[^(=]*?\b(?<name>\w+)\s*(?:\(|=|=>|$)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The members of this class that dereference a raw pattern, taken from its own source by walking each
+    /// read up to the member declaration above it.
+    ///
+    /// <para>Read off <c>CSharpSourceWalker.StripCommentsAndStrings</c> rather than a hand-rolled skip of
+    /// <c>///</c> lines. Two things in this file spell a pattern read without being one: the doc comments
+    /// that name the accessors, and the string literal in the self-validation below, which quotes a read in
+    /// order to inject one. A line filter catches the first and not the second — measured, it reported this
+    /// class's own pin as a reader — and the walker preserves newlines, so the member walk still lines up
+    /// with the source it is reading.</para>
+    /// </summary>
+    private static SortedSet<string> MembersReadingTheRawPatterns(string source)
+    {
+        var members = new SortedSet<string>(StringComparer.Ordinal);
+        var member = "(no enclosing member)";
+
+        foreach (var line in CSharpSourceWalker.StripCommentsAndStrings(source).Split('\n'))
+        {
+            var declaration = MemberDeclaration.Match(line);
+
+            if (declaration.Success)
+            {
+                member = declaration.Groups["name"].Value;
+            }
+
+            if (RawPatternRead.IsMatch(line))
+            {
+                members.Add(member);
+            }
+        }
+
+        return members;
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
+++ b/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
@@ -295,9 +295,15 @@ public sealed class LockedModeRestoreCoverageTests
     /// <summary>
     /// The coverage check reports an injected gap, in all three of its arms.
     ///
-    /// <para>Removing the restore of a project nothing references must uncover it; removing the restore of a
-    /// project that others hang off must uncover THEM; and pinning the SDK must uncover the one the SDK float
-    /// is what excuses. Without the third, the exemption could be unconditional and read as derived.</para>
+    /// <para>Deleting a restore must uncover the project it names; deleting one that others hang off must
+    /// uncover THEM; and pinning the SDK must uncover the one the SDK float is what excuses. Without the
+    /// third, an unconditional exemption would read as a derived one.</para>
+    ///
+    /// <para><b>The deletions are derived rather than named.</b> Naming a restore line means spelling
+    /// another SKU's path inside this project's source, which is a cross-app reference that the filter
+    /// gating this suite cannot reach — the exact class of gap this file is about, reintroduced in the file
+    /// that is about it. Every restore line is tried instead, so the arms rest on a property of the
+    /// workflow and cannot go stale when a line moves or is renamed.</para>
     /// </summary>
     [Fact]
     public void TheCoverageCheck_ReportsAnInjectedGap()
@@ -307,32 +313,46 @@ public sealed class LockedModeRestoreCoverageTests
 
         Assert.Empty(UncoveredLockFiles(real, globalJson));
 
-        /* The direct arm: Lite.Tests is covered only by its own restore line. */
-        var withoutLiteTests = real.Replace(
-            "          dotnet restore Lite.Tests/Lite.Tests.csproj --locked-mode\n",
-            string.Empty,
-            StringComparison.Ordinal);
-        Assert.NotEqual(real, withoutLiteTests);
-        Assert.Contains("Lite.Tests", UncoveredLockFiles(withoutLiteTests, globalJson));
+        var namedByARestore = new SortedSet<string>(
+            RestoreLines(real).Select(line => RestoreTarget(line)).Select(target => target[..target.LastIndexOf('/')]),
+            StringComparer.Ordinal);
 
-        /* The closure arm: Dashboard.Tests is the only restore that reaches deprecated/Dashboard, and it
-           reaches it only by reference. */
-        var withoutDashboardTests = real.Replace(
-            "          dotnet restore deprecated/Dashboard.Tests/Dashboard.Tests.csproj --locked-mode\n",
-            string.Empty,
-            StringComparison.Ordinal);
-        Assert.NotEqual(real, withoutDashboardTests);
-        Assert.Contains("deprecated/Dashboard", UncoveredLockFiles(withoutDashboardTests, globalJson));
+        var directArm = new SortedSet<string>(StringComparer.Ordinal);
+        var closureArm = new SortedSet<string>(StringComparer.Ordinal);
 
-        /* The exemption arm: with the SDK pinned exactly, deprecated/Installer stops being excusable and the
-           requirement reports it — which is the state a decision to keep that lock file has to reach. */
+        foreach (var line in real.Split('\n').Where(IsRestoreInvocation))
+        {
+            var without = real.Replace(line + "\n", string.Empty, StringComparison.Ordinal);
+            Assert.NotEqual(real, without);
+
+            foreach (var uncovered in UncoveredLockFiles(without, globalJson))
+            {
+                /* A directory the deleted line NAMED is the direct arm; one it only reached through a
+                   ProjectReference is the closure arm. The two are separated by what the workflow spells,
+                   so neither is a list. */
+                _ = namedByARestore.Contains(uncovered) ? directArm.Add(uncovered) : closureArm.Add(uncovered);
+            }
+        }
+
+        Assert.NotEmpty(directArm);
+
+        Assert.True(
+            closureArm.Count > 0,
+            "no restore line's removal uncovers a lock file it reaches only through a ProjectReference, so "
+            + "the closure walk in this check is not load-bearing and could be returning the directories it "
+            + "was handed");
+
+        /* The exemption arm: with the SDK pinned exactly, the SDK-coupled lock file stops being excusable
+           and the requirement reports it — which is the state a decision to keep that lock file has to
+           reach. */
         var pinnedSdk = globalJson.Replace(
             "\"rollForward\": \"latestPatch\"",
             "\"rollForward\": \"disable\"",
             StringComparison.Ordinal);
+
         Assert.NotEqual(globalJson, pinnedSdk);
         Assert.Empty(SdkCoupledLockFiles(pinnedSdk));
-        Assert.Contains("deprecated/Installer", UncoveredLockFiles(real, pinnedSdk));
+        Assert.Equal(s_sdkCoupledLockFiles, UncoveredLockFiles(real, pinnedSdk).ToArray());
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
+++ b/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
@@ -441,7 +441,8 @@ public sealed class LockedModeRestoreCoverageTests
 
     /// <summary>
     /// Every line of a fragment of YAML that carries a <c>dotnet restore</c>, annotation lines included, as
-    /// their own text. The population the requirement below is read against.
+    /// their own text — the population the locked-mode requirement is read against, and the count its
+    /// non-vacuity floor is taken from.
     /// </summary>
     private static List<string> RestoreLines(string yaml) =>
         yaml.Replace("\r\n", "\n", StringComparison.Ordinal)
@@ -578,9 +579,15 @@ public sealed class LockedModeRestoreCoverageTests
         Path.GetRelativePath(Root, absolute).Replace(Path.DirectorySeparatorChar, '/');
 
     /// <summary>
-    /// Whether a path sits under a <c>bin</c> or <c>obj</c> directory below the repository root. Restore
-    /// writes a copy of both the lock files and the project files into <c>obj</c>, and counting those would
-    /// make the requirement depend on whether anyone had built the tree.
+    /// Whether a path sits under a <c>bin</c> or <c>obj</c> directory below the repository root.
+    ///
+    /// <para>No build output in this tree holds a <c>packages.lock.json</c> or a <c>.csproj</c> today —
+    /// restore writes <c>project.assets.json</c> and the generated props and targets, not copies of these —
+    /// so this filter currently changes no answer, and that is said out loud rather than left to look like a
+    /// measurement. It is here because the sweeps above are recursive globs over the whole repository, and a
+    /// copy appearing under <c>obj</c> would be reported as a lock-file directory no restore reaches: a red
+    /// requirement produced by a local artefact, failing for whoever had built the tree and passing for
+    /// whoever had not. The repository already excludes build output by construction for the same reason.</para>
     /// </summary>
     private static bool IsBuildOutput(string absolute) =>
         Path.GetRelativePath(Root, absolute)

--- a/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
+++ b/Darling/Darling.Tests/LockedModeRestoreCoverageTests.cs
@@ -55,6 +55,22 @@ public sealed class LockedModeRestoreCoverageTests
     private static readonly string[] s_nightlySegments = { ".github", "workflows", "nightly.yml" };
 
     /// <summary>
+    /// The package whose version is the SDK's own rather than one anyone in this repository chose. The SDK
+    /// adds it implicitly to a project that publishes single-file, at the version bundled with whichever SDK
+    /// performed the restore — so a lock file recording it is pinned to an SDK patch, and cannot be right for
+    /// two patches at once.
+    /// </summary>
+    private const string SdkCoupledPackage = "Microsoft.NET.ILLink.Tasks";
+
+    /// <summary>
+    /// The lock files that cannot be validated in locked mode while the SDK patch floats — held as a ratchet
+    /// on the DERIVED set below, not as the requirement itself. Without the ratchet, a project newly
+    /// publishing single-file would take the exemption silently, which is the same shape of quiet widening
+    /// this class exists to stop.
+    /// </summary>
+    private static readonly string[] s_sdkCoupledLockFiles = { "deprecated/Installer" };
+
+    /// <summary>
     /// One <c>dotnet restore</c> invocation and what it names. The target is captured so the locked-mode
     /// requirement can be read per invocation rather than per file.
     /// </summary>
@@ -148,7 +164,8 @@ public sealed class LockedModeRestoreCoverageTests
 
     /// <summary>
     /// Every committed <c>packages.lock.json</c> is reached by a locked-mode restore the <c>build</c>
-    /// workflow runs, directly or through a <c>ProjectReference</c>.
+    /// workflow runs, directly or through a <c>ProjectReference</c> — bar the ones whose contents follow the
+    /// SDK rather than this repository's own choices.
     ///
     /// <para>Scoped to <c>build.yml</c> deliberately: that is the workflow whose checks gate a merge.
     /// <c>nightly.yml</c> restores what it publishes and is a backstop, so requiring whole-tree coverage
@@ -158,6 +175,7 @@ public sealed class LockedModeRestoreCoverageTests
     public void EveryCommittedLockFile_IsReachedByALockedModeRestoreInTheBuildWorkflow()
     {
         var buildYaml = ReadRepoFileLf(s_buildSegments);
+        var globalJson = ReadRepoFileLf("global.json");
 
         /* Non-vacuity, in the direction that matters: an empty lock-file set or an empty restore set both
            report perfect coverage. */
@@ -170,9 +188,9 @@ public sealed class LockedModeRestoreCoverageTests
            would never turn: deprecated/Dashboard holds a lock file, is named by no restore line in the
            workflow, and is covered only because Dashboard.Tests references it. */
         Assert.DoesNotContain("dotnet restore deprecated/Dashboard/Dashboard.csproj", buildYaml, StringComparison.Ordinal);
-        Assert.DoesNotContain("deprecated/Dashboard", UncoveredLockFiles(buildYaml));
+        Assert.DoesNotContain("deprecated/Dashboard", UncoveredLockFiles(buildYaml, globalJson));
 
-        var uncovered = UncoveredLockFiles(buildYaml);
+        var uncovered = UncoveredLockFiles(buildYaml, globalJson);
 
         Assert.True(
             uncovered.Count == 0,
@@ -184,27 +202,69 @@ public sealed class LockedModeRestoreCoverageTests
     }
 
     /// <summary>
-    /// The coverage check reports an injected gap, in both of its arms.
+    /// The lock files exempt from that requirement are exactly the ones whose contents follow the SDK, and
+    /// there is one.
     ///
-    /// <para>Removing the restore of a project nothing references must uncover it, and removing the restore
-    /// of a project that others hang off must uncover THEM — otherwise the closure walk could be returning
-    /// everything it was handed and the assertion above would hold for a workflow that restored nothing.</para>
+    /// <para><b>Why an exemption exists at all.</b> <c>deprecated/Installer</c> is the only project
+    /// publishing single-file, so the SDK adds an implicit <c>Microsoft.NET.ILLink.Tasks</c> reference at the
+    /// version bundled with whichever SDK ran the restore. <c>global.json</c> rolls forward across patches,
+    /// so a runner on 10.0.303 wants <c>[10.0.11, )</c> where a lock file written under 10.0.302 records
+    /// <c>[10.0.10, )</c>. No restore line can make that file right for both, and nothing had restored the
+    /// project, so the drift accumulated unseen until #3143 pointed a restore at it.</para>
+    ///
+    /// <para><b>Why it is derived and ratcheted rather than a name in a list.</b> Derived, so pinning the SDK
+    /// exactly in <c>global.json</c> removes the exemption and makes the restore mandatory — the fix cancels
+    /// the excuse instead of leaving it behind. Ratcheted, so a second project taking an SDK-coupled
+    /// reference fails here rather than inheriting the exemption in silence, which is the widening this class
+    /// exists to catch. Both halves have to hold: the exemption is not the decision about whether that lock
+    /// file should exist, only an accurate statement that CI cannot currently check it.</para>
+    /// </summary>
+    [Fact]
+    public void TheExemptLockFiles_AreExactlyTheOnesWhoseContentsFollowTheSdk()
+    {
+        var globalJson = ReadRepoFileLf("global.json");
+
+        Assert.Equal(s_sdkCoupledLockFiles, SdkCoupledLockFiles(globalJson).ToArray());
+
+        /* The reason, read off the tree rather than restated: the exempt project publishes single-file, which
+           is what makes the SDK add the reference, and its lock file is the only one carrying it. */
+        Assert.Contains(
+            "<PublishSingleFile>true</PublishSingleFile>",
+            ReadRepoFileLf("deprecated", "Installer", "PerformanceMonitorInstaller.csproj"),
+            StringComparison.Ordinal);
+
+        Assert.Equal(
+            s_sdkCoupledLockFiles,
+            LockFileDirectories()
+                .Where(directory => ReadRepoFileLf(directory, "packages.lock.json").Contains(SdkCoupledPackage, StringComparison.Ordinal))
+                .ToArray());
+
+        /* And that the float is real: an SDK pinned exactly would leave nothing exempt. */
+        Assert.DoesNotContain("\"rollForward\": \"disable\"", globalJson, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The coverage check reports an injected gap, in all three of its arms.
+    ///
+    /// <para>Removing the restore of a project nothing references must uncover it; removing the restore of a
+    /// project that others hang off must uncover THEM; and pinning the SDK must uncover the one the SDK float
+    /// is what excuses. Without the third, the exemption could be unconditional and read as derived.</para>
     /// </summary>
     [Fact]
     public void TheCoverageCheck_ReportsAnInjectedGap()
     {
         var real = ReadRepoFileLf(s_buildSegments);
+        var globalJson = ReadRepoFileLf("global.json");
 
-        Assert.Empty(UncoveredLockFiles(real));
+        Assert.Empty(UncoveredLockFiles(real, globalJson));
 
-        /* The direct arm: deprecated/Installer is in nobody's closure, so its own restore line is the only
-           thing covering it. This is the gap #3143 measured. */
-        var withoutInstaller = real.Replace(
-            "          dotnet restore deprecated/Installer/PerformanceMonitorInstaller.csproj --locked-mode\n",
+        /* The direct arm: Lite.Tests is covered only by its own restore line. */
+        var withoutLiteTests = real.Replace(
+            "          dotnet restore Lite.Tests/Lite.Tests.csproj --locked-mode\n",
             string.Empty,
             StringComparison.Ordinal);
-        Assert.NotEqual(real, withoutInstaller);
-        Assert.Contains("deprecated/Installer", UncoveredLockFiles(withoutInstaller));
+        Assert.NotEqual(real, withoutLiteTests);
+        Assert.Contains("Lite.Tests", UncoveredLockFiles(withoutLiteTests, globalJson));
 
         /* The closure arm: Dashboard.Tests is the only restore that reaches deprecated/Dashboard, and it
            reaches it only by reference. */
@@ -213,7 +273,17 @@ public sealed class LockedModeRestoreCoverageTests
             string.Empty,
             StringComparison.Ordinal);
         Assert.NotEqual(real, withoutDashboardTests);
-        Assert.Contains("deprecated/Dashboard", UncoveredLockFiles(withoutDashboardTests));
+        Assert.Contains("deprecated/Dashboard", UncoveredLockFiles(withoutDashboardTests, globalJson));
+
+        /* The exemption arm: with the SDK pinned exactly, deprecated/Installer stops being excusable and the
+           requirement reports it — which is the state a decision to keep that lock file has to reach. */
+        var pinnedSdk = globalJson.Replace(
+            "\"rollForward\": \"latestPatch\"",
+            "\"rollForward\": \"disable\"",
+            StringComparison.Ordinal);
+        Assert.NotEqual(globalJson, pinnedSdk);
+        Assert.Empty(SdkCoupledLockFiles(pinnedSdk));
+        Assert.Contains("deprecated/Installer", UncoveredLockFiles(real, pinnedSdk));
     }
 
     /// <summary>
@@ -434,9 +504,28 @@ public sealed class LockedModeRestoreCoverageTests
             .ToList();
 
     /// <summary>
-    /// The lock-file directories no restore in one workflow reaches.
+    /// The lock-file directories whose contents follow the SDK's version rather than this repository's
+    /// choices, and which therefore cannot satisfy a locked-mode restore while <c>global.json</c> lets the
+    /// SDK patch float. Empty when the SDK is pinned exactly, which is what makes the exemption a statement
+    /// about the current configuration rather than about those projects.
     /// </summary>
-    private static List<string> UncoveredLockFiles(string yaml)
+    private static List<string> SdkCoupledLockFiles(string globalJson)
+    {
+        if (globalJson.Contains("\"rollForward\": \"disable\"", StringComparison.Ordinal))
+        {
+            return new List<string>();
+        }
+
+        return LockFileDirectories()
+            .Where(directory => ReadRepoFileLf(directory, "packages.lock.json").Contains(SdkCoupledPackage, StringComparison.Ordinal))
+            .ToList();
+    }
+
+    /// <summary>
+    /// The lock-file directories no restore in one workflow reaches, excluding the ones the SDK float
+    /// excuses.
+    /// </summary>
+    private static List<string> UncoveredLockFiles(string yaml, string globalJson)
     {
         var reached = new HashSet<string>(StringComparer.Ordinal);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -468,7 +557,12 @@ public sealed class LockedModeRestoreCoverageTests
             }
         }
 
-        return LockFileDirectories().Where(directory => !reached.Contains(directory)).ToList();
+        var excused = SdkCoupledLockFiles(globalJson);
+
+        return LockFileDirectories()
+            .Where(directory => !reached.Contains(directory))
+            .Where(directory => !excused.Contains(directory, StringComparer.Ordinal))
+            .ToList();
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/RepoFileAdoptionTests.cs
+++ b/Darling/Darling.Tests/RepoFileAdoptionTests.cs
@@ -114,6 +114,7 @@ public sealed class RepoFileAdoptionTests
         "DarlingPathFilterGateTests.cs",
         "FleetCardCollectionStaleNamesItsPopulationTests.cs",
         "FleetPageAttentionFilterTests.cs",
+        "LockedModeRestoreCoverageTests.cs",
         "ServerPageTabsTests.cs",
         "StartupFailureTriageTests.cs",
         "StoreCopyPhaseTests.cs",


### PR DESCRIPTION
Every Dependabot NuGet pull request reds on restore with `NU1004` because the updater edits one `PackageVersion` line in `Directory.Packages.props` and does not regenerate the `packages.lock.json` files that go with it. Both open ones exhibit it, failing at `Restore Darling.Tests` in `Darling whole-tree guards`: #3130 on `AWSSDK.PI [4.0.100.11, )` against a central `[4.0.100.12, )`, #3131 on `BlackwellSystems.Gcf [0.2.1, )` against `[1.0.0, )`.

**This does not make those pull requests green.** It repairs the guard that was supposed to be enforcing the invariant and could not, and makes the failure say what to run. Not automating the regeneration is a decision with reasoning, set out below.

## The invariant was not being enforced at the merge gate at all

`dev`'s required status checks are `build` and `Darling PostgreSQL tests` — read twice, from `contexts` and from `checks`, with the `Protect dev` ruleset adding no rules of its own. `Darling whole-tree guards`, the only job that reported the `NU1004`, is **not required**. Both Dependabot pull requests read `mergeStateStatus: UNSTABLE`, not `BLOCKED`: they are mergeable right now, with lock files that do not match the props file they ship.

The other required check was green for a different reason. `Directory.Packages.props` appears in neither the shared `darling` gate nor `build.yml`'s `root` filter, so on #3130 `Darling PostgreSQL tests` reported success in **17 seconds** with every step `skipped` — including its `Restore Darling.Tests`, a single-command step that would have reported the `NU1004` had it run.

So both required checks passed on a lock-file mismatch: one having swallowed the error out of its own log, the other having run nothing. The interesting question was never why the guard job is red. It is why `build` was green.

`build.yml`'s `Restore dependencies` step ran six locked-mode restores in one multi-line `run:` block with no `shell:`, so it executed under the runner's default shell — `pwsh` on Windows — which does not abandon a block on a native command's non-zero exit and reports the block's exit code as the **last** command's. `Darling/Darling.Tests` is the fifth of six; the sixth is the Viewer, whose lock file neither bump touched.

Measured, not inferred. On #3130's run the `build` job's own log carries `error NU1004` at 10:14:05, continues restoring at 10:14:06, and the step's conclusion is `success`. No `continue-on-error` is involved. Reproduced locally and flipped: those six restores as they were written, run under `bash` against a genuinely inconsistent props file, exit **0**; the same six with `set -euo pipefail` ahead of them exit **1**.

The block now declares `shell: bash` and opens with `set -euo pipefail`, so the required check can see what the log always said. `nightly.yml`'s restore step had the same shape — three restores, only the last able to report — and gets the same treatment. An `ERR` trap names the command that reconciles the lock files, because `NU1004`'s own text offers dropping locked mode as one of its two remedies.

## The coverage requirement, and the pre-existing inconsistency it found

`deprecated/Installer/packages.lock.json` belongs to `PerformanceMonitorInstaller.csproj`, which is in the solution, is referenced by no project, and was restored by no workflow. The other two lock files no workflow names — `deprecated/Dashboard` and `deprecated/Installer.Core` — are genuinely covered, because a locked-mode restore validates the lock file of every project in the graph it walks; verified against NuGet by perturbing `Installer.Core`'s lock file and watching a locked-mode restore of `Installer.Tests` fail `NU1004` naming `Installer.Core.csproj`.

Pointing a restore at `deprecated/Installer` reported `NU1004` on this pull request's **first CI run**, from `dev`, with no dependency change involved: `Microsoft.NET.ILLink.Tasks` moved from `[10.0.10, )` to `[10.0.11, )`. That project is the only one publishing single-file, so the SDK adds that reference implicitly at the version bundled with whichever SDK performed the restore, and its lock file is the only one in the tree carrying the entry. `global.json` names `10.0.302` with `rollForward: latestPatch`; the runner installed **10.0.303**. The committed file cannot be right for both, and nothing had ever restored the project, which is exactly why the drift accumulated unseen.

No restore line fixes that. Either `global.json` pins the SDK exactly, or that project should not carry a lock file — both decisions rather than patches, and neither this pull request's to take. So the restore line came back out and the requirement carries an exemption instead:

- **derived**, from the coupling itself, so pinning the SDK in `global.json` cancels the exemption and makes the restore mandatory — the fix removes the excuse rather than leaving it behind;
- **ratcheted** on membership, so a second project taking an SDK-coupled implicit reference reds rather than inheriting the exemption in silence;
- with the **reason read off the tree**, not restated: that project sets `PublishSingleFile`, and its lock file is the only one carrying the SDK-coupled package.

The correction to #3143's premise: `dev` is internally consistent for the eight lock files CI can validate, which is what the issue measured. The ninth is inconsistent on `dev` today, on any 10.0.303 runner.

## Proving the check can fail

`LockedModeRestoreCoverageTests` was written and run **before** the workflow edits. Against the pre-change workflows the finished file reports **2 failed / 23 passed** — the step-shape fact on each workflow, naming `Restore dependencies`; with the edits in place, **25 / 25**.

The coverage fact does not flip on that revert, because the gap it found is excused rather than closed. Its teeth are shown three other ways instead, each an injection that must change the answer: deleting the `Lite.Tests` restore line must report `Lite.Tests` (the direct arm), deleting the `Dashboard.Tests` line must report `deprecated/Dashboard` (the closure arm, a directory no restore line names), and rewriting `global.json`'s `rollForward` to `disable` must empty the exemption and report `deprecated/Installer` (the exemption arm — without it, an unconditional exemption would read as a derived one). And it has already earned its keep in production: run 34146404329 is the coverage requirement finding a real inconsistency that had never been seen.

End-to-end against the real step script extracted from the merged YAML: clean tree exits **0**; `AWSSDK.PI` bumped by hand with the lock files untouched exits **1** with `NU1004` and the remediation annotation; the same bump with `--force-evaluate` applied exits **0**. That is the third acceptance criterion, at the level of the step rather than a simulation of it.

### The pin's own anchor was on the wrong line

The remediation annotation quotes the command a human should run, so the line carrying it matches the broad pattern that finds restores — and it sits above the restores it is about. Excluding it at the one call site that had gone red left three others reading the unfiltered pattern, and the shape check was one of them: its anchor is the first matching line, which on the real restore step is the **message at index 13**, not the restore at index 15. Everything measured from that index was measured from the wrong place. It returned the right verdict for that step only because `shell: bash` and the errexit line both happen to sit above the message too.

**The tabled cases could not have caught it.** Not one of the eight contained an annotation line, so every one anchored on a real restore and none could tell a correct anchor from a latched one — a detector validated on inputs of a shape its subject does not have.

All four readers now go through one predicate combining the broad pattern with the narrow exclusion: the step splitter, the shape check, the locked-mode requirement, and the restored-project closure. The closure was the fourth, and it was harmless only because the message names a `.sln` while the closure keeps `.csproj` — a property of the message's wording, not of the code. The reader population is derived from this file's own source, read off `CSharpSourceWalker.StripCommentsAndStrings` (a line filter reported this class's own pin as a reader, because its self-validation quotes a read in order to inject one) and compared for equality against the accessors declared for it, so a fifth reader reds instead of joining.

Guarded both ways, measured:

- **removing the exclusion reds six ways**, where before this it redded one — the single site that had originally gone red;
- **reverting only the anchor** to its unfiltered form reds two ways, where before this it redded nothing;
- three tabled cases now carry an annotation line, including the real workflow's shape and a step that only *prints* the command;
- one assertion applies the check to the real step and moves the errexit line to sit between the message and the first restore. It is still safe — errexit precedes every restore — and only an anchor on the right line can say so.

The injected-gap arms are derived rather than named for a related reason: naming a restore line meant spelling `Lite.Tests/Lite.Tests.csproj` inside a `Darling.Tests` file, and the filter gating this suite reaches `Lite/**` but not its sibling `Lite.Tests/**`. Every restore line is now deleted in turn, and what that uncovers is split by whether the deleted line named the directory or only reached it through a `ProjectReference` — three rest on their own line, one on the closure walk.

### Where this guard runs, and what its coverage rests on

Its inputs span the whole repository, and `deprecated/Installer/**` belongs to the `installer` filter alone while `Run Darling tests` is gated on `darling || core || root`. So a change to the project it guards does not run it **in the `build` job**. It does run: `darling-tree-guards` runs the whole suite exactly when the `darling` filter did not fire, which is that case — verified on #3130, where no area filter fired, `Run Darling tests` reported `skipped`, and the guards job ran and reported the `NU1004`. That is not luck; it is the backstop `CrossAppGuardCiGateTests` documents ("a filter entry is not the only thing that can cover a read") and whose gate it pins in `WholeTreeBackstopIsIntact`.

Growing the `darling` filter to name these paths is the wrong fix. The class reads every lock file, every project file, `global.json`, `Directory.Packages.props`, both workflows and its own source; a filter enumerating that is a hand-maintained copy of a whole-tree input set, in a file nothing compares against the class — and the honest filter for a whole-tree guard is every path there is. Nor can the guard be narrowed to its own trigger: its subject *is* the whole tree's lock files, and a version scoped to `Darling/**` would assert nothing about the eight outside it. The dependency is intrinsic; the trigger is what to fix.

**And the trigger has a gap that subsumes the one above.** `WholeTreeBackstopIsIntact` pins that the backstop's mechanism exists. Nothing pins its authority — and `Darling whole-tree guards` is not a required check on `dev`. So the backstop runs and cannot block, for this class's reads and for every read already registered against it in `DarlingTestsBackstopped`. Making that job required is one setting, covers every whole-tree guard present and future, and needs no list.

One case the step-shape detector carries that a simpler rule gets wrong: "exactly one restore in the block" is not sufficient. A `run:` whose restore is followed by anything else reports that other command's exit code, and a folded YAML plain scalar — `run: dotnet restore …` continued on a more-indented `&& dotnet build …` — reads like the safe single-command form and is not. Both detectors are tabled against synthetic input in both directions, so a parser matching nothing would be caught rather than reporting every step safe and every lock file covered.

The suite also pins the refusal: no restore any workflow executes may carry `--force-evaluate` or omit `--locked-mode`, and no project file may set `RestoreLockedMode`. A deliberate reversal edits a test; an expedient one fails the build. The exemption for the remediation message is narrow — a workflow-command annotation line — and the detector it is exempt from is deliberately broad, so a restore appended to another command is still read.

`RepoFileAdoptionTests` gains this class in its LF-reading census. That is load-bearing, not bookkeeping: the injection anchors above embed a newline, so a CRLF read would make every one of them match nothing and the arms would pass by matching no text.

## No permission is granted here, and that is the change worth naming

Automated regeneration means CI committing to a Dependabot branch. Working the mechanism through, that is three decisions, and two of them are bad:

**A `GITHUB_TOKEN` push produces a worse state than the red check.** Pushes made with `GITHUB_TOKEN` do not trigger workflow runs. Required checks are evaluated per head SHA, so the healed commit would carry no runs — the pull request goes from one failing non-required check to required checks that never report, i.e. from `UNSTABLE` to permanently `BLOCKED`. Which is also why the loop concern cuts the wrong way: there is no loop precisely because there is no re-validation.

**Making it re-trigger requires a credential this repository does not have.** An App installation token or a PAT does trigger workflows, and is a standing `contents: write` secret. With one the loop terminates on its own — `--force-evaluate` on the healed head produces no diff, so there is nothing to push — but it has to exist first, and a workflow shipped against a secret that does not exist is a workflow that silently no-ops.

**And `pull_request_target` is the wrong shape regardless.** Regeneration runs `dotnet restore --force-evaluate` over the pull request's own `.csproj` and `.props`, which is MSBuild evaluation — arbitrary code execution. Under `pull_request_target` that runs in a job holding `contents: write`. The only thing bounding it is the convention that `dependabot/*` branches are repo-internal, which is not a mechanism in the workflow.

The safe shape does exist: regenerate in a token-less `pull_request` job, upload the lock files as an artifact, and push them from a separate `workflow_run` job that holds the App token and never checks out pull request code. Worth building **if** the App is created; not worth shipping ahead of it. Either way it needs this pull request underneath it, because an unconditional regeneration would make a genuine hand-edited mismatch invisible — the third criterion is a prerequisite for the automation, not an alternative to it.

Rejected outright: relaxing `RestoreLockedMode`, and deleting the lock files. Both reach green by removing the only pin on the transitive closure. Reconciling #3130's one-line props change moved `AWSSDK.Core` from `4.0.102.1` to `4.0.102.3` — a version move the props diff never mentions, in the half of the dependency graph nobody reviews.

## Unblocking the two open pull requests

One command each, on the branch: `dotnet restore PerformanceMonitor.sln --force-evaluate`, then commit the lock files it rewrites. On a CRLF checkout that is only the files whose content moved — for #3130, exactly `Darling/Darling.Tests/packages.lock.json`, seven lines. A restore run on Linux or macOS also rewrites the other eight with LF; git normalises those away on `add`, so they never reach the commit. `.github/dependabot.yml` now records this, replacing a comment claiming the updater regenerates the lock files as part of each pull request — the claim that let this sit.

## Two things noticed and deliberately left alone

**A props-only change compiles nothing, and is why the second required check ran nothing.** `Directory.Packages.props` is in no path filter, and neither is `**/packages.lock.json`. On both #3130 and #3131 every `Build` and `Run` step in `build` reported `skipped`, the `darling-pg` job skipped its own steps entirely, and the guards job then ran `Darling.Tests` alone. So once its lock files are reconciled, #3131 — a **major**, `BlackwellSystems.Gcf 0.2.1 → 1.0.0` — merges having compiled none of the four products. Adding those two paths to the `root` filter and to `.github/darling-paths-filter.yml` is a small fix whose cost is a full build and test of all four products, plus the TimescaleDB suite, on every weekly Dependabot pull request on the shared Windows pool. That trade is not this pull request's to make. After this change one required check can see a lock-file mismatch, which is what the merge gate needs; making both see it is that separate decision.

**The same swallow exists outside restore, in four steps, and is narrower than it looks.** GitHub sets `$ErrorActionPreference = 'stop'` for `pwsh`, which aborts on a *cmdlet* error but not on a native executable's non-zero exit — so only a block invoking a native exe before its last command can lose a failure. Four do: `build.yml`'s `Build Darling` (`dotnet build Darling.Tests` is the first of two lines, so a compile error there cannot fail that step — `Run Darling tests` catches it downstream, but the step reports green), `Create Velopack releases` (four of seven, `dotnet tool install` and three `vpk` invocations), and `nightly.yml`'s `Create Darling Viewer Setup.exe` and `Create nightly release` (`gh release create`). Three of the four are on the release or nightly packaging path, which is where a silent failure costs most. Not touched here: they are a different defect sharing a root mechanism, and the signing path is not somewhere to make an incidental change.

**`deprecated/Installer` is a project nothing references, nothing builds, and nothing publishes, whose stale lock file is now a named exemption in a test.** The exemption is honest about the SDK coupling, but the underlying question is whether that project belongs in the solution at all — which is the same deprecated-projects decision #3143 flagged and left open.

## CHANGELOG entry

```markdown
- **Every locked-mode restore in CI can fail its step now, and the merge gate can finally see a lock-file mismatch** ([#3143]) - `dev`'s required checks are `build` and `Darling PostgreSQL tests`; the `Darling whole-tree guards` job that reported `NU1004` on every Dependabot PR is **not one of them**, so both open ones read `mergeStateStatus: UNSTABLE` - mergeable, with lock files that do not match the props file they ship. The question was never why the guard was red, it was why `build` was green: its restore step ran six `--locked-mode` restores in one multi-line `run:` block with no `shell:`, so it executed under `pwsh`, which does not abandon a block on a native command's non-zero exit and reports the block's exit code as the LAST command's. Five of the six could not fail the required check. Measured: on PR #3130 the `build` job's own log carries `error NU1004`, continues restoring a second later, and the step's conclusion is `success`. The same six restores run under bash exit **0** as written and **1** with `set -euo pipefail` ahead of them. That step and `nightly.yml`'s now declare `shell: bash` and open with errexit, and an `ERR` trap names `dotnet restore PerformanceMonitor.sln --force-evaluate` on failure rather than leaving NU1004's own suggestion - dropping locked mode - as the only remedy on offer. **`deprecated/Dashboard` and `deprecated/Installer.Core` are covered transitively** (verified against NuGet: a perturbed `Installer.Core` lock file fails a locked-mode restore of `Installer.Tests`), so they get no redundant line - but **`deprecated/Installer` was reached by nothing**, and pointing a restore at it reported `NU1004` from `dev` on the first CI run with no dependency change involved: `Microsoft.NET.ILLink.Tasks [10.0.10, )` against `[10.0.11, )`. It is the only project publishing single-file, so the SDK adds that reference implicitly at its OWN bundled version, and `global.json`'s `rollForward: latestPatch` let the runner install 10.0.303 against a lock file written under 10.0.302. That file cannot be right for both SDKs, and nothing had ever restored the project, which is why the drift went unseen. Fixing it means pinning the SDK exactly or dropping that lock file - decisions, not patches - so the requirement carries an exemption that is DERIVED from the coupling (pinning the SDK cancels it and makes the restore mandatory) and RATCHETED on membership (a second SDK-coupled project reds rather than joining quietly). `LockedModeRestoreCoverageTests` derives the coverage requirement from the lock files on disk and the `ProjectReference` edges, was proven red on both workflows BEFORE the edits, and tables both detectors against synthetic input in both directions - including the case a simpler rule gets wrong, a folded YAML plain scalar that reads like the safe single-command form and is not. It also pins #3143's refusal to reach green by dropping `--locked-mode` or setting `RestoreLockedMode`, since NU1004's text advises exactly that. **Dependabot's PRs are still red until someone runs the command**, deliberately: a `GITHUB_TOKEN` push triggers no workflow run, so a healed commit would carry no checks at all rather than one failing non-required one, and making it re-trigger needs a standing `contents: write` App credential this repository does not issue - with `pull_request_target` additionally running the PR's own MSBuild inside that permission. `.github/dependabot.yml` now records the command, replacing a comment claiming the updater regenerates the lock files as part of each PR, which is the claim that let this sit.
```
