### PR TITLE
Give pg_index_bloat its rows in the runbook's cadence and tool tables, and drop a per-database count that was wrong twice over

### DIFF
--- a/docs/postgres-first-target-runbook.md
+++ b/docs/postgres-first-target-runbook.md
@@ -292,11 +292,24 @@ difference a cumulative counter, so the first read after startup legitimately sh
 | `pg_autovacuum_stats` | 60 min | **60 min** | 2 h (growing/flat needs two) |
 | `pg_table_bloat_stats` | 60 min | **60 min** | 2 h (growing/flat needs two) |
 | `pg_index_usage_stats` | 24 h | **24 h** | 48 h (a scan count is a difference) |
+| `pg_index_bloat` | 24 h | **24 h** | a full PASS, not one cycle (see below) |
 
-The three per-database collectors are the ones that surprise people. `pg_autovacuum_stats` and
-`pg_table_bloat_stats` take an hour before the first row and two before "growing or flat" can be answered;
-`pg_index_usage_stats` takes a **day**, and two before a windowed scan count exists at all. Those cadences
-are deliberate — a PostgreSQL connection is bound to one database for life, so per-database collection
+The per-database collectors are the ones that surprise people — seven of them at the time of writing,
+which is every collector whose `RunsPerDatabase` returns true, so count them from `CollectorCatalog`
+rather than from this sentence. `pg_autovacuum_stats` and `pg_table_bloat_stats` take an hour before the
+first row and two before "growing or flat" can be answered; `pg_index_usage_stats` takes a **day**, and
+two before a windowed scan count exists at all.
+
+`pg_index_bloat` is the one whose first-answer column needs reading carefully. A cycle measures a
+**bounded, rotating slice** rather than every index — the cursor resumes below wherever the previous
+cycle stopped and wraps at the end of a pass — so a day gets you rows, and a complete answer for the
+whole index population takes a full pass. It also needs the `pgstattuple` extension created in
+`public`, or it reports the function as missing rather than returning bloat. And it is the **complete
+btree census with no size floor**, while `pg_index_usage_stats` floors at 64 kB, which is why the two
+report row counts differing by roughly 65% on the same target: the gap is entirely indexes too small
+for usage statistics to be worth recording.
+
+Those cadences are deliberate — a PostgreSQL connection is bound to one database for life, so per-database collection
 costs one connection per database per cycle, and index usage is a structural question that an hourly
 sample would re-record 24 times a day for nothing.
 
@@ -320,6 +333,7 @@ Through MCP, one tool per collector:
 | `get_pg_blocking` | blocking chains that were SAMPLED, with the root attributed |
 | `get_pg_database_stats` | temp-file spills, cache hit ratio, deadlocks, commit/rollback split |
 | `get_pg_index_usage` | which indexes nothing scans — **and whether each one can actually be dropped** |
+| `get_pg_index_bloat` | how much of each index is dead space — over a **rotating slice per cycle**, so read `measured_at` before treating a density as current |
 | `get_pg_table_bloat` | how much space the vacuum lag above has cost, as an **estimate** with its own error stated |
 | `get_pg_session_states` | who is holding a transaction open — **and whether they actually pin the xmin horizon** |
 


### PR DESCRIPTION
`docs/postgres-first-target-runbook.md` listed every other PostgreSQL collector in both its cadence table and its MCP tool table, and omitted `pg_index_bloat` from both — so the runbook answered "when does this answer arrive" and "how do I read it" for everything except the collector whose answer arrives differently from all of them.

## The cadence row

`pg_index_bloat` is `(1440, 90)` in `CollectorScheduleDefaults`, so 24 h like `pg_index_usage_stats`. Its **first-answer** cell is the one that differs, and it says a full **pass** rather than one cycle: after #3153/#3163 a cycle measures a bounded, **rotating** slice, resuming below wherever the previous cycle stopped and wrapping at the end of a pass. A day gets you rows; a complete answer for the whole index population takes a pass.

The prose beside it now carries two things a reader needs before trusting a density:

- it requires `pgstattuple` created in `public`, or it reports the function as missing rather than returning bloat;
- it is the **complete btree census with no size floor**, while `pg_index_usage_stats` floors at 64 kB — which is why the two report row counts differing by roughly 65% on the same target (#3158). The gap is entirely indexes too small for usage statistics to be worth recording, so neither census is wrong.

## The tool row

`get_pg_index_bloat` is registered in `DarlingMcpPgIndexTools.cs` and was absent from §8. Its entry points at `measured_at`, because under rotation the newest row for an index is often a label rather than a measurement.

## The counted claim is dropped, not corrected

The prose said *"The three per-database collectors are the ones that surprise people"* and named `pg_autovacuum_stats`, `pg_table_bloat_stats`, `pg_index_usage_stats`.

**It was wrong twice over.** Counted from the catalog rather than from the sentence, there are **seven** collectors whose `RunsPerDatabase` returns true: `pg_autovacuum_stats`, `pg_column_stats`, `pg_extension_availability`, `pg_index_bloat`, `pg_index_usage_stats`, `pg_predicate_stats`, `pg_table_bloat_stats`. And the three it named are a **different set** from the three the V95 migration comment names (`pg_column_stats`, `pg_index_bloat`, `pg_extension_availability`) — six distinct names between two sentences that both say "three".

So the numeral is gone in favour of naming the derivation: the sentence now says the class is every collector whose `RunsPerDatabase` returns true and to count them from `CollectorCatalog` rather than from the sentence. A count in prose is a frozen enumeration — right the day it is written, silently wrong after, with nothing failing.

## Checked rather than assumed

- The only pin that reads this file is `TheRunbookNamesEveryCoverageArm`, which asserts every `PgColumnStatsCoverageArm` value appears plus the `` | `coverage` | `` table header. Both verified by hand against the edited file — all 7 arms present, header intact.
- No test asserts any string this diff changes. The two source hits for "three per-database" are migration comments about V95's own scope, which remain accurate about V95 and were left alone.
- Line endings preserved: 535 CRLF, 0 bare LF, no BOM.
- Docs-only diff, so `build` will take the docs fast path; that is correct here rather than a no-op to be suspicious of.

**A schema question I raised and then closed against myself:** having found seven per-database collectors where V95 attributed `database_name` to three, I checked whether the other four lacked it. My first check returned zero for all seven — including the three V95 explicitly names, which is what gave it away as a broken extraction rather than a finding. Read directly, every per-database table carries `database_name` in its `CREATE TABLE`. **There is no gap**, and this paragraph exists so the non-finding is on the record rather than half-remembered.

## CHANGELOG entry text (not committed)

Under `### Fixed`:

> The PostgreSQL runbook lists `pg_index_bloat` in its cadence and MCP tool tables, with its first-answer time stated as a full rotation pass rather than one cycle, and its `pgstattuple` requirement and no-size-floor census beside it. The "three per-database collectors" count is replaced by the rule for deriving it, since there are seven and the sentence named a different three from the one the V95 migration comment names.