### PR TITLE
Collect the checkpointer and bgwriter counters on Aurora, which the WAL CROSS JOIN was taking down with them (#3156)

### DIFF
--- a/Darling/Darling.Tests/PostgresMajorVersionRegistryTests.cs
+++ b/Darling/Darling.Tests/PostgresMajorVersionRegistryTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Service.Mcp;
 using PerformanceMonitor.Darling.Storage;
@@ -116,18 +117,45 @@ public sealed class PostgresMajorVersionRegistryTests
     /* ---------------- what the reads may say ---------------- */
 
     /// <summary>
-    /// The lookup reads the registry column and nothing else. It must not fall back to
-    /// <c>sql_major_version</c>: 17 is a real major in both engines, so a reader joining them has no way to
-    /// tell which vocabulary a number belongs to.
+    /// The lookup reads the PostgreSQL major, and never falls back to <c>sql_major_version</c>: 17 is a real
+    /// major in both engines, so a reader joining them has no way to tell which vocabulary a number belongs
+    /// to.
     /// </summary>
     [Fact]
-    public void TheLookupReadsOnlyThePostgresColumn()
+    public void TheLookupReadsThePostgresColumn_AndNeverTheSqlServerOne()
     {
-        var sql = DarlingEngineCapability.PostgresMajorVersionSql;
+        var sql = DarlingEngineCapability.PostgresTargetFactsSql;
 
-        Assert.Contains("SELECT postgres_major_version", sql, StringComparison.Ordinal);
+        Assert.Contains("postgres_major_version", sql, StringComparison.Ordinal);
         Assert.Contains("FROM servers", sql, StringComparison.Ordinal);
         Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
         Assert.DoesNotContain("sql_major_version", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The major and the engine kind come from ONE statement. Two reads would let the VERSION axis be
+    /// answered from this server's row and the FLAVOUR axis from a stale copy, so one explanation could name
+    /// a major belonging to one server and an engine belonging to another — the hazard
+    /// <c>ServerEngineSql</c> is a single statement for, one axis over.
+    ///
+    /// <para>Asserted as "one SELECT, one FROM, both columns, no statement separator" rather than by
+    /// counting round trips, which a text pin cannot observe. A second round trip from this const would
+    /// have to appear as a second statement, so that is what is denied.</para>
+    /// </summary>
+    [Fact]
+    public void TheMajorAndTheEngineKind_ComeFromOneStatement()
+    {
+        var sql = DarlingEngineCapability.PostgresTargetFactsSql;
+
+        Assert.Contains("postgres_major_version", sql, StringComparison.Ordinal);
+        Assert.Contains("engine_kind", sql, StringComparison.Ordinal);
+
+        /* Counts into locals first: Assert.Equal on a .Count expression is what xUnit2013 flags. */
+        var selects = Regex.Matches(sql, @"\bSELECT\b", RegexOptions.IgnoreCase).Count;
+        var froms = Regex.Matches(sql, @"\bFROM\b", RegexOptions.IgnoreCase).Count;
+
+        Assert.Equal(1, selects);
+        Assert.Equal(1, froms);
+        Assert.DoesNotContain(";", sql, StringComparison.Ordinal);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingEngineCapability.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingEngineCapability.cs
@@ -112,79 +112,61 @@ WHERE server_id = $1";
     }
 
     /// <summary>
-    /// The target's engine KIND token as the registry holds it, or <c>null</c> when it makes no claim — no
-    /// row, or a row no connect has stamped since V82 landed. Decode it through
-    /// <see cref="MonitoredEngineKind"/> rather than comparing strings.
+    /// The registry's two PostgreSQL facts for one server (the major from V100 #2653, the kind from V82
+    /// #2530). $1 server_id.
     ///
-    /// <para><b>Null is not an error and must not be read as "not Aurora".</b> Same contract as
-    /// <see cref="PostgresMajorVersionAsync"/>: callers use this to decide whether they may state that a
-    /// column is structurally absent on this FLAVOUR, and with no claim they say nothing rather than
-    /// guessing. <see cref="MonitoredEngineKind.IsAurora"/> already answers false for null, which is the
-    /// direction that stays honest — an unexplained NULL column beats an explanation naming the wrong
-    /// engine.</para>
-    ///
-    /// <para>A registry read that FAILS answers null, for the reason the two methods around it do: this
-    /// runs on a path that already has its data, and a capability probe must never turn a good answer
-    /// into a read error.</para>
+    /// <para>ONE round trip for both, for the reason <see cref="ServerEngineSql"/> gives one axis over: they
+    /// are read together by every caller that has a NULL column to explain, and two reads would make it
+    /// possible to answer the VERSION axis from this server's row and the FLAVOUR axis from a stale copy —
+    /// which is how an explanation ends up naming a major belonging to one server and an engine belonging to
+    /// another. Exposed as a const so the tests can pin the shape without a live store.</para>
     /// </summary>
-    public static async Task<string?> EngineKindAsync(
-        NpgsqlDataSource postgres,
-        int serverId,
-        CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var (_, engineKind) = await ReadServerEngineAsync(postgres, serverId, cancellationToken);
-            return engineKind;
-        }
-        catch (Exception)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>The registry's PostgreSQL major for one server (V100, #2653). $1 server_id.</summary>
-    public const string PostgresMajorVersionSql = @"
-SELECT postgres_major_version
+    public const string PostgresTargetFactsSql = @"
+SELECT postgres_major_version, engine_kind
 FROM servers
 WHERE server_id = $1";
 
     /// <summary>
-    /// The target's probed PostgreSQL major, or <c>null</c> when the registry makes no claim — no row, a
-    /// server no connect has stamped since V100 landed, or a SQL Server target, where it is not a fact about
-    /// that server at all.
+    /// The target's probed PostgreSQL major and its engine KIND token, each <c>null</c> when the registry
+    /// makes no claim about that fact — no row, a server no connect has stamped since the rung adding the
+    /// column landed, or a SQL Server target, where the major is not a fact about that server at all.
+    /// Decode the token through <see cref="MonitoredEngineKind"/> rather than comparing strings.
     ///
-    /// <para><b>Null is not an error and must not be rendered as a version.</b> Callers use this to decide
-    /// whether they may state that a column is absent on this server's version; with no claim they say
-    /// nothing about the version instead of guessing, because a wrong version in an explanation is worse
-    /// than an unexplained NULL.</para>
+    /// <para><b>Neither null is an error.</b> A null major must not be rendered as a version, and a null
+    /// kind must not be read as "not Aurora". Callers use these to decide whether they may state that a
+    /// column is structurally absent on this server's version or on its flavour; with no claim they say
+    /// nothing rather than guessing, because a wrong version or a wrong engine inside an explanation is
+    /// worse than an unexplained NULL. <see cref="MonitoredEngineKind.IsAurora"/> already answers false for
+    /// null, which is the direction that stays honest.</para>
     ///
-    /// <para>A registry read that FAILS answers null for the same reason
+    /// <para>A registry read that FAILS answers both nulls, for the reason
     /// <see cref="NotCollectedStatusAsync"/> does: this runs on a path that already has its data, and a
     /// capability probe must never turn a good answer into a read error.</para>
     /// </summary>
-    public static async Task<int?> PostgresMajorVersionAsync(
+    public static async Task<(int? PostgresMajorVersion, string? EngineKind)> PostgresTargetFactsAsync(
         NpgsqlDataSource postgres,
         int serverId,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            await using var command = postgres.CreateCommand(PostgresMajorVersionSql);
+            await using var command = postgres.CreateCommand(PostgresTargetFactsSql);
             command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
             DarlingMcpReadParameters.AddInt(command, serverId);
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
-            if (!await reader.ReadAsync(cancellationToken) || reader.IsDBNull(0))
+            if (!await reader.ReadAsync(cancellationToken))
             {
-                return null;
+                return (null, null);
             }
 
-            return reader.GetInt32(0);
+            return (
+                reader.IsDBNull(0) ? null : reader.GetInt32(0),
+                reader.IsDBNull(1) ? null : reader.GetString(1));
         }
         catch (Exception)
         {
-            return null;
+            return (null, null);
         }
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingEngineCapability.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingEngineCapability.cs
@@ -111,6 +111,38 @@ WHERE server_id = $1";
         return (edition, kind);
     }
 
+    /// <summary>
+    /// The target's engine KIND token as the registry holds it, or <c>null</c> when it makes no claim — no
+    /// row, or a row no connect has stamped since V82 landed. Decode it through
+    /// <see cref="MonitoredEngineKind"/> rather than comparing strings.
+    ///
+    /// <para><b>Null is not an error and must not be read as "not Aurora".</b> Same contract as
+    /// <see cref="PostgresMajorVersionAsync"/>: callers use this to decide whether they may state that a
+    /// column is structurally absent on this FLAVOUR, and with no claim they say nothing rather than
+    /// guessing. <see cref="MonitoredEngineKind.IsAurora"/> already answers false for null, which is the
+    /// direction that stays honest — an unexplained NULL column beats an explanation naming the wrong
+    /// engine.</para>
+    ///
+    /// <para>A registry read that FAILS answers null, for the reason the two methods around it do: this
+    /// runs on a path that already has its data, and a capability probe must never turn a good answer
+    /// into a read error.</para>
+    /// </summary>
+    public static async Task<string?> EngineKindAsync(
+        NpgsqlDataSource postgres,
+        int serverId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var (_, engineKind) = await ReadServerEngineAsync(postgres, serverId, cancellationToken);
+            return engineKind;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
     /// <summary>The registry's PostgreSQL major for one server (V100, #2653). $1 server_id.</summary>
     public const string PostgresMajorVersionSql = @"
 SELECT postgres_major_version

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgServerStateTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgServerStateTools.cs
@@ -13,6 +13,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using ModelContextProtocol.Server;
 using Npgsql;
+using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Storage;
 
@@ -306,6 +307,14 @@ public sealed class DarlingMcpPgServerStateTools
                 postgres, resolved.ServerId);
             var backendCountersRemoved = postgresMajor >= BuffersBackendRemovedInMajor;
 
+            /* The FLAVOUR twin of the version fact above (#3156). Aurora does not implement pg_stat_wal at
+               all - pg_stat_get_wal() raises 0A000 there - so every wal_* column is structurally absent on
+               an Aurora target rather than a measurement that did not happen, and this read cannot tell
+               those apart without asking the registry. Read with the same discipline: a registry making no
+               claim produces no claim here. */
+            var walAbsentOnAurora = MonitoredEngineKind.IsAurora(
+                await DarlingEngineCapability.EngineKindAsync(postgres, resolved.ServerId));
+
             return JsonSerializer.Serialize(new
             {
                 server = resolved.ServerName,
@@ -341,6 +350,17 @@ public sealed class DarlingMcpPgServerStateTools
                 wal_buffers_full = row.WalBuffersFull,
                 wal_write_time_ms = row.WalWriteTimeMs,
                 wal_sync_time_ms = row.WalSyncTimeMs,
+                /* The flavour sibling of buffers_backend_availability, named for the same reason: without
+                   it a permanently absent column and an idle server both render as NULL. Absent from the
+                   payload unless the registry actually says Aurora, so a target whose kind is unknown gets
+                   no claim rather than a guessed one. */
+                wal_availability = walAbsentOnAurora
+                    ? "not_collected: Aurora does not implement pg_stat_wal, so the CLUSTER-WIDE WAL "
+                      + "volume and timing are not available on this server - pg_stat_get_wal() raises "
+                      + "0A000 there. Per-statement WAL volume is collected from pg_stat_statements and "
+                      + "read by get_pg_top_queries, and the checkpointer and background-writer counters "
+                      + "beside these are collected normally."
+                    : null,
                 counter_reset = row.ResetDuringWindow,
                 note = "Requested checkpoints mean max_wal_size filled before the scheduled interval, so a "
                      + "high requested share means write volume is forcing them. "
@@ -351,8 +371,15 @@ public sealed class DarlingMcpPgServerStateTools
                            + "server by pg_stat_io, which get_pg_io_stats reads. "
                          : "buffers_backend is a write a QUERY had to perform itself for want of a clean "
                            + "buffer. ")
-                     + "wal_fpi counts full-page images, which is why WAL volume spikes just after each "
-                     + "checkpoint."
+                     + (walAbsentOnAurora
+                         ? "The wal_* columns are NULL because Aurora does not implement pg_stat_wal, not "
+                           + "because no WAL was written: Aurora replaced the WAL layer with its own "
+                           + "distributed storage. The cluster-wide total is unavailable here, but "
+                           + "per-statement WAL volume is collected and get_pg_top_queries reads it, so "
+                           + "which statement is generating WAL is still answerable. The checkpointer and "
+                           + "background-writer figures above are unaffected."
+                         : "wal_fpi counts full-page images, which is why WAL volume spikes just after "
+                           + "each checkpoint.")
                      + (row.ResetDuringWindow
                          ? " The counters were RESET inside this window, so these figures cover only the "
                            + "time since the reset."

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgServerStateTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgServerStateTools.cs
@@ -299,21 +299,23 @@ public sealed class DarlingMcpPgServerStateTools
             var timed = row.CheckpointsTimed ?? 0;
             var requested = row.CheckpointsRequested ?? 0;
 
-            /* #2653: 17 removed buffers_backend / buffers_backend_fsync from pg_stat_bgwriter with no
-               successor there, so the collector writes NULL for them and the fact now lives in pg_stat_io.
-               Without the registry's major this read cannot tell that structural absence from a measurement
-               that did not happen, and its note explained a column that will never have a value here. */
-            var postgresMajor = await DarlingEngineCapability.PostgresMajorVersionAsync(
+            /* Both registry facts in ONE read, because this payload has two kinds of structurally
+               absent column and neither is distinguishable from an unmeasured one without asking.
+
+               VERSION (#2653): 17 removed buffers_backend / buffers_backend_fsync from
+               pg_stat_bgwriter with no successor there, so the collector writes NULL and the fact
+               lives in pg_stat_io.
+
+               FLAVOUR (#3156): Aurora does not implement pg_stat_wal at all - pg_stat_get_wal()
+               raises 0A000 there - so every wal_* column is NULL on an Aurora target.
+
+               Two reads would let one axis be answered from this server's row and the other from a
+               stale copy, which is the hazard PostgresTargetFactsSql is a single statement for. Same
+               discipline on both axes: a registry making no claim produces no claim here. */
+            var (postgresMajor, engineKind) = await DarlingEngineCapability.PostgresTargetFactsAsync(
                 postgres, resolved.ServerId);
             var backendCountersRemoved = postgresMajor >= BuffersBackendRemovedInMajor;
-
-            /* The FLAVOUR twin of the version fact above (#3156). Aurora does not implement pg_stat_wal at
-               all - pg_stat_get_wal() raises 0A000 there - so every wal_* column is structurally absent on
-               an Aurora target rather than a measurement that did not happen, and this read cannot tell
-               those apart without asking the registry. Read with the same discipline: a registry making no
-               claim produces no claim here. */
-            var walAbsentOnAurora = MonitoredEngineKind.IsAurora(
-                await DarlingEngineCapability.EngineKindAsync(postgres, resolved.ServerId));
+            var walAbsentOnAurora = MonitoredEngineKind.IsAurora(engineKind);
 
             return JsonSerializer.Serialize(new
             {

--- a/Lite.Tests/PgWriteStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgWriteStatsCollectorDefinitionTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.
@@ -26,7 +26,7 @@ public class PgWriteStatsCollectorDefinitionTests
 {
     private static readonly RecordingCollectorDeltaCalculator s_deltas = new();
 
-    private static CollectorContext MakeContext(int major)
+    private static CollectorContext MakeContext(int major, bool isAurora = false)
         => new()
         {
             ServerId = 42,
@@ -37,12 +37,18 @@ public class PgWriteStatsCollectorDefinitionTests
             {
                 Engine = CollectorTargetEngine.PostgreSql,
                 PostgresMajorVersion = major,
+                IsAurora = isAurora,
             },
             ExcludedDatabases = Array.Empty<string>(),
         };
 
+    /// <summary>Stock PostgreSQL, which is what every version-surface assertion here is about.</summary>
     private static string Sql(int major)
         => PgWriteStatsCollector.Instance.BuildQuery(MakeContext(major)).Text;
+
+    /// <summary>The Aurora flavour of the same major.</summary>
+    private static string AuroraSql(int major)
+        => PgWriteStatsCollector.Instance.BuildQuery(MakeContext(major, isAurora: true)).Text;
 
     /// <summary>
     /// The columns 17 REMOVED from <c>pg_stat_bgwriter</c> must not be referenced on 17 or later. Five of
@@ -258,4 +264,138 @@ public class PgWriteStatsCollectorDefinitionTests
             }
         }
     }
+
+    /// <summary>
+    /// Aurora must not NAME <c>pg_stat_wal</c> anywhere - not in the SELECT list and not in the FROM
+    /// clause, because naming it is itself the <c>0A000</c>. Asserted as "the view is absent and its alias
+    /// is never dereferenced" rather than "the join line is gone": dropping the join while leaving one
+    /// <c>w.</c> reference behind would still be a syntax error on every target, and dropping the columns
+    /// while leaving the join behind would still raise 0A000 on every Aurora target. Both halves have to
+    /// hold, so both are checked.
+    /// </summary>
+    [Theory]
+    [InlineData(14)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(18)]
+    [InlineData(99)]
+    public void Aurora_NeitherNamesPgStatWal_NorDereferencesItsAlias(int major)
+    {
+        var sql = AuroraSql(major);
+
+        Assert.DoesNotContain("pg_stat_wal", sql, StringComparison.Ordinal);
+        Assert.DoesNotMatch(new Regex(@"\bw\."), sql);
+    }
+
+    /// <summary>
+    /// The point of the branch: on Aurora the checkpointer and background-writer columns are still READ,
+    /// not NULLed alongside the WAL ones. That is the mutation this catches and the only one - a branch
+    /// that widened to NULL b.buffers_clean too fails here and passes everything else.
+    ///
+    /// <para>It does NOT catch gating the collector off on Aurora, because this reaches BuildQuery
+    /// directly and never consults the gate. <see cref="AppliesTo_StillPassesOnAurora"/> is the pin for
+    /// that, and the two are separate on purpose: the wrong fixes are different edits and a single
+    /// assertion covering both would name neither when it failed.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(16)]
+    [InlineData(17)]
+    public void Aurora_StillReadsTheCheckpointerAndBgwriterColumns(int major)
+    {
+        var sql = AuroraSql(major);
+
+        Assert.Contains("pg_catalog.pg_stat_bgwriter", sql, StringComparison.Ordinal);
+        Assert.Contains("b.buffers_clean", sql, StringComparison.Ordinal);
+        Assert.Contains("b.maxwritten_clean", sql, StringComparison.Ordinal);
+        Assert.Contains("b.buffers_alloc", sql, StringComparison.Ordinal);
+        Assert.Contains("bgwriter_stats_reset", sql, StringComparison.Ordinal);
+
+        /* 17 moved these into pg_stat_checkpointer; below it they are still inside pg_stat_bgwriter. Either
+           way the checkpoint counters must be READ, which is what the version branches already decide. */
+        Assert.Contains(major >= 17 ? "pg_catalog.pg_stat_checkpointer" : "checkpoints_timed",
+            sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The stored shape is the UNION and does not vary by FLAVOUR either - same 26 aliases, same order as
+    /// the stock path of the same major. <see cref="ThePayloadShape_DoesNotVaryByVersion"/> pins this
+    /// against the version axis; without the flavour twin, an Aurora branch could omit a column instead of
+    /// NULLing it and shift every ordinal after it, which is the failure that class of change makes.
+    /// </summary>
+    [Theory]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(18)]
+    public void Aurora_KeepsTheSamePayloadOrdinalsAsStock(int major)
+    {
+        /* Same line-based extraction ThePayloadShape_DoesNotVaryByVersion uses, and for the same reason:
+           the TABLE aliases (AS b, AS w) share the keyword with the column aliases, so a naive match
+           picks them up and shifts the list while looking like an ordering bug. Aurora has one table
+           alias and stock has two, so a naive match here would not merely be wrong - it would differ
+           BETWEEN the two shapes and make the flavour comparison below fail for the wrong reason. */
+        static string[] Aliases(string sql)
+            => sql.Split('\n')
+                .Where(line => !line.TrimStart().StartsWith("FROM", StringComparison.Ordinal)
+                            && !line.TrimStart().StartsWith("CROSS JOIN", StringComparison.Ordinal))
+                .Select(line => Regex.Match(line, @"\bAS\s+([a-z_]+),?\s*$"))
+                .Where(m => m.Success)
+                .Select(m => m.Groups[1].Value)
+                .ToArray();
+
+        var expected = PgWriteStatsCollector.Instance.PayloadColumns.Select(c => c.Name).ToArray();
+
+        Assert.Equal(expected, Aliases(AuroraSql(major)));
+        Assert.Equal(Aliases(Sql(major)), Aliases(AuroraSql(major)));
+    }
+
+    /// <summary>
+    /// Two UTC conversions on Aurora, not three: <c>wal_stats_reset</c> has no source to convert, so it is
+    /// a typed NULL. The stock path keeps all three, which
+    /// <see cref="StatsResetStamps_AreConvertedToUtc_NotBareCast"/> already holds. A NULL rather than a
+    /// bare cast matters for the same reason it does across majors: a read that differences a counter must
+    /// not be able to mistake an unavailable reset point for a known one.
+    /// </summary>
+    [Fact]
+    public void Aurora_ConvertsOnlyTheTwoResetStampsItCanRead()
+    {
+        var sql = AuroraSql(17);
+
+        Assert.Equal(2, Regex.Matches(sql, @"AT TIME ZONE 'UTC'").Count);
+        Assert.Contains("NULL::timestamp", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The stock path is UNCHANGED by the flavour branch - it still CROSS JOINs the view and still reads
+    /// the WAL counters. Without this, making the Aurora assertions pass by dropping the join everywhere
+    /// would go unnoticed, and stock PostgreSQL would silently lose the WAL half.
+    /// </summary>
+    [Theory]
+    [InlineData(16)]
+    [InlineData(17)]
+    public void StockPostgres_StillCrossJoinsPgStatWal_AndReadsItsCounters(int major)
+    {
+        var sql = Sql(major);
+
+        Assert.Contains("CROSS JOIN pg_catalog.pg_stat_wal AS w", sql, StringComparison.Ordinal);
+        Assert.Contains("w.wal_records", sql, StringComparison.Ordinal);
+        Assert.Contains("w.wal_bytes::numeric(38,0)", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The gate keeps passing on Aurora. This is the pin that stops the tempting wrong fix: an
+    /// <c>AppliesTo</c> that excluded Aurora would also silence the 0A000, and
+    /// <see cref="CollectorEngineCapability"/> would then derive a PERMANENT engine gap - telling an
+    /// operator the checkpoint and WAL write counters can never be collected on Aurora, when two thirds of
+    /// them now are.
+    /// </summary>
+    [Theory]
+    [InlineData(16)]
+    [InlineData(17)]
+    public void AppliesTo_StillPassesOnAurora(int major)
+        => Assert.True(PgWriteStatsCollector.Instance.AppliesTo(new CollectorTargetInfo
+        {
+            Engine = CollectorTargetEngine.PostgreSql,
+            PostgresMajorVersion = major,
+            IsAurora = true,
+        }));
 }

--- a/PerformanceMonitor.Collectors/PgWriteStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/PgWriteStatsCollector.cs
@@ -110,9 +110,16 @@ public sealed class PgWriteStatsCollector : PostgresCollectorDefinitionBase<PgWr
         double? WalSyncTimeMs,
         DateTime? WalStatsReset);
 
-    /* Three joinless scalar subqueries rather than a CROSS JOIN of three views. Each view is a guaranteed
-       single row, so the result is one row either way, but a subquery per column keeps every version branch
-       local to the column it affects instead of forcing the whole FROM clause to be version-shaped.
+    /* The CHECKPOINTER columns are joinless scalar subqueries; pg_stat_bgwriter and pg_stat_wal are
+       CROSS JOINed below as b and w. Each of the three views is a guaranteed single row, so the result
+       is one row whichever shape is used, but a subquery per column keeps a branch local to the column
+       it affects instead of letting it shape the FROM clause.
+
+       That difference is load-bearing rather than stylistic, and the two JOINED views are the proof: a
+       source named in FROM cannot be branched away one column at a time, so an engine that rejects it
+       fails the whole row and takes the other views' columns down with it. pg_stat_wal on Aurora is
+       exactly that case, which is what the isAurora branch below is for - it removes the view from FROM
+       rather than only NULLing the columns read from it.
 
        stats_reset is timestamptz on all three; AT TIME ZONE 'UTC' rather than ::timestamp, because the cast
        renders in the SESSION's TimeZone and the store contract is naive UTC. Same rule as pg_stat_io.

--- a/PerformanceMonitor.Collectors/PgWriteStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/PgWriteStatsCollector.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.
@@ -53,6 +53,16 @@ namespace PerformanceMonitor.Collectors;
 /// are where most people's knowledge is, but they are the ones PostgreSQL is moving away from, and
 /// translating for a reader is a documentation job rather than a reason to freeze a deprecated vocabulary
 /// into a schema.</para>
+///
+/// <para><b>The FLAVOUR surface is a second axis, and it bites the same way.</b> Aurora does not implement
+/// <c>pg_stat_wal</c>: reading it raises <c>0A000</c>, because Aurora replaced the WAL layer with its own
+/// distributed storage. Because the three views are CROSS JOINed, naming <c>pg_stat_wal</c> puts the
+/// checkpointer and bgwriter columns behind the same error even though Aurora supplies them, so on Aurora
+/// the WAL columns are typed NULLs and the join is dropped - exactly what the version branches do for a
+/// column a major removed.
+/// The gate is deliberately NOT narrowed: two thirds of this payload is collectable on Aurora, so
+/// <see cref="AppliesTo"/> must keep passing and <see cref="CollectorEngineCapability"/> must keep
+/// reporting no gap.</para>
 ///
 /// <para>Runs on standbys deliberately. <c>pg_stat_checkpointer</c>'s <c>restartpoints_*</c> columns exist
 /// precisely to describe a replica, and a standby that cannot keep up with restartpoints is exactly the
@@ -110,7 +120,7 @@ public sealed class PgWriteStatsCollector : PostgresCollectorDefinitionBase<PgWr
        All three views are kept as separate stats_reset columns. They CAN be reset independently
        (pg_stat_reset_shared takes a target), and a read that differenced across a reset it could not see
        would report a negative interval as a huge positive one. */
-    private static string BuildQueryText(int postgresMajorVersion)
+    private static string BuildQueryText(int postgresMajorVersion, bool isAurora)
     {
         var hasCheckpointer = postgresMajorVersion >= 17;
         var has18 = postgresMajorVersion >= 18;
@@ -154,13 +164,45 @@ public sealed class PgWriteStatsCollector : PostgresCollectorDefinitionBase<PgWr
         var buffersBackend = hasCheckpointer ? "NULL::bigint" : "(SELECT buffers_backend FROM pg_catalog.pg_stat_bgwriter)";
         var buffersBackendFsync = hasCheckpointer ? "NULL::bigint" : "(SELECT buffers_backend_fsync FROM pg_catalog.pg_stat_bgwriter)";
 
-        /* ---- WAL: 18 removed the four timing/count columns. This is the branch that would take the whole
-               collection down with 42703 on an 18 target if it were selected unconditionally, which is the
-               specific hazard #2544 was reopened to describe. ---- */
-        var walWrite = has18 ? "NULL::bigint" : "w.wal_write";
-        var walSync = has18 ? "NULL::bigint" : "w.wal_sync";
-        var walWriteTime = has18 ? "NULL::double precision" : "w.wal_write_time";
-        var walSyncTime = has18 ? "NULL::double precision" : "w.wal_sync_time";
+        /* ---- WAL: two independent reasons a column here is not selectable, and either one takes the
+               WHOLE row down rather than one column, because pg_stat_wal is CROSS JOINed and not read
+               per column.
+
+               18 removed the four timing/count columns, which raises 42703 on an 18 target - the hazard
+               #2544 was reopened to describe.
+
+               Aurora does not implement pg_stat_wal at all, and reading it raises 0A000: "Function
+               pg_stat_get_wal() is currently not supported for Aurora". Aurora replaced the WAL layer
+               with its own distributed storage, so this is a permanent FLAVOUR gap and not a version
+               floor an upgrade moves - which is why it branches on IsAurora, the one PostgreSQL fact
+               nothing an operator does can change.
+
+               Naming the view costs more than the WAL columns themselves, because the CROSS JOIN puts
+               every other column in this payload behind the same error: one 0A000 and the checkpointer
+               and bgwriter figures go with it, and Aurora supplies those. Hence a typed NULL plus a FROM
+               clause that does not name the view, and never a gate that stops the collector - AppliesTo
+               has to keep passing on Aurora, or the same two thirds of the payload are lost a second way
+               and CollectorEngineCapability reports a permanent gap for a collector that does run. ---- */
+        var walRecords = isAurora ? "NULL::bigint" : "w.wal_records";
+        var walFpi = isAurora ? "NULL::bigint" : "w.wal_fpi";
+        var walBuffersFull = isAurora ? "NULL::bigint" : "w.wal_buffers_full";
+        var walWrite = isAurora || has18 ? "NULL::bigint" : "w.wal_write";
+        var walSync = isAurora || has18 ? "NULL::bigint" : "w.wal_sync";
+        var walWriteTime = isAurora || has18 ? "NULL::double precision" : "w.wal_write_time";
+        var walSyncTime = isAurora || has18 ? "NULL::double precision" : "w.wal_sync_time";
+        var walStatsReset = isAurora ? "NULL::timestamp" : "(w.stats_reset AT TIME ZONE 'UTC')";
+
+        /* wal_bytes is NUMERIC, not bigint - it is allowed to exceed 2^63 over a long uptime, which is
+           exactly why upstream chose numeric. Cast to a bounded numeric so the store's column type is
+           decidable, and carried through C# as decimal rather than long for the same reason. */
+        var walBytes = isAurora ? "NULL::numeric(38,0)" : "w.wal_bytes::numeric(38,0)";
+
+        /* Naming the view in FROM is itself the 0A000, so the join has to go rather than just its
+           columns. The two-line literal keeps the repository's CRLF instead of hardcoding a newline. */
+        var fromClause = isAurora
+            ? "FROM pg_catalog.pg_stat_bgwriter AS b"
+            : @"FROM pg_catalog.pg_stat_bgwriter AS b
+CROSS JOIN pg_catalog.pg_stat_wal AS w";
 
         return $@"
 SELECT
@@ -181,20 +223,16 @@ SELECT
     {buffersBackend}                        AS buffers_backend,
     {buffersBackendFsync}                   AS buffers_backend_fsync,
     (b.stats_reset AT TIME ZONE 'UTC')      AS bgwriter_stats_reset,
-    w.wal_records                           AS wal_records,
-    w.wal_fpi                               AS wal_fpi,
-    /* wal_bytes is NUMERIC, not bigint - it is allowed to exceed 2^63 over a long uptime, which is exactly
-       why upstream chose numeric. Cast to a bounded numeric so the store's column type is decidable, and
-       carried through C# as decimal rather than long for the same reason. */
-    w.wal_bytes::numeric(38,0)              AS wal_bytes,
-    w.wal_buffers_full                      AS wal_buffers_full,
+    {walRecords}                            AS wal_records,
+    {walFpi}                                AS wal_fpi,
+    {walBytes}                              AS wal_bytes,
+    {walBuffersFull}                        AS wal_buffers_full,
     {walWrite}                              AS wal_write,
     {walSync}                               AS wal_sync,
     {walWriteTime}                          AS wal_write_time_ms,
     {walSyncTime}                           AS wal_sync_time_ms,
-    (w.stats_reset AT TIME ZONE 'UTC')      AS wal_stats_reset
-FROM pg_catalog.pg_stat_bgwriter AS b
-CROSS JOIN pg_catalog.pg_stat_wal AS w";
+    {walStatsReset}                         AS wal_stats_reset
+{fromClause}";
     }
 
     public override string Name => "pg_write_stats";
@@ -204,11 +242,16 @@ CROSS JOIN pg_catalog.pg_stat_wal AS w";
     /// <summary>
     /// <c>pg_stat_wal</c> is PostgreSQL 14+, which is the binding floor — <c>pg_stat_bgwriter</c> long
     /// predates it. Standbys included: <c>restartpoints_*</c> exists to describe exactly that case.
+    /// <para>The floor binds the STOCK path only, since the Aurora path never names <c>pg_stat_wal</c>. It is
+    /// left applying to both anyway: every Aurora major in the field is far above 14, and widening a gate
+    /// would change what <see cref="CollectorEngineCapability"/> derives for a reason unrelated to the
+    /// 0A000 this branch exists for. What matters is the direction it must NOT move - narrowing it to
+    /// exclude Aurora would discard the checkpointer and bgwriter columns that Aurora does supply.</para>
     /// </summary>
     public override bool AppliesTo(CollectorTargetInfo target) => target.PostgresMajorVersion >= 14;
 
     public override CollectorQuery BuildQuery(CollectorContext context)
-        => new(BuildQueryText(context.Target.PostgresMajorVersion));
+        => new(BuildQueryText(context.Target.PostgresMajorVersion, context.Target.IsAurora));
 
     public override IReadOnlyList<CollectorColumn> PayloadColumns { get; } = new[]
     {


### PR DESCRIPTION
`pg_write_stats` builds one `SELECT` over `pg_stat_bgwriter CROSS JOIN pg_stat_wal`. Aurora does not implement `pg_stat_wal` — reading it raises `0A000`, *"Function pg_stat_get_wal() is currently not supported for Aurora"* — and because the views are CROSS JOINed, that one error takes the checkpointer and background-writer columns down with the WAL ones, which Aurora supplies.

So on Aurora this collector stores nothing at all. Measured read-only on a 50-target Aurora fleet: **643,389 runs, 100% `PERMISSIONS` with no other status in the entire retention window, zero rows** — and the `pg_write_stats` table is empty for every target. It is the #3030 / #3109 shape (a collector that has never stored a row) wearing a status that reads as an accepted limitation, which is why the sweep that found it attributed it to retry cost rather than to data loss.

## The collector

On Aurora the nine WAL columns become typed NULLs and the join is dropped. That is the same remedy the version branches in this file already apply to a column a major removed — `pg_stat_wal`'s own PG18 branch is three lines above it — and the `IsAurora` branch sits in `BuildQuery`, matching `PgStatementStatsCollector`.

The stored shape does not vary by flavour: same 26 aliases in the same order, so the binary COPY ordinals hold. Omitting a column instead of NULLing it would shift every ordinal after it and write values into the wrong columns rather than failing, which is what `Aurora_KeepsTheSamePayloadOrdinalsAsStock` exists to catch.

**`AppliesTo` is deliberately untouched.** Excluding Aurora is the tempting fix and it is wrong twice over: it loses the same two thirds of the payload a second way, and it makes `CollectorEngineCapability` derive a *permanent engine gap* — telling an operator the checkpoint and WAL counters can never be collected on Aurora, when most of them now are. `AppliesTo_StillPassesOnAurora` pins that.

The comment above the query text claimed *"three joinless scalar subqueries rather than a CROSS JOIN of three views"*. Only the checkpointer columns are subqueries; `pg_stat_bgwriter` and `pg_stat_wal` are CROSS JOINed, so the comment asserted a property the code does not have — and it is what made the `0A000` look impossible on a reading of this file. Its own stated rationale turns out to be the principle whose absence causes the bug (a source named in `FROM` cannot be branched away one column at a time), so the correction records that rather than deleting the sentence.

## The read

`get_pg_write_stats` gains `wal_availability`, the flavour sibling of the existing `buffers_backend_availability`. Without it the now-NULL `wal_*` columns read as an idle server under a note explaining full-page images.

The message says what is unavailable *precisely* — the cluster-wide total — and points at `get_pg_top_queries`, which carries per-statement `wal_bytes` from `pg_stat_statements` on Aurora. "WAL volume is unavailable here" was the easier sentence and would have been false.

Both registry facts come from **one statement**. `PostgresTargetFactsAsync` replaces `PostgresMajorVersionAsync` and `EngineKindAsync`, neither of which had another caller. Two reads of `servers WHERE server_id = $1` would make it possible to answer the VERSION axis from this server's row and the FLAVOUR axis from a stale copy — the hazard `ServerEngineSql`'s own doc comment names one axis over, and a new read in the shape this file documents as wrong is how that shape spreads. `TheMajorAndTheEngineKind_ComeFromOneStatement` pins one `SELECT`, one `FROM`, both columns and no statement separator, because a text pin cannot observe a round trip directly. The `sql_major_version` guard is kept: 17 is a real major in both engines.

Both nulls keep the file's no-claim discipline — a registry that has not stamped a fact produces no explanation rather than one naming the wrong version or the wrong engine.

## Tests

18 new cases in `PgWriteStatsCollectorDefinitionTests`; the 22 existing version-surface cases are unchanged. Each new pin was mutation-tested, and every mutation is caught only by the pin that claims it:

| mutation | fails |
|---|---|
| the CROSS JOIN returns on Aurora | `Aurora_NeitherNamesPgStatWal_NorDereferencesItsAlias` (5 cases) |
| `AppliesTo` excludes Aurora | `AppliesTo_StillPassesOnAurora` (2) |
| a WAL column omitted rather than NULLed | `Aurora_KeepsTheSamePayloadOrdinalsAsStock` (3) + `ThePayloadShape_DoesNotVaryByVersion` |
| `wal_stats_reset` still dereferences the dropped alias | `Aurora_ConvertsOnlyTheTwoResetStampsItCanRead` + the alias pin |
| the Aurora branch NULLs the bgwriter columns too | `Aurora_StillReadsTheCheckpointerAndBgwriterColumns` (2) |

That last mutation is why the bgwriter pin and the gate pin are separate assertions: the bgwriter pin reaches `BuildQuery` directly and never consults the gate, so it cannot catch a gated-off collector. Its doc comment said it could, until the mutation run said otherwise.

## Verification note

The recovered columns are asserted at the SQL-text level, not against a live Aurora target. `pg_stat_bgwriter` and `pg_stat_checkpointer` are core cumulative-statistics views that Aurora documents as available, and `pg_stat_io` — the same subsystem — collects 26M rows over the same window on this fleet. The change is also monotonically non-worse regardless: the collector stores zero rows today, so the worst case is that it continues to.

## CHANGELOG entry text

Not committed here, per the batching convention:

```
- `pg_write_stats` now collects the checkpointer and background-writer counters on Aurora PostgreSQL. Aurora does not implement `pg_stat_wal`, and because the three views were CROSS JOINed the resulting `0A000` discarded the whole row — so the collector stored nothing at all on an Aurora target while reporting an accepted limitation. The WAL columns are typed NULLs there and `get_pg_write_stats` explains why, pointing at `get_pg_top_queries` for the per-statement WAL volume Aurora does expose. (#3156)
```
