### PR TITLE
Let a collector definition record what it measured on its own collection_log row (#3161)

### DIFF
--- a/Darling/Darling.Tests/CollectionLogDrainForensicsStoreTests.cs
+++ b/Darling/Darling.Tests/CollectionLogDrainForensicsStoreTests.cs
@@ -185,10 +185,10 @@ public class CollectionLogDrainForensicsStoreTests
     [Fact]
     public void TheForensicsAreAbsentUnlessThePathMeasuredThem()
     {
-        Assert.Null(new CollectorRunResult(0, 0, 0).Drain);
+        Assert.Null(new CollectorRunResult(0, 0, 0, CollectorContext.NoMeasurements).Drain);
 
         var measured = new CollectorRunResult(
-            0, 120051, 0, Abandoned: true, ServerPhasesMeasured: true,
+            0, 120051, 0, CollectorContext.NoMeasurements, Abandoned: true, ServerPhasesMeasured: true,
             ServerOpenMs: 104, ServerDrainMs: 119945,
             ServerRowsRead: 0, ServerBytesRead: 0, ServerLastReadMs: -1, TargetSessionId: 77);
 
@@ -213,7 +213,7 @@ public class CollectionLogDrainForensicsStoreTests
     {
         /* Exactly the shape the abandon-during-open path produces. */
         var openStall = new CollectorRunResult(
-            0, 120051, 0, Abandoned: true, ServerPhasesMeasured: true,
+            0, 120051, 0, CollectorContext.NoMeasurements, Abandoned: true, ServerPhasesMeasured: true,
             ServerOpenMs: 120051, ServerDrainMs: 0);
 
         var drain = openStall.Drain!.Value;

--- a/Darling/Darling.Tests/CollectionLogPhaseSplitStoreTests.cs
+++ b/Darling/Darling.Tests/CollectionLogPhaseSplitStoreTests.cs
@@ -9,6 +9,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Service.Mcp;
 using PerformanceMonitor.Darling.Storage;
@@ -108,7 +109,7 @@ public class CollectionLogPhaseSplitStoreTests
     public void ThePhaseTriple_IsAllOrNothing_AndAMeasuredZeroSurvives()
     {
         var measured = new CollectorRunResult(
-            Rows: 150, SqlMs: 4902, StorageMs: 300,
+            Rows: 150, SqlMs: 4902, StorageMs: 300, Measurements: CollectorContext.NoMeasurements,
             ServerPhasesMeasured: true, ServerOpenMs: 149, ServerDrainMs: 4724, ServerWatermarkMs: 51);
 
         var phases = measured.ServerPhases;
@@ -121,14 +122,14 @@ public class CollectionLogPhaseSplitStoreTests
            "this path emits no split", which is a different fact and the one #2851 added the flag to tell
            apart. */
         var instant = new CollectorRunResult(
-            Rows: 5, SqlMs: 100, StorageMs: 10,
+            Rows: 5, SqlMs: 100, StorageMs: 10, Measurements: CollectorContext.NoMeasurements,
             ServerPhasesMeasured: true, ServerOpenMs: 0, ServerDrainMs: 0, ServerWatermarkMs: 0);
 
         Assert.NotNull(instant.ServerPhases);
         Assert.Equal(0, instant.ServerPhases!.Value.OpenMs);
 
         /* Not measured - the enumerated and per-database paths - stores nothing rather than three zeros. */
-        var unmeasured = new CollectorRunResult(Rows: 10, SqlMs: 500, StorageMs: 20);
+        var unmeasured = new CollectorRunResult(Rows: 10, SqlMs: 500, StorageMs: 20, Measurements: CollectorContext.NoMeasurements);
         Assert.Null(unmeasured.ServerPhases);
     }
 

--- a/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
+++ b/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
@@ -1,0 +1,555 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Service;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3161: a collector DEFINITION can contribute to <c>collection_log.error_message</c>, and what it
+/// contributes is COUNTS.
+///
+/// <para><b>The defect.</b> Every value <c>CollectorRunResult.Note</c> could take was runner-authored, so a
+/// collector that could work out why it returned nothing — cheaply, on the target, inside the round trip it
+/// had already made — had nowhere to put it, and the run recorded SUCCESS with a NULL note. Five issues in a
+/// row were that shape (#3030, #3109, #3114, #3153, #3154) and every one was repaired at READ time, because
+/// read time was the only seam that existed.</para>
+///
+/// <para><b>Why counts and not verdicts, which is what these pins are mostly about.</b>
+/// <c>CollectorRuntimePrecondition</c> (#2546) argues that a MUTABLE, ACTIONABLE condition has to be
+/// re-derived on every read, and it is right: a stored verdict "would silently ignore the fix we ourselves
+/// recommended, which is the worst possible direction to be wrong in". A stored COUNT has no such problem —
+/// <c>candidates=1264 visible=0</c> is a fact about one instant and stays true, and the read draws the
+/// conclusion fresh every time it looks.</para>
+///
+/// <para><b>The guard is STRUCTURAL, and deliberately not a keyword check.</b> A blocklist over free prose
+/// passes on the wording nobody thought of, and it is the kind of pin that reports discrimination it stopped
+/// providing. <see cref="CollectorMeasurement.Value"/> being a <see cref="long"/> is what makes a verdict
+/// unrepresentable, and the label grammar is what stops the sentence relocating one field left. Those two
+/// are pinned separately here, and for the reason PR #3159 arrived at independently one collector over:
+/// <c>PgColumnStatsCoverage</c> keeps its <c>Census</c> free of verdicts and its <c>Cause</c> free of
+/// counts as SEPARATE pins, because a distinctness check over the combined message would pass on the
+/// numbers rather than on the verdicts.</para>
+/// </summary>
+public class CollectorMeasurementSeamTests
+{
+    /* A rendered note may contain NOTHING but label=value tokens separated by single spaces. Anchored at
+       both ends, so an appended clause fails rather than being tolerated as a suffix. */
+    private static readonly Regex s_countsOnly =
+        new(@"^[a-z][a-z0-9_]*=-?[0-9]+( [a-z][a-z0-9_]*=-?[0-9]+)*$", RegexOptions.Compiled);
+
+    /* ── the structural half: a verdict is unrepresentable, rather than discouraged ── */
+
+    [Fact]
+    public void TheMeasuredValueIsAnInteger_SoAStoredVerdictIsUnrepresentable()
+    {
+        /* The pin that carries the whole design. If this type ever widens its value to string or object —
+           the obvious "let a collector explain itself properly" change — then every other guard in this file
+           becomes advisory, because prose would have a first-class home again and #2546's stale-gate defect
+           would be back with our own blessing. Asserted by reflection on the TYPE rather than by trying to
+           store a sentence, because the failure being prevented is a compile-time widening that no runtime
+           attempt can reach. */
+        var value = typeof(CollectorMeasurement).GetProperty(nameof(CollectorMeasurement.Value));
+
+        Assert.NotNull(value);
+        Assert.Equal(typeof(long), value!.PropertyType);
+    }
+
+    [Fact]
+    public void ADefinitionSuppliedNoteCarriesNoRenderedConclusion_EvenWhenHandedOne()
+    {
+        /* The adversarial direction, and the one that makes this pin discriminate what it claims rather than
+           something adjacent: the caller tries to put a real verdict through the seam. Not an invented
+           sentence — PgColumnStatsCoverage.PrivilegeRemedy is the actual shipped remedy text for the actual
+           collector #3154 was filed about, so if this seam can carry a conclusion, THAT is the conclusion it
+           would carry. */
+        var context = Context();
+        context.Measure("candidates", 1264);
+        context.Measure("visible", 0);
+
+        var note = CollectorMeasurementNote.Render(context.Measurements);
+
+        Assert.NotNull(note);
+        Assert.Equal("candidates=1264 visible=0", note);
+        Assert.Matches(s_countsOnly, note!);
+
+        /* And the same seam handed the verdict directly renders no part of it. */
+        var handFed = new[]
+        {
+            new CollectorMeasurement("candidates", 1264),
+            new CollectorMeasurement(PgColumnStatsCoverage.PrivilegeRemedy, 1),
+            new CollectorMeasurement("statistics not visible to this login; GRANT SELECT", 1),
+        };
+
+        var rendered = CollectorMeasurementNote.Render(handFed);
+
+        Assert.NotNull(rendered);
+        Assert.Matches(s_countsOnly, rendered!);
+        Assert.DoesNotContain("GRANT", rendered!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("not visible", rendered!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(PgColumnStatsCoverage.PrivilegeRemedy, rendered!, StringComparison.Ordinal);
+
+        /* The two it refused are COUNTED, not swallowed. A silent drop would be the same invisibility this
+           whole seam exists to end, one level up. */
+        Assert.Equal(
+            "candidates=1264 " + CollectorMeasurementNote.RejectedLabelCount + "=2",
+            rendered);
+    }
+
+    [Theory]
+    /* Every spelling of a sentence, and each is rejected by more than one clause of the grammar. */
+    [InlineData("statistics not visible to this login")]
+    [InlineData("GRANT SELECT")]
+    [InlineData("Remedy: grant the monitoring login read access")]
+    [InlineData("candidates=1264 visible=0")]
+    [InlineData("events read")]
+    [InlineData("events-read")]
+    [InlineData("events.read")]
+    [InlineData("EventsRead")]
+    [InlineData("Events_Read")]
+    [InlineData("_events_read")]
+    [InlineData("1events")]
+    [InlineData("")]
+    [InlineData(null)]
+    /* Long enough that no clause fits is part of the grammar, so the ceiling is pinned as grammar. */
+    [InlineData("this_label_is_far_too_long_to_be_a_count_name_and_is_really_a_sentence")]
+    public void TheLabelGrammarRejectsAnythingThatCouldHoldAClause(string? label)
+    {
+        Assert.False(CollectorMeasurementNote.IsValidLabel(label));
+
+        /* And Measure REFUSES it rather than storing it — the chokepoint a definition actually goes
+           through. Throwing is right here and only here: labels are first-party constants in definition
+           source, so this is a build-and-test-time failure, and
+           EveryMeasurementLabelInTheCollectorsIsLegal below is what keeps it out of a release. */
+        Assert.Throws<ArgumentException>(() => Context().Measure(label!, 1));
+    }
+
+    [Theory]
+    [InlineData("events_read")]
+    [InlineData("candidates")]
+    [InlineData("visible")]
+    [InlineData("a")]
+    [InlineData("tables_above_floor_24h")]
+    public void TheLabelGrammarAcceptsACountName(string label)
+    {
+        Assert.True(CollectorMeasurementNote.IsValidLabel(label));
+
+        var context = Context();
+        context.Measure(label, 7);
+
+        Assert.Equal(label + "=7", CollectorMeasurementNote.Render(context.Measurements));
+    }
+
+    [Fact]
+    public void TheCeilingIsTheGrammarsOwnConstant_NotARetypedNumber()
+    {
+        /* At the ceiling is legal and one past it is not, asserted against the constant rather than against
+           40 — a pin that retyped the number would keep passing while the two disagreed. */
+        var atCeiling = "a" + new string('b', CollectorMeasurementNote.MaxLabelLength - 1);
+        Assert.Equal(CollectorMeasurementNote.MaxLabelLength, atCeiling.Length);
+        Assert.True(CollectorMeasurementNote.IsValidLabel(atCeiling));
+        Assert.False(CollectorMeasurementNote.IsValidLabel(atCeiling + "b"));
+    }
+
+    /* ── counts, so repeats sum: the property that makes the fan-out shapes correct ── */
+
+    [Fact]
+    public void MeasureAccumulatesARepeatedLabel_SoAPerDatabaseCycleReportsItsSum()
+    {
+        /* The host calls ReadAsync once per database against ONE context on the Azure per-database shape
+           (blocked_process_report.RunsPerDatabase is true there), and once per item on the enumerated shape.
+           Appending instead of accumulating would render "events_read=3 events_read=0 events_read=11", which
+           is not a count of anything — and a reader summing it by eye would get the right answer for the
+           wrong reason on the day one database is missing. */
+        var context = Context();
+        context.Measure("events_read", 3);
+        context.Measure("events_read", 0);
+        context.Measure("events_read", 11);
+        context.Measure("events_stored", 2);
+
+        Assert.Equal(2, context.Measurements.Count);
+        Assert.Equal("events_read=14 events_stored=2", CollectorMeasurementNote.Render(context.Measurements));
+
+        /* First-measured order is kept, so the pairs read in the order the definition declared them rather
+           than in whatever order the last cycle happened to touch them. */
+        Assert.Equal("events_read", context.Measurements[0].Label);
+    }
+
+    /* ── composition: the definition half is exactly the counts, and nothing else ── */
+
+    [Fact]
+    public void AnOrdinaryRunLeavesTheColumnNull_ExactlyAsBefore()
+    {
+        /* 69 collectors measure nothing. None of them may start writing a note. */
+        Assert.Null(CollectorMeasurementNote.Render(CollectorContext.NoMeasurements));
+        Assert.Null(CollectorMeasurementNote.Compose(null, CollectorContext.NoMeasurements));
+        Assert.Null(new CollectorRunResult(12, 34, 56, CollectorContext.NoMeasurements).Note);
+    }
+
+    [Fact]
+    public void TheDefinitionHalfOfAComposedNoteIsExactlyTheRenderedCounts()
+    {
+        /* The complement of the no-conclusion pin: the HOST cannot wrap the counts in a sentence on the way
+           past either. With no host note the composed value IS the render, character for character, and with
+           one the render survives intact at the tail. */
+        var context = Context();
+        context.Measure("events_read", 40);
+        context.Measure("events_stored", 0);
+
+        var rendered = CollectorMeasurementNote.Render(context.Measurements)!;
+
+        Assert.Equal(rendered, CollectorMeasurementNote.Compose(null, context.Measurements));
+        Assert.Equal(rendered, CollectorMeasurementNote.Compose("   ", context.Measurements));
+
+        var composed = CollectorMeasurementNote.Compose(
+            EnumeratedCollectorDriver.EmptyEnumerationMessage, context.Measurements);
+
+        Assert.Equal(
+            EnumeratedCollectorDriver.EmptyEnumerationMessage + "; " + rendered,
+            composed);
+
+        /* Host note FIRST, because both hosts truncate this column and the classified half is the one that
+           has to survive a cut. */
+        Assert.StartsWith(EnumeratedCollectorDriver.EmptyEnumerationMessage, composed, StringComparison.Ordinal);
+        Assert.EndsWith(rendered, composed, StringComparison.Ordinal);
+    }
+
+    /* ── the discrimination claim: the COUNTS separate the outcomes, the NOTE concludes nothing ── */
+
+    [Fact]
+    public void TheCountsSeparateAQuietServerFromAFault_WhileTheNoteJudgesNeither()
+    {
+        /* Both halves of the claim, in one place, because either alone is satisfiable by the wrong thing:
+           notes that never differ would pass a no-verdict check, and notes that name their verdict would
+           pass a distinctness check. This is the pair PR #3159 pinned separately for the same reason. */
+        var quiet = Measured(("events_read", 0), ("report_xml_empty", 0), ("report_xml_unparsed", 0), ("events_stored", 0));
+        var fault = Measured(("events_read", 40), ("report_xml_empty", 0), ("report_xml_unparsed", 40), ("events_stored", 0));
+        var healthy = Measured(("events_read", 40), ("report_xml_empty", 0), ("report_xml_unparsed", 0), ("events_stored", 40));
+
+        /* They discriminate: three outcomes that used to be one SUCCESS-with-a-NULL-note are now three
+           distinct rows. */
+        Assert.NotEqual(quiet, fault);
+        Assert.NotEqual(fault, healthy);
+        Assert.NotEqual(quiet, healthy);
+
+        /* And not one of them says WHICH it is. The verdict is the read's job, every time it reads. */
+        foreach (var note in new[] { quiet, fault, healthy })
+        {
+            Assert.Matches(s_countsOnly, note);
+
+            foreach (var verdict in new[]
+                     {
+                         "fault", "quiet", "idle", "healthy", "broken", "cannot", "unable", "failed",
+                         "grant", "privilege", "permission", "remedy", "should", "expected", "not measured",
+                     })
+            {
+                Assert.DoesNotContain(verdict, note, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+
+    /* ── the consumer, run for real ── */
+
+    [Fact]
+    public async Task BlockedProcessReportMeasuresWhatItReadAndWhatItDropped()
+    {
+        /* Against the collector's own ReadAsync and its real 5-column projection, not a description of it.
+           A quiet server and a server whose every captured report we failed to parse both arrived as
+           SUCCESS / zero rows / NULL note before this, and only the second is a fault. */
+        var quiet = Context();
+        var quietRows = await BlockedProcessReportCollector.Instance.ReadAsync(
+            MakeReader(Array.Empty<string?>()), quiet, CancellationToken.None);
+
+        Assert.Empty(quietRows);
+        Assert.Equal(
+            "events_read=0 report_xml_empty=0 report_xml_unparsed=0 events_stored=0",
+            CollectorMeasurementNote.Render(quiet.Measurements));
+
+        /* Three captured events: one with no report XML at all, one whose XML will not parse, one good. */
+        var mixed = Context();
+        var mixedRows = await BlockedProcessReportCollector.Instance.ReadAsync(
+            MakeReader(new[] { null, "<not-a-blocked-process-report/>", ReportXml }), mixed, CancellationToken.None);
+
+        Assert.Single(mixedRows);
+        Assert.Equal(
+            "events_read=3 report_xml_empty=1 report_xml_unparsed=1 events_stored=1",
+            CollectorMeasurementNote.Render(mixed.Measurements));
+
+        /* The one that matters: the ring buffer delivered events and NOT ONE became a row. Indistinguishable
+           from the quiet server above until this seam existed. */
+        var allDropped = Context();
+        var droppedRows = await BlockedProcessReportCollector.Instance.ReadAsync(
+            MakeReader(new[] { "<not-a-blocked-process-report/>", "<not-a-blocked-process-report/>" }),
+            allDropped,
+            CancellationToken.None);
+
+        Assert.Empty(droppedRows);
+        Assert.Equal(
+            "events_read=2 report_xml_empty=0 report_xml_unparsed=2 events_stored=0",
+            CollectorMeasurementNote.Render(allDropped.Measurements));
+    }
+
+    [Fact]
+    public void TheConsumersLabelsAreLegalAndDistinct()
+    {
+        var labels = new[]
+        {
+            BlockedProcessReportCollector.EventsReadMeasurement,
+            BlockedProcessReportCollector.EmptyReportMeasurement,
+            BlockedProcessReportCollector.UnparsedReportMeasurement,
+            BlockedProcessReportCollector.EventsStoredMeasurement,
+        };
+
+        Assert.All(labels, label => Assert.True(CollectorMeasurementNote.IsValidLabel(label), label));
+
+        /* Distinct, or Measure would silently ACCUMULATE two different readings into one figure — the
+           accumulation that is correct across a fan-out is wrong between two different counts. */
+        Assert.Equal(labels.Length, labels.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /* ── the labels that actually ship ── */
+
+    [Fact]
+    public void EveryMeasurementLabelInTheCollectorsIsLegal()
+    {
+        /* Measure THROWS on an illegal label, which would turn a first-party typo into a FAILING collector
+           on a healthy server — the loud unrelated defect this seam is supposed to avoid trading the quiet
+           one for. This is the gate that means it cannot get that far.
+
+           Read through CSharpSourceWalker rather than a bare regex, because a label named in a comment or
+           a doc-comment must not count as a call — three hand-rolled maskers in this repo produced three
+           different wrong answers, and two of them agreed. It resolves BOTH argument spellings: a literal
+           at the call site, and the `const string` a collector declares for it (which is the form the one
+           shipped consumer uses, so a literal-only scan would have checked nothing while passing).
+
+           An argument it CANNOT resolve FAILS rather than being skipped. That is the direction that costs
+           least to be wrong in: a future author passing a computed label is told to make it a const, where
+           a skip would silently exempt exactly the case a scanner cannot reason about. */
+        var directory = Path.Combine(RepoFile.Root, "PerformanceMonitor.Collectors");
+        var files = Directory.EnumerateFiles(directory, "*.cs", SearchOption.TopDirectoryOnly).ToList();
+
+        /* The sweep is only evidence if it read the tree. An empty enumeration would pass this test while
+           checking nothing, which is the shape of a guard that cannot fail. */
+        Assert.True(files.Count > 90, $"the sweep found only {files.Count} .cs files under {directory}");
+
+        var callSites = 0;
+        var resolved = new List<string>();
+
+        foreach (var file in files)
+        {
+            var source = File.ReadAllText(file);
+            var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+            var literals = CSharpSourceWalker.StringLiteralBodies(source)
+                .ToDictionary(l => l.Start, l => l.Text);
+
+            /* `const string NAME = "..."` — the const map, keyed by the literal that follows the
+               declaration in the CODE stream (so a declaration inside a comment contributes nothing). */
+            var constants = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var (offset, text) in literals)
+            {
+                var declaration = Regex.Match(
+                    code[..Math.Max(0, offset - 1)],
+                    @"const\s+string\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*$");
+
+                if (declaration.Success)
+                {
+                    constants[declaration.Groups[1].Value] = text;
+                }
+            }
+
+            foreach (var call in Regex.Matches(code, @"\.Measure\(").Cast<Match>())
+            {
+                callSites++;
+
+                var argumentStart = call.Index + call.Length;
+                var comma = code.IndexOf(',', argumentStart);
+                Assert.True(comma > argumentStart, $"unparsable Measure( call in {Path.GetFileName(file)}");
+
+                var argument = source[argumentStart..comma].Trim();
+                string? label;
+
+                if (argument.StartsWith('"'))
+                {
+                    /* A literal at the call site: its body starts one character past the opening quote. */
+                    var quote = source.IndexOf('"', argumentStart);
+                    Assert.True(literals.TryGetValue(quote + 1, out label),
+                        $"could not read the literal label at {Path.GetFileName(file)}:{quote}");
+                }
+                else
+                {
+                    /* An identifier, optionally type-qualified. The declaring collector is the one that
+                       calls it, so the last segment is the const name in this same file. */
+                    var name = argument[(argument.LastIndexOf('.') + 1)..];
+                    Assert.True(
+                        constants.TryGetValue(name, out label),
+                        $"measurement label argument \"{argument}\" in {Path.GetFileName(file)} resolves to "
+                        + "no `const string` in that file — declare the label as a const beside the "
+                        + "collector so this gate can read it");
+                }
+
+                Assert.True(
+                    CollectorMeasurementNote.IsValidLabel(label),
+                    $"illegal measurement label \"{label}\" in {Path.GetFileName(file)} — Measure would "
+                    + "throw at runtime and fail an otherwise healthy collector");
+
+                resolved.Add(label!);
+            }
+        }
+
+        /* And the scan REACHED the calls that ship, or it proved nothing about them. Compared against the
+           consumer's own constants rather than a literal count, so a fifth measurement fails here until
+           this expectation is updated instead of passing on a stale numeral. */
+        Assert.True(callSites > 0, "the scan found no Measure( call sites at all");
+
+        Assert.Equal(
+            new[]
+            {
+                BlockedProcessReportCollector.EventsReadMeasurement,
+                BlockedProcessReportCollector.EmptyReportMeasurement,
+                BlockedProcessReportCollector.UnparsedReportMeasurement,
+                BlockedProcessReportCollector.EventsStoredMeasurement,
+            }.OrderBy(l => l, StringComparer.Ordinal).ToList(),
+            resolved.Distinct(StringComparer.Ordinal).OrderBy(l => l, StringComparer.Ordinal).ToList());
+    }
+
+    /* ── both SKUs, or the member reads as permanently empty in one of them ── */
+
+    [Fact]
+    public void DarlingsRunNoteIsComputed_SoTheHostCannotReadOneHalfWithoutTheOther()
+    {
+        var note = typeof(CollectorRunResult).GetProperty(nameof(CollectorRunResult.Note));
+
+        Assert.NotNull(note);
+
+        /* No setter, and no init accessor either — there is no spelling of "the host note alone" for a
+           caller to reach for. This is the parity guarantee: a shared seam wired into one runner reads as a
+           permanently-empty value in the other SKU and NOTHING FAILS TO BUILD, which is the failure mode
+           CONTRIBUTING's two-store parity rules name. */
+        Assert.Null(note!.SetMethod);
+
+        /* And the definition's half is REQUIRED on the way in, so the compiler names every construction site
+           rather than a grep doing it. This is what turned "roughly the success return plus the early
+           outs" into an enumerated 22. */
+        var constructor = typeof(CollectorRunResult).GetConstructors().Single();
+        var measurements = constructor.GetParameters()
+            .Single(p => p.Name == nameof(CollectorRunResult.Measurements));
+
+        Assert.False(measurements.IsOptional);
+        Assert.Equal(typeof(IReadOnlyList<CollectorMeasurement>), measurements.ParameterType);
+
+        /* Both halves reach the column, in that order. */
+        var result = new CollectorRunResult(
+            0, 5, 0,
+            new[] { new CollectorMeasurement("events_read", 0) },
+            EnumeratedCollectorDriver.EmptyEnumerationMessage);
+
+        Assert.Equal(
+            EnumeratedCollectorDriver.EmptyEnumerationMessage + "; events_read=0",
+            result.Note);
+    }
+
+    [Fact]
+    public void LitesRunNoteIsComputedTheSameWay_ThroughTheSameSharedCompose()
+    {
+        /* Lite's WPF assembly is not referenced here, so this half is a source pin; Lite.Tests asserts the
+           same thing against the live object. Both are needed: the source pin is what fails in THIS
+           project's CI when Darling gains a note channel Lite never learned about. */
+        var source = RepoFile.ReadRepoFile("Lite", "Services", "RemoteCollectorService.cs");
+
+        Assert.Contains(
+            "public string? Note => CollectorMeasurementNote.Compose(HostNote, Measurements);",
+            source);
+
+        /* The settable Note is GONE rather than merely unused — while it existed, the read site could pick
+           up the host half and drop the definition half without anything failing to build. */
+        Assert.DoesNotContain("public string? Note { get; set; }", source);
+
+        /* And the bridge to the column still reads the composed property. */
+        Assert.Contains("errorMessage = telemetry.Note;", source);
+
+        /* Darling's own runner passes the LIVE list at its success return and the empty one everywhere else;
+           the argument being required is what makes that a choice each site had to state. */
+        var runner = RepoFile.ReadRepoFile(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingCollectorRunner.cs");
+        var definitionRunner = RepoFile.ReadRepoFile(
+            "Lite", "Services", "RemoteCollectorService.DefinitionRunner.cs");
+
+        Assert.Contains("storageMs, context.Measurements, collectionNote", Regex.Replace(runner, @"\s+", " "));
+        Assert.Contains("telemetry.Measurements.AddRange(context.Measurements);", definitionRunner);
+    }
+
+    /* ── helpers ── */
+
+    private static string Measured(params (string Label, long Value)[] counts)
+    {
+        var context = Context();
+        foreach (var (label, value) in counts)
+        {
+            context.Measure(label, value);
+        }
+
+        return CollectorMeasurementNote.Render(context.Measurements)!;
+    }
+
+    private static CollectorContext Context() => new()
+    {
+        ServerId = 42,
+        ServerName = "test-server",
+        CollectionTime = new DateTime(2026, 9, 7, 12, 0, 0, DateTimeKind.Utc),
+        Deltas = null!,
+        Target = new CollectorTargetInfo(),
+    };
+
+    private const string ReportXml =
+        "<blocked-process-report monitorLoop=\"7\">" +
+        "<blocked-process><process spid=\"55\" ecid=\"0\" waittime=\"9000\" " +
+        "waitresource=\"PAGE: 6:5:2093167\" currentdbname=\"target_database\">" +
+        "<inputbuf>UPDATE dbo.some_table SET x = 1;</inputbuf></process></blocked-process>" +
+        "<blocking-process><process spid=\"66\" ecid=\"0\"><inputbuf>BEGIN TRAN;</inputbuf></process></blocking-process>" +
+        "</blocked-process-report>";
+
+    /// <summary>
+    /// The collector's real 5-column payload projection, one row per supplied report XML (null renders as
+    /// SQL NULL — the "event captured, no report" case). CapturePlanXml stays false, which is the shape that
+    /// omits the two trailing plan ordinals entirely.
+    /// </summary>
+    private static DataTableReader MakeReader(string?[] reports)
+    {
+        var payload = new DataTable("payload");
+        payload.Columns.Add("event_time", typeof(DateTime));
+        payload.Columns.Add("blocked_process_report_xml", typeof(string));
+        payload.Columns.Add("object_id", typeof(int));
+        payload.Columns.Add("database_id", typeof(int));
+        payload.Columns.Add("contentious_object", typeof(string));
+
+        foreach (var report in reports)
+        {
+            payload.Rows.Add(
+                new DateTime(2026, 9, 7, 11, 59, 0, DateTimeKind.Utc),
+                (object?)report ?? DBNull.Value,
+                DBNull.Value,
+                6,
+                DBNull.Value);
+        }
+
+        var dataSet = new DataSet();
+        dataSet.Tables.Add(payload);
+        return dataSet.CreateDataReader();
+    }
+}

--- a/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
+++ b/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
@@ -72,6 +72,28 @@ public class CollectorMeasurementSeamTests
     }
 
     [Fact]
+    public void TheMeasurementTypeCarriesOnlyANameAndACount()
+    {
+        /* The escape route the grammar pins CANNOT see, found by mutation: adding a third member —
+           `string? Detail`, "counts are great but let the collector add one clarifying sentence" — routes a
+           verdict through a seam whose every other guard still passes, because those guards check the
+           inputs the TEST chose and a new field is populated by the DEFINITION. Freezing the member set is
+           what catches it, and it catches it at the type rather than at whichever collector happens to have
+           a pin. Adding a count to a measurement is not a thing anyone needs to do; adding prose is, and
+           this is the pin that says no.
+
+           Asserted as an exact set rather than a count, so renaming a member is caught too — a numeral
+           would keep passing while the shape changed underneath it. */
+        var members = typeof(CollectorMeasurement)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name + ":" + p.PropertyType.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(new[] { "Label:String", "Value:Int64" }, members);
+    }
+
+    [Fact]
     public void ADefinitionSuppliedNoteCarriesNoRenderedConclusion_EvenWhenHandedOne()
     {
         /* The adversarial direction, and the one that makes this pin discriminate what it claims rather than
@@ -110,6 +132,29 @@ public class CollectorMeasurementSeamTests
         Assert.Equal(
             "candidates=1264 " + CollectorMeasurementNote.RejectedLabelCount + "=2",
             rendered);
+    }
+
+    [Fact]
+    public async Task WhatARealDefinitionProducesIsCountsOnlyToo()
+    {
+        /* The pin above chooses its own measurements, so it can only prove the RENDERER adds no conclusion —
+           not that a definition cannot introduce one by another route. This one asks the same question of
+           what a shipped collector actually put in the context, driving its real read. Mutation found the
+           gap: a third member on CollectorMeasurement, populated by the definition, left every
+           hand-built-input pin green. */
+        var context = Context();
+
+        await BlockedProcessReportCollector.Instance.ReadAsync(
+            MakeReader(new[] { "<not-a-blocked-process-report/>" }), context, CancellationToken.None);
+
+        var note = CollectorMeasurementNote.Render(context.Measurements);
+
+        Assert.NotNull(note);
+        Assert.Matches(s_countsOnly, note!);
+
+        /* Every measurement it recorded is a legal count name and nothing else. */
+        Assert.All(context.Measurements, m => Assert.True(
+            CollectorMeasurementNote.IsValidLabel(m.Label), m.Label));
     }
 
     [Theory]

--- a/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
+++ b/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
@@ -385,8 +385,25 @@ public class CollectorMeasurementSeamTests
 
            An argument it CANNOT resolve FAILS rather than being skipped. That is the direction that costs
            least to be wrong in: a future author passing a computed label is told to make it a const, where
-           a skip would silently exempt exactly the case a scanner cannot reason about. */
+           a skip would silently exempt exactly the case a scanner cannot reason about.
+
+           WHAT THIS SCAN CANNOT SEE, stated rather than assumed. It reads PerformanceMonitor.Collectors
+           only - which is where every definition lives (69 concrete ones, flat, one-to-one with
+           CollectorCatalog.All), but Measure is public, so a HOST could call it and this would not know.
+           Widening the sweep would be worse rather than better: `.Measure(` is a name this codebase uses
+           heavily for unrelated things - WPF's UIElement.Measure(Size), and the Compose subsystem's
+           MeasureCatalog.Measure(key) - so a repo-wide sweep would try to resolve `ratio.NumeratorKey` as
+           a measurement label and fail on code that has nothing to do with this seam.
+
+           That boundary is affordable because the invariant that MATTERS is closed for every caller rather
+           than only the scanned ones: Render rejects an illegal label and counts the rejection, so no
+           prose reaches error_message from anywhere. This sweep is not what makes prose unreachable - it
+           is what turns a first-party typo from a runtime throw on a healthy collector into a CI failure,
+           in the directory where such a typo would actually be written. */
         var directory = Path.Combine(RepoFile.Root, "PerformanceMonitor.Collectors");
+
+        /* TopDirectoryOnly because the directory is flat - verified rather than assumed: it holds no
+           subdirectories at all besides obj/ and bin/, which a recursive sweep would have to exclude. */
         var files = Directory.EnumerateFiles(directory, "*.cs", SearchOption.TopDirectoryOnly).ToList();
 
         /* The sweep is only evidence if it read the tree. An empty enumeration would pass this test while

--- a/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
+++ b/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
@@ -185,6 +185,20 @@ public class CollectorMeasurementSeamTests
         Assert.Throws<ArgumentException>(() => Context().Measure(label!, 1));
     }
 
+    [Fact]
+    public void TheRejectCounterIsReservedAgainstADefinitionsOwnLabel()
+    {
+        /* It passes the grammar, so nothing else stops a collector using it - and then the note carries
+           `invalid_labels` twice with two different meanings, one the collector's count and one the
+           renderer's, which no reader can take apart. Refused at the chokepoint rather than de-duplicated
+           at render time: silently folding two different measurements into one figure is worse than
+           refusing one of them. */
+        Assert.True(CollectorMeasurementNote.IsValidLabel(CollectorMeasurementNote.RejectedLabelCount));
+
+        Assert.Throws<ArgumentException>(
+            () => Context().Measure(CollectorMeasurementNote.RejectedLabelCount, 1));
+    }
+
     [Theory]
     [InlineData("events_read")]
     [InlineData("candidates")]

--- a/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
+++ b/Darling/Darling.Tests/CollectorMeasurementSeamTests.cs
@@ -186,6 +186,39 @@ public class CollectorMeasurementSeamTests
     }
 
     [Fact]
+    public void ARenderedNoteNeverRepeatsALabel_WhichAShapeCheckCannotSee()
+    {
+        /* The counts-only grammar is a SHAPE check: two tokens carrying the same label are still
+           label=value pairs, so it passes on a note whose reader cannot tell which figure is which. That
+           is the #3159 lesson in its other direction - a pin over the composed form passing on the part
+           that did not break - and it is the route a hand-built list takes into Render, bypassing the
+           accumulation and the reservation that Measure applies.
+
+           The adversarial case is the reserved label supplied deliberately, beside a genuinely rejected
+           one: without Render enforcing the reservation too, that renders `invalid_labels=7
+           invalid_labels=1`, which is shape-legal and meaningless. */
+        var handBuilt = new[]
+        {
+            new CollectorMeasurement("events_read", 40),
+            new CollectorMeasurement(CollectorMeasurementNote.RejectedLabelCount, 7),
+            new CollectorMeasurement("GRANT SELECT", 1),
+            new CollectorMeasurement("events_read", 2),
+        };
+
+        var note = CollectorMeasurementNote.Render(handBuilt)!;
+
+        Assert.Matches(s_countsOnly, note);
+
+        var labels = note.Split(' ').Select(pair => pair.Split('=')[0]).ToList();
+        Assert.Equal(labels.Count, labels.Distinct(StringComparer.Ordinal).Count());
+
+        /* The duplicate is SUMMED, in first-seen position, and the reserved label appears exactly once
+           meaning exactly one thing: the count of labels Render refused - here the verdict and the
+           reserved label supplied as a measurement. */
+        Assert.Equal("events_read=42 " + CollectorMeasurementNote.RejectedLabelCount + "=2", note);
+    }
+
+    [Fact]
     public void TheRejectCounterIsReservedAgainstADefinitionsOwnLabel()
     {
         /* It passes the grammar, so nothing else stops a collector using it - and then the note carries

--- a/Darling/Darling.Tests/DarlingEmptyEnumerationNoteTests.cs
+++ b/Darling/Darling.Tests/DarlingEmptyEnumerationNoteTests.cs
@@ -46,13 +46,13 @@ public sealed class DarlingEmptyEnumerationNoteTests
     public void An_Ordinary_Run_Result_Carries_No_Note()
     {
         /* The default keeps every other collector's row exactly as it was — message column null. */
-        Assert.Null(new CollectorRunResult(12, 34, 56).Note);
+        Assert.Null(new CollectorRunResult(12, 34, 56, CollectorContext.NoMeasurements).Note);
     }
 
     [Fact]
     public void A_Run_Result_Round_Trips_The_Note()
     {
-        var result = new CollectorRunResult(0, 5, 0, EnumeratedCollectorDriver.EmptyEnumerationMessage);
+        var result = new CollectorRunResult(0, 5, 0, CollectorContext.NoMeasurements, EnumeratedCollectorDriver.EmptyEnumerationMessage);
 
         Assert.Equal(EnumeratedCollectorDriver.EmptyEnumerationMessage, result.Note);
         Assert.Equal(0, result.Rows);
@@ -70,7 +70,7 @@ public sealed class DarlingEmptyEnumerationNoteTests
            note — through the shared driver does, because there is then no host-side text at all. Lite's
            twin pin asserts the identical routing on its runner. */
         Assert.Contains("EnumeratedCollectorDriver.ReadEnumerationAsync(enumerationReader, cancellationToken)", source);
-        Assert.Contains("new CollectorRunResult(0, sqlMs, 0, enumeration.Note)", source);
+        Assert.Contains("new CollectorRunResult(0, sqlMs, 0, CollectorContext.NoMeasurements, enumeration.Note)", source);
 
         /* Via the shared driver, never a copy of the text — a literal here is exactly the drift this
            fix exists to prevent. */
@@ -95,6 +95,11 @@ public sealed class DarlingEmptyEnumerationNoteTests
            argument DROPPED from this call — the note included — fail here instead of silently reaching the
            store as a null.
 
+           #3161 added the definition-supplied Measurements as a REQUIRED parameter, so a site that drops it
+           now fails to COMPILE rather than failing here — but the argument's POSITION and the fact that the
+           success return is the one site passing the live `context.Measurements` rather than
+           CollectorContext.NoMeasurements are still only pinned here.
+
            #2851 wrapped the call across lines, which broke the single-line literal this used to be. Collapsing
            runs of whitespace before matching makes the pin survive REFORMATTING while still failing on a
            dropped argument, which is the property it exists for — the previous form conflated the two, so a
@@ -102,7 +107,8 @@ public sealed class DarlingEmptyEnumerationNoteTests
         var collapsed = Regex.Replace(source, @"\s+", " ");
 
         Assert.Contains(
-            "return new CollectorRunResult( rowsWritten, sqlMs, storageMs, collectionNote, fanout.Result, " +
+            "return new CollectorRunResult( rowsWritten, sqlMs, storageMs, context.Measurements, "
+            + "collectionNote, fanout.Result, " +
             "ServerPhasesMeasured: serverPhasesMeasured, ServerOpenMs: context.ServerScopeOpenMs, " +
             "ServerDrainMs: context.ServerScopeDrainMs, ServerWatermarkMs: serverWatermarkMs, " +
             "ServerRowsRead: context.ServerScopeRowsRead, ServerBytesRead: context.ServerScopeBytesRead, " +

--- a/Darling/Darling.Tests/ServerScopePhaseSplitTests.cs
+++ b/Darling/Darling.Tests/ServerScopePhaseSplitTests.cs
@@ -152,6 +152,7 @@ public sealed class ServerScopePhaseSplitTests
             Rows: 150,
             SqlMs: 4644,
             StorageMs: 184,
+            Measurements: CollectorContext.NoMeasurements,
             ServerPhasesMeasured: true,
             ServerOpenMs: 3900,
             ServerDrainMs: 700,
@@ -172,6 +173,7 @@ public sealed class ServerScopePhaseSplitTests
             Rows: 1,
             SqlMs: 100,
             StorageMs: 0,
+            Measurements: CollectorContext.NoMeasurements,
             ServerPhasesMeasured: true,
             ServerOpenMs: 60,
             ServerDrainMs: 45);
@@ -185,7 +187,7 @@ public sealed class ServerScopePhaseSplitTests
         /* The enumerated and Azure branches leave the flag false. The log site gates on the FLAG, so their
            zeros never print as a split — which is the distinction `PerItemOpenMs > 0` cannot make, because
            it reads a genuinely instant open and a path that measures nothing as the same thing. */
-        var enumerated = new CollectorRunResult(Rows: 3956, SqlMs: 316065, StorageMs: 41);
+        var enumerated = new CollectorRunResult(Rows: 3956, SqlMs: 316065, StorageMs: 41, Measurements: CollectorContext.NoMeasurements);
 
         Assert.False(enumerated.ServerPhasesMeasured);
         Assert.Equal(0, enumerated.ServerOpenMs);
@@ -194,7 +196,7 @@ public sealed class ServerScopePhaseSplitTests
         /* And a measured run whose open really was instant still reports measured, with a zero that means
            what it says. */
         var instant = new CollectorRunResult(
-            Rows: 0, SqlMs: 0, StorageMs: 0, ServerPhasesMeasured: true);
+            Rows: 0, SqlMs: 0, StorageMs: 0, Measurements: CollectorContext.NoMeasurements, ServerPhasesMeasured: true);
 
         Assert.True(instant.ServerPhasesMeasured);
         Assert.Equal(0, instant.ServerOtherMs);
@@ -211,6 +213,7 @@ public sealed class ServerScopePhaseSplitTests
             Rows: 10,
             SqlMs: 1000,
             StorageMs: 5,
+            Measurements: CollectorContext.NoMeasurements,
             ServerPhasesMeasured: true,
             ServerOpenMs: 600,
             ServerDrainMs: 300,
@@ -395,7 +398,7 @@ public sealed class ServerScopePhaseSplitTests
         Assert.Equal(0, perDatabase.PerItemOpenMs);
 
         /* And neither of them is the server-scoped path, whose own flag stays false on both. */
-        Assert.False(new CollectorRunResult(Rows: 1, SqlMs: 1, StorageMs: 0).ServerPhasesMeasured);
+        Assert.False(new CollectorRunResult(Rows: 1, SqlMs: 1, StorageMs: 0, Measurements: CollectorContext.NoMeasurements).ServerPhasesMeasured);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/StoreWriteReattemptTests.cs
+++ b/Darling/Darling.Tests/StoreWriteReattemptTests.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
@@ -557,10 +558,28 @@ public class StoreWriteReattemptTests
             "a write that faulted and then succeeded writes a row indistinguishable from one that never " +
             "faulted at all.");
 
-        var successReturn = source.IndexOf(
-            "rowsWritten, sqlMs, storageMs, collectionNote", StringComparison.Ordinal);
+        /* Whitespace collapsed before matching, and the anchor's EXISTENCE asserted separately from the
+           ordering. Both halves are #3161's lesson, learned the expensive way: that change added the
+           definition-supplied `context.Measurements` argument to this very call, the single-line literal
+           stopped matching, IndexOf returned -1, and `-1 > merge` failed with the ORDERING message — so the
+           pin reported a reordering that had not happened and said nothing about the anchor that had moved.
+           A pin whose failure names the wrong cause costs more than one that does not fire. */
+        var collapsed = Regex.Replace(source, @"\s+", " ");
+        const string successReturnArguments =
+            "rowsWritten, sqlMs, storageMs, context.Measurements, collectionNote";
+
+        var successReturn = collapsed.IndexOf(successReturnArguments, StringComparison.Ordinal);
         Assert.True(
-            successReturn > merge,
+            successReturn >= 0,
+            "the success return's argument list no longer matches \"" + successReturnArguments + "\". This " +
+            "pin has gone blind rather than caught anything: re-anchor it on the current argument list, " +
+            "then check the ordering below still holds.");
+
+        var collapsedMerge = collapsed.IndexOf(
+            "StoreWriteReattemptNote(context.StoreWriteReattempts)", StringComparison.Ordinal);
+
+        Assert.True(
+            successReturn > collapsedMerge,
             "the merge must happen BEFORE the success return that carries the note, and after every write " +
             "on all three dispatch paths.");
     }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -28,12 +28,27 @@ using PerformanceMonitor.Darling.Storage;
 namespace PerformanceMonitor.Darling.Service;
 
 /// <summary>
-/// Per-run outcome the worker logs (mirrors Lite's fetch/store phase split, #1180). <paramref name="Note"/>
-/// annotates a run that SUCCEEDED but is worth explaining on its collection_log row — today only the
-/// empty-enumeration case (see <see cref="EnumeratedCollectorDriver.EmptyEnumerationMessage"/>). It is the
-/// Darling twin of Lite's <c>_lastCollectionNote</c>; null (the default) leaves the row's message column
-/// null exactly as before.
+/// Per-run outcome the worker logs (mirrors Lite's fetch/store phase split, #1180).
+/// <see cref="Note"/> — what reaches <c>collection_log.error_message</c> — is COMPUTED from the two halves
+/// below and cannot be assigned, so no caller can pick up one half and drop the other.
 /// </summary>
+/// <param name="Measurements">
+/// The labelled counts the DEFINITION measured on the target (#3161), straight off
+/// <see cref="CollectorContext.Measurements"/>. REQUIRED rather than defaulted, and for the reason
+/// <c>DarlingObservability.LogCollectionAsync</c>'s <c>fanout</c> is: most construction sites here are the
+/// early returns of runs that never reached a definition's read — an <c>AppliesTo</c> miss, an enumeration
+/// that listed nothing, a cycle the wall-clock budget abandoned — and
+/// <see cref="CollectorContext.NoMeasurements"/> is their correct answer rather than a value they forgot. A
+/// default would let those sites stand in for the ONE success site that must pass the real list, which is
+/// the site whose silence #3161 was filed about. The compiler names every site instead of a grep.
+/// </param>
+/// <param name="HostNote">
+/// The note the RUNNER authored for a run worth explaining on its collection_log row: the RDS ingest
+/// outcome, the whole-cycle budget, the probe-failure summary, the fan-out bookkeeping. Null (the default)
+/// on an ordinary run. Named <c>HostNote</c> rather than <c>Note</c> because it is only one half of what
+/// the column receives — the rename is what made the compiler point at every site that used to assume
+/// otherwise.
+/// </param>
 /// <param name="Fanout">
 /// The per-database rollup for a run that fanned out, null for one that did not (#2472). Defaulted because
 /// the great majority of construction sites here are the early returns of runs that never reached a fan-out
@@ -77,7 +92,8 @@ public sealed record CollectorRunResult(
     int Rows,
     long SqlMs,
     long StorageMs,
-    string? Note = null,
+    IReadOnlyList<CollectorMeasurement> Measurements,
+    string? HostNote = null,
     FanoutCost? Fanout = null,
     bool Abandoned = false,
     bool ServerPhasesMeasured = false,
@@ -95,6 +111,20 @@ public sealed record CollectorRunResult(
        arrives the same way for the same reason. */
     FetchPhaseCost? FetchPhases = null)
 {
+    /// <summary>
+    /// What this run puts in <c>collection_log.error_message</c>: the runner's own
+    /// <see cref="HostNote"/> and then the definition's <see cref="Measurements"/>, composed through the
+    /// shared <see cref="CollectorMeasurementNote.Compose"/> that Lite's <c>RunTelemetry.Note</c> also
+    /// computes through — so the two SKUs cannot come to disagree about what a run note contains.
+    ///
+    /// <para><b>Computed rather than stored, and that is the parity guarantee.</b> There is no spelling of
+    /// "the host note alone" for a caller to reach for, so a definition-supplied count cannot be dropped by
+    /// a host that simply never learned about it. A shared member wired into one runner reads as a
+    /// permanently-empty value in the other SKU and nothing fails to build, which is the failure mode
+    /// CONTRIBUTING's two-store parity rules name.</para>
+    /// </summary>
+    public string? Note => CollectorMeasurementNote.Compose(HostNote, Measurements);
+
     /// <summary>
     /// The part of <see cref="SqlMs"/> that is neither the open nor the drain — query building, command
     /// construction, the optional probe-failure rowset and the supplemental query. Computed as the residual so
@@ -611,7 +641,7 @@ public sealed class DarlingCollectorRunner
         /* Counted as STORAGE time rather than SQL time: no query ran against the monitored server, and
            filing an HTTPS round trip under sql_duration_ms would make one target's numbers mean something
            different from every other target's. */
-        return new CollectorRunResult(outcome.Rows, 0, elapsedMs,
+        return new CollectorRunResult(outcome.Rows, 0, elapsedMs, CollectorContext.NoMeasurements,
             RdsIngestNote(outcome, RdsPlanLogNotReachedNote, RdsPlanLogEmptyNote));
     }
 
@@ -636,7 +666,7 @@ public sealed class DarlingCollectorRunner
 
         var elapsedMs = (long)Stopwatch.GetElapsedTime(started).TotalMilliseconds;
 
-        return new CollectorRunResult(outcome.Rows, 0, elapsedMs,
+        return new CollectorRunResult(outcome.Rows, 0, elapsedMs, CollectorContext.NoMeasurements,
             RdsIngestNote(outcome, RdsDeadlockLogNotReachedNote, RdsDeadlockLogEmptyNote));
     }
 
@@ -665,7 +695,7 @@ public sealed class DarlingCollectorRunner
         /* Counted as STORAGE time rather than SQL time, matching the other two RDS-API ingestors: no query
            ran against the monitored server, and filing an HTTPS round trip under sql_duration_ms would make
            one target's numbers mean something different from every other target's. */
-        return new CollectorRunResult(outcome.Rows, 0, elapsedMs,
+        return new CollectorRunResult(outcome.Rows, 0, elapsedMs, CollectorContext.NoMeasurements,
             RdsIngestNote(outcome, PiCpuNotReachedNote, PiCpuEmptyNote));
     }
 
@@ -808,7 +838,7 @@ public sealed class DarlingCollectorRunner
            dispatched at a non-SQL-Server target. */
         if (!CollectorCatalog.AppliesTo(definition, server.Target))
         {
-            return new CollectorRunResult(0, 0, 0);
+            return new CollectorRunResult(0, 0, 0, CollectorContext.NoMeasurements);
         }
 
         /* Watermark = the newest already-collected value of the definition's time column,
@@ -1631,7 +1661,7 @@ public sealed class DarlingCollectorRunner
                        empty-enumeration breadcrumb, the probe-failure summary, or both) rides onto the
                        collection_log row so it is distinguishable from a healthy collector whose databases
                        were simply quiet (#1837). Mirrors Lite's _lastCollectionNote. */
-                    return new CollectorRunResult(0, sqlMs, 0, enumeration.Note);
+                    return new CollectorRunResult(0, sqlMs, 0, CollectorContext.NoMeasurements, enumeration.Note);
                 }
 
                 /* Optional quick scalar probe (query_store's live PRODUCTVERSION check) —
@@ -2243,6 +2273,11 @@ public sealed class DarlingCollectorRunner
                         0,
                         sqlSlice.ElapsedMilliseconds,
                         0,
+                        /* Deliberately NOT context.Measurements: this cycle stored nothing and advanced no
+                           watermark, so a partial count from the slice that ran before the budget fired
+                           would describe a read that was thrown away. "12 read, 0 stored" on an abandoned
+                           run reads as a collection fault, and the cause is a timeout. */
+                        CollectorContext.NoMeasurements,
                         EnumeratedCollectorDriver.WholeCycleBudgetNote(budgetSeconds),
                         Abandoned: true,
                         /* #2851: the abandoned cycle reports its phases too. A collector that blew a
@@ -2342,7 +2377,7 @@ public sealed class DarlingCollectorRunner
             collectionNote, StoreWriteReattemptNote(context.StoreWriteReattempts));
 
         return new CollectorRunResult(
-            rowsWritten, sqlMs, storageMs, collectionNote, fanout.Result,
+            rowsWritten, sqlMs, storageMs, context.Measurements, collectionNote, fanout.Result,
             ServerPhasesMeasured: serverPhasesMeasured,
             ServerOpenMs: context.ServerScopeOpenMs,
             ServerDrainMs: context.ServerScopeDrainMs,

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -57,7 +57,7 @@ namespace PerformanceMonitor.Darling.Service;
 /// </param>
 /// <param name="Abandoned">
 /// True only for a cycle the #2673 whole-server wall-clock budget gave up on: nothing was stored and no
-/// watermark advanced. Carried as its own field rather than inferred from <paramref name="Note"/>, because
+/// watermark advanced. Carried as its own field rather than inferred from <see cref="Note"/>, because
 /// matching on the note's TEXT would make the collection_log status depend on a human-readable string that
 /// exists to be reworded — the classification and the wording have to move independently. Defaulted false so
 /// the seven ordinary construction sites are unchanged; the abandonment return is the only site that sets it.

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -6995,7 +6995,7 @@ LIMIT 1";
         catch (SqlException)
         {
             /* DBCC may be denied — degrade to zero rows, mirrors Lite's warning path. */
-            return new CollectorRunResult(0, 0, 0);
+            return new CollectorRunResult(0, 0, 0, CollectorContext.NoMeasurements);
         }
     }
 }

--- a/Lite.Tests/CollectorMeasurementNoteTests.cs
+++ b/Lite.Tests/CollectorMeasurementNoteTests.cs
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Collectors;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #3161, Lite half: this SKU's run note is COMPOSED from the runner's own note and the counts the
+/// DEFINITION measured, and there is no way to read one without the other.
+///
+/// <para><b>Why this half exists at all.</b> Lite has no PostgreSQL target, so the collectors that
+/// motivated #3161 are Darling-only — but the seam is engine-agnostic and the SQL Server collectors have
+/// the identical silence: <c>blocked_process_report</c>, <c>dmv_blocking_snapshot</c> and
+/// <c>deadlocks</c> all record SUCCESS with zero rows and no note on a quiet fleet. A shared member wired
+/// into one runner reads as a permanently-empty value in the other SKU and NOTHING FAILS TO BUILD, which
+/// is exactly the parity failure CONTRIBUTING's two-store rules name — so it is both SKUs or neither, and
+/// the consumer #3161 shipped with is a SQL Server collector that runs on both.</para>
+///
+/// <para>Darling's twin pins are in <c>Darling.Tests/CollectorMeasurementSeamTests.cs</c>, which also
+/// carries the engine-neutral half: the label grammar, the no-rendered-conclusion guard, and the source
+/// walk over every shipped label. This file asserts against the LIVE telemetry object, which that project
+/// cannot reference.</para>
+/// </summary>
+public class CollectorMeasurementNoteTests
+{
+    [Fact]
+    public void The_Run_Note_Carries_Both_Halves_Host_First()
+    {
+        var telemetry = CreateService().TelemetryFor(1);
+
+        telemetry.HostNote = EnumeratedCollectorDriver.EmptyEnumerationMessage;
+        telemetry.Measurements.Add(new CollectorMeasurement("events_read", 40));
+        telemetry.Measurements.Add(new CollectorMeasurement("events_stored", 0));
+
+        /* Host note first, because both hosts truncate error_message and the classified half is the one
+           that has to survive a cut. Same order, same separator and the same shared Compose that Darling's
+           CollectorRunResult.Note computes through, so the two SKUs cannot come to disagree about what a
+           run note contains. */
+        Assert.Equal(
+            EnumeratedCollectorDriver.EmptyEnumerationMessage + "; events_read=40 events_stored=0",
+            telemetry.Note);
+    }
+
+    [Fact]
+    public void The_Definition_Half_Reaches_The_Row_With_No_Host_Note_At_All()
+    {
+        /* THE case #3161 was filed about: a run that succeeded, stored nothing, and had no runner-authored
+           note to hang anything off. Before this seam the column was NULL here, which is what made 85,549
+           empty SUCCESS runs indistinguishable from an idle fleet (#3030). */
+        var telemetry = CreateService().TelemetryFor(1);
+
+        telemetry.Measurements.Add(new CollectorMeasurement("events_read", 0));
+        telemetry.Measurements.Add(new CollectorMeasurement("events_stored", 0));
+
+        Assert.Null(telemetry.HostNote);
+        Assert.Equal("events_read=0 events_stored=0", telemetry.Note);
+    }
+
+    [Fact]
+    public void A_Collector_That_Measures_Nothing_Still_Leaves_The_Column_Null()
+    {
+        /* 69 collectors measure nothing and none of them may start writing a note. */
+        var telemetry = CreateService().TelemetryFor(1);
+
+        Assert.Null(telemetry.Note);
+    }
+
+    [Fact]
+    public void The_Note_Cannot_Be_Assigned_So_The_Host_Cannot_Drop_The_Definition_Half()
+    {
+        /* The parity guarantee, asserted rather than described: there is no spelling of "the host note
+           alone" for the read site to reach for. While Note was settable, a runner could assign the host
+           half and the definition's counts would never reach the column — with nothing failing to build,
+           in either SKU. Making it computed is also what made the compiler enumerate the six sites that
+           used to assign it. */
+        var note = typeof(RemoteCollectorService.RunTelemetry)
+            .GetProperty(nameof(RemoteCollectorService.RunTelemetry.Note));
+
+        Assert.NotNull(note);
+        Assert.Null(note!.SetMethod);
+    }
+
+    [Fact]
+    public void Resetting_Clears_Both_Halves_So_One_Run_Cannot_Annotate_The_Next()
+    {
+        /* The note rides the same per-run slot as the sql/storage timings, so BOTH halves have to clear at
+           the top of every definition run. Clearing only the host half would leave one collector's counts
+           on the next collector's row — and the counts are the half that looks authoritative, because it
+           looks like a measurement of the collector whose row it is sitting on. */
+        var telemetry = CreateService().TelemetryFor(1);
+
+        telemetry.HostNote = EnumeratedCollectorDriver.EmptyEnumerationMessage;
+        telemetry.Measurements.Add(new CollectorMeasurement("events_read", 40));
+        Assert.NotNull(telemetry.Note);
+
+        telemetry.ResetNote();
+
+        Assert.Null(telemetry.HostNote);
+        Assert.Empty(telemetry.Measurements);
+        Assert.Null(telemetry.Note);
+    }
+
+    [Fact]
+    public void One_Servers_Counts_Cannot_Land_On_Another_Servers_Row()
+    {
+        /* A collection cycle runs the monitored servers in PARALLEL on one service instance, and the
+           measurement list is now part of what the per-server slot holds. A shared list would blend two
+           servers' counts into one figure that describes neither — and unlike a blended note, a blended
+           COUNT reads as a valid measurement. */
+        var service = CreateService();
+
+        var serverA = service.TelemetryFor(1);
+        var serverB = service.TelemetryFor(2);
+
+        Assert.NotSame(serverA, serverB);
+        Assert.NotSame(serverA.Measurements, serverB.Measurements);
+
+        serverA.Measurements.Add(new CollectorMeasurement("events_read", 40));
+        serverB.ResetNote();
+
+        Assert.Equal("events_read=40", serverA.Note);
+        Assert.Null(serverB.Note);
+        Assert.Same(serverA, service.TelemetryFor(1));
+    }
+
+    /* ── helpers ── */
+
+    private static RemoteCollectorService CreateService() =>
+        new(duckDb: null!, serverManager: null!, scheduleManager: null!);
+}

--- a/Lite.Tests/EmptyEnumerationNoteTests.cs
+++ b/Lite.Tests/EmptyEnumerationNoteTests.cs
@@ -58,7 +58,7 @@ public class EmptyEnumerationNoteTests
            the whole enumeration read — items, probe failures, and the composed note — through the shared
            driver does, because there is then no host-side text at all. */
         Assert.Contains("EnumeratedCollectorDriver.ReadEnumerationAsync(enumerationReader, cancellationToken)", source);
-        Assert.Contains("telemetry.Note = enumeration.Note;", source);
+        Assert.Contains("telemetry.HostNote = enumeration.Note;", source);
 
         /* Via the shared driver, never a copy of the text — a literal here is exactly the drift this
            fix exists to prevent. */
@@ -75,7 +75,7 @@ public class EmptyEnumerationNoteTests
         var source = File.ReadAllText(FindRepoFile(
             Path.Combine("Lite", "Services", "RemoteCollectorService.DefinitionRunner.cs")));
 
-        var assignment = source.IndexOf("telemetry.Note = enumeration.Note;", StringComparison.Ordinal);
+        var assignment = source.IndexOf("telemetry.HostNote = enumeration.Note;", StringComparison.Ordinal);
         var earlyReturn = source.IndexOf("if (items.Count == 0)", StringComparison.Ordinal);
 
         Assert.True(assignment >= 0 && earlyReturn >= 0, "both the note assignment and the zero-item branch must exist");
@@ -92,7 +92,7 @@ public class EmptyEnumerationNoteTests
         var source = File.ReadAllText(FindRepoFile(
             Path.Combine("Lite", "Services", "RemoteCollectorService.DefinitionRunner.cs")));
 
-        Assert.Contains("telemetry.Note = null;", source);
+        Assert.Contains("telemetry.ResetNote();", source);
 
         var service = File.ReadAllText(FindRepoFile(
             Path.Combine("Lite", "Services", "RemoteCollectorService.cs")));
@@ -113,11 +113,11 @@ public class EmptyEnumerationNoteTests
         var serverB = service.TelemetryFor(2);
         Assert.NotSame(serverA, serverB);
 
-        serverA.Note = EnumeratedCollectorDriver.EmptyEnumerationMessage;
+        serverA.HostNote = EnumeratedCollectorDriver.EmptyEnumerationMessage;
         serverA.SqlMs = 1234;
 
         /* Server B starting its own run resets ITS slot — the shape RunCollectorAsync uses. */
-        serverB.Note = null;
+        serverB.ResetNote();
         serverB.SqlMs = 0;
 
         Assert.Equal(EnumeratedCollectorDriver.EmptyEnumerationMessage, serverA.Note);

--- a/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
+++ b/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
@@ -876,7 +876,7 @@ public partial class RemoteCollectorService
            read (an AppliesTo miss, an enumeration that listed nothing) or that threw their read away (the
            wall-clock abandonment), and an empty list is their correct answer. Darling's twin is the single
            `context.Measurements` argument on DarlingCollectorRunner's success return; the argument there is
-           REQUIRED so its compiler names every sibling site, and this assignment is the reason Note is a
+           REQUIRED so the compiler names every sibling site, and this assignment is the reason Note is a
            computed property here rather than a settable one. */
         telemetry.Measurements.AddRange(context.Measurements);
 

--- a/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
+++ b/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
@@ -42,7 +42,7 @@ public partial class RemoteCollectorService
         var telemetry = TelemetryFor(serverId);
         telemetry.SqlMs = 0;
         telemetry.StorageMs = 0;
-        telemetry.Note = null;
+        telemetry.ResetNote();
         telemetry.Fanout = null;
 
         /* The per-database rollup (#2472), fed by both fan-out shapes — the Azure per-database connection
@@ -484,7 +484,7 @@ public partial class RemoteCollectorService
             /* #1875: ONE note for the cycle and ONE capped log burst, composed from every database's
                failures together. Assigned unconditionally — a cycle where nothing failed composes null,
                which is exactly what this path carried before. */
-            telemetry.Note = EnumeratedCollectorDriver.MergeNotes(
+            telemetry.HostNote = EnumeratedCollectorDriver.MergeNotes(
                 cycleProbeFailures.Note,
                 EnumeratedCollectorDriver.BuildPartialFailureNote(
                     failed, attempted, failedDatabases, firstFailure?.Message));
@@ -531,7 +531,7 @@ public partial class RemoteCollectorService
                 /* Null on the ordinary path; the empty-enumeration breadcrumb, the probe-failure summary,
                    or both otherwise. Assigned BEFORE the zero-item early return so that cycle — the one
                    that used to log a bare SUCCESS indistinguishable from healthy — carries it too. */
-                telemetry.Note = enumeration.Note;
+                telemetry.HostNote = enumeration.Note;
                 LogEnumerationProbeFailures(definition, server, enumeration.ProbeFailures);
 
                 if (items.Count == 0)
@@ -784,7 +784,7 @@ public partial class RemoteCollectorService
                     if (definition.EmitsProbeFailures)
                     {
                         var probes = await EnumeratedCollectorDriver.ReadPayloadProbeFailuresAsync(reader, itemToken);
-                        telemetry.Note = probes.Note;
+                        telemetry.HostNote = probes.Note;
                         LogEnumerationProbeFailures(definition, server, probes.ProbeFailures);
                     }
                 }
@@ -797,7 +797,7 @@ public partial class RemoteCollectorService
                     _ = ex;
                     var budgetSeconds = (int)definition.PerItemWallClockBudget!.Value.TotalSeconds;
                     telemetry.SqlMs = sqlSlice.ElapsedMilliseconds;
-                    telemetry.Note = EnumeratedCollectorDriver.WholeCycleBudgetNote(budgetSeconds);
+                    telemetry.HostNote = EnumeratedCollectorDriver.WholeCycleBudgetNote(budgetSeconds);
                     telemetry.Abandoned = true;
                     _logger?.LogWarning(
                         "{Collector} on '{Server}' reached its {Budget}s wall-clock budget mid-collection — abandoned this cycle, will retry next (#2673).",
@@ -870,6 +870,15 @@ public partial class RemoteCollectorService
         telemetry.SqlMs = sqlMs;
         telemetry.StorageMs = storageMs;
         telemetry.Fanout = fanout.Result;
+
+        /* #3161: the counts the DEFINITION measured on the target, onto this run's collection_log row. The
+           only site that copies them — the early returns above are runs that never reached a definition's
+           read (an AppliesTo miss, an enumeration that listed nothing) or that threw their read away (the
+           wall-clock abandonment), and an empty list is their correct answer. Darling's twin is the single
+           `context.Measurements` argument on DarlingCollectorRunner's success return; the argument there is
+           REQUIRED so its compiler names every sibling site, and this assignment is the reason Note is a
+           computed property here rather than a settable one. */
+        telemetry.Measurements.AddRange(context.Measurements);
 
         _logger?.LogDebug("Collected {RowCount} {Collector} rows for server '{Server}'", rowsWritten, definition.Name, server.DisplayName);
         return rowsWritten;

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -138,7 +138,43 @@ public partial class RemoteCollectorService
     {
         public long SqlMs { get; set; }
         public long StorageMs { get; set; }
-        public string? Note { get; set; }
+
+        /// <summary>
+        /// The note the RUNNER authored — an enumeration that yielded 0 items, items whose enumeration
+        /// probe failed, a whole-cycle budget abandonment. One half of what the collection_log row
+        /// receives; <see cref="Note"/> is the whole of it. Named <c>HostNote</c> rather than <c>Note</c>
+        /// so the compiler pointed at every site that used to assume the two were the same thing.
+        /// </summary>
+        public string? HostNote { get; set; }
+
+        /// <summary>
+        /// The labelled counts the DEFINITION measured on the target this cycle (#3161), copied off
+        /// <see cref="CollectorContext.Measurements"/> when the run reaches its storage phase. Empty for
+        /// every collector that measures nothing, and for a run that never got that far.
+        /// </summary>
+        public List<CollectorMeasurement> Measurements { get; } = new();
+
+        /// <summary>
+        /// What this run puts in <c>collection_log.error_message</c>: <see cref="HostNote"/> then
+        /// <see cref="Measurements"/>, through the same shared
+        /// <see cref="CollectorMeasurementNote.Compose"/> that Darling's <c>CollectorRunResult.Note</c>
+        /// computes through — so the two SKUs cannot come to disagree about what a run note contains.
+        ///
+        /// <para><b>Computed rather than settable, and that is the parity guarantee.</b> There is no
+        /// spelling of "the host note alone" for the read site to reach for, so a definition-supplied
+        /// count cannot be dropped by a host that simply never learned about it. A shared seam wired into
+        /// one runner reads as a permanently-empty value in the other SKU and nothing fails to build,
+        /// which is the failure mode CONTRIBUTING's two-store parity rules name. Making this read-only is
+        /// also what made the compiler enumerate the six sites that used to assign it.</para>
+        /// </summary>
+        public string? Note => CollectorMeasurementNote.Compose(HostNote, Measurements);
+
+        /// <summary>Clears both halves for a new run. Called at the top of every collector.</summary>
+        public void ResetNote()
+        {
+            HostNote = null;
+            Measurements.Clear();
+        }
 
         /// <summary>
         /// True only for a cycle the #2673 whole-server wall-clock budget gave up on. Its own field rather
@@ -512,7 +548,7 @@ public partial class RemoteCollectorService
         var telemetry = TelemetryFor(GetServerId(server));
         telemetry.SqlMs = 0;
         telemetry.StorageMs = 0;
-        telemetry.Note = null;
+        telemetry.ResetNote();
         telemetry.Abandoned = false;
 
         try

--- a/PerformanceMonitor.Collectors/BlockedProcessReportCollector.cs
+++ b/PerformanceMonitor.Collectors/BlockedProcessReportCollector.cs
@@ -802,12 +802,40 @@ OUTER APPLY
         new CollectorColumn("blocking_query_plan_xml", CollectorColumnType.Varchar),
     };
 
+    /* ── #3161: what this collector measured, for its own collection_log row ───────────────────────────
+       A quiet server and a server whose every captured report we failed to parse both used to arrive as
+       SUCCESS, zero rows, NULL note — and only the second is a fault. The ring buffer read is already
+       filtered to the watermark SERVER-side, so a zero EventsRead is genuinely "nothing new was captured",
+       and these four counts separate that from the two ways a captured event gets dropped in this method.
+
+       COUNTS, not a verdict: the read derives which situation it is looking at, every time it looks. A
+       stored conclusion would be a stale gate the moment somebody restarted the session or fixed the
+       capture — see CollectorMeasurement and CollectorRuntimePrecondition (#2546). Nothing here is computed
+       for the note: all four figures are the loop's own bookkeeping, so the cost is four increments and no
+       extra round trip. */
+
+    /// <summary>Events the ring-buffer read delivered — already watermark-filtered server-side.</summary>
+    public const string EventsReadMeasurement = "events_read";
+
+    /// <summary>Delivered events carrying no report XML at all.</summary>
+    public const string EmptyReportMeasurement = "report_xml_empty";
+
+    /// <summary>Delivered events whose report XML this collector could not parse.</summary>
+    public const string UnparsedReportMeasurement = "report_xml_unparsed";
+
+    /// <summary>Events that became stored rows.</summary>
+    public const string EventsStoredMeasurement = "events_stored";
+
     public override async ValueTask<List<Row>> ReadAsync(DbDataReader reader, CollectorContext context, CancellationToken cancellationToken)
     {
         var rows = new List<Row>();
+        var eventsRead = 0;
+        var emptyReports = 0;
+        var unparsedReports = 0;
 
         while (await reader.ReadAsync(cancellationToken))
         {
+            eventsRead++;
             var eventTime = reader.IsDBNull(0) ? (DateTime?)null : reader.GetDateTime(0);
             var reportXml = reader.IsDBNull(1) ? null : reader.GetString(1);
             /* #1140: object_id/database_id are the event's own data fields and contentious_object
@@ -822,6 +850,7 @@ OUTER APPLY
 
             if (string.IsNullOrEmpty(reportXml))
             {
+                emptyReports++;
                 continue;
             }
 
@@ -829,6 +858,7 @@ OUTER APPLY
             var parsed = ParseReportXml(reportXml, eventTime);
             if (parsed == null)
             {
+                unparsedReports++;
                 continue;
             }
 
@@ -846,6 +876,14 @@ OUTER APPLY
             parsed.DatabaseName = context.CurrentDatabaseName ?? parsed.DatabaseName;
             rows.Add(parsed);
         }
+
+        /* Measure() ACCUMULATES a repeated label, which is what makes this correct on the per-database
+           shape: RunsPerDatabase is true on Azure SQL DB, so the host calls this method once per database
+           against the one context, and the cycle reports the sum rather than the last database's slice. */
+        context.Measure(EventsReadMeasurement, eventsRead);
+        context.Measure(EmptyReportMeasurement, emptyReports);
+        context.Measure(UnparsedReportMeasurement, unparsedReports);
+        context.Measure(EventsStoredMeasurement, rows.Count);
 
         return rows;
     }

--- a/PerformanceMonitor.Collectors/CollectorContext.cs
+++ b/PerformanceMonitor.Collectors/CollectorContext.cs
@@ -152,7 +152,7 @@ public sealed class CollectorContext
     ///
     /// <para>Throws on a label <see cref="CollectorMeasurementNote.IsValidLabel"/> rejects. Labels are
     /// first-party constants in definition source, so that is a build-and-test-time failure rather than
-    /// anything a monitored server can cause - and <c>MeasurementLabelSourceGuardTests</c> walks the source
+    /// anything a monitored server can cause - and <c>CollectorMeasurementSeamTests.EveryMeasurementLabelInTheCollectorsIsLegal</c> walks the source
     /// so it cannot reach a release either. The renderer counts rejects instead of throwing, for a list some
     /// caller assembled by hand.</para>
     /// </summary>

--- a/PerformanceMonitor.Collectors/CollectorContext.cs
+++ b/PerformanceMonitor.Collectors/CollectorContext.cs
@@ -169,6 +169,15 @@ public sealed class CollectorContext
                 nameof(label));
         }
 
+        if (string.Equals(label, CollectorMeasurementNote.RejectedLabelCount, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "Measurement label '" + label + "' is reserved for the renderer's own count of labels it "
+                + "rejected. A note carrying it twice, once as a collector's count and once as that "
+                + "counter, is not readable by anything.",
+                nameof(label));
+        }
+
         for (var i = 0; i < _measurements.Count; i++)
         {
             if (string.Equals(_measurements[i].Label, label, StringComparison.Ordinal))

--- a/PerformanceMonitor.Collectors/CollectorContext.cs
+++ b/PerformanceMonitor.Collectors/CollectorContext.cs
@@ -26,6 +26,15 @@ public sealed class CollectorContext
     public static readonly IReadOnlyDictionary<string, string> NoState =
         new Dictionary<string, string>(StringComparer.Ordinal);
 
+    /// <summary>
+    /// The empty <see cref="Measurements"/> — what a host passes for a run that never reached a
+    /// definition's read at all (the <c>AppliesTo</c> early-out, an enumeration that listed nothing, a
+    /// cycle the wall-clock budget abandoned). Named rather than an inline empty array so those sites read
+    /// as a deliberate "this run measured nothing" instead of a value somebody forgot.
+    /// </summary>
+    public static readonly IReadOnlyList<CollectorMeasurement> NoMeasurements =
+        Array.Empty<CollectorMeasurement>();
+
     public required int ServerId { get; init; }
 
     public required string ServerName { get; init; }
@@ -106,6 +115,71 @@ public sealed class CollectorContext
     /// <see cref="CatchupClampApplied"/>).
     /// </summary>
     public Dictionary<string, string> PendingState { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The labelled COUNTS this definition measured on the target during the round trip it had already
+    /// made, rendered onto this run's <c>collection_log.error_message</c> by whichever host is running it
+    /// (#3161). Empty for every collector that measures nothing, which leaves the column NULL exactly as
+    /// before. Written through <see cref="Measure"/>; the other context members a definition writes back to
+    /// the host are <see cref="PendingState"/>, <see cref="PerItemTextBudgetExceeded"/> and
+    /// <see cref="CatchupClampApplied"/>.
+    ///
+    /// <para><b>What this is for.</b> A definition previously had NO channel into that column - every value
+    /// <c>CollectorRunResult.Note</c> took was runner-authored - so a collector that could work out why it
+    /// returned nothing had nowhere to put it, and the run recorded SUCCESS with a NULL note. Five issues in
+    /// a row were that shape (#3030, #3109, #3114, #3153, #3154) and each had to be repaired at READ time,
+    /// because read time was the only seam that existed.</para>
+    ///
+    /// <para><b>Counts, never verdicts</b> - see <see cref="CollectorMeasurement"/> for why the value's type
+    /// is what enforces that rather than a convention. A stored conclusion is a stale gate the moment an
+    /// operator acts on it, which is the failure <c>CollectorRuntimePrecondition</c> (#2546) exists to
+    /// prevent; a stored count stays true and lets the read derive the verdict fresh on every call.</para>
+    /// </summary>
+    public IReadOnlyList<CollectorMeasurement> Measurements => _measurements;
+
+    private readonly List<CollectorMeasurement> _measurements = new();
+
+    /// <summary>
+    /// Records that this definition measured <paramref name="value"/> of <paramref name="label"/> - the only
+    /// supported way to add to <see cref="Measurements"/>.
+    ///
+    /// <para><b>A repeated label ACCUMULATES rather than appending a second entry</b>, because these are
+    /// counts and one context serves the whole cycle: the per-database and per-item loops call
+    /// <c>ReadAsync</c>/<c>ReadItemAsync</c> once each against this same object, so a definition measures
+    /// its own slice and the cycle reports the sum without every collector remembering to hold its own
+    /// totals. Appending instead would render <c>events_read=3 events_read=0 events_read=11</c>, which is
+    /// not a count of anything.</para>
+    ///
+    /// <para>Throws on a label <see cref="CollectorMeasurementNote.IsValidLabel"/> rejects. Labels are
+    /// first-party constants in definition source, so that is a build-and-test-time failure rather than
+    /// anything a monitored server can cause - and <c>MeasurementLabelSourceGuardTests</c> walks the source
+    /// so it cannot reach a release either. The renderer counts rejects instead of throwing, for a list some
+    /// caller assembled by hand.</para>
+    /// </summary>
+    /// <exception cref="ArgumentException">The label is not a legal count name.</exception>
+    public void Measure(string label, long value)
+    {
+        if (!CollectorMeasurementNote.IsValidLabel(label))
+        {
+            throw new ArgumentException(
+                "Measurement label '" + label + "' is not lowercase snake_case within "
+                + CollectorMeasurementNote.MaxLabelLength.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                + " characters. Measurements carry counts, so a label must be a count NAME and never "
+                + "a sentence - see CollectorMeasurement.",
+                nameof(label));
+        }
+
+        for (var i = 0; i < _measurements.Count; i++)
+        {
+            if (string.Equals(_measurements[i].Label, label, StringComparison.Ordinal))
+            {
+                _measurements[i] = new CollectorMeasurement(label, _measurements[i].Value + value);
+                return;
+            }
+        }
+
+        _measurements.Add(new CollectorMeasurement(label, value));
+    }
 
     /// <summary>Wait types excluded from collection (Lite: ignored_wait_types.json — #1240).</summary>
     public IReadOnlySet<string> IgnoredWaitTypes { get; init; } = s_emptySet;

--- a/PerformanceMonitor.Collectors/CollectorMeasurement.cs
+++ b/PerformanceMonitor.Collectors/CollectorMeasurement.cs
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace PerformanceMonitor.Collectors;
+
+/// <summary>
+/// One labelled COUNT a collector definition measured on the target inside the round trip it had
+/// already made (#3161) — the unit of the only channel a definition has into
+/// <c>collection_log.error_message</c>.
+///
+/// <para><b><see cref="Value"/> is an integer, and that is the whole design.</b> A definition records
+/// WHAT IT MEASURED and never WHAT IT CONCLUDED, so the read derives the verdict fresh on every call.
+/// <c>candidates=1264 visible=0</c> is a fact about one instant and stays true;
+/// <c>statistics not visible to this login; GRANT SELECT</c> is a stale gate the moment somebody issues
+/// the grant, and it is the exact failure <c>CollectorRuntimePrecondition</c> (#2546) exists to prevent —
+/// "the operator does the thing the message asked for and nothing changes, with no way to tell why".
+/// Making the value a <see cref="long"/> is what makes a stored verdict UNREPRESENTABLE rather than
+/// merely discouraged: no keyword blocklist over free prose can be relied on, and a guard shaped like
+/// one passes on the wording it failed to think of.</para>
+///
+/// <para><see cref="Label"/> is narrow for the same reason — see
+/// <see cref="CollectorMeasurementNote.IsValidLabel"/>. Without a grammar on the label, the sentence the
+/// value cannot carry simply moves one field left.</para>
+///
+/// <para><b>Counts, so repeats SUM.</b> <see cref="CollectorContext.Measure"/> accumulates a repeated
+/// label rather than appending a second entry, which is what makes the seam correct on the fan-out
+/// shapes without every definition remembering to hold its own totals: one context serves the whole
+/// cycle, so a per-database or per-item read measures its own slice and the cycle reports the sum.</para>
+/// </summary>
+/// <param name="Label">A snake_case count name — see <see cref="CollectorMeasurementNote.IsValidLabel"/>.</param>
+/// <param name="Value">The count. Never a verdict, a name, a timestamp or a rendered sentence.</param>
+public readonly record struct CollectorMeasurement(string Label, long Value);
+
+/// <summary>
+/// Renders a definition's <see cref="CollectorMeasurement"/> list into the one string
+/// <c>collection_log.error_message</c> carries, and composes it with the note the HOST authored (#3161).
+///
+/// <para><b>The defect this closes.</b> A collector definition had no way to contribute to
+/// <c>collection_log.error_message</c> at all: <c>CollectorRunResult.Note</c> existed, and every value it
+/// took was runner-authored — the RDS ingest outcome, the whole-cycle budget, the probe-failure count, the
+/// fan-out bookkeeping. So a collector that could compute WHY it returned nothing, cheaply, on the target,
+/// in the round trip it had already made, had nowhere to put it, and the run reported SUCCESS with a NULL
+/// note. Five issues in a row were that shape (#3030, #3109, #3114, #3153, #3154) and every one had to be
+/// repaired at READ time, because read time was the only seam there was.</para>
+///
+/// <para><b>Why this is not the thing #2546 forbids.</b> <c>CollectorRuntimePrecondition</c> argues that a
+/// MUTABLE, ACTIONABLE condition must be answered at read time and re-derived every call, and it is right.
+/// But that class does not oppose stored notes — it depends on them, and its own doc says the remedy text
+/// is "FRAMED here, not authored here", quoting what the runners already wrote. What it has nothing to
+/// quote is a run that SUCCEEDS WITH ZERO ROWS, which is the entire population above. Counts extend that
+/// same division to quiet runs instead of inventing a parallel one: the collector quotes, the read
+/// frames.</para>
+/// </summary>
+public static class CollectorMeasurementNote
+{
+    /// <summary>
+    /// Longest accepted <see cref="CollectorMeasurement.Label"/>. Short enough that no clause fits, which
+    /// is the point: the ceiling is part of the grammar rather than a storage concern.
+    /// </summary>
+    public const int MaxLabelLength = 40;
+
+    /// <summary>
+    /// What <see cref="Render"/> reports instead of a measurement whose label it rejected. A COUNT, so the
+    /// rejection travels through the same shape as everything else on the row, and a dropped measurement is
+    /// never silent — the alternative directions are both worse: throwing turns a first-party typo into a
+    /// failed collection cycle on a working collector, and dropping quietly is the invisibility this whole
+    /// seam exists to end. <see cref="CollectorContext.Measure"/> throws on the same condition, so a
+    /// rejected label is a build-and-test-time failure and this counter is the backstop for a list some
+    /// caller assembled by hand.
+    /// </summary>
+    public const string RejectedLabelCount = "invalid_labels";
+
+    /// <summary>
+    /// Whether <paramref name="label"/> is a legal count name: lowercase snake_case, starting with a
+    /// letter, at most <see cref="MaxLabelLength"/> characters.
+    ///
+    /// <para>Narrow ON PURPOSE, and the narrowness is doing the work that
+    /// <see cref="CollectorMeasurement.Value"/>'s type does on the other field. A grammar with no space, no
+    /// punctuation and no capital rejects <c>GRANT SELECT on the tables</c> three separate ways, so the
+    /// remedy sentence cannot relocate from the value into the label. It also fails toward REFUSING: a
+    /// label that is merely unusual is rejected rather than rendered, and the cost of that is a caught
+    /// typo.</para>
+    /// </summary>
+    public static bool IsValidLabel(string? label)
+    {
+        if (string.IsNullOrEmpty(label) || label.Length > MaxLabelLength)
+        {
+            return false;
+        }
+
+        if (label[0] is < 'a' or > 'z')
+        {
+            return false;
+        }
+
+        foreach (var c in label)
+        {
+            if (c is (< 'a' or > 'z') and (< '0' or > '9') and not '_')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The measurements as <c>label=value</c> pairs separated by single spaces — <c>candidates=1264
+    /// visible=0</c>, the form #3161 specified. Null for an empty list, so a collector that measured
+    /// nothing leaves the column NULL exactly as before.
+    ///
+    /// <para>Invariant formatting throughout: the note is read by operators on whatever desktop they have
+    /// and parsed by machines through the MCP surface, and a thousands separator that moved with the host
+    /// locale would render one reading two ways. No grouping either — <c>1264</c>, not <c>1,264</c> — so a
+    /// value is one token and the pairs stay splittable.</para>
+    /// </summary>
+    public static string? Render(IReadOnlyList<CollectorMeasurement> measurements)
+    {
+        if (measurements is null || measurements.Count == 0)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder();
+        var rejected = 0;
+
+        foreach (var measurement in measurements)
+        {
+            if (!IsValidLabel(measurement.Label))
+            {
+                rejected++;
+                continue;
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append(' ');
+            }
+
+            builder.Append(measurement.Label)
+                .Append('=')
+                .Append(measurement.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (rejected > 0)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append(' ');
+            }
+
+            builder.Append(RejectedLabelCount)
+                .Append('=')
+                .Append(rejected.ToString(CultureInfo.InvariantCulture));
+        }
+
+        return builder.Length == 0 ? null : builder.ToString();
+    }
+
+    /// <summary>
+    /// The host's own note and the definition's measurements as the one string the
+    /// <c>collection_log.error_message</c> column takes, composed through
+    /// <see cref="EnumeratedCollectorDriver.MergeNotes"/> so the separator is the one every other note
+    /// producer in both hosts already uses.
+    ///
+    /// <para><b>Both hosts read their run note THROUGH here, and neither can spell "the host note
+    /// alone".</b> <c>CollectorRunResult.Note</c> and Lite's <c>RunTelemetry.Note</c> are both computed
+    /// properties over this call, so a SKU cannot pick up the host half and quietly drop the definition
+    /// half. State added to one store that "reads as permanently empty on the other, and nothing fails to
+    /// build" is the parity failure CONTRIBUTING names, and a shared seam wired into one runner is exactly
+    /// its shape.</para>
+    ///
+    /// <para>Host note FIRST: it is the classified thing an operator scans for — a budget abandonment, a
+    /// partial fan-out failure — while the counts explain a run that otherwise looks fine. Both hosts
+    /// truncate this column, so the half that must survive a cut goes in front.</para>
+    /// </summary>
+    public static string? Compose(string? hostNote, IReadOnlyList<CollectorMeasurement> measurements) =>
+        EnumeratedCollectorDriver.MergeNotes(hostNote, Render(measurements));
+}

--- a/PerformanceMonitor.Collectors/CollectorMeasurement.cs
+++ b/PerformanceMonitor.Collectors/CollectorMeasurement.cs
@@ -77,6 +77,11 @@ public static class CollectorMeasurementNote
     /// seam exists to end. <see cref="CollectorContext.Measure"/> throws on the same condition, so a
     /// rejected label is a build-and-test-time failure and this counter is the backstop for a list some
     /// caller assembled by hand.
+    ///
+    /// <para>RESERVED: <see cref="CollectorContext.Measure"/> refuses it as a definition's own label. It is
+    /// a legal count name by the grammar, so without the reservation a collector could measure something it
+    /// called <c>invalid_labels</c> and the rendered note would carry that label twice with two different
+    /// meanings - one the collector's count and one this counter - which no reader could take apart.</para>
     /// </summary>
     public const string RejectedLabelCount = "invalid_labels";
 

--- a/PerformanceMonitor.Collectors/CollectorMeasurement.cs
+++ b/PerformanceMonitor.Collectors/CollectorMeasurement.cs
@@ -78,7 +78,10 @@ public static class CollectorMeasurementNote
     /// rejected label is a build-and-test-time failure and this counter is the backstop for a list some
     /// caller assembled by hand.
     ///
-    /// <para>RESERVED: <see cref="CollectorContext.Measure"/> refuses it as a definition's own label. It is
+    /// <para>RESERVED at BOTH doors: <see cref="CollectorContext.Measure"/> refuses it, and
+    /// <see cref="Render"/> folds it into this counter rather than printing it. Guarding only the first
+    /// would leave the invariant resting on call-site discipline in a type whose whole claim is that the
+    /// TYPE enforces it, and <see cref="Render"/> is public. It is
     /// a legal count name by the grammar, so without the reservation a collector could measure something it
     /// called <c>invalid_labels</c> and the rendered note would carry that label twice with two different
     /// meanings - one the collector's count and one this counter - which no reader could take apart.</para>
@@ -136,25 +139,62 @@ public static class CollectorMeasurementNote
             return null;
         }
 
-        var builder = new StringBuilder();
+        /* Accumulated HERE as well as in CollectorContext.Measure, and not only there. A rendered note is
+           what a reader parses, and two tokens carrying the same label mean nothing whichever door they
+           came through - so the guarantee belongs at the door everything must pass rather than at the one
+           a hand-built list can go round. Measure's own accumulation is not redundant: it keeps
+           Measurements itself a set of counts, which is what lets a definition read back what it has
+           measured so far. Insertion-ordered so the pairs print in the order the definition declared them.
+
+           A shape check cannot substitute for this. Two tokens with one label are still label=value pairs,
+           so the counts-only grammar passes on a note whose figures a reader cannot attribute - the #3159
+           lesson in its other direction, a pin over the composed form passing on the part that broke. */
+        var totals = new List<KeyValuePair<string, long>>(measurements.Count);
         var rejected = 0;
 
         foreach (var measurement in measurements)
         {
-            if (!IsValidLabel(measurement.Label))
+            /* RejectedLabelCount passes IsValidLabel, so a list assembled by hand could carry it beside a
+               genuinely rejected label and render TWO invalid_labels= tokens with two different meanings -
+               exactly what the reservation exists to prevent, arriving through the door Measure does not
+               guard. Folded into the counter rather than dropped, so the note still records a refusal. */
+            if (!IsValidLabel(measurement.Label)
+                || string.Equals(measurement.Label, RejectedLabelCount, StringComparison.Ordinal))
             {
                 rejected++;
                 continue;
             }
 
+            var seen = false;
+            for (var i = 0; i < totals.Count; i++)
+            {
+                if (string.Equals(totals[i].Key, measurement.Label, StringComparison.Ordinal))
+                {
+                    totals[i] = new KeyValuePair<string, long>(
+                        totals[i].Key, totals[i].Value + measurement.Value);
+                    seen = true;
+                    break;
+                }
+            }
+
+            if (!seen)
+            {
+                totals.Add(new KeyValuePair<string, long>(measurement.Label, measurement.Value));
+            }
+        }
+
+        var builder = new StringBuilder();
+
+        foreach (var (label, value) in totals)
+        {
             if (builder.Length > 0)
             {
                 builder.Append(' ');
             }
 
-            builder.Append(measurement.Label)
+            builder.Append(label)
                 .Append('=')
-                .Append(measurement.Value.ToString(CultureInfo.InvariantCulture));
+                .Append(value.ToString(CultureInfo.InvariantCulture));
         }
 
         if (rejected > 0)


### PR DESCRIPTION
Closes #3161 — a collector definition can now contribute to `collection_log.error_message`, and what it contributes is COUNTS.

## The defect

`CollectorRunResult.Note` existed and every value it took was runner-authored: the RDS ingest outcome, the whole-cycle budget, the probe-failure summary, the fan-out bookkeeping. `CollectorContext` contained zero occurrences of `Note` and `ICollectorDefinition` had none. So a collector that could work out *why* it returned nothing — cheaply, on the target, inside the round trip it had already made — had nowhere to put it, and the run recorded SUCCESS with a NULL note. Five issues in a row were that shape (#3030, #3109, #3114, #3153, #3154) and every one had to be repaired at READ time, because read time was the only seam there was.

## The seam

`CollectorContext.Measure(label, value)` records one labelled count; `CollectorContext.Measurements` is what the host reads. It sits beside the other context members a definition writes back to the host (`PendingState`, `PerItemTextBudgetExceeded`, `CatchupClampApplied`), so no definition signature changes and a collector opts in by measuring something. 69 concrete definitions are untouched.

**Counts, never verdicts, enforced structurally rather than by convention.** `CollectorMeasurement.Value` is a `long`, so a stored conclusion is *unrepresentable* — not discouraged. `candidates=1264 visible=0` is a fact about one instant and stays true; `statistics not visible to this login; GRANT SELECT` is a stale gate the moment somebody issues the grant, which is precisely the failure `CollectorRuntimePrecondition` (#2546) exists to prevent. That class does not oppose stored notes, it depends on them and quotes what the server said; what it has nothing to quote is a run that succeeds with zero rows, which is this whole population. The label carries a grammar (lowercase snake_case, 40 characters) because without one the sentence the value cannot hold just moves one field left.

A guard over free prose would have been a keyword blocklist, which passes on the wording nobody thought of. The structural pins instead are: the value's type, the type's exact member set, an anchored counts-only grammar over the rendered form, and that same grammar over what a shipped collector actually recorded. That is the discipline PR #3159 arrived at independently, where `Census` carries no verdict and `Cause` carries no counts as *separate* pins, because a distinctness check over the combined message passes on the numbers rather than the verdicts.

**A repeated label accumulates.** One context serves the whole cycle, so the per-database and per-item fan-out shapes measure their own slice and the cycle reports the sum, without every definition holding its own totals. Appending would render `events_read=3 events_read=0 events_read=11`, which is not a count of anything.

`invalid_labels` — the renderer's own count of labels it refused — is reserved against a definition's own label, because it passes the grammar and a note carrying it twice with two different meanings is not readable by anything. Refused at the chokepoint rather than de-duplicated at render time: folding two different measurements into one figure silently is worse than refusing one.

## Both SKUs, and the parity is structural

Both hosts now COMPUTE their run note from the runner's half and the definition's half through one shared `CollectorMeasurementNote.Compose`. `CollectorRunResult.Note` and `RunTelemetry.Note` have **no setter**, so there is no spelling of "the host note alone" for a read site to reach for. State added to one store that reads as permanently empty on the other while nothing fails to build is the failure mode CONTRIBUTING's two-store parity rules name, and a shared seam wired into one runner is exactly its shape.

Neither `collection_log` writer changed: both already take `string? errorMessage` and both already receive the composed note, so the composed-property design is what makes them correct rather than a signature edit. `DarlingObservability.LogRetentionRunAsync` writes the same table but records a fleet retention run with no definition in its path, so it has nothing to compose.

## The compiler named the sites, not a grep

The definition's half is a **required** parameter on `CollectorRunResult`, per CONTRIBUTING and for the same reason `DarlingObservability.LogCollectionAsync`'s `fanout` is required: most construction sites are early returns of runs that never reached a definition's read, `CollectorContext.NoMeasurements` is their correct answer, and a default would let them stand in for the one success site that must pass the live list — the site whose silence #3161 was filed about.

- **22 `CollectorRunResult` construction sites** (8 production, 14 test), enumerated by CS7036/CS1503. An independent grep found the same 8 and the same 14, by a method that fails differently.
- **6 Lite `telemetry.Note` assignment sites**, enumerated by CS0200 once `RunTelemetry.Note` became computed — verified by restoring all the old assignment spellings against the computed property and counting what the compiler named, which was the same 6 the grep found.
- The new parameter's type is deliberately not `string?`, so the existing positional `new CollectorRunResult(0, sqlMs, 0, enumeration.Note)` fails to compile rather than silently binding the note to the new slot.

## The consumer

`blocked_process_report` — one of the SQL Server collectors #3160 names, and it runs through both runners, so one wiring covers both SKUs with no PostgreSQL target needed. Its `ReadAsync` already held every figure: it reports `events_read`, `report_xml_empty`, `report_xml_unparsed` and `events_stored` from the loop's own bookkeeping, no query change and no extra round trip. That separates a quiet server from one whose every captured report failed to parse — two outcomes that were byte-identical SUCCESS / 0-row / NULL-note rows before.

## Two decisions worth challenging

**Every `blocked_process_report` run now carries a note, where almost none did before.** That is deliberate and it is the expensive half of the design. Measuring only when the run stored nothing would leave `events_read=40 events_stored=40` unrecorded, and then "measured forty and stored forty" is indistinguishable from "this collector did not look" — the same distinction `PgColumnStatsCoverage.NotMeasured` exists to preserve one collector over, where a word rather than a zero is the point. The cost is that this collector's Note column in Collection Health is never blank again. Nothing treats a non-null `error_message` as a failure (`EmptyEnumerationNoteTests` and its Darling twin both pin against exactly that broadening), and the health grid's exemplar columns rank by recency rather than by `MAX()` since #1855, so a note that changes every cycle displays correctly.

**The definition side is opt-in, not a required member — a deliberate departure from #3161's blast radius.** #3161 listed "every definition and every test fake", which would mean an abstract member on `CollectorDefinitionBase<TRow>` and 69 no-op overrides. That buys no guarantee: an author who writes `=> null` to satisfy the compiler has skipped it exactly as silently as one who never overrode a virtual, and `ICollectorSchemaInfo.TargetEngine` already documents the opposite choice for the same surface and the same reason. CONTRIBUTING's required-member rule is scoped to two-store parity seams with one implementation per store — which is the HOST side, where a silent skip means a permanently-empty value in one SKU, and where `required` costs 22 sites instead of 69 and buys the guarantee outright. So required where the compiler enumerating is both cheap and load-bearing, opt-in where it would be 69 `=> null`s that prove nothing.

## Verification

41 new pin cases (35 in `Darling.Tests`, 6 in `Lite.Tests`). Nineteen mutations, each confirmed applied by `git diff --numstat` before the run and confirmed restored after; every one of the 35 executable cases is reddened by at least one of them:

| mutation | red pins |
|---|---|
| `Render` appends a conclusion when a count is zero | 5, incl. both no-conclusion pins |
| label grammar accepts anything non-empty | 14 |
| label grammar rejects everything | 15, incl. all five accept-a-count-name cases |
| empty and null labels are accepted | the two cases no other mutation reaches |
| `Measure` appends instead of accumulating | the fan-out sum pin |
| `Compose` drops the definition half | both parity pins |
| an empty measurement set renders a string | the leaves-the-column-null pin |
| the reject-counter label is not reserved | the reservation pin |
| consumer stops counting unparsed reports | the consumer's behavioural pin |
| consumer declares an illegal label | 4, incl. the source walk — proving it resolves the `const`, not just literals |
| Darling's `Note` becomes the host half only | the Darling parity pin |
| Lite's `Note` becomes the host half only | the Lite parity pin |
| a `string? Detail` member is added and populated | 3 |
| value widens to `decimal` | both structural type pins |
| value widens to `string` | does not compile — caught by the compiler at four sites |
| the reattempt merge is removed | #3099's ordering pin, with the merge-missing message |
| the success return's argument list is renamed | #3099's ordering pin, now with the *anchor* message |
| `Render` drops its accumulation | the label-uniqueness pin |
| `Render` stops reserving the counter label | the label-uniqueness pin |

The `Detail` mutation is worth calling out: **it survived the first pin set.** Every grammar pin stayed green because those pins check the measurements the *test* builds, and a new field is populated by the *definition*. Two pins were added to close it — the type's member set asserted as an exact set, and the counts-only grammar asserted over what a shipped collector actually recorded by driving its real read.

**One existing pin broke and it is fixed in its own commit.** `StoreWriteReattemptTests.TheReattemptCountReachesTheCollectionLogNote` (#3099) anchors on this success return's argument list, and the new argument moved it. Its failure was worse than the break: `IndexOf` returned -1, `-1 > merge` failed, and the pin reported an ORDERING violation that had not happened while saying nothing about the anchor that had. The anchor's existence is now asserted separately with a message that says the pin has gone blind, and whitespace is collapsed before matching so a reformat cannot break it while a dropped argument still does. Both directions are demonstrated by mutation, and the two now produce different messages.

The source walk resolves both argument spellings (a literal at the call site, and the `const string` a collector declares for it — which is the form the shipped consumer uses, so a literal-only scan would have checked nothing while passing), and it FAILS on an argument it cannot resolve rather than skipping it. Its boundary is recorded in the pin itself: it reads `PerformanceMonitor.Collectors` only, and widening it would be worse rather than better, because `.Measure(` is a name this codebase uses heavily for WPF layout and for the Compose measure catalog. That boundary is affordable because the invariant that matters is closed for every caller — `Render` rejects an illegal label and counts the rejection, so no prose reaches `error_message` from anywhere.

## Review findings, both taken

The review bot raised two, and the second one defeated this type's own stated claim — that the TYPE enforces the invariant rather than discipline at one call site. `Render` is public, so a list assembled by hand rather than accumulated through `Measure` went round the only door that guarded anything. `Render` now applies both invariants itself: a repeated label is summed in first-seen position, and the reserved `invalid_labels` is folded into the rejection counter rather than printed.

Writing the pin for that found a third thing on my own side: my first version of it asserted that a rendered note never repeats a label, and that was **false** before the fix — `Render` rendered what it was given. The assertion was right and the code was wrong, which is the direction worth having. `Measure` keeps its own accumulation, because that is what makes `Measurements` itself a set of counts a definition can read back.

The new pin asserts label UNIQUENESS over the rendered note, which the counts-only grammar cannot see: two tokens with the same label are still `label=value` pairs, so a shape check passes on exactly the note whose figures nobody can attribute. The other finding — a stale `<paramref name="Note"/>` left by the `Note` → `HostNote` rename — is fixed in the same commit.

## CI

Run `34180063593`, head `0c94236d7`, all 8 checks green:

| job | duration | evidence |
|---|---|---|
| `build` (windows) | 10m13s | `Lite.Tests` 3496 total, **Failed 0, Skipped 0, Not Run 0** (298s of test time); `Darling.Tests` 8112 total, Failed 0, Skipped 329 (live-PG gated), Not Run 0; `Dashboard.Tests` 782, Failed 0. The three publish steps ran, so this was not the docs fast path. |
| `Darling PostgreSQL tests` | 4m31s | `Darling.Tests` 8112 total, **Failed 0, Skipped 6, Not Run 0** — the live-Postgres pass, 114s of test time |
| `verify` | 6m9s | |
| `review` | 6m2s | |
| `Darling Linux build` | 1m36s | |
| `Darling whole-tree guards` | 18s | |
| `check-branches` / `description-drift` | 2s / 6s | |

The `Lite.Tests` line is the verification that matters here: that project is `net10.0-windows` with `UseWPF` and references the WPF assembly, so its six pins cannot be executed on macOS. They ran on Windows with zero failures and zero not-run. `Darling.Tests` moving 8111 → 8112 across the two runs is the arithmetic confirming the new uniqueness pin was collected rather than silently absent.

An earlier head failed `build` and `Darling PostgreSQL tests` on the single broken #3099 anchor described above — 8111 total, Failed 1, Not Run 0 in both jobs, so nothing else regressed.

## CHANGELOG entry text

Not committed here — for the coordinator to batch into `[Unreleased]`:

```
- A collector definition can now record what it measured on its own `collection_log` row (#3161). `CollectorContext.Measure` takes a labelled count and never a verdict, so the read derives the conclusion fresh on every call instead of quoting one frozen at collect time. Both SKUs compute their run note from the runner's half and the definition's half through one shared composer, and neither can read one without the other. `blocked_process_report` is the first consumer: it reports how many events it read and how many it dropped, which separates a quiet server from one whose every captured report failed to parse.
```
