### PR TITLE
Name which cause produced a pg_column_stats zero, rather than listing them (#3154)

### DIFF
--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -92,6 +92,8 @@ public sealed class PgColumnStatsCoverageTests
             PgColumnStatsCoverage.Classify(true, 361, 12, 5_000), PgColumnStatsCoverageArm.PartialVisibility),
         ("stored, covering all of them",
             PgColumnStatsCoverage.Classify(true, 361, 361, 5_000), PgColumnStatsCoverageArm.FullyMeasured),
+        ("stored, but the evidence says nothing clears the floor",
+            PgColumnStatsCoverage.Classify(true, 0, 0, 5_000), PgColumnStatsCoverageArm.EvidenceStale),
     };
 
     /// <summary>R1: no outcome may arrive without an arm, and every arm must be reachable.</summary>
@@ -161,6 +163,7 @@ public sealed class PgColumnStatsCoverageTests
             PgColumnStatsCoverage.Classify(true, 424_242, 31_337, 0),
             PgColumnStatsCoverage.Classify(true, 424_242, 31_337, 90_210),
             PgColumnStatsCoverage.Classify(true, 424_242, 424_242, 90_210),
+            PgColumnStatsCoverage.Classify(true, 0, 0, 90_210),
             PgColumnStatsCoverage.EvidenceUnreadable(90_210),
         };
 
@@ -236,9 +239,19 @@ public sealed class PgColumnStatsCoverageTests
 
         /* A measured zero prints as a figure; an unmeasured one prints as a WORD. Rendering both as 0 is
            how "we looked and everything is small" became indistinguishable from "we never looked". */
-        Assert.Contains("floor: 0.", measured.Census, StringComparison.Ordinal);
+        var floorLabel = "floor (" + PgColumnStatsCoverage.EvidenceHoursDescription + "): ";
+
+        Assert.Contains(floorLabel + "0.", measured.Census, StringComparison.Ordinal);
         Assert.DoesNotContain(PgColumnStatsCoverage.NotMeasured, measured.Census, StringComparison.Ordinal);
-        Assert.Contains("floor: " + PgColumnStatsCoverage.NotMeasured, unmeasured.Census, StringComparison.Ordinal);
+        Assert.Contains(
+            floorLabel + PgColumnStatsCoverage.NotMeasured, unmeasured.Census, StringComparison.Ordinal);
+
+        /* And the census SAYS the two figures are measured over different spans, because that is what makes
+           EvidenceStale intelligible rather than a contradiction. A reader drawing a ratio from a
+           24h candidate count and a 168h row count has to be told before doing it, not after. */
+        Assert.Contains(
+            PgColumnStatsCoverage.EvidenceHoursDescription, measured.Census, StringComparison.Ordinal);
+        Assert.Contains("over the window you asked for", measured.Census, StringComparison.Ordinal);
 
         /* And the Undetermined arm must not smuggle a verdict in. */
         Assert.DoesNotContain("CAUSE:", unmeasured.Cause, StringComparison.Ordinal);
@@ -260,7 +273,7 @@ public sealed class PgColumnStatsCoverageTests
     public void TheEvidenceLookbackIsFixedRatherThanTakenFromTheCallersWindow()
     {
         var end = new DateTime(2026, 9, 7, 20, 0, 0, DateTimeKind.Utc);
-        var hours = DarlingPgColumnStatsReader.EvidenceHours;
+        var hours = PgColumnStatsCoverage.EvidenceHours;
 
         Assert.Equal(end.AddHours(-hours), DarlingPgColumnStatsReader.EvidenceStart(end));
 
@@ -371,6 +384,71 @@ public sealed class PgColumnStatsCoverageTests
         Assert.True(
             precondition < coverage,
             "the coverage verdict is computed ahead of the precondition that outranks it");
+    }
+
+    /// <summary>
+    /// The invariant, swept over the whole input space: <b>the verdict never contradicts the row set printed
+    /// beside it.</b>
+    ///
+    /// <para>This is the check that would have caught the defect review found, and the arm-by-arm cases
+    /// above would not have. They enumerate ARMS; this enumerates INPUT REGIONS. The two counts are measured
+    /// over different spans — a fixed <see cref="PgColumnStatsCoverage.EvidenceHours"/> lookback for the
+    /// evidence, the caller's own window for the rows — so <c>candidateTables == 0</c> alongside
+    /// <c>storedColumnRows &gt; 0</c> is reachable, and it took the size-floor arm: "no table is large
+    /// enough … nothing to fix", printed next to real statistics. Reading the branches finds a wrong
+    /// assertion; only enumerating the regions finds a missing one.</para>
+    ///
+    /// <para>Two directions, because the contradiction has two: a non-empty result must never be told
+    /// nothing was collectable, and an empty one must never be told coverage is whole or partial — partial
+    /// coverage of nothing is not a thing an operator can act on.</para>
+    /// </summary>
+    [Fact]
+    public void NoVerdictContradictsTheRowSetPrintedBesideIt()
+    {
+        var seen = new HashSet<PgColumnStatsCoverageArm>();
+        var regions = 0;
+
+        foreach (var ran in new[] { false, true })
+        foreach (var candidates in new[] { 0, 1, 12, 361 })
+        foreach (var visible in new[] { 0, 1, 12, 361 })
+        foreach (var stored in new[] { 0, 1, 5_000 })
+        {
+            /* visible can never exceed candidates - the census counts a SUBSET - so those combinations are
+               not reachable and asserting over them would guard arithmetic the query cannot produce. */
+            if (visible > candidates) continue;
+
+            regions++;
+            var verdict = PgColumnStatsCoverage.Classify(ran, candidates, visible, stored);
+            seen.Add(verdict.Arm);
+
+            var inputs = $"ran={ran} candidates={candidates} visible={visible} stored={stored} "
+                + $"-> {verdict.Arm}";
+
+            Assert.False(string.IsNullOrWhiteSpace(verdict.Cause), "unclassified region: " + inputs);
+
+            if (stored > 0)
+            {
+                Assert.NotEqual(PgColumnStatsCoverageArm.BelowSizeFloor, verdict.Arm);
+                Assert.DoesNotContain("nothing to fix", verdict.Cause, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("nothing to collect", verdict.Cause, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("nothing was stored", verdict.Cause, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                Assert.NotEqual(PgColumnStatsCoverageArm.FullyMeasured, verdict.Arm);
+                Assert.NotEqual(PgColumnStatsCoverageArm.PartialVisibility, verdict.Arm);
+                Assert.DoesNotContain("FULL COVERAGE", verdict.Cause, StringComparison.Ordinal);
+                Assert.DoesNotContain("PARTIAL COVERAGE", verdict.Cause, StringComparison.Ordinal);
+            }
+        }
+
+        /* The sweep is only worth its assertions if it actually reaches everything. Both halves: enough
+           regions to be a sweep rather than a handful, and every arm visited - an arm the grid cannot
+           reach is an arm this invariant says nothing about. */
+        Assert.True(regions >= 60, $"the sweep covered only {regions} region(s)");
+        Assert.Equal(
+            Enum.GetValues<PgColumnStatsCoverageArm>().OrderBy(a => a).ToArray(),
+            seen.OrderBy(a => a).ToArray());
     }
 
     /// <summary>R7: a populated result that covers part of the target is its own answer, not the clean one.</summary>

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -57,13 +57,13 @@ namespace Darling.Tests;
 /// <see cref="TheQuotedFloorIsTheOneTheShippedQueriesFilterOn"/>.</item>
 /// </list>
 ///
-/// <para><b>Which cause actually applies, measured.</b> The privilege filter, on the whole fleet. Read-only
-/// against a live store on 2026-09-07: <c>estimate_unavailable</c> was TRUE on 331,357 of 331,357
-/// <c>pg_table_bloat_stats</c> rows in every era, and independently the collector's own width arithmetic
-/// bottomed out at its empty-input residue on 59,981 of 59,981 rows in 48 hours — two readings that fail
-/// differently and agree. The floor is demonstrably NOT the explanation: 1,263 of 1,264 distinct tables past
-/// the byte floor also clear the page floor, on all 49 targets that report, and the busiest holds 361 of
-/// them, which is the figure the collector's own comment cites.</para>
+/// <para><b>Which cause actually applies, measured.</b> The privilege filter, on the whole fleet. One
+/// read-only pass against a live store at 2026-09-07 21:37 UTC: <c>estimate_unavailable</c> TRUE on
+/// 332,611 of 332,611 <c>pg_table_bloat_stats</c> rows in every era, and independently that collector's own
+/// width arithmetic at its empty-input residue on 60,202 of 60,202 rows in 48 hours — two readings that
+/// fail differently and agree. The floor is demonstrably NOT the explanation: 1,263 of 1,264 distinct
+/// tables past the byte floor also clear the page floor, on all 49 targets that report, and the busiest
+/// holds 361 of them, which is the figure the collector's own comment cites.</para>
 /// </summary>
 public sealed class PgColumnStatsCoverageTests
 {

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -284,9 +284,27 @@ public sealed class PgColumnStatsCoverageTests
 
         Assert.Contains("EvidenceStart(endUtc)", verdictRead, StringComparison.Ordinal);
 
-        /* And the read must not quietly go back to the caller's start: the parameter still exists, for the
-           ROW read, so a one-character edit reinstates the defect this closes. */
-        Assert.DoesNotContain("EvidenceStart(startUtc", verdictRead, StringComparison.Ordinal);
+        /* And it does not ACCEPT a window start it would then ignore. The signature is the guard here, not
+           the body: a parameter passed and dropped is worse than an absent one, because the caller believes
+           its window was honoured and neither the compiler nor the answer says otherwise. Scoped to the
+           declaration rather than the body, so the ROW read's own startUtc - which it does use - is out of
+           scope by construction. */
+        var verdictSignature = MemberSignature(
+            "Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs",
+            "GetCoverageVerdictAsync");
+
+        Assert.DoesNotContain("startUtc", verdictSignature, StringComparison.Ordinal);
+        Assert.Contains("DateTime endUtc", verdictSignature, StringComparison.Ordinal);
+
+        /* The raw-counts reader is the opposite case and stays that way: it takes both ends BECAUSE it
+           uses both, and it is what a caller wanting its own span reaches for. Asserting it keeps the
+           narrowing above from being read as "windows are not a thing here". */
+        var evidenceSignature = MemberSignature(
+            "Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs",
+            "GetCoverageEvidenceAsync");
+
+        Assert.Contains("DateTime startUtc", evidenceSignature, StringComparison.Ordinal);
+        Assert.Contains("DateTime endUtc", evidenceSignature, StringComparison.Ordinal);
 
         /* And the census asks BOTH questions from BOTH sources. The run probe reads collection_log for the
            evidence collector's name; the counts read its stored rows. A census that dropped the log half
@@ -312,6 +330,47 @@ public sealed class PgColumnStatsCoverageTests
         }
 
         Assert.Contains("AND   status IN (", census, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The three miss answers are asked in <c>CollectorRuntimePrecondition</c>'s documented order —
+    /// capability, then precondition, then this read's own miss — and the coverage evidence is not queried
+    /// before the branch that might not need it.
+    ///
+    /// <para>The cost is the visible half: the query used to run ahead of both precedence checks, so a
+    /// server that cannot have this surface at all, or whose collector recorded a denial, paid for evidence
+    /// the <c>??</c> chain then discarded — and those are the callers least able to afford a round trip.
+    /// The half worth guarding is the other one: computing the LAST of three ranked answers FIRST is how
+    /// somebody later reorders the chain and does not notice they have changed which one wins. A source
+    /// order assertion is the only thing that notices, because every ordering compiles and every ordering
+    /// returns a plausible answer.</para>
+    /// </summary>
+    [Fact]
+    public void TheMissAnswersAreAskedInTheirDocumentedPrecedenceOrder()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(MemberBody(
+            "Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs",
+            "GetPgColumnStats"));
+
+        var branch = code.IndexOf("rows.Count == 0", StringComparison.Ordinal);
+        var capability = code.IndexOf("NotCollectedStatusAsync", StringComparison.Ordinal);
+        var precondition = code.IndexOf("DarlingRuntimePrecondition.StatusAsync", StringComparison.Ordinal);
+        var coverage = code.IndexOf("GetCoverageVerdictAsync", StringComparison.Ordinal);
+
+        Assert.True(branch > 0, "the empty-result branch is gone");
+        Assert.True(capability > 0, "the capability answer is gone");
+        Assert.True(precondition > 0, "the precondition answer is gone");
+        Assert.True(coverage > 0, "the coverage answer is gone");
+
+        Assert.True(
+            branch < coverage,
+            "the coverage evidence is queried BEFORE the branch that decides whether anything needs it");
+        Assert.True(
+            capability < precondition,
+            "a precondition is answered ahead of a permanent engine gap, which #2511 closed");
+        Assert.True(
+            precondition < coverage,
+            "the coverage verdict is computed ahead of the precondition that outranks it");
     }
 
     /// <summary>R7: a populated result that covers part of the target is its own answer, not the clean one.</summary>
@@ -558,6 +617,28 @@ public sealed class PgColumnStatsCoverageTests
                 yield return at;
             }
         }
+    }
+
+    /// <summary>
+    /// One member's SIGNATURE — the declaration up to the brace or arrow that begins its body, comments and
+    /// literals blanked. Separate from <see cref="MemberBody"/> because a claim about what a method ACCEPTS
+    /// cannot be made against its body: the body is where an ignored parameter is conspicuously absent.
+    /// </summary>
+    private static string MemberSignature(string relativePath, string member)
+    {
+        var stripped = CSharpSourceWalker.StripCommentsAndStrings(ReadSource(relativePath));
+        var declarations = Declarations(stripped, member).ToList();
+
+        Assert.Equal(1, declarations.Count);
+
+        var at = declarations[0];
+        var open = stripped.IndexOf('{', at);
+        var arrow = stripped.IndexOf("=>", at, StringComparison.Ordinal);
+        var stops = new[] { open, arrow }.Where(i => i > at).ToArray();
+
+        Assert.NotEmpty(stops);
+
+        return stripped[at..stops.Min()];
     }
 
     private static string ReadSource(string relative)

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -297,6 +297,21 @@ public sealed class PgColumnStatsCoverageTests
         Assert.Contains("FROM collection_log", census, StringComparison.Ordinal);
         Assert.Contains("collector_name = 'pg_table_bloat_stats'", census, StringComparison.Ordinal);
         Assert.Contains("FROM pg_table_bloat_stats", census, StringComparison.Ordinal);
+
+        /* And the run probe counts only runs that SUCCEEDED. A bloat collector erroring on a target still
+           writes a collection_log row, so an unfiltered probe says "it ran" while the collector stored
+           nothing - candidate_tables 0, visible 0 - and the classifier answers BelowSizeFloor, "nothing to
+           fix". That is this issue's own false innocence, one level down in the evidence collector's health.
+
+           Asserted against the SHARED status list, not a retyped copy: the bar for "valid evidence" has to
+           be the one the freshness reads and the self-alert evaluator apply, and a status added there must
+           reach this probe. */
+        foreach (var status in EnumeratedCollectorDriver.FreshnessSuccessStatuses)
+        {
+            Assert.Contains("'" + status + "'", census, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("AND   status IN (", census, StringComparison.Ordinal);
     }
 
     /// <summary>R7: a populated result that covers part of the target is its own answer, not the clean one.</summary>

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -461,6 +461,45 @@ public sealed class PgColumnStatsCoverageTests
             seen.OrderBy(a => a).ToArray());
     }
 
+    /// <summary>
+    /// The operator documentation names EVERY arm, derived from the enum rather than from a list somebody
+    /// remembered to extend.
+    ///
+    /// <para>This exists because the doc went stale inside this PR. The runbook table was written when there
+    /// were six arms and named four of them; adding <see cref="PgColumnStatsCoverageArm.EvidenceStale"/>
+    /// left it a partial enumeration reading as though it covered the field — and the missing arm was the
+    /// one an operator is least able to interpret unaided, since it prints a verdict that cannot be
+    /// attributed directly beside a non-empty result. A prose list of enum members is a frozen enumeration:
+    /// correct on the day it is written and silently wrong afterwards, with nothing that fails.</para>
+    ///
+    /// <para>The runbook is the target rather than the README because it is the file that tells an operator
+    /// what to DO about each arm, which is the claim going stale matters for.</para>
+    /// </summary>
+    [Fact]
+    public void TheRunbookNamesEveryCoverageArm()
+    {
+        var runbook = ReadSource("docs/postgres-first-target-runbook.md");
+
+        var missing = Enum.GetValues<PgColumnStatsCoverageArm>()
+            .Where(arm => !runbook.Contains(arm.ToString(), StringComparison.Ordinal))
+            .Select(arm => arm.ToString())
+            .ToList();
+
+        Assert.Empty(missing);
+
+        /* And the field itself is named, or the table above is a glossary for something the reader has no
+           way to find. */
+        Assert.Contains("`coverage`", runbook, StringComparison.Ordinal);
+
+        /* And the span caveat travels with it: the two counts and the row count are measured over different
+           intervals, which is the fact that makes EvidenceStale intelligible rather than a contradiction.
+           A doc naming the arm without that fact tells an operator the name of something inexplicable. */
+        Assert.Contains(
+            PgColumnStatsCoverage.EvidenceHours.ToString(CultureInfo.InvariantCulture) + "-hour",
+            runbook,
+            StringComparison.Ordinal);
+    }
+
     /// <summary>R7: a populated result that covers part of the target is its own answer, not the clean one.</summary>
     [Fact]
     public void PartialCoverageIsItsOwnArm()

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -288,6 +288,16 @@ public sealed class PgColumnStatsCoverageTests
             hours >= 24,
             $"the evidence lookback is {hours}h, shorter than pg_column_stats' own daily cadence");
 
+        /* And the LABEL the census prints describes the span the query actually used. The two are one
+           figure by construction, but "by construction" is what a retyped literal quietly ends - and this
+           label is the only thing telling a reader that the candidate count and the row count span
+           different intervals, which is what makes EvidenceStale intelligible rather than a contradiction.
+           A label saying 168h over a 24h query would misexplain every stale verdict on the surface. */
+        Assert.Contains(
+            hours.ToString(CultureInfo.InvariantCulture) + "h",
+            PgColumnStatsCoverage.EvidenceHoursDescription,
+            StringComparison.Ordinal);
+
         /* AND THE VERDICT READ ACTUALLY USES IT. Everything above tests a pure function; deleting the one
            call that applies it left every assertion here green, which is the seam this whole issue is a
            third instance of - a correct mechanism nothing reaches. */

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -487,9 +487,11 @@ public sealed class PgColumnStatsCoverageTests
 
         Assert.Empty(missing);
 
-        /* And the field itself is named, or the table above is a glossary for something the reader has no
-           way to find. */
-        Assert.Contains("`coverage`", runbook, StringComparison.Ordinal);
+        /* And the field is named IN THE TABLE HEADER, not merely somewhere in the file. "Appears at least
+           once" is satisfied by a mention three sections away, which leaves the arm list a glossary for
+           something the reader has no way to look up - and a mutation that stripped the field name from
+           the prose passed exactly that way. The header is the occurrence a reader keys off. */
+        Assert.Contains("| `coverage` |", runbook, StringComparison.Ordinal);
 
         /* And the span caveat travels with it: the two counts and the row count are measured over different
            intervals, which is the fact that makes EvidenceStale intelligible rather than a contradiction.

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -142,24 +142,47 @@ public sealed class PgColumnStatsCoverageTests
     /// <summary>
     /// R3's falsifier. Without this, <see cref="NoTwoDifferentArmsRenderTheSameCause"/> is satisfied by a
     /// classifier that had stopped selecting anything and merely echoed its inputs — the arms can never hold
-    /// identical counts, so their composed messages differ whatever the verdict says. Distinctive figures,
-    /// then assert none of them survives into the cause.
+    /// identical counts, so their composed messages differ whatever the verdict says.
+    ///
+    /// <para><b>Every arm, not one.</b> The first draft of this used a single input, which landed on
+    /// <see cref="PgColumnStatsCoverageArm.PartialVisibility"/>; a mutation that echoed the counts into the
+    /// <see cref="PgColumnStatsCoverageArm.CollectionFault"/> cause went GREEN under it. A falsifier has to
+    /// discriminate the thing being claimed, and the claim is about all of them.</para>
     /// </summary>
     [Fact]
     public void TheCauseCarriesNoneOfTheInputFigures()
     {
-        var verdict = PgColumnStatsCoverage.Classify(8_675_309, 424_242, 31_337, 90_210);
-
-        foreach (var figure in new[] { "8675309", "8,675,309", "424242", "424,242", "31337", "31,337", "90210", "90,210" })
+        var probes = new[]
         {
-            Assert.DoesNotContain(figure, verdict.Cause, StringComparison.Ordinal);
+            PgColumnStatsCoverage.Classify(0, 424_242, 31_337, 90_210),
+            PgColumnStatsCoverage.Classify(8_675_309, 0, 0, 0),
+            PgColumnStatsCoverage.Classify(8_675_309, 424_242, 0, 0),
+            PgColumnStatsCoverage.Classify(8_675_309, 424_242, 31_337, 0),
+            PgColumnStatsCoverage.Classify(8_675_309, 424_242, 31_337, 90_210),
+            PgColumnStatsCoverage.Classify(8_675_309, 424_242, 424_242, 90_210),
+            PgColumnStatsCoverage.EvidenceUnreadable(90_210),
+        };
+
+        /* And the probe set really does visit every arm, or "no arm echoes its inputs" would be a claim
+           about however many arms this list happens to reach. */
+        Assert.Equal(
+            Enum.GetValues<PgColumnStatsCoverageArm>().OrderBy(a => a).ToArray(),
+            probes.Select(p => p.Arm).Distinct().OrderBy(a => a).ToArray());
+
+        foreach (var probe in probes)
+        {
+            foreach (var figure in new[]
+                { "8675309", "8,675,309", "424242", "424,242", "31337", "31,337", "90210", "90,210" })
+            {
+                Assert.DoesNotContain(figure, probe.Cause, StringComparison.Ordinal);
+            }
         }
 
         /* And the counts are not merely absent from the cause - they are PRESENT in the census, or the
-           check above would be satisfied by a class that had stopped reporting them at all. */
-        Assert.Contains("424,242", verdict.Census, StringComparison.Ordinal);
-        Assert.Contains("31,337", verdict.Census, StringComparison.Ordinal);
-        Assert.Contains("90,210", verdict.Census, StringComparison.Ordinal);
+           checks above would be satisfied by a class that had stopped reporting them at all. */
+        Assert.Contains("424,242", probes[4].Census, StringComparison.Ordinal);
+        Assert.Contains("31,337", probes[4].Census, StringComparison.Ordinal);
+        Assert.Contains("90,210", probes[4].Census, StringComparison.Ordinal);
     }
 
     /// <summary>R3, on the specific pair the issue is about: the two LEGITIMATE zero-causes.</summary>
@@ -331,6 +354,12 @@ public sealed class PgColumnStatsCoverageTests
     /// causes and should — it describes what the tool collects — and a file-scoped scan would be satisfied by
     /// that attribute while the body went on reciting. Same reason the viewer scan is scoped to the loader
     /// rather than to a file holding twenty panels.</para>
+    ///
+    /// <para><b>The literals are JOINED before matching, not tested one at a time.</b> A per-literal check
+    /// went green against a restored copy of the exact prose this issue is about, because an operator-facing
+    /// sentence in this repo is a chain of concatenated literals wrapped at column 110 — "above a size
+    /// floor, " and "a monitoring login without SELECT on a " are two literals and one sentence. Matching
+    /// per literal tests the line wrapping.</para>
     /// </summary>
     [Fact]
     public void NeitherSurfaceAuthorsItsOwnMultiCauseProse()
@@ -338,21 +367,28 @@ public sealed class PgColumnStatsCoverageTests
         foreach (var (file, member, _) in Surfaces)
         {
             var body = MemberBody(file, member);
+            var prose = string.Join(
+                string.Empty,
+                CSharpSourceWalker.StringLiteralBodies(body).Select(l => l.Text));
 
-            foreach (var (start, literal) in CSharpSourceWalker.StringLiteralBodies(body))
-            {
-                var namesTheFloor = literal.Contains("size floor", StringComparison.OrdinalIgnoreCase)
-                    || literal.Contains("1 MB floor", StringComparison.OrdinalIgnoreCase);
-                var namesThePrivilegeFilter =
-                    literal.Contains("has_column_privilege", StringComparison.OrdinalIgnoreCase)
-                    || literal.Contains("SELECT privilege", StringComparison.OrdinalIgnoreCase)
-                    || literal.Contains("without SELECT", StringComparison.OrdinalIgnoreCase);
+            var namesTheFloor = prose.Contains("size floor", StringComparison.OrdinalIgnoreCase)
+                || prose.Contains("1 MB floor", StringComparison.OrdinalIgnoreCase);
+            var namesThePrivilegeFilter =
+                prose.Contains("has_column_privilege", StringComparison.OrdinalIgnoreCase)
+                || prose.Contains("SELECT privilege", StringComparison.OrdinalIgnoreCase)
+                || prose.Contains("without SELECT", StringComparison.OrdinalIgnoreCase);
 
-                Assert.False(
-                    namesTheFloor && namesThePrivilegeFilter,
-                    $"{member} authors a literal at offset {start} that recites BOTH zero-causes and selects "
-                    + $"neither, which is what #3154 is: {literal}");
-            }
+            Assert.False(
+                namesTheFloor && namesThePrivilegeFilter,
+                $"{member} authors prose reciting BOTH zero-causes and selecting neither, which is what "
+                + $"#3154 is. It has a classifier for that. Its literals joined: {prose}");
+
+            /* Neither half on its own either, in the surface's OWN words: a body that named only the
+               privilege filter would still be pre-empting the classifier, and would be wrong on the
+               target where the floor is the answer. */
+            Assert.False(
+                namesTheFloor || namesThePrivilegeFilter,
+                $"{member} names a zero-cause in its own prose rather than printing the verdict: {prose}");
         }
     }
 

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -244,6 +244,46 @@ public sealed class PgColumnStatsCoverageTests
         Assert.Contains("cannot be established", unmeasured.Cause, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// R5's other half: the evidence lookback must not be the caller's window, or a short panel window
+    /// MANUFACTURES <see cref="PgColumnStatsCoverageArm.Undetermined"/> on a server whose answer is known.
+    ///
+    /// <para>The evidence collector is hourly and the subject collector is daily, so a one-hour viewer
+    /// window straddles zero or one evidence run — and reporting "no evidence" for a target measured 167
+    /// times in the past week is the failing-toward-a-confident-nothing direction. A wider caller window is
+    /// honoured as-is; only the floor is imposed.</para>
+    /// </summary>
+    [Fact]
+    public void TheEvidenceLookbackIsFlooredRatherThanTakenFromTheCallersWindow()
+    {
+        var end = new DateTime(2026, 9, 7, 20, 0, 0, DateTimeKind.Utc);
+        var floorHours = DarlingPgColumnStatsReader.MinimumEvidenceHours;
+
+        /* A one-hour read still looks back the floor. */
+        Assert.Equal(
+            end.AddHours(-floorHours),
+            DarlingPgColumnStatsReader.EvidenceStart(end.AddHours(-1), end));
+
+        /* A month-long read is NOT narrowed to the floor - the rows it returned come from that month, and
+           narrowing would report coverage over a population the data does not come from. */
+        Assert.Equal(
+            end.AddDays(-30),
+            DarlingPgColumnStatsReader.EvidenceStart(end.AddDays(-30), end));
+
+        /* Anchored on the END, so an as_of read gets evidence contemporary with the data it explains
+           rather than today's. */
+        var earlier = end.AddDays(-10);
+        Assert.Equal(
+            earlier.AddHours(-floorHours),
+            DarlingPgColumnStatsReader.EvidenceStart(earlier.AddHours(-1), earlier));
+
+        /* And the floor is at least the SUBJECT collector's cadence: pg_column_stats runs daily, so
+           evidence over a shorter span than one of its own cycles cannot describe the run being explained. */
+        Assert.True(
+            floorHours >= 24,
+            $"the evidence floor is {floorHours}h, shorter than pg_column_stats' own daily cadence");
+    }
+
     /// <summary>R7: a populated result that covers part of the target is its own answer, not the clean one.</summary>
     [Fact]
     public void PartialCoverageIsItsOwnArm()

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -1,0 +1,479 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3154: a <c>pg_column_stats</c> row count must say WHICH of its outcomes produced it.
+///
+/// <para><b>The property, in one sentence.</b> Whenever a surface reports a <c>pg_column_stats</c> result,
+/// the answer names which cause produced it — nothing clears the collector's page floor, the monitoring login
+/// cannot see <c>pg_stats</c>, coverage is partial, or neither legitimate cause applies and it is a fault —
+/// or states that it cannot tell and why; and it never presents those as one undifferentiated list.</para>
+///
+/// <para><b>Derived from the property's violation routes, not from reading the code.</b> Enumerating the ways
+/// a zero can arise is the work here, because the population of causes IS what the guard has to discriminate:</para>
+///
+/// <list type="number">
+/// <item>A zero with NO cause named. Shipped state: 553 SUCCESS runs across 50 targets, zero rows ever, a
+/// NULL note on 99 of the last 100. Guarded by <see cref="EveryOutcomeSelectsAnArm"/>.</item>
+/// <item>A cause named as PROSE that recites every arm and selects none. Also the shipped state — the read's
+/// own message listed the floor and the privilege filter in one sentence, which tells a reader what it MIGHT
+/// be. Guarded by <see cref="NeitherSurfaceAuthorsItsOwnMultiCauseProse"/>, which scans the two member
+/// BODIES rather than their files, so the tool's own <c>[Description]</c> attribute — which legitimately
+/// describes both — cannot satisfy it.</item>
+/// <item>The floor arm and the privilege arm rendering the SAME thing. Guarded by
+/// <see cref="NoTwoDifferentArmsRenderTheSameCause"/> — and by
+/// <see cref="TheCauseCarriesNoneOfTheInputFigures"/>, without which that check would pass on the counts
+/// differing rather than on the verdicts differing, since the two arms can never hold the same counts.</item>
+/// <item>A COLLECTION FAULT reporting as one of the legitimate arms, which is false innocence and the route
+/// by which a wrong query would never be noticed. Guarded by
+/// <see cref="AReadableTableWithNothingStoredIsAFaultAndSaysSo"/>.</item>
+/// <item>Insufficient evidence reported AS a diagnosis — "nothing is big enough" asserted where nothing was
+/// measured. Guarded by <see cref="NoEvidenceIsNotTheSameAsNothingAboveTheFloor"/>, the pair the live store
+/// confirms: the evidence collector ran 168 times and found no qualifying table on one target, and ran zero
+/// times for an unknown one, and those two must not answer alike.</item>
+/// <item>The verdict computed and NOT reaching the surface where the zero is seen — captured and unread, the
+/// invariant #3017 turned into a rule. Guarded by <see cref="BothSurfacesPrintTheSharedVerdict"/>.</item>
+/// <item>A NON-empty result hiding a partial view, so a ranking over four visible tables of twenty reads as
+/// a ranking of the server. Guarded by <see cref="BothSurfacesPrintTheVerdictOnThePopulatedPathToo"/> and by
+/// <see cref="PartialCoverageIsItsOwnArm"/>.</item>
+/// <item>The floor an operator is TOLD about drifting from the floor the query filters on. Guarded by
+/// <see cref="TheQuotedFloorIsTheOneTheShippedQueriesFilterOn"/>.</item>
+/// </list>
+///
+/// <para><b>Which cause actually applies, measured.</b> The privilege filter, on the whole fleet. Read-only
+/// against a live store on 2026-09-07: <c>estimate_unavailable</c> was TRUE on 331,357 of 331,357
+/// <c>pg_table_bloat_stats</c> rows in every era, and independently the collector's own width arithmetic
+/// bottomed out at its empty-input residue on 59,981 of 59,981 rows in 48 hours — two readings that fail
+/// differently and agree. The floor is demonstrably NOT the explanation: 1,263 of 1,264 distinct tables past
+/// the byte floor also clear the page floor, on all 49 targets that report, and the busiest holds 361 of
+/// them, which is the figure the collector's own comment cites.</para>
+/// </summary>
+public sealed class PgColumnStatsCoverageTests
+{
+    /// <summary>
+    /// Every arm, reached from the counts that produce it. Named cases rather than a loop so a failure says
+    /// which situation regressed.
+    /// </summary>
+    private static readonly (string Name, PgColumnStatsCoverageVerdict Verdict, PgColumnStatsCoverageArm Expected)[] s_cases =
+    {
+        ("evidence collector never ran, nothing stored",
+            PgColumnStatsCoverage.Classify(0, 0, 0, 0), PgColumnStatsCoverageArm.Undetermined),
+        ("evidence collector never ran, rows stored anyway",
+            PgColumnStatsCoverage.Classify(0, 361, 0, 1_000), PgColumnStatsCoverageArm.Undetermined),
+        ("evidence read itself failed",
+            PgColumnStatsCoverage.EvidenceUnreadable(0), PgColumnStatsCoverageArm.Undetermined),
+        ("measured, and nothing clears the floor",
+            PgColumnStatsCoverage.Classify(168, 0, 0, 0), PgColumnStatsCoverageArm.BelowSizeFloor),
+        ("361 candidates, none readable - the fleet's answer",
+            PgColumnStatsCoverage.Classify(167, 361, 0, 0), PgColumnStatsCoverageArm.StatisticsNotVisible),
+        ("one candidate, not readable",
+            PgColumnStatsCoverage.Classify(1, 1, 0, 0), PgColumnStatsCoverageArm.StatisticsNotVisible),
+        ("candidates readable and nothing stored",
+            PgColumnStatsCoverage.Classify(167, 361, 361, 0), PgColumnStatsCoverageArm.CollectionFault),
+        ("stored, covering some of the candidates",
+            PgColumnStatsCoverage.Classify(167, 361, 12, 5_000), PgColumnStatsCoverageArm.PartialVisibility),
+        ("stored, covering all of them",
+            PgColumnStatsCoverage.Classify(167, 361, 361, 5_000), PgColumnStatsCoverageArm.FullyMeasured),
+    };
+
+    /// <summary>R1: no outcome may arrive without an arm, and every arm must be reachable.</summary>
+    [Fact]
+    public void EveryOutcomeSelectsAnArm()
+    {
+        foreach (var (name, verdict, expected) in s_cases)
+        {
+            Assert.Equal(expected, verdict.Arm);
+            Assert.False(string.IsNullOrWhiteSpace(verdict.Cause), name + " produced no cause");
+            Assert.False(string.IsNullOrWhiteSpace(verdict.Census), name + " produced no census");
+        }
+
+        /* Both directions. A classifier that had collapsed to one arm would satisfy the loop above for
+           whichever arm survived, and an arm nothing can reach is a branch no test covers. */
+        Assert.Equal(
+            Enum.GetValues<PgColumnStatsCoverageArm>().OrderBy(a => a).ToArray(),
+            s_cases.Select(c => c.Verdict.Arm).Distinct().OrderBy(a => a).ToArray());
+    }
+
+    /// <summary>
+    /// R3: different arm, different verdict. Pairwise over DIFFERING arms rather than a distinctness check
+    /// over every case, because two inputs reaching the same arm are REQUIRED to render the same cause — that
+    /// is what makes the text a function of the arm rather than of the numbers.
+    /// </summary>
+    [Fact]
+    public void NoTwoDifferentArmsRenderTheSameCause()
+    {
+        var collisions =
+            (from a in s_cases
+             from b in s_cases
+             where a.Verdict.Arm != b.Verdict.Arm
+             && string.Equals(a.Verdict.Cause, b.Verdict.Cause, StringComparison.Ordinal)
+             select a.Name + " reads the same as " + b.Name).ToList();
+
+        Assert.Empty(collisions);
+
+        /* Named rather than counted: two inputs whose only difference is the candidate count reach the same
+           arm, and the cause has to be identical - otherwise the text is a function of the numbers. */
+        Assert.Equal(
+            Named("361 candidates, none readable - the fleet's answer").Cause,
+            Named("one candidate, not readable").Cause);
+
+        /* The two Undetermined situations are deliberately NOT one sentence: "the evidence collector does not
+           run here" is the design working on a replica, and "the store read failed" is a monitoring fault. */
+        Assert.NotEqual(s_cases[0].Verdict.Cause, s_cases[2].Verdict.Cause);
+    }
+
+    /// <summary>
+    /// R3's falsifier. Without this, <see cref="NoTwoDifferentArmsRenderTheSameCause"/> is satisfied by a
+    /// classifier that had stopped selecting anything and merely echoed its inputs — the arms can never hold
+    /// identical counts, so their composed messages differ whatever the verdict says. Distinctive figures,
+    /// then assert none of them survives into the cause.
+    /// </summary>
+    [Fact]
+    public void TheCauseCarriesNoneOfTheInputFigures()
+    {
+        var verdict = PgColumnStatsCoverage.Classify(8_675_309, 424_242, 31_337, 90_210);
+
+        foreach (var figure in new[] { "8675309", "8,675,309", "424242", "424,242", "31337", "31,337", "90210", "90,210" })
+        {
+            Assert.DoesNotContain(figure, verdict.Cause, StringComparison.Ordinal);
+        }
+
+        /* And the counts are not merely absent from the cause - they are PRESENT in the census, or the
+           check above would be satisfied by a class that had stopped reporting them at all. */
+        Assert.Contains("424,242", verdict.Census, StringComparison.Ordinal);
+        Assert.Contains("31,337", verdict.Census, StringComparison.Ordinal);
+        Assert.Contains("90,210", verdict.Census, StringComparison.Ordinal);
+    }
+
+    /// <summary>R3, on the specific pair the issue is about: the two LEGITIMATE zero-causes.</summary>
+    [Fact]
+    public void TheTwoLegitimateZeroCausesNameThemselvesAndRuleTheOtherOut()
+    {
+        var floor = Case(PgColumnStatsCoverageArm.BelowSizeFloor).Cause;
+        var privilege = Case(PgColumnStatsCoverageArm.StatisticsNotVisible).Cause;
+
+        Assert.NotEqual(floor, privilege);
+
+        Assert.Contains("size floor", floor, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("has_column_privilege", floor, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("GRANT", floor, StringComparison.Ordinal);
+
+        Assert.Contains("not the size floor", privilege, StringComparison.Ordinal);
+        Assert.Contains("has_column_privilege", privilege, StringComparison.Ordinal);
+        /* The remedy is the difference between naming a cause and being actionable about it. */
+        Assert.Contains("GRANT pg_read_all_data", privilege, StringComparison.Ordinal);
+    }
+
+    /// <summary>R4: a readable table plus a stored nothing is a fault and must not read as either innocent arm.</summary>
+    [Fact]
+    public void AReadableTableWithNothingStoredIsAFaultAndSaysSo()
+    {
+        var fault = PgColumnStatsCoverage.Classify(167, 361, 1, 0);
+
+        Assert.Equal(PgColumnStatsCoverageArm.CollectionFault, fault.Arm);
+        Assert.Contains("COLLECTION FAULT", fault.Cause, StringComparison.Ordinal);
+        Assert.Contains("neither legitimate", fault.Cause, StringComparison.OrdinalIgnoreCase);
+        /* Both innocent explanations refused BY NAME, so the sentence cannot be skimmed as either. */
+        Assert.Contains("floor does not explain it", fault.Cause, StringComparison.Ordinal);
+        Assert.Contains("privilege filter does not explain it", fault.Cause, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// R5: the pair that has to differ, and the one the live store confirms — one target's evidence collector
+    /// ran 168 times and found no qualifying table, and an unknown target's ran zero times. Identical counts,
+    /// different answers, and the RUN count is the only thing that separates them.
+    /// </summary>
+    [Fact]
+    public void NoEvidenceIsNotTheSameAsNothingAboveTheFloor()
+    {
+        var measured = PgColumnStatsCoverage.Classify(168, 0, 0, 0);
+        var unmeasured = PgColumnStatsCoverage.Classify(0, 0, 0, 0);
+
+        Assert.Equal(PgColumnStatsCoverageArm.BelowSizeFloor, measured.Arm);
+        Assert.Equal(PgColumnStatsCoverageArm.Undetermined, unmeasured.Arm);
+        Assert.NotEqual(measured.Cause, unmeasured.Cause);
+
+        /* A measured zero prints as a figure; an unmeasured one prints as a WORD. Rendering both as 0 is
+           how "we looked and everything is small" became indistinguishable from "we never looked". */
+        Assert.Contains("floor: 0.", measured.Census, StringComparison.Ordinal);
+        Assert.DoesNotContain(PgColumnStatsCoverage.NotMeasured, measured.Census, StringComparison.Ordinal);
+        Assert.Contains("floor: " + PgColumnStatsCoverage.NotMeasured, unmeasured.Census, StringComparison.Ordinal);
+
+        /* And the Undetermined arm must not smuggle a verdict in. */
+        Assert.DoesNotContain("CAUSE:", unmeasured.Cause, StringComparison.Ordinal);
+        Assert.Contains("cannot be established", unmeasured.Cause, StringComparison.Ordinal);
+    }
+
+    /// <summary>R7: a populated result that covers part of the target is its own answer, not the clean one.</summary>
+    [Fact]
+    public void PartialCoverageIsItsOwnArm()
+    {
+        var partial = PgColumnStatsCoverage.Classify(167, 20, 4, 900);
+        var whole = PgColumnStatsCoverage.Classify(167, 20, 20, 900);
+
+        Assert.Equal(PgColumnStatsCoverageArm.PartialVisibility, partial.Arm);
+        Assert.Equal(PgColumnStatsCoverageArm.FullyMeasured, whole.Arm);
+        Assert.NotEqual(partial.Cause, whole.Cause);
+        Assert.Contains("PARTIAL COVERAGE", partial.Cause, StringComparison.Ordinal);
+        Assert.Contains("GRANT pg_read_all_data", partial.Cause, StringComparison.Ordinal);
+        Assert.DoesNotContain("GRANT", whole.Cause, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// R8: the floor quoted at an operator is the floor the queries filter on. Read from the SHIPPED query
+    /// text and the SHIPPED census SQL, not from a retyped 128 — a message promising "128 pages" over a
+    /// query filtering on something else is a lie no arithmetic test would see.
+    /// </summary>
+    [Fact]
+    public void TheQuotedFloorIsTheOneTheShippedQueriesFilterOn()
+    {
+        var collectorSql = PgColumnStatsCollector.Instance.BuildQuery(new CollectorContext
+        {
+            ServerId = 1,
+            ServerName = "server",
+            CollectionTime = DateTime.UtcNow,
+            Deltas = null!,
+        }).Text;
+
+        var floor = PgColumnStatsCollector.MinimumRelPages.ToString(CultureInfo.InvariantCulture);
+
+        Assert.Contains("c.relpages >= " + floor, collectorSql, StringComparison.Ordinal);
+
+        /* Twice in the census: the candidate count and the visible count are the same predicate, and a
+           census that filtered the two halves differently would report a visible count over a different
+           population than the candidate count it is reported against. */
+        var floorFiltersInCensus = DarlingPgColumnStatsReader.CoverageEvidenceSql
+            .Split("heap_pages >= " + floor, StringSplitOptions.None).Length - 1;
+
+        Assert.Equal(2, floorFiltersInCensus);
+
+        /* And every arm's census quotes it, so the number an operator reads came from the same place. */
+        foreach (var (name, verdict, _) in s_cases)
+        {
+            Assert.Contains(floor + " page floor", verdict.Census, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// R6: both surfaces print the SHARED verdict. The MCP tool and the WPF panel answer the same question
+    /// for the same operator, and a fix applied to one of them is the defect this issue is a third instance
+    /// of. Scanning for the shared call is what makes "they cannot disagree" a property rather than a hope.
+    /// </summary>
+    [Fact]
+    public void BothSurfacesPrintTheSharedVerdict()
+    {
+        foreach (var (file, member, accessor) in Surfaces)
+        {
+            /* CODE only. A design comment saying "this calls the shared classifier" would satisfy a raw
+               scan while the call itself had been removed - correct narration over absent behaviour. */
+            var code = CSharpSourceWalker.StripCommentsAndStrings(MemberBody(file, member));
+
+            Assert.Contains(accessor, code, StringComparison.Ordinal);
+            Assert.Contains("coverage.Message", code, StringComparison.Ordinal);
+
+            /* And neither surface may build a verdict of its own. Calling the accessor is only half the
+               claim: a body that called it and then overwrote the result would pass the line above. */
+            Assert.DoesNotContain("new PgColumnStatsCoverageVerdict", code, StringComparison.Ordinal);
+        }
+
+        /* The viewer reaches the classifier through its data service, so the CHAIN is what the property is
+           about - pinning the panel's call alone would leave a passthrough free to author its own answer. */
+        var passthrough = CSharpSourceWalker.StripCommentsAndStrings(MemberBody(
+            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs",
+            "GetPgColumnStatsCoverageAsync"));
+
+        Assert.Contains("DarlingPgColumnStatsReader.GetCoverageVerdictAsync", passthrough, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// R7 at the surface. The coverage sentence has to ride the POPULATED branch as well, or a partial view
+    /// is diagnosed only in the one case where nobody needs the diagnosis. Asserted by counting the prints:
+    /// one branch printing it twice would satisfy a presence check.
+    /// </summary>
+    [Fact]
+    public void BothSurfacesPrintTheVerdictOnThePopulatedPathToo()
+    {
+        foreach (var (file, member, _) in Surfaces)
+        {
+            var code = CSharpSourceWalker.StripCommentsAndStrings(MemberBody(file, member));
+            var prints = code.Split("coverage.Message", StringSplitOptions.None).Length - 1;
+
+            Assert.True(
+                prints >= 2,
+                $"{member} prints the coverage verdict {prints} time(s); it has to reach the empty result AND "
+                + "the populated one, or a partial view is only ever explained when it is total");
+        }
+    }
+
+    /// <summary>
+    /// R2: neither surface authors its own multi-cause prose. This is the check that would have failed on
+    /// the shipped code — both surfaces held a literal naming the size floor AND the privilege filter in one
+    /// breath, which is a description of the mechanism standing in for a diagnosis of it.
+    ///
+    /// <para>Scoped to the member BODY, deliberately. The tool's <c>[Description]</c> attribute names both
+    /// causes and should — it describes what the tool collects — and a file-scoped scan would be satisfied by
+    /// that attribute while the body went on reciting. Same reason the viewer scan is scoped to the loader
+    /// rather than to a file holding twenty panels.</para>
+    /// </summary>
+    [Fact]
+    public void NeitherSurfaceAuthorsItsOwnMultiCauseProse()
+    {
+        foreach (var (file, member, _) in Surfaces)
+        {
+            var body = MemberBody(file, member);
+
+            foreach (var (start, literal) in CSharpSourceWalker.StringLiteralBodies(body))
+            {
+                var namesTheFloor = literal.Contains("size floor", StringComparison.OrdinalIgnoreCase)
+                    || literal.Contains("1 MB floor", StringComparison.OrdinalIgnoreCase);
+                var namesThePrivilegeFilter =
+                    literal.Contains("has_column_privilege", StringComparison.OrdinalIgnoreCase)
+                    || literal.Contains("SELECT privilege", StringComparison.OrdinalIgnoreCase)
+                    || literal.Contains("without SELECT", StringComparison.OrdinalIgnoreCase);
+
+                Assert.False(
+                    namesTheFloor && namesThePrivilegeFilter,
+                    $"{member} authors a literal at offset {start} that recites BOTH zero-causes and selects "
+                    + $"neither, which is what #3154 is: {literal}");
+            }
+        }
+    }
+
+    private static PgColumnStatsCoverageVerdict Case(PgColumnStatsCoverageArm arm) =>
+        s_cases.First(c => c.Verdict.Arm == arm).Verdict;
+
+    /// <summary>
+    /// The two surfaces that report this collector's results to a person, the member on each that does it,
+    /// and the accessor that member has to obtain the verdict FROM.
+    ///
+    /// <para>A list, because both are named in the property — a scan for "everything that reads
+    /// pg_column_stats" would also sweep the reader and the data-service passthrough, neither of which
+    /// renders anything. The accessor differs per surface and that is not incidental: the MCP tool calls the
+    /// store reader directly while the panel goes through the viewer's data service, and asserting one name
+    /// for both would have to be the loosest of the two to pass.</para>
+    /// </summary>
+    private static IEnumerable<(string File, string Member, string Accessor)> Surfaces =>
+    [
+        ("Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs",
+            "GetPgColumnStats", "DarlingPgColumnStatsReader.GetCoverageVerdictAsync"),
+        ("Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs",
+            "LoadPgColumnStatsAsync", "_dataService.GetPgColumnStatsCoverageAsync"),
+    ];
+
+    private static PgColumnStatsCoverageVerdict Named(string name) =>
+        s_cases.First(c => string.Equals(c.Name, name, StringComparison.Ordinal)).Verdict;
+
+    /// <summary>
+    /// One member's brace-balanced body, verbatim. Callers narrow it themselves — the call-presence scans
+    /// strip comments and literals, the prose scan reads the literals — because the two questions need
+    /// opposite halves of the same text and a single pre-stripped form would silently answer one of them
+    /// against the wrong half.
+    /// </summary>
+    private static string MemberBody(string relativePath, string member)
+    {
+        var source = ReadSource(relativePath);
+
+        /* The signature is located on a comment-and-string-stripped copy so a mention of the member name
+           inside a doc comment cannot be mistaken for its declaration; the OFFSETS are then used against
+           the original text, which the walker guarantees are the same because it replaces rather than
+           removes.
+
+           The DECLARATION, not the first occurrence - and this is not defensive tidiness. The viewer calls
+           LoadPgColumnStatsAsync from the storage-tab loader 60 lines ABOVE declaring it, so a first-match
+           scan lands on the call site, brace-balances the WRONG method, and then reports whatever that
+           method happens to contain. It read a sibling panel's body and failed for a reason that had
+           nothing to do with this collector. Every occurrence is classified and exactly one must be a
+           declaration, so a rename or an added overload fails loudly rather than silently re-aiming. */
+        var stripped = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var declarations = Declarations(stripped, member).ToList();
+
+        Assert.Equal(1, declarations.Count);
+
+        var at = declarations[0];
+        var open = stripped.IndexOf('{', at);
+        var semicolon = stripped.IndexOf(';', at);
+
+        Assert.True(open > at || semicolon > at, $"{member} in {relativePath} has no body of either shape");
+
+        /* Expression-bodied members are in scope, not an exception to skip: the viewer's data-service
+           passthrough is one, and it is the middle link of the chain this asserts. Whichever terminator
+           comes first decides the shape - a `;` before any `{` is `=> expression;`, and reaching for the
+           brace regardless would balance the NEXT member's block and scan the wrong code, which is the
+           same failure the declaration-versus-call-site lookup above exists to prevent. */
+        if (semicolon > at && (open < 0 || semicolon < open))
+        {
+            return source[at..(semicolon + 1)];
+        }
+
+        var extent = CSharpSourceWalker.BraceBalanced(stripped, open).Length;
+
+        return source[open..(open + extent)];
+    }
+
+    /// <summary>
+    /// Offsets in <paramref name="stripped"/> where <paramref name="member"/> is DECLARED rather than
+    /// called. A declaration carries an access modifier ahead of it within its own statement; a call site
+    /// carries <c>await</c>, a receiver, or nothing at all. Classifying every occurrence rather than taking
+    /// the first is what makes the count assertable.
+    /// </summary>
+    private static IEnumerable<int> Declarations(string stripped, string member)
+    {
+        for (var at = stripped.IndexOf(member + "(", StringComparison.Ordinal);
+             at >= 0;
+             at = stripped.IndexOf(member + "(", at + 1, StringComparison.Ordinal))
+        {
+            /* Back to the end of the previous statement or block. Whatever sits between that and the name
+               is this occurrence's own head, and only a declaration's head holds a modifier. */
+            var statementStart = stripped.LastIndexOfAny([';', '{', '}'], at) + 1;
+            var head = stripped[statementStart..at];
+
+            if (head.Contains(" private ", StringComparison.Ordinal)
+                || head.Contains(" public ", StringComparison.Ordinal)
+                || head.Contains(" internal ", StringComparison.Ordinal)
+                || head.Contains(" protected ", StringComparison.Ordinal))
+            {
+                yield return at;
+            }
+        }
+    }
+
+    private static string ReadSource(string relative)
+    {
+        var path = Path.Combine(RepoRoot(), relative);
+
+        Assert.True(File.Exists(path), $"#3154 scan target not found: {path}");
+
+        return File.ReadAllText(path);
+    }
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null
+               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
+               && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -282,6 +282,15 @@ public sealed class PgColumnStatsCoverageTests
         Assert.True(
             floorHours >= 24,
             $"the evidence floor is {floorHours}h, shorter than pg_column_stats' own daily cadence");
+
+        /* AND THE VERDICT READ ACTUALLY USES IT. Everything above tests a pure function; deleting the one
+           call that applies it left every assertion here green, which is the seam this whole issue is a
+           third instance of - a correct mechanism nothing reaches. */
+        var verdictRead = CSharpSourceWalker.StripCommentsAndStrings(MemberBody(
+            "Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs",
+            "GetCoverageVerdictAsync"));
+
+        Assert.Contains("EvidenceStart(startUtc, endUtc)", verdictRead, StringComparison.Ordinal);
     }
 
     /// <summary>R7: a populated result that covers part of the target is its own answer, not the clean one.</summary>

--- a/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
+++ b/Darling/Darling.Tests/PgColumnStatsCoverageTests.cs
@@ -74,23 +74,24 @@ public sealed class PgColumnStatsCoverageTests
     private static readonly (string Name, PgColumnStatsCoverageVerdict Verdict, PgColumnStatsCoverageArm Expected)[] s_cases =
     {
         ("evidence collector never ran, nothing stored",
-            PgColumnStatsCoverage.Classify(0, 0, 0, 0), PgColumnStatsCoverageArm.Undetermined),
+            PgColumnStatsCoverage.Classify(evidenceCollectorRan: false, 0, 0, 0),
+            PgColumnStatsCoverageArm.Undetermined),
         ("evidence collector never ran, rows stored anyway",
-            PgColumnStatsCoverage.Classify(0, 361, 0, 1_000), PgColumnStatsCoverageArm.Undetermined),
+            PgColumnStatsCoverage.Classify(false, 361, 0, 1_000), PgColumnStatsCoverageArm.Undetermined),
         ("evidence read itself failed",
             PgColumnStatsCoverage.EvidenceUnreadable(0), PgColumnStatsCoverageArm.Undetermined),
         ("measured, and nothing clears the floor",
-            PgColumnStatsCoverage.Classify(168, 0, 0, 0), PgColumnStatsCoverageArm.BelowSizeFloor),
+            PgColumnStatsCoverage.Classify(true, 0, 0, 0), PgColumnStatsCoverageArm.BelowSizeFloor),
         ("361 candidates, none readable - the fleet's answer",
-            PgColumnStatsCoverage.Classify(167, 361, 0, 0), PgColumnStatsCoverageArm.StatisticsNotVisible),
+            PgColumnStatsCoverage.Classify(true, 361, 0, 0), PgColumnStatsCoverageArm.StatisticsNotVisible),
         ("one candidate, not readable",
-            PgColumnStatsCoverage.Classify(1, 1, 0, 0), PgColumnStatsCoverageArm.StatisticsNotVisible),
+            PgColumnStatsCoverage.Classify(true, 1, 0, 0), PgColumnStatsCoverageArm.StatisticsNotVisible),
         ("candidates readable and nothing stored",
-            PgColumnStatsCoverage.Classify(167, 361, 361, 0), PgColumnStatsCoverageArm.CollectionFault),
+            PgColumnStatsCoverage.Classify(true, 361, 361, 0), PgColumnStatsCoverageArm.CollectionFault),
         ("stored, covering some of the candidates",
-            PgColumnStatsCoverage.Classify(167, 361, 12, 5_000), PgColumnStatsCoverageArm.PartialVisibility),
+            PgColumnStatsCoverage.Classify(true, 361, 12, 5_000), PgColumnStatsCoverageArm.PartialVisibility),
         ("stored, covering all of them",
-            PgColumnStatsCoverage.Classify(167, 361, 361, 5_000), PgColumnStatsCoverageArm.FullyMeasured),
+            PgColumnStatsCoverage.Classify(true, 361, 361, 5_000), PgColumnStatsCoverageArm.FullyMeasured),
     };
 
     /// <summary>R1: no outcome may arrive without an arm, and every arm must be reachable.</summary>
@@ -154,12 +155,12 @@ public sealed class PgColumnStatsCoverageTests
     {
         var probes = new[]
         {
-            PgColumnStatsCoverage.Classify(0, 424_242, 31_337, 90_210),
-            PgColumnStatsCoverage.Classify(8_675_309, 0, 0, 0),
-            PgColumnStatsCoverage.Classify(8_675_309, 424_242, 0, 0),
-            PgColumnStatsCoverage.Classify(8_675_309, 424_242, 31_337, 0),
-            PgColumnStatsCoverage.Classify(8_675_309, 424_242, 31_337, 90_210),
-            PgColumnStatsCoverage.Classify(8_675_309, 424_242, 424_242, 90_210),
+            PgColumnStatsCoverage.Classify(false, 424_242, 31_337, 90_210),
+            PgColumnStatsCoverage.Classify(true, 0, 0, 0),
+            PgColumnStatsCoverage.Classify(true, 424_242, 0, 0),
+            PgColumnStatsCoverage.Classify(true, 424_242, 31_337, 0),
+            PgColumnStatsCoverage.Classify(true, 424_242, 31_337, 90_210),
+            PgColumnStatsCoverage.Classify(true, 424_242, 424_242, 90_210),
             PgColumnStatsCoverage.EvidenceUnreadable(90_210),
         };
 
@@ -208,7 +209,7 @@ public sealed class PgColumnStatsCoverageTests
     [Fact]
     public void AReadableTableWithNothingStoredIsAFaultAndSaysSo()
     {
-        var fault = PgColumnStatsCoverage.Classify(167, 361, 1, 0);
+        var fault = PgColumnStatsCoverage.Classify(true, 361, 1, 0);
 
         Assert.Equal(PgColumnStatsCoverageArm.CollectionFault, fault.Arm);
         Assert.Contains("COLLECTION FAULT", fault.Cause, StringComparison.Ordinal);
@@ -226,8 +227,8 @@ public sealed class PgColumnStatsCoverageTests
     [Fact]
     public void NoEvidenceIsNotTheSameAsNothingAboveTheFloor()
     {
-        var measured = PgColumnStatsCoverage.Classify(168, 0, 0, 0);
-        var unmeasured = PgColumnStatsCoverage.Classify(0, 0, 0, 0);
+        var measured = PgColumnStatsCoverage.Classify(true, 0, 0, 0);
+        var unmeasured = PgColumnStatsCoverage.Classify(false, 0, 0, 0);
 
         Assert.Equal(PgColumnStatsCoverageArm.BelowSizeFloor, measured.Arm);
         Assert.Equal(PgColumnStatsCoverageArm.Undetermined, unmeasured.Arm);
@@ -245,43 +246,34 @@ public sealed class PgColumnStatsCoverageTests
     }
 
     /// <summary>
-    /// R5's other half: the evidence lookback must not be the caller's window, or a short panel window
-    /// MANUFACTURES <see cref="PgColumnStatsCoverageArm.Undetermined"/> on a server whose answer is known.
+    /// R5's other half: the evidence lookback is a FIXED span ending where the read ends, not the caller's
+    /// window — which would be wrong in both directions.
     ///
-    /// <para>The evidence collector is hourly and the subject collector is daily, so a one-hour viewer
-    /// window straddles zero or one evidence run — and reporting "no evidence" for a target measured 167
-    /// times in the past week is the failing-toward-a-confident-nothing direction. A wider caller window is
-    /// honoured as-is; only the floor is imposed.</para>
+    /// <para>Too narrow manufactures <see cref="PgColumnStatsCoverageArm.Undetermined"/>: the evidence
+    /// collector is hourly, so a one-hour panel window straddles zero or one of its runs and would report
+    /// "no evidence" for a target measured 167 times in the past week. Too wide just costs — the MCP tool
+    /// defaults to 168 hours, where the census measured 242 ms against 41 ms over a day, on a diagnostic
+    /// that runs on every call. And it is not a question about history at all: <c>CollectorRuntimePrecondition</c>
+    /// consults the LATEST run for exactly this reason.</para>
     /// </summary>
     [Fact]
-    public void TheEvidenceLookbackIsFlooredRatherThanTakenFromTheCallersWindow()
+    public void TheEvidenceLookbackIsFixedRatherThanTakenFromTheCallersWindow()
     {
         var end = new DateTime(2026, 9, 7, 20, 0, 0, DateTimeKind.Utc);
-        var floorHours = DarlingPgColumnStatsReader.MinimumEvidenceHours;
+        var hours = DarlingPgColumnStatsReader.EvidenceHours;
 
-        /* A one-hour read still looks back the floor. */
-        Assert.Equal(
-            end.AddHours(-floorHours),
-            DarlingPgColumnStatsReader.EvidenceStart(end.AddHours(-1), end));
-
-        /* A month-long read is NOT narrowed to the floor - the rows it returned come from that month, and
-           narrowing would report coverage over a population the data does not come from. */
-        Assert.Equal(
-            end.AddDays(-30),
-            DarlingPgColumnStatsReader.EvidenceStart(end.AddDays(-30), end));
+        Assert.Equal(end.AddHours(-hours), DarlingPgColumnStatsReader.EvidenceStart(end));
 
         /* Anchored on the END, so an as_of read gets evidence contemporary with the data it explains
            rather than today's. */
         var earlier = end.AddDays(-10);
-        Assert.Equal(
-            earlier.AddHours(-floorHours),
-            DarlingPgColumnStatsReader.EvidenceStart(earlier.AddHours(-1), earlier));
+        Assert.Equal(earlier.AddHours(-hours), DarlingPgColumnStatsReader.EvidenceStart(earlier));
 
-        /* And the floor is at least the SUBJECT collector's cadence: pg_column_stats runs daily, so
-           evidence over a shorter span than one of its own cycles cannot describe the run being explained. */
+        /* At least the SUBJECT collector's cadence: pg_column_stats runs daily, so evidence over a shorter
+           span than one of its own cycles cannot describe the run being explained. */
         Assert.True(
-            floorHours >= 24,
-            $"the evidence floor is {floorHours}h, shorter than pg_column_stats' own daily cadence");
+            hours >= 24,
+            $"the evidence lookback is {hours}h, shorter than pg_column_stats' own daily cadence");
 
         /* AND THE VERDICT READ ACTUALLY USES IT. Everything above tests a pure function; deleting the one
            call that applies it left every assertion here green, which is the seam this whole issue is a
@@ -290,15 +282,29 @@ public sealed class PgColumnStatsCoverageTests
             "Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs",
             "GetCoverageVerdictAsync"));
 
-        Assert.Contains("EvidenceStart(startUtc, endUtc)", verdictRead, StringComparison.Ordinal);
+        Assert.Contains("EvidenceStart(endUtc)", verdictRead, StringComparison.Ordinal);
+
+        /* And the read must not quietly go back to the caller's start: the parameter still exists, for the
+           ROW read, so a one-character edit reinstates the defect this closes. */
+        Assert.DoesNotContain("EvidenceStart(startUtc", verdictRead, StringComparison.Ordinal);
+
+        /* And the census asks BOTH questions from BOTH sources. The run probe reads collection_log for the
+           evidence collector's name; the counts read its stored rows. A census that dropped the log half
+           could only ever answer "it ran", which erases the whole Undetermined arm - and it would do so
+           silently, because both remaining counts would still be zero. */
+        var census = DarlingPgColumnStatsReader.CoverageEvidenceSql;
+
+        Assert.Contains("FROM collection_log", census, StringComparison.Ordinal);
+        Assert.Contains("collector_name = 'pg_table_bloat_stats'", census, StringComparison.Ordinal);
+        Assert.Contains("FROM pg_table_bloat_stats", census, StringComparison.Ordinal);
     }
 
     /// <summary>R7: a populated result that covers part of the target is its own answer, not the clean one.</summary>
     [Fact]
     public void PartialCoverageIsItsOwnArm()
     {
-        var partial = PgColumnStatsCoverage.Classify(167, 20, 4, 900);
-        var whole = PgColumnStatsCoverage.Classify(167, 20, 20, 900);
+        var partial = PgColumnStatsCoverage.Classify(true, 20, 4, 900);
+        var whole = PgColumnStatsCoverage.Classify(true, 20, 20, 900);
 
         Assert.Equal(PgColumnStatsCoverageArm.PartialVisibility, partial.Arm);
         Assert.Equal(PgColumnStatsCoverageArm.FullyMeasured, whole.Arm);

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs
@@ -138,7 +138,7 @@ public sealed class DarlingMcpPgIndexTools
         }
     }
 
-    [McpServerTool(Name = "get_pg_column_stats"), Description("Gets PostgreSQL per-column distribution statistics from pg_stats: n_distinct, null fraction, average width, physical correlation, and the frequency of the single most common value. These are the numbers the PLANNER uses, so they explain plan shapes that otherwise look arbitrary. n_distinct is negative when PostgreSQL expresses it as a RATIO of table rows (-1 means every value is unique) and positive when it is an absolute count - do not compare the two without checking the sign. correlation near 1 or -1 means the column's physical order matches its logical order, which is what makes an index range scan cheap; near 0 makes the same scan expensive. A high top_value_frequency is the classic cause of a plan that is right for the common value and wrong for every other one. Only columns on tables above a size floor are collected, and only where the monitoring login can see the statistics.")]
+    [McpServerTool(Name = "get_pg_column_stats"), Description("Gets PostgreSQL per-column distribution statistics from pg_stats: n_distinct, null fraction, average width, physical correlation, and the frequency of the single most common value. These are the numbers the PLANNER uses, so they explain plan shapes that otherwise look arbitrary. n_distinct is negative when PostgreSQL expresses it as a RATIO of table rows (-1 means every value is unique) and positive when it is an absolute count - do not compare the two without checking the sign. correlation near 1 or -1 means the column's physical order matches its logical order, which is what makes an index range scan cheap; near 0 makes the same scan expensive. A high top_value_frequency is the classic cause of a plan that is right for the common value and wrong for every other one. Only columns on tables above a size floor are collected, and only where the monitoring login can see the statistics - so ALWAYS read the coverage field before acting on this: it names which of those produced the result, and PartialVisibility or StatisticsNotVisible means the statistics you are looking at are not all of them.")]
     public static async Task<string> GetPgColumnStats(
         NpgsqlDataSource postgres,
         [Description("Server name or display name.")] string? server_name = null,
@@ -156,8 +156,16 @@ public sealed class DarlingMcpPgIndexTools
 
         try
         {
+            var windowStart = windowEnd.AddHours(-hours_back);
+
             var rows = await DarlingPgColumnStatsReader.GetPgColumnStatsAsync(
-                postgres, resolved.ServerId, windowEnd.AddHours(-hours_back), windowEnd, limit);
+                postgres, resolved.ServerId, windowStart, windowEnd, limit);
+
+            /* Asked on BOTH paths, not just the empty one (#3154). A returned row set that covers a
+               fraction of the tables above the floor is the same defect as an unexplained empty, one
+               degree weaker: the ranking looks complete and is not. */
+            var coverage = await DarlingPgColumnStatsReader.GetCoverageVerdictAsync(
+                postgres, resolved.ServerId, windowStart, windowEnd, rows.Count);
 
             if (rows.Count == 0)
             {
@@ -165,13 +173,15 @@ public sealed class DarlingMcpPgIndexTools
                     postgres, resolved.ServerId, resolved.ServerName, "pg_column_stats")
                     ?? await DarlingRuntimePrecondition.StatusAsync(
                         postgres, resolved.ServerId, resolved.ServerName, "pg_column_stats")
+                    /* The arm, not a list of the arms. This message used to recite the size floor AND the
+                       privilege filter and select neither, which is prose about the mechanism rather than a
+                       diagnosis of it - measured on a 50-target fleet where the answer was the privilege
+                       filter on every one of them and no read said so. */
                     ?? McpHelpers.Status(
                         "empty",
                         $"No column statistics for {resolved.ServerName} in the last {hours_back} hour(s). "
-                        + "This collector runs DAILY and only reads tables above a size floor, so a small "
-                        + "database can be legitimately empty here. pg_stats is also filtered by "
-                        + "privilege: a monitoring login without SELECT on a table sees no rows for it, "
-                        + "and that looks identical to a table with no statistics.");
+                        + "This collector runs DAILY, so a window shorter than a day can be empty on a "
+                        + "perfectly healthy server - widen it before concluding anything. " + coverage.Message);
             }
 
             var columns = rows.Select(r => new
@@ -197,10 +207,15 @@ public sealed class DarlingMcpPgIndexTools
                 server = resolved.ServerName,
                 hours_back,
                 column_count = rows.Count,
+                /* The arm as its own field, beside the sentence. Automation keys on names rather than
+                   parsing prose, and a caller deciding whether this ranking is safe to act on needs the
+                   partial-coverage answer in a form it can branch on. */
+                coverage = coverage.Arm.ToString(),
                 note = "n_distinct is a RATIO of table rows when negative and an absolute count when "
                      + "positive — check the sign before comparing two columns. correlation near ±1 is "
                      + "what makes an index range scan cheap. A null common_value_count means the column "
-                     + "has no most-common-value list at all, not that the list is empty.",
+                     + "has no most-common-value list at all, not that the list is empty. "
+                     + coverage.Message,
                 columns,
             }, McpHelpers.JsonOptions);
         }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs
@@ -14,6 +14,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using ModelContextProtocol.Server;
 using Npgsql;
+using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Storage;
 
@@ -164,25 +165,44 @@ public sealed class DarlingMcpPgIndexTools
             /* Asked on BOTH paths, not just the empty one (#3154). A returned row set that covers a
                fraction of the tables above the floor is the same defect as an unexplained empty, one
                degree weaker: the ranking looks complete and is not. */
-            var coverage = await DarlingPgColumnStatsReader.GetCoverageVerdictAsync(
-                postgres, resolved.ServerId, windowStart, windowEnd, rows.Count);
+            PgColumnStatsCoverageVerdict coverage;
 
             if (rows.Count == 0)
             {
-                return await DarlingEngineCapability.NotCollectedStatusAsync(
-                    postgres, resolved.ServerId, resolved.ServerName, "pg_column_stats")
-                    ?? await DarlingRuntimePrecondition.StatusAsync(
-                        postgres, resolved.ServerId, resolved.ServerName, "pg_column_stats")
-                    /* The arm, not a list of the arms. This message used to recite the size floor AND the
-                       privilege filter and select neither, which is prose about the mechanism rather than a
-                       diagnosis of it - measured on a 50-target fleet where the answer was the privilege
-                       filter on every one of them and no read said so. */
-                    ?? McpHelpers.Status(
-                        "empty",
-                        $"No column statistics for {resolved.ServerName} in the last {hours_back} hour(s). "
-                        + "This collector runs DAILY, so a window shorter than a day can be empty on a "
-                        + "perfectly healthy server - widen it before concluding anything. " + coverage.Message);
+                /* CAPABILITY, then PRECONDITION, then this read's own miss - the order
+                   CollectorRuntimePrecondition documents, and the three are asked in it rather than
+                   composed with ?? over three already-computed values. The coverage query used to run
+                   ahead of both, so a server that cannot have this surface at all, or whose collector
+                   recorded a denial, paid for evidence the ?? chain then threw away - and those are the
+                   callers least able to afford a round trip. Worse than the cost: computing the LAST
+                   answer first is how somebody later reorders the chain and does not notice they have
+                   changed which of the three wins. */
+                var capability = await DarlingEngineCapability.NotCollectedStatusAsync(
+                    postgres, resolved.ServerId, resolved.ServerName, "pg_column_stats");
+
+                if (capability != null) return capability;
+
+                var precondition = await DarlingRuntimePrecondition.StatusAsync(
+                    postgres, resolved.ServerId, resolved.ServerName, "pg_column_stats");
+
+                if (precondition != null) return precondition;
+
+                coverage = await DarlingPgColumnStatsReader.GetCoverageVerdictAsync(
+                    postgres, resolved.ServerId, windowEnd, rows.Count);
+
+                /* The arm, not a list of the arms. This message used to recite the size floor AND the
+                   privilege filter and select neither, which is prose about the mechanism rather than a
+                   diagnosis of it - measured on a 50-target fleet where the answer was the privilege
+                   filter on every one of them and no read said so. */
+                return McpHelpers.Status(
+                    "empty",
+                    $"No column statistics for {resolved.ServerName} in the last {hours_back} hour(s). "
+                    + "This collector runs DAILY, so a window shorter than a day can be empty on a "
+                    + "perfectly healthy server - widen it before concluding anything. " + coverage.Message);
             }
+
+            coverage = await DarlingPgColumnStatsReader.GetCoverageVerdictAsync(
+                postgres, resolved.ServerId, windowEnd, rows.Count);
 
             var columns = rows.Select(r => new
             {

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
@@ -181,7 +181,7 @@ FROM (
         try
         {
             var evidence = await GetCoverageEvidenceAsync(
-                postgres, serverId, startUtc, endUtc, cancellationToken);
+                postgres, serverId, EvidenceStart(startUtc, endUtc), endUtc, cancellationToken);
 
             return PgColumnStatsCoverage.Classify(
                 evidence.EvidenceRuns,
@@ -194,6 +194,43 @@ FROM (
             return PgColumnStatsCoverage.EvidenceUnreadable(storedColumnRows);
         }
     }
+
+    /// <summary>
+    /// The shortest evidence lookback that can answer the coverage question, whatever window the CALLER
+    /// asked its data over.
+    ///
+    /// <para><b>The read's own window is the wrong window for this, and using it would manufacture
+    /// <see cref="PgColumnStatsCoverageArm.Undetermined"/> on servers whose answer is known.</b> Whether the
+    /// monitoring login can read <c>pg_stats</c> is a CURRENT state of the target, not a property of the
+    /// interval somebody happened to select in the viewer. <c>pg_table_bloat_stats</c> collects hourly, so a
+    /// one-hour panel window straddles zero or one of its runs, and a zero would report "no evidence" for a
+    /// target measured 167 times in the past week. Same reasoning as
+    /// <c>CollectorRuntimePrecondition</c>, which consults the LATEST run rather than a window for exactly
+    /// this: a precondition is a state, and a window is a question about history.</para>
+    ///
+    /// <para>A day rather than no lower bound at all, because the store table is a hypertable and an
+    /// unbounded scan would read every chunk of a 90-day retention to answer a diagnostic. A day is the
+    /// SUBJECT collector's own cadence — <c>pg_column_stats</c> runs daily, so evidence older than its last
+    /// run could describe a grant that has since changed, and evidence newer than a day is guaranteed to
+    /// exist wherever the hourly collector is running at all.</para>
+    ///
+    /// <para>Anchored on <paramref name="endUtc"/>, so an <c>as_of</c> read gets the evidence contemporary
+    /// with the data it is explaining rather than today's.</para>
+    /// </summary>
+    internal static DateTime EvidenceStart(DateTime startUtc, DateTime endUtc)
+    {
+        var floor = endUtc.AddHours(-MinimumEvidenceHours);
+
+        /* The WIDER of the two. A caller asking about a month gets a month - narrowing to a day there would
+           throw away measurements of tables the read's own rows come from. */
+        return startUtc < floor ? startUtc : floor;
+    }
+
+    /// <summary>
+    /// How far back <see cref="EvidenceStart"/> looks when the caller's window is shorter. Named so the
+    /// relationship to the subject collector's cadence is assertable rather than a number in a call.
+    /// </summary>
+    internal const int MinimumEvidenceHours = 24;
 
     /// <summary>The raw evidence, for callers that want the counts rather than the sentence.</summary>
     public static async Task<PgColumnStatsCoverageEvidence> GetCoverageEvidenceAsync(

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
+using PerformanceMonitor.Collectors;
 
 namespace PerformanceMonitor.Darling.Storage;
 
@@ -37,10 +38,13 @@ namespace PerformanceMonitor.Darling.Storage;
 /// quantity: <c>-1</c> means distinct ≈ every row. A caller that formats it as a count will print
 /// "-1 distinct values" on the commonest possible column, a unique key.</para>
 ///
-/// <para><b>Zero rows has two causes and they are not the same.</b> <c>pg_stats</c> filters on
+/// <para><b>Zero rows has several causes and they are not the same.</b> <c>pg_stats</c> filters on
 /// <c>has_column_privilege</c>, so a monitoring role without SELECT on a table sees nothing for it — and
-/// row-level security empties the view too. Neither is an absence of problems, and a caller must say so
-/// rather than reporting healthy statistics.</para>
+/// row-level security empties the view too, while a target with no table above the collector's size floor
+/// has nothing to read in the first place. Neither is an absence of problems. Callers do not have to say
+/// which: <see cref="GetCoverageEvidenceAsync"/> reads the evidence and
+/// <see cref="PgColumnStatsCoverage.Classify"/> selects the arm, so the WPF panel and the MCP tool cannot
+/// disagree about what an empty means (#3154).</para>
 ///
 /// <para>Shared by the WPF tab and the MCP surface so there is one copy of this SQL, per #2530.</para>
 /// </summary>
@@ -95,6 +99,131 @@ public static class DarlingPgColumnStatsReader
                  database_name, schema_name, table_name, column_name
         LIMIT $4
         """;
+
+    /// <summary>
+    /// What <c>pg_table_bloat_stats</c> recorded about this server in this window: whether it ran at all,
+    /// how many tables clear <see cref="PgColumnStatsCollector.MinimumRelPages"/>, and how many of those had
+    /// every column's <c>pg_stats</c> row readable by the monitoring login. The three inputs
+    /// <see cref="PgColumnStatsCoverage.Classify"/> needs, and nothing else.
+    /// </summary>
+    /// <param name="EvidenceRuns">
+    /// <c>pg_table_bloat_stats</c> runs logged for this server in the window — a RUN count, not a row count,
+    /// and that distinction is the whole reason this field exists. A run that stored no rows is the
+    /// measurement establishing that nothing on the target clears the floor; collapsing the two would make
+    /// "measured, and everything is small" indistinguishable from "never measured here".
+    /// </param>
+    public readonly record struct PgColumnStatsCoverageEvidence(
+        int EvidenceRuns,
+        int CandidateTables,
+        int TablesWithVisibleStatistics);
+
+    /* Both counts come from the LATEST measurement of each table in the window, which is why the derived
+       table exists at all: pg_table_bloat_stats is hourly and per-database, so a plain aggregate over the
+       window would count one table once per hour and report a fleet-sized candidate count for a schema
+       holding twelve tables.
+
+       estimate_unavailable is the pg_stats visibility signal, and it is read in its SOUND direction only:
+       false cannot happen unless every column of that table had a pg_stats row this login could read, so
+       count(... NOT estimate_unavailable) is a floor on visibility rather than an estimate of it. True has
+       three other causes (a name-typed column, reltuples < 0, a null page estimate), which is why the arm
+       built on zero-visible names the privilege filter as the cause and says what else the reading admits
+       instead of asserting a denied grant.
+
+       heap_pages is pg_class.relpages - the same column, on the same catalog, that the collector's own
+       WHERE filters on - so the candidate count is the collector's own predicate re-evaluated, not a
+       size-based approximation of it. The 1 MB floor pg_table_bloat_stats collects at is a different
+       measure (pg_relation_size), so the page filter here is not redundant with it: measured on the fleet,
+       1,263 of 1,264 tables past the byte floor also clear the page floor, and the one that does not is a
+       table this collector would genuinely skip.
+
+       The run count is a scalar subquery rather than a join, so a server whose bloat collector ran and
+       stored NOTHING still reports its run - a join would drop exactly the row that distinguishes the
+       size-floor arm from the no-evidence one. $1 server_id, $2 window start, $3 window end. */
+    public static readonly string CoverageEvidenceSql = @"
+SELECT
+    (
+        SELECT count(*)
+        FROM collection_log
+        WHERE server_id = $1
+        AND   collector_name = 'pg_table_bloat_stats'
+        AND   collection_time >= $2
+        AND   collection_time <= $3
+    )::int                                                              AS evidence_runs,
+    count(*) FILTER (WHERE latest.heap_pages >= " + PgColumnStatsCollector.MinimumRelPages + @")::int
+                                                                        AS candidate_tables,
+    count(*) FILTER (WHERE latest.heap_pages >= " + PgColumnStatsCollector.MinimumRelPages + @"
+                     AND   NOT latest.estimate_unavailable)::int        AS visible_tables
+FROM (
+    SELECT DISTINCT ON (database_name, schema_name, table_name)
+           heap_pages, estimate_unavailable
+    FROM pg_table_bloat_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    AND   collection_time <= $3
+    ORDER BY database_name, schema_name, table_name, collection_time DESC
+) AS latest";
+
+    /// <summary>
+    /// The coverage verdict for a <c>pg_column_stats</c> read — which arm produced
+    /// <paramref name="storedColumnRows"/>, and the sentence saying so.
+    ///
+    /// <para>A failed evidence read answers <see cref="PgColumnStatsCoverageArm.Undetermined"/> with its own
+    /// wording rather than throwing, the same rule <c>DarlingRuntimePrecondition</c> follows: this runs to
+    /// EXPLAIN a result the caller already has, and turning that into a read error would replace an
+    /// under-described answer with no answer.</para>
+    /// </summary>
+    public static async Task<PgColumnStatsCoverageVerdict> GetCoverageVerdictAsync(
+        NpgsqlDataSource postgres, int serverId, DateTime startUtc, DateTime endUtc, int storedColumnRows,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(postgres);
+
+        try
+        {
+            var evidence = await GetCoverageEvidenceAsync(
+                postgres, serverId, startUtc, endUtc, cancellationToken);
+
+            return PgColumnStatsCoverage.Classify(
+                evidence.EvidenceRuns,
+                evidence.CandidateTables,
+                evidence.TablesWithVisibleStatistics,
+                storedColumnRows);
+        }
+        catch (Exception)
+        {
+            return PgColumnStatsCoverage.EvidenceUnreadable(storedColumnRows);
+        }
+    }
+
+    /// <summary>The raw evidence, for callers that want the counts rather than the sentence.</summary>
+    public static async Task<PgColumnStatsCoverageEvidence> GetCoverageEvidenceAsync(
+        NpgsqlDataSource postgres, int serverId, DateTime startUtc, DateTime endUtc,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(postgres);
+
+        await using var command = postgres.CreateCommand(CoverageEvidenceSql);
+        command.CommandTimeout = StorageCommandDeadlines.McpReadSeconds;
+        command.Parameters.AddWithValue(serverId);
+        /* SpecifyKind(Unspecified) at the bind, for the reason the row read below documents: Kind=Utc
+           infers timestamptz and the comparison against these naive columns then resolves at the store
+           session's TimeZone, which east of UTC slides the window off the data. An evidence read that
+           silently returned nothing would answer Undetermined on a server that has the evidence. */
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified));
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return new PgColumnStatsCoverageEvidence(0, 0, 0);
+        }
+
+        return new PgColumnStatsCoverageEvidence(
+            EvidenceRuns: reader.IsDBNull(0) ? 0 : reader.GetInt32(0),
+            CandidateTables: reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
+            TablesWithVisibleStatistics: reader.IsDBNull(2) ? 0 : reader.GetInt32(2));
+    }
 
     public static async Task<List<PgColumnStatRow>> GetPgColumnStatsAsync(
         NpgsqlDataSource postgres, int serverId, DateTime startUtc, DateTime endUtc, int limit,

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
@@ -266,13 +266,11 @@ FROM (
     /// <para>Anchored on <paramref name="endUtc"/>, so an <c>as_of</c> read gets the evidence contemporary
     /// with the data it is explaining rather than today's.</para>
     /// </summary>
-    internal static DateTime EvidenceStart(DateTime endUtc) => endUtc.AddHours(-EvidenceHours);
-
-    /// <summary>
-    /// How far back <see cref="EvidenceStart"/> looks. Named so the relationship to the subject collector's
-    /// cadence is assertable rather than a number in a call.
-    /// </summary>
-    internal const int EvidenceHours = 24;
+    /// <para>The span itself lives on <see cref="PgColumnStatsCoverage.EvidenceHours"/>, not here: it
+    /// appears in the census an operator reads, so the label and the query have to be the same figure and a
+    /// copy in this file is how they stop being.</para>
+    internal static DateTime EvidenceStart(DateTime endUtc) =>
+        endUtc.AddHours(-PgColumnStatsCoverage.EvidenceHours);
 
     /// <summary>The raw evidence, for callers that want the counts rather than the sentence.</summary>
     public static async Task<PgColumnStatsCoverageEvidence> GetCoverageEvidenceAsync(

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
@@ -106,14 +106,21 @@ public static class DarlingPgColumnStatsReader
     /// every column's <c>pg_stats</c> row readable by the monitoring login. The three inputs
     /// <see cref="PgColumnStatsCoverage.Classify"/> needs, and nothing else.
     /// </summary>
-    /// <param name="EvidenceRuns">
-    /// <c>pg_table_bloat_stats</c> runs logged for this server in the window — a RUN count, not a row count,
+    /// <param name="EvidenceCollectorRan">
+    /// Whether <c>pg_table_bloat_stats</c> RAN for this server in the evidence window — a run, not a row,
     /// and that distinction is the whole reason this field exists. A run that stored no rows is the
     /// measurement establishing that nothing on the target clears the floor; collapsing the two would make
     /// "measured, and everything is small" indistinguishable from "never measured here".
+    ///
+    /// <para>A boolean rather than a count because a count is what the decision costs, not what it needs:
+    /// nothing reads how MANY times it ran, and measured against the production store an
+    /// <c>EXISTS</c> probe answers in 6 ms where <c>count(*)</c> over the same predicate takes 152 —
+    /// <c>collection_log</c> has no index on (server_id, collector_name), so counting means a bitmap heap
+    /// scan that discarded 14,060 rows to keep 22. Proving ABSENCE is the worst case for a short-circuit and
+    /// it still measured 4.5 ms.</para>
     /// </param>
     public readonly record struct PgColumnStatsCoverageEvidence(
-        int EvidenceRuns,
+        bool EvidenceCollectorRan,
         int CandidateTables,
         int TablesWithVisibleStatistics);
 
@@ -136,19 +143,22 @@ public static class DarlingPgColumnStatsReader
        1,263 of 1,264 tables past the byte floor also clear the page floor, and the one that does not is a
        table this collector would genuinely skip.
 
-       The run count is a scalar subquery rather than a join, so a server whose bloat collector ran and
+       The run probe is a scalar subquery rather than a join, so a server whose bloat collector ran and
        stored NOTHING still reports its run - a join would drop exactly the row that distinguishes the
-       size-floor arm from the no-evidence one. $1 server_id, $2 window start, $3 window end. */
+       size-floor arm from the no-evidence one. EXISTS rather than count(*) because only the zero test is
+       read, and it is 25x cheaper on this store. $1 server_id, $2 window start, $3 window end. */
     public static readonly string CoverageEvidenceSql = @"
 SELECT
     (
-        SELECT count(*)
-        FROM collection_log
-        WHERE server_id = $1
-        AND   collector_name = 'pg_table_bloat_stats'
-        AND   collection_time >= $2
-        AND   collection_time <= $3
-    )::int                                                              AS evidence_runs,
+        SELECT EXISTS (
+            SELECT 1
+            FROM collection_log
+            WHERE server_id = $1
+            AND   collector_name = 'pg_table_bloat_stats'
+            AND   collection_time >= $2
+            AND   collection_time <= $3
+        )
+    )                                                                   AS evidence_collector_ran,
     count(*) FILTER (WHERE latest.heap_pages >= " + PgColumnStatsCollector.MinimumRelPages + @")::int
                                                                         AS candidate_tables,
     count(*) FILTER (WHERE latest.heap_pages >= " + PgColumnStatsCollector.MinimumRelPages + @"
@@ -181,10 +191,10 @@ FROM (
         try
         {
             var evidence = await GetCoverageEvidenceAsync(
-                postgres, serverId, EvidenceStart(startUtc, endUtc), endUtc, cancellationToken);
+                postgres, serverId, EvidenceStart(endUtc), endUtc, cancellationToken);
 
             return PgColumnStatsCoverage.Classify(
-                evidence.EvidenceRuns,
+                evidence.EvidenceCollectorRan,
                 evidence.CandidateTables,
                 evidence.TablesWithVisibleStatistics,
                 storedColumnRows);
@@ -196,41 +206,39 @@ FROM (
     }
 
     /// <summary>
-    /// The shortest evidence lookback that can answer the coverage question, whatever window the CALLER
-    /// asked its data over.
+    /// The evidence lookback: a FIXED span ending where the caller's read ends, independent of how wide a
+    /// window the caller asked its data over.
     ///
-    /// <para><b>The read's own window is the wrong window for this, and using it would manufacture
-    /// <see cref="PgColumnStatsCoverageArm.Undetermined"/> on servers whose answer is known.</b> Whether the
-    /// monitoring login can read <c>pg_stats</c> is a CURRENT state of the target, not a property of the
-    /// interval somebody happened to select in the viewer. <c>pg_table_bloat_stats</c> collects hourly, so a
-    /// one-hour panel window straddles zero or one of its runs, and a zero would report "no evidence" for a
-    /// target measured 167 times in the past week. Same reasoning as
-    /// <c>CollectorRuntimePrecondition</c>, which consults the LATEST run rather than a window for exactly
-    /// this: a precondition is a state, and a window is a question about history.</para>
+    /// <para><b>The read's own window is the wrong window for this, in both directions.</b> A one-hour panel
+    /// window straddles zero or one run of the hourly evidence collector, so it would manufacture
+    /// <see cref="PgColumnStatsCoverageArm.Undetermined"/> for a target measured 167 times in the past week.
+    /// And a wide one is no better: the MCP tool defaults to 168 hours, where the census measured 242 ms
+    /// against 41 ms over a day — a diagnostic that runs on every call, empty or not, paying six times over
+    /// for history it does not use.</para>
     ///
-    /// <para>A day rather than no lower bound at all, because the store table is a hypertable and an
-    /// unbounded scan would read every chunk of a 90-day retention to answer a diagnostic. A day is the
-    /// SUBJECT collector's own cadence — <c>pg_column_stats</c> runs daily, so evidence older than its last
-    /// run could describe a grant that has since changed, and evidence newer than a day is guaranteed to
-    /// exist wherever the hourly collector is running at all.</para>
+    /// <para><b>Because it is not a question about history.</b> Whether the monitoring login can read
+    /// <c>pg_stats</c>, and whether anything on the target clears the size floor, are CURRENT states — and
+    /// <c>CollectorRuntimePrecondition</c> settled this shape already: it consults the LATEST run rather than
+    /// a window, on the reasoning that a precondition somebody has since satisfied must not keep being
+    /// reported. Averaging a month of candidate counts would answer a question nobody asked and cost more to
+    /// do it.</para>
+    ///
+    /// <para>A day rather than the latest row alone, because the store table is a hypertable and the count
+    /// is over DISTINCT tables — so it needs a span, and a day both bounds the chunks scanned and is the
+    /// SUBJECT collector's own cadence: <c>pg_column_stats</c> runs daily, so this is the evidence
+    /// contemporary with the run being explained, and it is guaranteed to exist wherever the hourly
+    /// collector is running at all.</para>
     ///
     /// <para>Anchored on <paramref name="endUtc"/>, so an <c>as_of</c> read gets the evidence contemporary
     /// with the data it is explaining rather than today's.</para>
     /// </summary>
-    internal static DateTime EvidenceStart(DateTime startUtc, DateTime endUtc)
-    {
-        var floor = endUtc.AddHours(-MinimumEvidenceHours);
-
-        /* The WIDER of the two. A caller asking about a month gets a month - narrowing to a day there would
-           throw away measurements of tables the read's own rows come from. */
-        return startUtc < floor ? startUtc : floor;
-    }
+    internal static DateTime EvidenceStart(DateTime endUtc) => endUtc.AddHours(-EvidenceHours);
 
     /// <summary>
-    /// How far back <see cref="EvidenceStart"/> looks when the caller's window is shorter. Named so the
-    /// relationship to the subject collector's cadence is assertable rather than a number in a call.
+    /// How far back <see cref="EvidenceStart"/> looks. Named so the relationship to the subject collector's
+    /// cadence is assertable rather than a number in a call.
     /// </summary>
-    internal const int MinimumEvidenceHours = 24;
+    internal const int EvidenceHours = 24;
 
     /// <summary>The raw evidence, for callers that want the counts rather than the sentence.</summary>
     public static async Task<PgColumnStatsCoverageEvidence> GetCoverageEvidenceAsync(
@@ -253,11 +261,11 @@ FROM (
 
         if (!await reader.ReadAsync(cancellationToken))
         {
-            return new PgColumnStatsCoverageEvidence(0, 0, 0);
+            return new PgColumnStatsCoverageEvidence(false, 0, 0);
         }
 
         return new PgColumnStatsCoverageEvidence(
-            EvidenceRuns: reader.IsDBNull(0) ? 0 : reader.GetInt32(0),
+            EvidenceCollectorRan: !reader.IsDBNull(0) && reader.GetBoolean(0),
             CandidateTables: reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
             TablesWithVisibleStatistics: reader.IsDBNull(2) ? 0 : reader.GetInt32(2));
     }

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
@@ -206,9 +206,18 @@ FROM (
     /// wording rather than throwing, the same rule <c>DarlingRuntimePrecondition</c> follows: this runs to
     /// EXPLAIN a result the caller already has, and turning that into a read error would replace an
     /// under-described answer with no answer.</para>
+    ///
+    /// <para><b>No window START, deliberately, and the signature says so by not having one.</b> The evidence
+    /// span is <see cref="EvidenceStart"/> to <paramref name="endUtc"/> whatever the caller read its rows
+    /// over — see that method for why. An accepted-but-ignored <c>startUtc</c> is worse than an absent one:
+    /// the caller passes a window, reasonably believes it is honoured, and neither the compiler nor the
+    /// answer tells them otherwise. Callers that want the raw counts over a span of their own choosing have
+    /// <see cref="GetCoverageEvidenceAsync"/>, which takes both ends and uses both.</para>
     /// </summary>
+    /// <param name="endUtc">The instant the caller's read ENDS at, which the evidence window is anchored
+    /// on so an <c>as_of</c> read is explained by contemporary evidence rather than by today's.</param>
     public static async Task<PgColumnStatsCoverageVerdict> GetCoverageVerdictAsync(
-        NpgsqlDataSource postgres, int serverId, DateTime startUtc, DateTime endUtc, int storedColumnRows,
+        NpgsqlDataSource postgres, int serverId, DateTime endUtc, int storedColumnRows,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(postgres);

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgColumnStatsReader.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
@@ -146,7 +147,30 @@ public static class DarlingPgColumnStatsReader
        The run probe is a scalar subquery rather than a join, so a server whose bloat collector ran and
        stored NOTHING still reports its run - a join would drop exactly the row that distinguishes the
        size-floor arm from the no-evidence one. EXISTS rather than count(*) because only the zero test is
-       read, and it is 25x cheaper on this store. $1 server_id, $2 window start, $3 window end. */
+       read, and it is 25x cheaper on this store.
+
+       And it counts only runs that SUCCEEDED, which is not a detail: a bloat collector erroring on a
+       target still writes a collection_log row, so an unfiltered probe would say "it ran" while the
+       collector stored nothing - candidate_tables 0, visible 0 - and the classifier would answer
+       BelowSizeFloor, "nothing to fix". That is the exact false-innocence this whole issue closes,
+       reintroduced one level down in the EVIDENCE collector's own health. The status set is read from
+       EnumeratedCollectorDriver.FreshnessSuccessStatuses rather than retyped, so it is the same bar the
+       freshness reads and the self-alert evaluator apply, and a status added there propagates here.
+
+       $1 server_id, $2 window start, $3 window end. */
+    /// <summary>
+    /// <see cref="EnumeratedCollectorDriver.FreshnessSuccessStatuses"/> as a SQL <c>IN</c> list. Built from
+    /// the shared list rather than retyped so the bar for "this collector produced valid evidence" is the
+    /// one the freshness reads and the self-alert evaluator already use, and so a status added there reaches
+    /// this probe without anybody remembering to come here.
+    ///
+    /// <para>Literal-safe by construction: every element is a compile-time constant in this repo's own
+    /// source, never operator input.</para>
+    /// </summary>
+    private static readonly string EvidenceStatusList = string.Join(
+        ", ",
+        EnumeratedCollectorDriver.FreshnessSuccessStatuses.Select(status => "'" + status + "'"));
+
     public static readonly string CoverageEvidenceSql = @"
 SELECT
     (
@@ -157,6 +181,7 @@ SELECT
             AND   collector_name = 'pg_table_bloat_stats'
             AND   collection_time >= $2
             AND   collection_time <= $3
+            AND   status IN (" + EvidenceStatusList + @")
         )
     )                                                                   AS evidence_collector_ran,
     count(*) FILTER (WHERE latest.heap_pages >= " + PgColumnStatsCollector.MinimumRelPages + @")::int

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs
@@ -425,12 +425,22 @@ public sealed partial class ViewerDataService
 
     /// <summary>Storage tab - per-column planner statistics (#2543), latest per column and ranked by
     /// suspicion rather than alphabetically: heavy skew first (the parameter-sensitivity signal), then low
-    /// correlation (why an index scan was rejected). Zero rows has TWO causes - no qualifying table, or a
-    /// monitoring role without SELECT, since pg_stats filters on has_column_privilege - and the caller must
-    /// not report either as healthy statistics.</summary>
+    /// correlation (why an index scan was rejected). This returns the ROWS only; what the row count MEANS is
+    /// <see cref="GetPgColumnStatsCoverageAsync"/>, and a caller that prints one without the other is back
+    /// to reporting a privilege denial as healthy statistics.</summary>
     public Task<List<DarlingPgColumnStatsReader.PgColumnStatRow>> GetPgColumnStatsAsync(
         int serverId, DateTime startUtc, DateTime endUtc, int limit = 100, CancellationToken cancellationToken = default) =>
         DarlingPgColumnStatsReader.GetPgColumnStatsAsync(_dataSource, serverId, startUtc, endUtc, limit, cancellationToken);
+
+    /// <summary>Storage tab - WHICH of pg_column_stats' outcomes produced the row count above (#3154):
+    /// nothing clears the collector's page floor, the monitoring login cannot see pg_stats, coverage is
+    /// partial, or neither legitimate cause applies and it is a fault. The same classifier
+    /// <c>get_pg_column_stats</c> calls, over the same evidence, so the panel and the tool cannot give one
+    /// operator two answers.</summary>
+    public Task<PgColumnStatsCoverageVerdict> GetPgColumnStatsCoverageAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, int storedColumnRows, CancellationToken cancellationToken = default) =>
+        DarlingPgColumnStatsReader.GetCoverageVerdictAsync(
+            _dataSource, serverId, startUtc, endUtc, storedColumnRows, cancellationToken);
 
     /// <summary>Replication tab - connected standbys and how far behind each got (#2544). Returns the latest
     /// sample AND the window's worst, because a replica that drifts hundreds of MB behind and recovers reads

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs
@@ -436,11 +436,14 @@ public sealed partial class ViewerDataService
     /// nothing clears the collector's page floor, the monitoring login cannot see pg_stats, coverage is
     /// partial, or neither legitimate cause applies and it is a fault. The same classifier
     /// <c>get_pg_column_stats</c> calls, over the same evidence, so the panel and the tool cannot give one
-    /// operator two answers.</summary>
+    /// operator two answers.
+    /// <para>Takes the window END only, mirroring the reader: coverage is a CURRENT state of the target, so
+    /// there is no start to honour and no start is accepted. A parameter passed and ignored would let the
+    /// panel look as though its own window governed this answer.</para></summary>
     public Task<PgColumnStatsCoverageVerdict> GetPgColumnStatsCoverageAsync(
-        int serverId, DateTime startUtc, DateTime endUtc, int storedColumnRows, CancellationToken cancellationToken = default) =>
+        int serverId, DateTime endUtc, int storedColumnRows, CancellationToken cancellationToken = default) =>
         DarlingPgColumnStatsReader.GetCoverageVerdictAsync(
-            _dataSource, serverId, startUtc, endUtc, storedColumnRows, cancellationToken);
+            _dataSource, serverId, endUtc, storedColumnRows, cancellationToken);
 
     /// <summary>Replication tab - connected standbys and how far behind each got (#2544). Returns the latest
     /// sample AND the window's worst, because a replica that drifts hundreds of MB behind and recovers reads

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
@@ -1009,7 +1009,7 @@ public partial class ViewerServerTab
            the same question differently is how a defect gets fixed in one surface and left in the other,
            and the arm selection is the whole content of the answer here - so neither surface authors it. */
         var coverage = await _dataService.GetPgColumnStatsCoverageAsync(
-            _server.ServerId, startUtc, endUtc, rows.Count);
+            _server.ServerId, endUtc, rows.Count);
 
         PgColumnStatsNote.Text = rows.Count == 0
             ? "No column statistics were collected. That is NOT the same as clean statistics. "

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
@@ -979,11 +979,16 @@ public partial class ViewerServerTab
     /// The column-statistics panel (#2543) — the planner inputs that explain WHY a plan was chosen, and the
     /// same statistics the bloat estimate above is computed from.
     ///
-    /// <para><b>Zero rows has two causes and the note must not collapse them.</b> <c>pg_stats</c> filters on
-    /// <c>has_column_privilege</c>, so a monitoring login without SELECT on a table sees nothing for it —
-    /// measured: a <c>pg_monitor</c>-only role gets zero rows where a superuser gets all of them. Row-level
-    /// security empties it the same way. Neither is an absence of problems, and reporting "no statistics" as
-    /// though the data were clean is the exact claim the miss vocabulary exists to prevent.</para>
+    /// <para><b>Zero rows has several causes and the note names WHICH, rather than listing them.</b> Listing
+    /// them is what this panel used to do: <c>pg_stats</c> filters on <c>has_column_privilege</c> so a
+    /// monitoring login without SELECT sees nothing, and a server with no table above the collector's floor
+    /// has nothing to read — and an operator reading both in one sentence learns which two things it might
+    /// be and not which one it is. <see cref="PgColumnStatsCoverage"/> selects the arm from what
+    /// <c>pg_table_bloat_stats</c> already measured, and this panel prints it (#3154).</para>
+    ///
+    /// <para><b>Printed on the POPULATED path as well.</b> A partial view is the same defect one degree
+    /// weaker — the grid ranks what it was given and cannot show what was withheld — so the coverage
+    /// sentence rides both branches rather than being an empty-state message.</para>
     /// </summary>
     private async Task LoadPgColumnStatsAsync(DateTime startUtc, DateTime endUtc)
     {
@@ -1000,17 +1005,25 @@ public partial class ViewerServerTab
 
         var skewed = rows.Count(r => r.TopValueFrequency >= 0.25);
 
+        /* The SAME classifier the MCP tool calls, deliberately (#3154). The panel and the tool answering
+           the same question differently is how a defect gets fixed in one surface and left in the other,
+           and the arm selection is the whole content of the answer here - so neither surface authors it. */
+        var coverage = await _dataService.GetPgColumnStatsCoverageAsync(
+            _server.ServerId, startUtc, endUtc, rows.Count);
+
         PgColumnStatsNote.Text = rows.Count == 0
-            ? "No column statistics were collected. That is NOT the same as clean statistics, and it has two "
-              + "causes worth telling apart: pg_stats is filtered by SELECT privilege, so a monitoring login "
-              + "without it on a table sees nothing for that table (row-level security empties the view the "
-              + "same way) — or the server genuinely has no table above the 1 MB floor this collects at."
+            ? "No column statistics were collected. That is NOT the same as clean statistics. "
+              + coverage.Message
             : $"Ranked by suspicion, not alphabetically. {skewed:N0} column(s) have a single value covering "
               + "a quarter or more of the table, which is the PostgreSQL analogue of parameter sniffing: a "
               + "plan that suits most values is catastrophic for that one. Low correlation on a wide column "
               + "is the other shape, and it is why an index scan was rejected on a column that obviously "
               + "has an index. Distinct is NEGATIVE when it is a ratio of row count — -1 means nearly every "
               + "row is unique, not minus one value. Most-common VALUES and histogram bounds are "
-              + "deliberately not collected: they hold raw column data.";
+              + "deliberately not collected: they hold raw column data. "
+              /* On the POPULATED path too. A grid that ranks the columns of four tables while sixteen more
+                 are withheld by the privilege filter reads as a ranking of the server, and the operator has
+                 no way to see the difference from the grid itself. */
+              + coverage.Message;
     }
 }

--- a/PerformanceMonitor.Collectors/PgColumnStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/PgColumnStatsCollector.cs
@@ -46,8 +46,15 @@ namespace PerformanceMonitor.Collectors;
 /// <c>pg_statistic</c> underneath is permission-denied outright. That is why Datadog ships a
 /// <c>SECURITY DEFINER</c> helper. Row-level security empties the view too, via the third conjunct of the
 /// same filter. This slice deliberately does NOT install a helper: it collects what the granted role can
-/// see, and records the shortfall so the read can say which of the two is in force rather than reporting an
-/// absence of statistics as an absence of problems.</para>
+/// see.</para>
+///
+/// <para><b>Which of the two is in force is answered by the read, from
+/// <see cref="PgColumnStatsCoverage"/>.</b> The zero row count itself carries nothing that separates them —
+/// the query completes in under 300 ms and returns an empty result either way, with no error to classify —
+/// so the arm is selected at read time from <c>pg_table_bloat_stats</c>' per-table measurements, which
+/// already carry both the page count that decides the floor and the <c>pg_stats</c> visibility this filter
+/// governs. #3154: for 553 runs across 50 targets this collector reported SUCCESS with a NULL note and
+/// stored nothing, and no read could say which arm produced it.</para>
 ///
 /// <para>Per-database, because <c>pg_stats</c> describes the connected database only.</para>
 /// </summary>
@@ -82,21 +89,29 @@ public sealed class PgColumnStatsCollector : PostgresCollectorDefinitionBase<PgC
         float? TopValueFrequency,
         int? CommonValueCount);
 
-    /* Restricted to tables above a size floor. Statistics on a 40-page table cannot produce a misestimate
-       anyone will ever notice - the planner is choosing between two cheap paths - so collecting every column
-       of every tiny table would multiply the row count by the long tail of the schema for no finding. 128
-       pages is 1 MB at the default block size.
+    /// <summary>
+    /// Tables at or above this catalog page count are read. Statistics on a 40-page table cannot produce a
+    /// misestimate anyone will ever notice — the planner is choosing between two cheap paths — so collecting
+    /// every column of every tiny table would multiply the row count by the long tail of the schema for no
+    /// finding. 128 pages is 1 MB at the default block size.
+    ///
+    /// <para>Named rather than inlined because it is the number an operator gets TOLD about: the read that
+    /// reports "nothing on this server reaches N pages" has to quote the figure the shipped query filters on,
+    /// and a retyped copy in the message is how that stops being true (#3154). Interpolated into
+    /// <c>QueryText</c> for the same reason, matching <c>PgTableBloatStatsCollector.MinimumHeapBytes</c>.</para>
+    /// </summary>
+    public const long MinimumRelPages = 128;
 
-       most_common_freqs[1] rather than the whole array: the first element IS the skew signal, and storing
+    /* most_common_freqs[1] rather than the whole array: the first element IS the skew signal, and storing
        the array would be storing a distribution nobody reads to more depth than its head.
 
        cardinality(most_common_vals) reads only the LENGTH of that array and never its contents, which is the
        one thing worth knowing about it - how many values dominate - without copying any of them.
 
        pg_stats is a view over pg_statistic filtered by has_column_privilege, so this returns only what the
-       monitoring role may read. That is a feature of the view rather than something to work around here;
-       the shortfall is reported by the read instead. */
-    private const string QueryText = @"
+       monitoring role may read. That is a feature of the view rather than something to work around here; the
+       shortfall it causes is classified by the read, from PgColumnStatsCoverage. */
+    internal static readonly string QueryText = @"
 SELECT
     current_database()::text                AS database_name,
     s.schemaname::text                      AS schema_name,
@@ -118,7 +133,7 @@ JOIN pg_catalog.pg_namespace AS n
  AND n.nspname = s.schemaname
 WHERE s.schemaname NOT IN ('pg_catalog', 'information_schema')
 AND   c.relkind IN ('r', 'm', 'p')
-AND   c.relpages >= 128
+AND   c.relpages >= " + MinimumRelPages + @"
 ORDER BY c.relpages DESC, s.schemaname, s.tablename, s.attname
 /* Bounded (#2617's lesson applied before it bites). This is a catalog read rather than a page scan, so
    it is nowhere near as costly as pg_index_bloat was - but it was still unbounded, and row count here is

--- a/PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs
+++ b/PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs
@@ -140,18 +140,18 @@ public static class PgColumnStatsCoverage
     /// The arm that produced <paramref name="storedColumnRows"/>, the counts it was decided from, and the
     /// sentence for it.
     ///
-    /// <para>Order is load-bearing. <paramref name="evidenceRuns"/> is asked FIRST because every other arm
-    /// is an inference from counts that only mean something once the collector supplying them has run —
-    /// asking it later would let an absent evidence collector answer
+    /// <para>Order is load-bearing. <paramref name="evidenceCollectorRan"/> is asked FIRST because every
+    /// other arm is an inference from counts that only mean something once the collector supplying them has
+    /// run — asking it later would let an absent evidence collector answer
     /// <see cref="PgColumnStatsCoverageArm.BelowSizeFloor"/>, which is a confident all-clear built on no
     /// measurement. Then the floor, because a target with nothing to read cannot have a privilege problem
     /// worth reporting. Only then the two arms that need the visible count to tell apart.</para>
     /// </summary>
-    /// <param name="evidenceRuns">
-    /// <c>pg_table_bloat_stats</c> runs recorded for this server in the window. Zero means no evidence, and
-    /// it is deliberately a RUN count rather than a row count: a run that stored no rows is the measurement
-    /// that establishes <see cref="PgColumnStatsCoverageArm.BelowSizeFloor"/>, so collapsing the two would
-    /// throw away the only reading that distinguishes it from an absent collector.
+    /// <param name="evidenceCollectorRan">
+    /// Whether <c>pg_table_bloat_stats</c> RAN for this server in the evidence window. It is deliberately a
+    /// RUN rather than a row count: a run that stored no rows is the measurement that establishes
+    /// <see cref="PgColumnStatsCoverageArm.BelowSizeFloor"/>, so collapsing the two would throw away the
+    /// only reading that distinguishes it from an absent collector.
     /// </param>
     /// <param name="candidateTables">
     /// Distinct tables whose latest measurement in the window is at or above
@@ -163,12 +163,12 @@ public static class PgColumnStatsCoverage
     /// </param>
     /// <param name="storedColumnRows">Column statistic rows the read actually returned.</param>
     public static PgColumnStatsCoverageVerdict Classify(
-        int evidenceRuns,
+        bool evidenceCollectorRan,
         int candidateTables,
         int tablesWithVisibleStatistics,
         int storedColumnRows)
     {
-        if (evidenceRuns <= 0)
+        if (!evidenceCollectorRan)
         {
             return new PgColumnStatsCoverageVerdict(
                 PgColumnStatsCoverageArm.Undetermined,

--- a/PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs
+++ b/PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Globalization;
+
+namespace PerformanceMonitor.Collectors;
+
+/// <summary>
+/// Which of <see cref="PgColumnStatsCollector"/>'s outcomes produced the row count a read is looking at
+/// (#3154). Named arms rather than a boolean, because the whole defect was that a zero row count arrived
+/// with no way to tell four different situations apart.
+/// </summary>
+public enum PgColumnStatsCoverageArm
+{
+    /// <summary>
+    /// No per-table evidence for this server in the window, so no arm can be selected. This is the arm that
+    /// keeps the others honest: without it, "the evidence collector never ran here" and "nothing on this
+    /// target is large enough" both present as zero candidate tables, and only one of them is a diagnosis.
+    /// </summary>
+    Undetermined,
+
+    /// <summary>
+    /// Nothing on the target reaches <see cref="PgColumnStatsCollector.MinimumRelPages"/>. The collector had
+    /// nothing to read, the empty is correct, and there is nothing for an operator to fix.
+    /// </summary>
+    BelowSizeFloor,
+
+    /// <summary>
+    /// Tables clear the floor and not one of them has column statistics this monitoring login can read.
+    /// <c>pg_stats</c> filters on <c>has_column_privilege</c>, so a login without SELECT gets an empty view
+    /// and no error at all — the arm that is measured on a managed fleet with a restricted login, and the
+    /// only arm carrying a remedy.
+    /// </summary>
+    StatisticsNotVisible,
+
+    /// <summary>
+    /// Tables clear the floor, statistics on some of them ARE readable by this login, and the collector still
+    /// stored nothing. Neither legitimate cause is in force, so this is a collection fault. Today's read
+    /// reports it identically to the two legitimate arms, which is how a broken query would go unnoticed.
+    /// </summary>
+    CollectionFault,
+
+    /// <summary>
+    /// Statistics were stored, and they describe FEWER tables than clear the floor. A ranking over a partial
+    /// view is not a ranking over the target — the same rule #3114 established for a measurement cap, one
+    /// collector over.
+    /// </summary>
+    PartialVisibility,
+
+    /// <summary>Statistics were stored, and they cover every table that clears the floor.</summary>
+    FullyMeasured,
+}
+
+/// <summary>
+/// One <see cref="PgColumnStatsCoverageArm"/>, the figures it was decided from, and the verdict sentence —
+/// as one value, so a caller cannot print the arm without its explanation or the explanation without the
+/// counts it rests on.
+///
+/// <para><b><see cref="Census"/> and <see cref="Cause"/> are separate on purpose, and it is not cosmetic.</b>
+/// The census is the two counts, in one format for every arm; the cause is the verdict, and it carries NO
+/// figures at all. A guard that the arms are distinguishable has to compare the CAUSE — comparing the whole
+/// message would pass on the counts differing, which they always do (the floor arm needs zero candidate
+/// tables and the privilege arm needs some), so a pin over the composed string would report discrimination
+/// this class had stopped providing.</para>
+/// </summary>
+/// <param name="Census">The figures, labelled, in the same shape whatever the arm — so two servers'
+/// answers are comparable and an operator reading one arm knows what the next arm's numbers would mean.</param>
+/// <param name="Cause">The verdict and its remedy, carrying no counts.</param>
+public readonly record struct PgColumnStatsCoverageVerdict(
+    PgColumnStatsCoverageArm Arm,
+    string Census,
+    string Cause)
+{
+    /// <summary>The census then the cause, for the surfaces that print one string.</summary>
+    public string Message => Census + " " + Cause;
+}
+
+/// <summary>
+/// Which of <c>pg_column_stats</c>' outcomes produced a given row count, and the one sentence that says so
+/// (#3154).
+///
+/// <para><b>The defect this closes.</b> <see cref="PgColumnStatsCollector"/> documents two legitimate ways
+/// to return nothing — the size floor and <c>pg_stats</c>' privilege filter — and distinguishes them in its
+/// documentation and not in its output. Measured on a 50-target Aurora fleet: 553 SUCCESS runs since the
+/// store was built, zero rows stored, ever, and a NULL note on 99 of the last 100 runs. The reads then
+/// recited BOTH causes in one message and selected neither, which is prose about the mechanism rather than a
+/// diagnosis of it — an operator could not tell which thing to go and do.</para>
+///
+/// <para><b>Where the evidence comes from, and why it is not a new probe.</b> Both counts are already in the
+/// store, collected by <c>pg_table_bloat_stats</c>: it measures every table at or above 1 MB and carries
+/// <c>estimate_unavailable</c>, which is TRUE whenever a table has any column with no <c>pg_stats</c> row —
+/// the identical filter, on the identical view, from the identical login. So the arm is answered at READ
+/// time from collected rows, the way <c>CollectorRuntimePrecondition</c> answers a precondition and the way
+/// <c>get_pg_blocking</c> gets its capture denominator. No monitored server is touched to produce it.</para>
+///
+/// <para><b>What each direction of the evidence actually proves.</b> <c>estimate_unavailable = false</c> is
+/// a SUFFICIENT condition for visibility: the flag cannot be false unless every column of that table had a
+/// <c>pg_stats</c> row this login could read. That is the strong direction and it is the one
+/// <see cref="PgColumnStatsCoverageArm.CollectionFault"/> rests on — a readable table plus a stored nothing
+/// is a fault, with no privilege explanation available. The other direction is weaker: the flag is also set
+/// by a <c>name</c>-typed column and by <c>reltuples &lt; 0</c>, so a table with no confirmed-readable
+/// statistics is not by itself proof of a denied grant. Measured against the fleet those arms are
+/// negligible — 2 of 59,981 rows carried <c>reltuples &lt; 0</c> and 47,739 had been analyzed at some point
+/// — so <see cref="PgColumnStatsCoverageArm.StatisticsNotVisible"/> names the privilege filter as the cause
+/// and says "confirmed readable" rather than claiming a certainty the flag cannot carry.</para>
+///
+/// <para><b>Pure policy, no clock and no I/O.</b> The caller reads the counts and passes them in, the same
+/// discipline as <c>RollingCountAlertGate</c> — which is what lets the arm selection be asserted without a
+/// store, and what lets one classifier serve the MCP tool and the WPF panel so the two cannot disagree
+/// about what an empty means.</para>
+/// </summary>
+public static class PgColumnStatsCoverage
+{
+    /// <summary>
+    /// The remedy sentence, one copy. It names the PostgreSQL 14+ role because that is the grant measured to
+    /// restore byte-identical agreement with a superuser's numbers (#2542), and it names the explicit GRANT
+    /// beside it because 13 has no such role.
+    /// </summary>
+    public const string PrivilegeRemedy =
+        "Remedy: grant the monitoring login read access to the tables - GRANT pg_read_all_data TO <login> on "
+        + "PostgreSQL 14 and above, or GRANT SELECT on the tables themselves on 13, both verified to restore "
+        + "the statistics in full. Row-level security empties the same view by the same filter, so check for "
+        + "policies on these tables if the grant is already in place.";
+
+    /// <summary>
+    /// What the census prints where a count should be, when there is no measurement to put there. A word,
+    /// never a zero: "0 tables above the floor" is a finding and "we did not look" is not, and this whole
+    /// class exists because those two were rendered identically.
+    /// </summary>
+    public const string NotMeasured = "not measured";
+
+    /// <summary>
+    /// The arm that produced <paramref name="storedColumnRows"/>, the counts it was decided from, and the
+    /// sentence for it.
+    ///
+    /// <para>Order is load-bearing. <paramref name="evidenceRuns"/> is asked FIRST because every other arm
+    /// is an inference from counts that only mean something once the collector supplying them has run —
+    /// asking it later would let an absent evidence collector answer
+    /// <see cref="PgColumnStatsCoverageArm.BelowSizeFloor"/>, which is a confident all-clear built on no
+    /// measurement. Then the floor, because a target with nothing to read cannot have a privilege problem
+    /// worth reporting. Only then the two arms that need the visible count to tell apart.</para>
+    /// </summary>
+    /// <param name="evidenceRuns">
+    /// <c>pg_table_bloat_stats</c> runs recorded for this server in the window. Zero means no evidence, and
+    /// it is deliberately a RUN count rather than a row count: a run that stored no rows is the measurement
+    /// that establishes <see cref="PgColumnStatsCoverageArm.BelowSizeFloor"/>, so collapsing the two would
+    /// throw away the only reading that distinguishes it from an absent collector.
+    /// </param>
+    /// <param name="candidateTables">
+    /// Distinct tables whose latest measurement in the window is at or above
+    /// <see cref="PgColumnStatsCollector.MinimumRelPages"/> - what the collector would have read.
+    /// </param>
+    /// <param name="tablesWithVisibleStatistics">
+    /// How many of <paramref name="candidateTables"/> had every column's <c>pg_stats</c> row readable by
+    /// this login (<c>estimate_unavailable = false</c>).
+    /// </param>
+    /// <param name="storedColumnRows">Column statistic rows the read actually returned.</param>
+    public static PgColumnStatsCoverageVerdict Classify(
+        int evidenceRuns,
+        int candidateTables,
+        int tablesWithVisibleStatistics,
+        int storedColumnRows)
+    {
+        if (evidenceRuns <= 0)
+        {
+            return new PgColumnStatsCoverageVerdict(
+                PgColumnStatsCoverageArm.Undetermined,
+                Census(null, null, storedColumnRows),
+                "WHICH cause produced this cannot be established. pg_table_bloat_stats supplies both counts "
+                + "above and recorded no run for this server in this window; it collects on WRITERS only "
+                + "and hourly, so a read replica - where pg_column_stats does run - and a window shorter "
+                + "than an hour both legitimately have no evidence here. So this read will not say whether "
+                + "the size floor, the pg_stats privilege filter or a collection fault is responsible, and "
+                + "it will not guess.");
+        }
+
+        var census = Census(candidateTables, tablesWithVisibleStatistics, storedColumnRows);
+
+        if (candidateTables <= 0)
+        {
+            return new PgColumnStatsCoverageVerdict(
+                PgColumnStatsCoverageArm.BelowSizeFloor,
+                census,
+                "CAUSE: the size floor. No table on this server is large enough for this collector to read, "
+                + "so there was nothing to collect - statistics on a table that small cannot produce a "
+                + "misestimate worth reading. Not a privilege problem, and nothing to fix.");
+        }
+
+        if (storedColumnRows <= 0)
+        {
+            if (tablesWithVisibleStatistics <= 0)
+            {
+                return new PgColumnStatsCoverageVerdict(
+                    PgColumnStatsCoverageArm.StatisticsNotVisible,
+                    census,
+                    "CAUSE: the privilege filter, not the size floor. Tables clear the floor and not one of "
+                    + "them has column statistics confirmed readable by this monitoring login, so pg_stats - "
+                    + "a view over pg_statistic filtered by has_column_privilege - returned an empty result "
+                    + "and no error at all. The statistics exist on the target; this login cannot see them. "
+                    + PrivilegeRemedy);
+            }
+
+            return new PgColumnStatsCoverageVerdict(
+                PgColumnStatsCoverageArm.CollectionFault,
+                census,
+                "CAUSE: neither legitimate one - this is a COLLECTION FAULT. Tables clear the floor AND some "
+                + "of them have column statistics this login CAN read, and nothing was stored anyway. The "
+                + "floor does not explain it and the privilege filter does not explain it, so the collector "
+                + "or its query is wrong. Raise it rather than reading the empty as healthy statistics.");
+        }
+
+        if (tablesWithVisibleStatistics < candidateTables)
+        {
+            return new PgColumnStatsCoverageVerdict(
+                PgColumnStatsCoverageArm.PartialVisibility,
+                census,
+                "PARTIAL COVERAGE, not a clean bill of health. Fewer tables are represented here than clear "
+                + "the floor, and the rest have column statistics this monitoring login cannot read - so "
+                + "their columns are ABSENT from the ranking rather than unremarkable in it. "
+                + PrivilegeRemedy);
+        }
+
+        return new PgColumnStatsCoverageVerdict(
+            PgColumnStatsCoverageArm.FullyMeasured,
+            census,
+            "FULL COVERAGE: every table above the floor is represented, with none withheld by the pg_stats "
+            + "privilege filter. The ranking describes the whole of what this collector reads.");
+    }
+
+    /// <summary>
+    /// The verdict when the evidence read itself failed — <see cref="PgColumnStatsCoverageArm.Undetermined"/>
+    /// with its own wording, because "the store could not be read" and "the evidence collector does not run
+    /// here" are different situations and only one of them is the design working.
+    ///
+    /// <para>Here rather than at the call site so every operator-facing sentence about this collector's
+    /// coverage lives in one file and is pinned together. A caller that composed its own would be the second
+    /// copy, and the second copy is the one that drifts.</para>
+    /// </summary>
+    public static PgColumnStatsCoverageVerdict EvidenceUnreadable(int storedColumnRows) =>
+        new(PgColumnStatsCoverageArm.Undetermined,
+            Census(null, null, storedColumnRows),
+            "WHICH cause produced this cannot be established: the monitoring store read that supplies the "
+            + "counts above FAILED. That is a monitoring-side fault rather than anything about the target, so "
+            + "check collection health for THIS store - and read nothing about the target's statistics into "
+            + "it either way.");
+
+    /// <summary>
+    /// The two counts and the row count, labelled, in the one format every arm uses. Nulls render as
+    /// <see cref="NotMeasured"/>.
+    ///
+    /// <para>The floor is quoted from <see cref="PgColumnStatsCollector.MinimumRelPages"/> rather than
+    /// retyped: the number an operator is told about has to be the number the shipped query filters on.
+    /// Every figure is formatted invariantly - the viewer runs on whatever desktop the operator has and the
+    /// MCP answer is parsed by machines, so a thousands separator that moved with the host locale would
+    /// render one reading two ways.</para>
+    /// </summary>
+    private static string Census(int? candidateTables, int? tablesWithVisibleStatistics, int storedColumnRows) =>
+        "Tables at or above the " + Figure(PgColumnStatsCollector.MinimumRelPages) + " page floor: "
+        + Figure(candidateTables) + ". Of those, with column statistics this monitoring login can read: "
+        + Figure(tablesWithVisibleStatistics) + ". Column statistic rows returned: "
+        + Figure(storedColumnRows) + ".";
+
+    private static string Figure(long? value) =>
+        value is { } present ? present.ToString("N0", CultureInfo.InvariantCulture) : NotMeasured;
+}

--- a/PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs
+++ b/PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs
@@ -54,6 +54,20 @@ public enum PgColumnStatsCoverageArm
 
     /// <summary>Statistics were stored, and they cover every table that clears the floor.</summary>
     FullyMeasured,
+
+    /// <summary>
+    /// Statistics were stored, and the evidence says nothing on the target clears the floor — so the two
+    /// describe different populations and neither the floor arm nor a coverage ratio can be claimed.
+    ///
+    /// <para>Reachable because the two counts are measured over DIFFERENT spans: the evidence is a fixed
+    /// <see cref="PgColumnStatsCoverage.EvidenceHoursDescription"/> lookback, while the row count is over
+    /// whatever window the caller read. A table that has since shrunk below the floor, been truncated or
+    /// been dropped leaves rows behind with no candidate to match them. Without this arm that combination
+    /// took <see cref="BelowSizeFloor"/> and printed "nothing to fix" beside a non-empty result set, which
+    /// is the self-contradiction this whole class exists to prevent, arriving through the window mismatch
+    /// rather than through the privilege filter.</para>
+    /// </summary>
+    EvidenceStale,
 }
 
 /// <summary>
@@ -137,6 +151,28 @@ public static class PgColumnStatsCoverage
     public const string NotMeasured = "not measured";
 
     /// <summary>
+    /// How far back the evidence counts are measured, and the single definition of it — the store reader
+    /// applies this rather than holding its own copy, because the figure appears in operator-facing text
+    /// and a second definition is how the label stops describing the query.
+    ///
+    /// <para>A day because it is the SUBJECT collector's own cadence: <c>pg_column_stats</c> runs daily, so
+    /// this is the evidence contemporary with the run being explained. It is deliberately NOT the caller's
+    /// window — see the store reader's <c>EvidenceStart</c> for why, and
+    /// <see cref="PgColumnStatsCoverageArm.EvidenceStale"/> for what happens when the two spans disagree.</para>
+    /// </summary>
+    public const int EvidenceHours = 24;
+
+    /// <summary>
+    /// How the census labels the span its two counts are measured over, derived from
+    /// <see cref="EvidenceHours"/> rather than retyped. Spelled out beside the figures because the row count
+    /// is measured over a DIFFERENT span — the caller's own window — and a reader drawing a ratio from them
+    /// has to know that first. <see cref="PgColumnStatsCoverageArm.EvidenceStale"/> is what happens when
+    /// they disagree, and this label is why it is not a surprise when they do.
+    /// </summary>
+    public static readonly string EvidenceHoursDescription =
+        "measured over the last " + EvidenceHours.ToString(CultureInfo.InvariantCulture) + "h";
+
+    /// <summary>
     /// The arm that produced <paramref name="storedColumnRows"/>, the counts it was decided from, and the
     /// sentence for it.
     ///
@@ -185,6 +221,23 @@ public static class PgColumnStatsCoverage
 
         if (candidateTables <= 0)
         {
+            /* The ROW COUNT is asked before the floor verdict is claimed, because the two figures are
+               measured over different spans and can therefore disagree. Rows in hand say tables DID clear
+               the floor when they were collected, whatever the evidence says about now - so "nothing is
+               large enough" is a statement the data sitting beside it contradicts. */
+            if (storedColumnRows > 0)
+            {
+                return new PgColumnStatsCoverageVerdict(
+                    PgColumnStatsCoverageArm.EvidenceStale,
+                    census,
+                    "CAUSE: cannot be attributed - the evidence and the rows describe different "
+                    + "populations. Statistics were stored, so tables DID clear the floor when they were "
+                    + "collected, yet no table clears it in the evidence window. The two are measured over "
+                    + "different spans, so a table that has since shrunk below the floor, been truncated or "
+                    + "been dropped produces exactly this. Read the rows as describing tables that may no "
+                    + "longer qualify, and do not read this as full coverage or as an absence of problems.");
+            }
+
             return new PgColumnStatsCoverageVerdict(
                 PgColumnStatsCoverageArm.BelowSizeFloor,
                 census,
@@ -221,9 +274,9 @@ public static class PgColumnStatsCoverage
             return new PgColumnStatsCoverageVerdict(
                 PgColumnStatsCoverageArm.PartialVisibility,
                 census,
-                "PARTIAL COVERAGE, not a clean bill of health. Fewer tables are represented here than clear "
-                + "the floor, and the rest have column statistics this monitoring login cannot read - so "
-                + "their columns are ABSENT from the ranking rather than unremarkable in it. "
+                "PARTIAL COVERAGE, not a clean bill of health. Fewer tables have statistics confirmed "
+                + "readable by this monitoring login than clear the floor, so the columns of the rest are "
+                + "ABSENT from the ranking rather than unremarkable in it. "
                 + PrivilegeRemedy);
         }
 
@@ -262,9 +315,11 @@ public static class PgColumnStatsCoverage
     /// render one reading two ways.</para>
     /// </summary>
     private static string Census(int? candidateTables, int? tablesWithVisibleStatistics, int storedColumnRows) =>
-        "Tables at or above the " + Figure(PgColumnStatsCollector.MinimumRelPages) + " page floor: "
-        + Figure(candidateTables) + ". Of those, with column statistics this monitoring login can read: "
-        + Figure(tablesWithVisibleStatistics) + ". Column statistic rows returned: "
+        "Tables at or above the " + Figure(PgColumnStatsCollector.MinimumRelPages) + " page floor ("
+        + EvidenceHoursDescription + "): " + Figure(candidateTables)
+        + ". Of those, with column statistics this monitoring login can read: "
+        + Figure(tablesWithVisibleStatistics)
+        + ". Column statistic rows returned (over the window you asked for): "
         + Figure(storedColumnRows) + ".";
 
     private static string Figure(long? value) =>

--- a/PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs
+++ b/PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs
@@ -86,10 +86,11 @@ public readonly record struct PgColumnStatsCoverageVerdict(
 ///
 /// <para><b>The defect this closes.</b> <see cref="PgColumnStatsCollector"/> documents two legitimate ways
 /// to return nothing — the size floor and <c>pg_stats</c>' privilege filter — and distinguishes them in its
-/// documentation and not in its output. Measured on a 50-target Aurora fleet: 553 SUCCESS runs since the
-/// store was built, zero rows stored, ever, and a NULL note on 99 of the last 100 runs. The reads then
-/// recited BOTH causes in one message and selected neither, which is prose about the mechanism rather than a
-/// diagnosis of it — an operator could not tell which thing to go and do.</para>
+/// documentation and not in its output. Read read-only against a 50-target Aurora store on 2026-09-07:
+/// 553 SUCCESS runs since that store was built, ONE distinct status, zero rows stored ever, 299 ms at its
+/// slowest, and a NULL note on 99 of the last 100 runs. The reads then recited BOTH causes in one message
+/// and selected neither, which is prose about the mechanism rather than a diagnosis of it — an operator
+/// could not tell which thing to go and do.</para>
 ///
 /// <para><b>Where the evidence comes from, and why it is not a new probe.</b> Both counts are already in the
 /// store, collected by <c>pg_table_bloat_stats</c>: it measures every table at or above 1 MB and carries
@@ -104,10 +105,11 @@ public readonly record struct PgColumnStatsCoverageVerdict(
 /// <see cref="PgColumnStatsCoverageArm.CollectionFault"/> rests on — a readable table plus a stored nothing
 /// is a fault, with no privilege explanation available. The other direction is weaker: the flag is also set
 /// by a <c>name</c>-typed column and by <c>reltuples &lt; 0</c>, so a table with no confirmed-readable
-/// statistics is not by itself proof of a denied grant. Measured against the fleet those arms are
-/// negligible — 2 of 59,981 rows carried <c>reltuples &lt; 0</c> and 47,739 had been analyzed at some point
-/// — so <see cref="PgColumnStatsCoverageArm.StatisticsNotVisible"/> names the privilege filter as the cause
-/// and says "confirmed readable" rather than claiming a certainty the flag cannot carry.</para>
+/// statistics is not by itself proof of a denied grant. Against that same store on 2026-09-07 those arms
+/// were negligible — 2 of 60,202 rows in 48 hours carried <c>reltuples &lt; 0</c>, and 47,960 had been
+/// analyzed at some point, so the statistics exist on the targets — so
+/// <see cref="PgColumnStatsCoverageArm.StatisticsNotVisible"/> names the privilege filter as the cause and
+/// says "confirmed readable" rather than claiming a certainty the flag cannot carry.</para>
 ///
 /// <para><b>Pure policy, no clock and no I/O.</b> The caller reads the counts and passes them in, the same
 /// discipline as <c>RollingCountAlertGate</c> — which is what lets the arm selection be asserted without a

--- a/docs/postgres-first-target-runbook.md
+++ b/docs/postgres-first-target-runbook.md
@@ -372,6 +372,16 @@ target carrying 361 tables over the collector's size floor, 107 of them analyzed
 and collected nothing. An empty per-column statistics panel on a busy database means this grant is missing,
 not that the planner has no statistics.
 
+**You no longer have to know that from here.** Until #3154 that sentence was the only place the distinction
+was written down, and nobody reads a runbook while looking at an empty grid: the panel and
+`get_pg_column_stats` both listed the size floor and the privilege filter and selected neither. They now name
+which one applies, and report it on a POPULATED result too — a login that can read four tables of twenty
+produces a ranking that looks complete. `get_pg_column_stats` returns the arm as its own `coverage` field
+(`StatisticsNotVisible` is this grant; `BelowSizeFloor` is a server with nothing large enough and needs no
+action; `CollectionFault` means neither explains it and is ours to fix). The two counts behind the verdict
+come from `pg_table_bloat_stats`, which collects on **writers only**, so on a read replica the answer is
+honestly `Undetermined` rather than a guess.
+
 The fix is one grant:
 
 ```sql

--- a/docs/postgres-first-target-runbook.md
+++ b/docs/postgres-first-target-runbook.md
@@ -376,11 +376,24 @@ not that the planner has no statistics.
 was written down, and nobody reads a runbook while looking at an empty grid: the panel and
 `get_pg_column_stats` both listed the size floor and the privilege filter and selected neither. They now name
 which one applies, and report it on a POPULATED result too — a login that can read four tables of twenty
-produces a ranking that looks complete. `get_pg_column_stats` returns the arm as its own `coverage` field
-(`StatisticsNotVisible` is this grant; `BelowSizeFloor` is a server with nothing large enough and needs no
-action; `CollectionFault` means neither explains it and is ours to fix). The two counts behind the verdict
-come from `pg_table_bloat_stats`, which collects on **writers only**, so on a read replica the answer is
-honestly `Undetermined` rather than a guess.
+produces a ranking that looks complete. `get_pg_column_stats` returns the arm as its own `coverage` field, and
+every value it can take means something different to you:
+
+| `coverage` | what it means | your move |
+|---|---|---|
+| `StatisticsNotVisible` | tables clear the floor, none of their statistics are readable by the monitoring login | **this grant** |
+| `PartialVisibility` | some are readable, the rest are not — the ranking you are looking at is a subset | **this grant**; treat the result as partial until then |
+| `BelowSizeFloor` | nothing on the server is large enough for this collector to read | nothing; there is nothing to collect |
+| `FullyMeasured` | every table above the floor is represented | nothing |
+| `CollectionFault` | tables clear the floor AND are readable, and nothing was stored anyway | ours — neither cause explains it, so raise it |
+| `EvidenceStale` | rows exist, yet no table clears the floor in the evidence window | nothing on the grant; the rows describe tables that may have since shrunk, been truncated or been dropped |
+| `Undetermined` | the two counts could not be established | nothing; see below |
+
+The two counts behind every verdict come from `pg_table_bloat_stats`, which collects on **writers only** and
+hourly, so on a read replica — where `pg_column_stats` does run — the answer is honestly `Undetermined`
+rather than a guess. They are measured over a fixed 24-hour lookback while the row count is measured over
+whatever window you asked for, which is why `EvidenceStale` exists and why the census states the span beside
+each figure: do not draw a ratio between two numbers spanning different intervals.
 
 The fix is one grant:
 


### PR DESCRIPTION
Closes #3154.

## Which cause actually applies, measured

**The privilege filter, on every target that reports.** The collector was right all along; nothing could say so.

One read-only pass against a live 50-target Aurora store at **2026-09-07 21:37 UTC** — every figure below from that one instant, because a rolling count that moves is why the instant belongs beside the number:

| | |
|---|---|
| `pg_column_stats` runs, ever | **553**, **one** distinct status (SUCCESS), **0** rows stored ever, max **299 ms**, 50 servers, since 2026-08-25 |
| **reading 1** — `pg_table_bloat_stats` rows with `estimate_unavailable` TRUE | **332,611 of 332,611**, every era; FALSE on **0** |
| **reading 2** — the same collector's width arithmetic at its empty-input residue | **60,202 of 60,202** rows in 48h, all 49 reporting targets, `alignment_bytes` 8 everywhere; **0** above it |

The two readings fail differently. `estimate_unavailable` is TRUE whenever any column of a table has no `pg_stats` row — the identical filter on the identical view from the identical login. Reading 2 is independent of that flag: it is a computed width sum that can only bottom out at its empty-input value when every `avg_width` came back absent. The flag's other arms are ruled out — **2** rows of 60,202 carried `reltuples < 0`, and **47,960** had been analyzed at some point, so the statistics exist on the targets and this login cannot see them.

**The size floor is demonstrably not the explanation.** 1,263 of 1,264 distinct tables past the byte floor also clear the 128-page floor, on **all 49** reporting targets, max 8,510,902 pages, and the busiest holds **361** — which is the figure the collector's own comment cites, reproduced by the census SQL this PR ships.

Both legitimate arms occur on this fleet: one target's evidence collector ran **168** times and found no table over 1 MB.

## The defect, precisely

The chain passed the buck in a circle and nobody recorded anything:

- the collector said the shortfall is *"recorded ... so the read can say which of the two is in force"* — it never recorded it,
- the reader said *"a caller must say so"*,
- the caller recited both causes in one message and selected neither.

`docs/postgres-first-target-runbook.md` had the answer written down since the collector shipped. Nobody reads a runbook while looking at an empty grid.

## What changes

`PgColumnStatsCoverage` selects the arm at read time from what `pg_table_bloat_stats` already measured — the way `CollectorRuntimePrecondition` answers a precondition and `get_pg_blocking` gets its capture denominator. **No monitored server is touched, no schema moves, no migration rung.**

Six arms: `BelowSizeFloor`, `StatisticsNotVisible` (the only one with a remedy), `PartialVisibility`, `CollectionFault` (neither legitimate cause applies — today that reports as innocent), `FullyMeasured`, and `Undetermined` when the evidence is missing and the read says so instead of guessing.

`Undetermined` is what keeps the rest honest. `pg_table_bloat_stats` collects on writers only, and a **run count** rather than a row count is what separates "measured, and everything is small" from "never measured here" — both of which are zero candidate tables. Confirmed on the live store: 168 runs / 0 candidates versus 0 runs / 0 candidates.

`Undetermined` also depends on counting only runs that **succeeded** — the finding review caught. A bloat collector erroring on a target still writes a `collection_log` row, so an unfiltered probe said "it ran" while the collector had stored nothing, and the classifier answered `BelowSizeFloor`: *"nothing to fix."* That is this issue's own false innocence relocated one level down into the evidence collector's health, and it is the harder instance to find, because the verdict is confident and the collector it describes is not the broken one. The status set is read from `EnumeratedCollectorDriver.FreshnessSuccessStatuses` rather than retyped, so the bar is the one the freshness reads and the self-alert evaluator already apply.

The evidence lookback is a **fixed 24 hours** anchored on the read's end, not the caller's window, which is wrong in both directions. Too narrow manufactures `Undetermined`: the evidence collector is hourly, so a one-hour panel window would have reported "no evidence" for a target measured 167 times in the past week. Too wide only costs: the MCP tool defaults to 168 hours, where the census measured **242 ms against 41 ms** over a day, on a read that fires on every call. And it is not a question about history — `CollectorRuntimePrecondition` settled this shape by consulting the latest run rather than a window, on the reasoning that a precondition somebody has since satisfied must not keep being reported.

**Cost, measured on the production store** with the shipped SQL run verbatim. The run probe is `EXISTS`, not `count(*)`, because only its zero test is ever read and `collection_log` has no index on `(server_id, collector_name)` — counting meant a bitmap heap scan discarding 14,060 rows to keep 22.

| | before | after |
|---|---|---|
| busiest target, 361 candidate tables | 242 ms | **30 ms** warm (81 ms cold) |
| target with nothing over the floor | — | **7.3 ms** |
| target with no evidence | — | **6.2 ms** |
| the run probe alone | 152 ms | **6 ms**; 4.5 ms proving *absence*, the worst case for a short circuit |

And the narrowed window costs no coverage: over a 24-hour span, **all 50** targets running `pg_column_stats` have a successful `pg_table_bloat_stats` run, so `Undetermined` fires on **zero** enrolled targets. It exists for the cases that are real but not present — a read replica (where the size collector is gated off but this one runs), a failing evidence collector, a store read that throws — rather than as a fallback the fleet lands in.

Reported on the **populated** path too. A login that can read four tables of twenty produces a ranking that looks complete; `get_pg_column_stats` returns the arm as its own `coverage` field so a caller can branch on it rather than parse prose. Both surfaces call the one classifier, so the MCP tool and the WPF panel cannot answer one operator two ways.

The census and the verdict are separate members, and that is not cosmetic: the two zero arms can never hold the same counts, so a distinctness check over the composed message would pass on the numbers rather than the verdicts. `Cause` carries no figures at all and is asserted to carry none.

Also: the collector's claim to record its own shortfall is removed, and the floor becomes a named const the census SQL and the messages read rather than retype — so the figure an operator is told is the figure the query filters on.

## Verification

The `Darling.Tests` facts cannot run on macOS, so the actual test source was compiled into a `net10.0` console harness against the real build and executed: **11 of 11 pass**. It earned its keep twice — it caught the member scan matching `LoadPgColumnStatsAsync`'s *call site* 60 lines above its declaration and brace-balancing a sibling panel, and it caught the expression-bodied passthrough having no block body.

The shipped census SQL was dumped from the built assembly and run verbatim against the production store (positional parameters substituted, asserted none survived), returning all three distinguishable readings:

| target | `evidence_collector_ran` | `candidate_tables` | `visible_tables` | arm |
|---|---|---|---|---|
| busiest | `t` | **361** | 0 | `StatisticsNotVisible` |
| smallest | `t` | 0 | 0 | `BelowSizeFloor` |
| unknown | `f` | 0 | 0 | `Undetermined` |

The last two rows are the pair R5 is about: identical counts, different answers, and the run probe is the only thing that separates them.

**33 mutations, each applied in isolation, each confirmed landed before running, each required to go red naming its cause.** Including the one this issue demands — making the two zero-causes report the same thing — which reds on two facts.

Four of those mutations came back GREEN first time. Three were real gaps:

- the input-echo falsifier probed **one** input, which landed on `PartialVisibility`; a mutation echoing the counts into the `CollectionFault` cause passed it. It now probes every arm and asserts the probe set reaches every arm.
- the multi-cause-prose scan matched **per string literal**, and an operator-facing sentence here is a chain of literals wrapped at column 110. A verbatim restoration of the prose this issue is about went green. Literals are now joined before matching, and naming *either* cause in a surface's own words fails, not just both.
- deleting the one call to `EvidenceStart` left every assertion about the evidence floor green — the pure function was guarded and its call site was not, which is a correct mechanism nothing reaches, the exact shape this issue is a third instance of. Pinned now.

The fourth was a badly designed mutation of mine rather than a gap: it added an unused constant.

The mutation harness itself first reported red for all 12 — it searched the build output for `error`, which matches `0 Error(s)`, so it could not return a green. It reads the exit code now, and was re-verified against an unmutated tree before the results above were taken.

## Both review findings, fixed rather than deferred

**The coverage evidence was queried unconditionally**, ahead of the capability and precondition checks that outrank it in the `??` chain — so a server that cannot have this surface at all, or whose collector recorded a denial, paid for a round trip whose result was then discarded, and those are the callers least able to afford one. The cost is the visible half. The half worth guarding is that computing the *last* of three ranked answers *first* is how somebody later reorders the chain and does not notice they changed which one wins: every ordering compiles and every ordering returns a plausible answer, so only a source-order assertion notices. The three are now asked in `CollectorRuntimePrecondition`'s documented order, with the evidence query after the branch that decides whether anything needs it. Guarded by `TheMissAnswersAreAskedInTheirDocumentedPrecedenceOrder`; M23 and M24 red.

**`GetCoverageVerdictAsync` accepted a `startUtc` it never used.** The behaviour is right and stays — the evidence span is `EvidenceStart(endUtc)..endUtc` whatever the caller read over — but the signature was not. An accepted-and-ignored parameter is worse than an absent one: the caller passes a window, reasonably believes it is honoured, and neither the compiler nor the answer says otherwise. Dropped through the whole chain, and the guard is on the **declaration** rather than the body, because the body is exactly where an ignored parameter is conspicuously absent. `GetCoverageEvidenceAsync` keeps both ends and is asserted to, since it uses both and is what a caller wanting its own span reaches for. M25 and M26 red in both directions.

Three mutation anchors went stale against these edits and reported ANCHOR-MISS rather than red — retargeted and re-run, because a mutation that did not apply is coverage not verified, which reads identically to coverage that passed.

## The third review finding: a verdict contradicting the rows beside it

**A defect I introduced two commits earlier.** Fixing the evidence window to a day made the two counts span different intervals — evidence over a fixed 24h, `storedColumnRows` over the caller's window (168h by default) — and I did not follow that consequence into the classifier. `candidateTables <= 0` was tested before `storedColumnRows`, so a table truncated or dropped inside the last 24h left rows behind with no candidate to match, and the answer was `BelowSizeFloor`: *"no table is large enough … nothing to fix"*, printed directly above real column statistics. The self-contradiction this class exists to prevent, arriving through the window mismatch rather than the privilege filter.

**A distinct arm, not a guard on the old one.** `EvidenceStale` — because "the size evidence is stale relative to the stored rows" is a different fact about the server than either neighbouring arm, and folding it into `BelowSizeFloor` or `FullyMeasured` re-creates a verdict that does not match its data one level down. It says the evidence and the rows describe different populations, tells the reader the rows may describe tables that no longer qualify, and refuses both *"full coverage"* and *"nothing to fix"*.

Two supporting changes fall out of it. The census now labels the span each figure is measured over, so a reader comparing a 24h candidate count with a 168h row count is told **before** drawing a ratio — that label is what makes a stale verdict intelligible instead of looking like a bug. And `PartialVisibility` drops its own cross-window claim, saying only what is measured: fewer tables *confirmed readable* than clear the floor.

**Guarded as the invariant, not the branch.** `NoVerdictContradictsTheRowSetPrintedBesideIt` sweeps the reachable input space — skipping `visible > candidates`, which the census cannot produce — and asserts in both directions: a non-empty result is never told nothing was collectable, an empty one is never told coverage is whole or partial. The arm-by-arm cases enumerate *arms* and would not have caught this. Only enumerating input *regions* finds a missing branch rather than a wrong one. The sweep asserts its own reach too, so a grid that stopped visiting an arm fails rather than quietly narrowing.

Red-then-green, with the branch order reverted and everything else kept — and it pins the **arm chosen**, not merely that a verdict returned:

```
FAIL  EveryOutcomeSelectsAnArm                     expected: EvidenceStale   actual: BelowSizeFloor
FAIL  NoVerdictContradictsTheRowSetPrintedBesideIt NotEqual failed: both are BelowSizeFloor
FAIL  TheCauseCarriesNoneOfTheInputFigures         probe set no longer reaches EvidenceStale
```

The mutation compiles and returns a plausible verdict at every call site; three facts still name it. `EvidenceHours` also moves to `PgColumnStatsCoverage`, because the figure now appears in operator-facing text and the label and the query have to be one number — a mutation retyping it went green until that was pinned.

## The runbook went stale inside this PR

`docs/postgres-first-target-runbook.md` is in the diff, so this is worth naming rather than leaving to be diffed. The paragraph I added was written when there were six arms and it named **four**. Adding `EvidenceStale` left it a partial enumeration reading as though it covered the field — and the arm it omitted is the one an operator can least interpret unaided, because it prints a verdict that cannot be attributed directly beside a non-empty result.

A prose list of enum members is a frozen enumeration: right on the day it is written, silently wrong afterwards, with nothing that fails. It is now a table of **all seven** arms with the operator's move for each, and `TheRunbookNamesEveryCoverageArm` derives the expected set from `Enum.GetValues` rather than from a list somebody remembers to extend. The runbook rather than the README, because it is the file that says what to *do* about an arm — which is what a stale claim actually costs. The guard also holds the span caveat, since a doc naming `EvidenceStale` without saying the two figures span different intervals has told a reader the name of something inexplicable.

M31 (add an arm, leave the runbook alone), M32 (drop the span caveat) and M33 (strip the field name from the table header) all red. M33 exposed a weak assertion of my own first: `Assert.Contains("\`coverage\`")` passes on a mention three sections away, so it is now pinned to the table header — the occurrence a reader keys off.

## CHANGELOG entry text

```
- **PostgreSQL column statistics now say WHICH cause produced an empty result** (#3154) — `pg_column_stats` had never stored a row on any target: 553 runs, one distinct status, zero rows in every era, a NULL note on 99 of the last 100. The collector documents two legitimate ways to return nothing — a 128-page size floor and `pg_stats`' `has_column_privilege` filter — and distinguished them in its documentation and not in its output, while both reads recited both causes in one message and selected neither. Measured across 49 Aurora targets, the answer is the privilege filter on every one: `estimate_unavailable` is TRUE on 332,611 of 332,611 table measurements, and the size floor is not the explanation because 1,263 of 1,264 qualifying tables clear it. `get_pg_column_stats` now returns the arm as a `coverage` field and both surfaces print one classifier's verdict — including on a populated result, where a login that can read four tables of twenty produces a ranking that looks complete. A collection fault, which neither legitimate cause explains, is now its own answer instead of reading as innocent; a target whose evidence collector is FAILING reports undetermined rather than "nothing to fix"; and where the evidence is simply absent — a read replica, where the size collector does not run — the read says so rather than guessing. The verdict is served from measurements already in the store, so no monitored server is touched and no schema moves: 30 ms on the busiest target.
```
