### PR TITLE
Re-derive HeaviestHourlyRefreshObservedCeilingSeconds from a job_history census: 594 s becomes 896 s, and the watch-line ordering inverts

### DIFF
--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -40,12 +40,16 @@ namespace Darling.Tests;
 /// figures drawn against that reading derived rather than restated. A pin that restated the summary
 /// would go stale by precisely the mechanism it exists to stop.</para>
 ///
-/// <para><b>One pin is written to expire, deliberately.</b> The comment's reason for taking the maximum
-/// rather than a percentile is partly that at this sample size the 95th percentile IS the maximum by nearest
-/// rank. <see cref="Verify"/> checks that, so the pin goes red once the population grows past the point where
-/// it holds — which is the moment the maximum-versus-percentile decision genuinely has to be re-taken rather
-/// than inherited. A check that simply kept passing would let the stated reason quietly stop being the real
-/// one.</para>
+/// <para><b>One pin was written to expire, and it has (#3166).</b> The comment's reason for taking the
+/// maximum rather than a percentile was PARTLY that at sixteen readings the 95th percentile IS the maximum by
+/// nearest rank; <see cref="Verify"/> checked that, so it went red once the census grew the population past
+/// the point where it held, which is the moment the maximum-versus-percentile decision genuinely had to be
+/// re-taken rather than inherited. It was re-taken, the estimator is still the maximum, and the surviving
+/// reason — a scheduling exclusion may accept no exceedance over its own record — does not reference the
+/// population's size. So the expiring clause is gone with the argument it guarded, and the two percentiles
+/// are now pinned as readings that TRACK the population. There is no replacement expiry, because a reason
+/// independent of <c>n</c> has nothing left to expire; what a growing population now moves is the ceiling
+/// itself, which is checked directly.</para>
 ///
 /// <para><b>Which numeral KIND these are, because the repo handles two differently and neither #3072 nor
 /// #3073 says so out loud.</b> A numeral that restates an adjacent list gets DELETION offered in its
@@ -60,11 +64,15 @@ namespace Darling.Tests;
 ///
 /// <para><b>What is deliberately NOT pinned, said plainly rather than left looking covered.</b> The
 /// snapshot readings are quoted evidence, not derived quantities — nothing in the code can know them — so
-/// they are held only by the DISJOINTNESS the paragraph is about (see
-/// <see cref="TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries"/>), which is the failure
-/// mode that matters: an unfiltered reading migrating into the population a constant may be set from. The
+/// they are held only by their MEMBERSHIP of the census population (see
+/// <see cref="TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries"/>). That is the inverse of
+/// the relationship the sixteen-run record held them to, and the inversion is the finding rather than a
+/// weakening (#3166): disjointness was a property of a SAMPLE, and a census of the same job contains by
+/// construction whatever a snapshot of its last run reported — so a value-level test could never have
+/// encoded a rule about SOURCES, and the rule is checked against the shipped SQL of all three reads by
+/// <see cref="TheInadmissibilityClaim_MatchesTheShippedSql"/> instead. The
 /// pre-narrowing band and the 3.8x ratio drawn against it are likewise evidence — that band is #3012's
-/// measurement and no constant here spells it — so they carry no pin. The excluded run's 1.45x ratio to the
+/// measurement and no constant here spells it — so they carry no pin. The excluded run's ratio to the
 /// population maximum IS pinned, because both of its terms are stated here. The live envelope's measured
 /// maximum is evidence on the same footing, and its day count with it; what IS pinned is every figure the
 /// prose draws AGAINST that maximum — the slot margin, the share of the slot and the distance past the
@@ -80,7 +88,7 @@ namespace Darling.Tests;
 /// in the list and never asserted against anything looks exactly like a pattern doing work.</para>
 ///
 /// <para><b>And the SCOPING rule, held file-wide rather than only where it is stated (#3133).</b>
-/// <see cref="Verify"/> requires the ceiling paragraph's own enumeration to carry a CLOSED scope;
+/// <see cref="Verify"/> requires the ceiling paragraph's live-envelope population to carry a CLOSED scope;
 /// <see cref="NoOpenPopulationClaim_SurvivesOutsideTheSentenceThatRejectsIt"/> requires the rest of the
 /// file not to break the same rule. A rule stated in one paragraph binds nothing in the paragraphs a
 /// reader meets thousands of lines away, so where it is stated is not where it needs enforcing.</para>
@@ -163,7 +171,7 @@ public sealed class RefreshCeilingProvenancePinTests
         yield return (
             "the excluded run's ratio to the population maximum",
             CeilingDeclaration,
-            @"([0-9]+)\.([0-9]+)x slower than the largest reading",
+            @"([0-9]+)\.([0-9]+)x of the largest reading",
             true);
 
         yield return (
@@ -181,13 +189,20 @@ public sealed class RefreshCeilingProvenancePinTests
         yield return (
             "the population summary",
             CeilingDeclaration,
-            @"Together ([0-9]+) runs spanning ([0-9]+) s to ([0-9]+) s, mean ([0-9]+)\.([0-9]+) s, median ([0-9]+) s",
+            @"Together ([0-9]+) runs spanning ([0-9]+) s to ([0-9]+) s, totalling ([0-9]+) s, median ([0-9]+) s",
             true);
 
+        /* A TOTAL rather than a mean (#3166). 27799 s over 57 runs has no exact one-decimal form, so a
+           stated mean would be a rounded figure the comparison below could only accept by rounding too -
+           and a pin that rounds is a pin with a tolerance nobody wrote down. The total is exact in the unit
+           the population is listed in, and it keeps every individual reading load-bearing for the same
+           reason the mean did: a single digit moved anywhere in the list changes it, which is what
+           EveryNumericPin_ReportsAnInjectedDrift depends on for the middle-ranked readings that move
+           neither the range nor the median. */
         yield return (
             "the percentile decision",
             CeilingDeclaration,
-            @"by nearest rank over ([0-9]+) readings the 95th percentile IS the largest of them, and the 90th is ([0-9]+) s, only ([0-9]+) s below it",
+            @"by nearest rank over ([0-9]+) readings the 95th percentile is ([0-9]+) s and the 90th is ([0-9]+) s, ([0-9]+) s and ([0-9]+) s below the maximum",
             true);
 
         /* ARITY-FREE, and that is the point rather than a convenience. This list gains a reading every hour
@@ -199,7 +214,15 @@ public sealed class RefreshCeilingProvenancePinTests
            NOT drift-swept either: these are quoted readings, so bumping a digit only produces another number
            the code cannot contradict. What IS checked is the rule the paragraph is actually about - see
            TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries and the as-at scope guard in
-           Verify. */
+           Verify.
+
+           THE RELATIONSHIP TO THE POPULATION INVERTED at #3166 and the check inverted with it. These three
+           used to be held DISJOINT from the published population, which held only while that population was
+           a sixteen-run SAMPLE of this job. Against a CENSUS of the same job disjointness cannot hold: the
+           self-metrics snapshot reads that job's last run and the census contains every run, so all three
+           readings are members. Verify now requires CONTAINMENT, which is the same evidence read the right
+           way round - it is what demonstrates the two series read the same runs, and therefore why a
+           value-level test could never have encoded a rule about SOURCES. */
         yield return (
             "the inadmissible snapshot readings",
             CeilingDeclaration,
@@ -232,7 +255,7 @@ public sealed class RefreshCeilingProvenancePinTests
         yield return (
             "the exclude-whole occupancy sentence",
             CompressionMinutesDeclaration,
-            @"occupies ([0-9]+)\.([0-9]+) of the ([0-9]+) minutes",
+            @"occupies ([0-9]+) of the ([0-9]+) seconds",
             true);
 
         yield return (
@@ -280,13 +303,22 @@ public sealed class RefreshCeilingProvenancePinTests
     }
 
     /// <summary>
-    /// The paragraph's whole job is to keep the unfiltered self-metrics readings OUT of the population a
-    /// constant may be set from, so the mutation is the merge itself rather than a digit bump: put a
-    /// status-verified reading in the snapshot pair's place and require verification to fail.
+    /// The paragraph's whole job is to keep the unfiltered self-metrics readings OUT of the SOURCES a
+    /// constant may be set from while stating what they corroborate, so the mutation is a reading with no
+    /// run behind it rather than a digit bump: put a value the census does not contain in the snapshot
+    /// list's place and require verification to fail.
     ///
-    /// <para>Both populations are asserted NON-EMPTY first. Disjointness is a claim about an absence, and an
-    /// absence is also exactly what a pattern matching nothing produces — so emptiness has to be excluded
-    /// before the disjointness result says anything at all.</para>
+    /// <para><b>The relationship checked here inverted at #3166, and the mutation inverted with it.</b> It
+    /// used to be DISJOINTNESS, which held only while the published population was a sixteen-run sample of
+    /// this job — so the mutation then was to inject a population member. Against a CENSUS of the same job
+    /// disjointness is impossible: the snapshot reads that job's last run, and every run is in the census.
+    /// What is checkable is CONTAINMENT, so the mutation is a NON-member, and the failure it forces is the
+    /// one worth having: a quoted reading with no census run behind it means the two reads disagree about
+    /// what the job did.</para>
+    ///
+    /// <para>Both populations are asserted NON-EMPTY first. Containment over an empty snapshot list is
+    /// vacuously true and an empty list is also exactly what a pattern matching nothing produces — so
+    /// emptiness has to be excluded before the result says anything at all.</para>
     /// </summary>
     [Fact]
     public void TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries()
@@ -299,25 +331,33 @@ public sealed class RefreshCeilingProvenancePinTests
 
         Assert.NotEmpty(series);
         Assert.NotEmpty(snapshot);
-        Assert.Empty(series.Intersect(snapshot));
+        Assert.All(snapshot, reading => Assert.Contains(reading, series));
 
         /* Injected through the same ordinal rewrite the drift sweep uses, rather than by string-replacing
            the reading. A bare Replace would depend on the surrounding emphasis tags - the very coupling
            DocProseFor now normalises away - and would silently find nothing if someone unbolded the figure,
-           which is a mutation that proves nothing wearing a caught drift's clothes. */
+           which is a mutation that proves nothing wearing a caught drift's clothes.
+
+           WIDTH-PRESERVING, so the replacement has to be a non-member of the same digit count as the
+           reading it displaces: the rewrite pads to the original width and a longer value would leave the
+           pattern matching a number the source does not contain. The census maximum plus one is a
+           non-member by construction and is chosen over an arbitrary value for that reason. */
         var snapshotPattern = PatternFor("the inadmissible snapshot readings");
         var firstReading = OrdinalOfFirstNumberInGroups(prose, snapshotPattern);
         Assert.True(firstReading >= 0, "the snapshot pair's pattern captured no number, so its pin is vacuous.");
+
+        var nonMember = series.Max() + 1;
+        Assert.DoesNotContain(nonMember, series);
 
         var mutated = RewriteNumberInDocRun(
             source,
             CeilingDeclaration,
             snapshotPattern,
             firstReading,
-            series[^1].ToString(CultureInfo.InvariantCulture));
+            nonMember.ToString(CultureInfo.InvariantCulture));
 
         Assert.True(mutated is not null,
-            "could not inject a series reading into the snapshot pair, so nothing was proved.");
+            "could not inject a non-member into the snapshot list, so nothing was proved.");
         Assert.NotEqual(source, mutated);
 
         var failure = Assert.ThrowsAny<Exception>(() => Verify(mutated!));
@@ -461,10 +501,13 @@ public sealed class RefreshCeilingProvenancePinTests
     [Fact]
     public void TheDerivedFiguresAreExactlyStateable_AndTheConstantIsThePopulationMaximum()
     {
-        /* CompressionPhaseMinutes quotes the ceiling in minutes to one decimal, which is only faithful while
-           the ceiling is an exact tenth of a minute: 9.9 for a 9.91666 value is a rounded claim wearing an
-           exact one's clothes. */
-        Assert.Equal(0, Ceiling * 10 % 60);
+        /* CompressionPhaseMinutes used to quote the ceiling in minutes to one decimal, which was only
+           faithful while the ceiling was an exact tenth of a minute - 9.9 for a 9.91666 value is a rounded
+           claim wearing an exact one's clothes. That divisibility requirement is gone with the sentence:
+           896 is not a multiple of six seconds, and a check demanding that a MEASUREMENT be divisible makes
+           an honest figure unstateable rather than catching a drift. The occupancy is stated in seconds
+           against a slot in seconds instead, which is exact for every value the constant can take, and
+           Verify pins it in that unit. */
 
         var population = CleanPopulation(DocProseFor(ReadTimescaleSupportSource(), CeilingDeclaration));
         Assert.NotEmpty(population);
@@ -474,27 +517,46 @@ public sealed class RefreshCeilingProvenancePinTests
            above the maximum is the unestablished-bound shape the derivation replaces. */
         Assert.Equal(population.Max(), Ceiling);
 
-        /* The mean is stated to one decimal and the median as a whole number, so both have to be exactly
-           stateable in those shapes. */
-        Assert.Equal(0, population.Sum() * 10 % population.Length);
+        /* The median is stated as a whole number, so it has to be exactly stateable in that shape. The mean
+           is no longer stated at all - 27799 s over 57 readings has no exact one-decimal form - so the
+           prose carries the exact TOTAL instead and Verify pins that. An exactness check on a figure the
+           prose does not state would pass on any population and guard nothing.
+
+           At an ODD population size this parity check is vacuous: both indices are the same element, so the
+           sum is even by construction. It is kept because the population's size is a measurement and the
+           next census may be even, and a check that is vacuous today is not the same as one that is
+           wrong. */
         var sorted = population.OrderBy(v => v).ToArray();
         Assert.Equal(0, (sorted[(sorted.Length - 1) / 2] + sorted[sorted.Length / 2]) % 2);
 
         /* The relationship the grid depends on, over the WHOLE population rather than one true clause
-           standing in for it: every clean run fits inside the slot, and inside the routine band. */
+           standing in for it: every clean run fits inside the slot, and inside the routine band.
+
+           THE SECOND CLAUSE AND THE ORDERING BELOW NOW FAIL, on #3166's census re-derivation, and both are
+           left with their CONDITIONS exactly as written. Only their messages moved, because the reason the
+           old ones gave - "the doc comment claims otherwise" - is no longer why they matter: the comment now
+           states the crossings plainly, so what these clauses guard is the GRID, not the prose. Seven of the
+           57 census readings are in the warning band and the sizing figure is 146 s above the line. Fixing
+           that means moving the watch line, moving the slot, or making the refresh cheaper; re-typing either
+           condition is the only edit that makes the failure go away while changing nothing about the
+           store. */
         Assert.All(population, reading => Assert.True(reading < Slot,
             $"a clean post-boundary reading of {reading} s is at or past the {Slot} s refresh slot, so the "
             + "compression grid's stated precondition is false and #3035 has to be re-derived rather than "
             + "renumbered"));
         Assert.All(population, reading => Assert.True(reading < WatchLine,
             $"a clean post-boundary reading of {reading} s is at or past the {WatchLine} s watch line, so "
-            + "the doc comment's claim that every reading in the population is below it is false"));
+            + "the grid is no longer clear of the load it is sized against: the warning band is meant to "
+            + "hold readings this record has no instance of, and it now holds several. A scheduling "
+            + "decision (#3035, #3044, #3107), not a condition to renumber"));
 
-        /* And the contrast the prose draws: the watch line sits ABOVE the derived ceiling, which is what
-           makes a crossing news rather than a restatement of the grid's own sizing figure. */
+        /* And the ordering the whole #3044 watch rests on: the line sits ABOVE the derived ceiling, which is
+           what makes a crossing news rather than a restatement of the grid's own sizing figure. */
         Assert.True(Ceiling < WatchLine,
-            "the ceiling now classifies as a warning, so the doc comment's claim that the watch line sits "
-            + "above the observed range is stale.");
+            $"the {Ceiling} s ceiling is at or above the {WatchLine} s watch line, so the figure the grid is "
+            + "sized against classifies as a warning and the watch reports the sizing rather than anything "
+            + "new. This is the outcome RefreshSlotWarningSeconds' own summary pre-registered; re-take the "
+            + "slot or the fraction (#3035, #3044, #3107) rather than editing this assertion.");
     }
 
     /// <summary>
@@ -625,7 +687,7 @@ public sealed class RefreshCeilingProvenancePinTests
         var sorted = population.OrderBy(v => v).ToArray();
         var min = sorted[0];
         var max = sorted[^1];
-        var mean10 = population.Sum() * 10 / population.Length;
+        var total = population.Sum();
         var median = (sorted[(sorted.Length - 1) / 2] + sorted[sorted.Length / 2]) / 2;
 
         /* THE DERIVATION, and the one relationship everything else here is decoration on: the constant is
@@ -634,9 +696,6 @@ public sealed class RefreshCeilingProvenancePinTests
             $"the published population {Join(sorted)} has maximum {max} s, but this constant holds "
             + $"{Ceiling} s — the comment says the estimator is the maximum, so one of the two is wrong");
 
-        Require(population.Sum() * 10 % population.Length == 0,
-            "the population's mean is no longer an exact tenth of a second, so the prose cannot state it to "
-            + "one decimal — restate it rather than removing this check");
         Require((sorted[(sorted.Length - 1) / 2] + sorted[sorted.Length / 2]) % 2 == 0,
             "the population's median is no longer a whole number of seconds, so the prose cannot state it as "
             + "one — restate it rather than removing this check");
@@ -646,26 +705,41 @@ public sealed class RefreshCeilingProvenancePinTests
             $"stated count {summary[0]} against {population.Length} listed");
         Require(summary[1] == min, $"stated low {summary[1]} s against {min} s listed");
         Require(summary[2] == max, $"stated high {summary[2]} s against {max} s listed");
-        Require(summary[3] * 10 + summary[4] == mean10,
-            $"stated mean {summary[3]}.{summary[4]} s against {mean10 / 10}.{mean10 % 10} s computed");
-        Require(summary[5] == median, $"stated median {summary[5]} s against {median} s computed");
 
-        /* THE ESTIMATOR CHOICE, checked rather than asserted in prose — and written to EXPIRE. The comment
-           takes the maximum partly because at this sample size the 95th percentile is the maximum by nearest
-           rank; when the population grows past that, this goes red and the decision gets re-taken instead of
-           inherited. */
+        /* A TOTAL rather than a mean (#3166): 27799 s over 57 readings has no exact one-decimal form, and a
+           comparison that accepted a rounded mean would be a pin with an unwritten tolerance. The total is
+           exact in the unit the readings are listed in and catches the same drift — a bump to a
+           middle-ranked reading moves neither the range nor the median, and this is what sees it. */
+        Require(summary[3] == total, $"stated total {summary[3]} s against {total} s summed from the list");
+        Require(summary[4] == median, $"stated median {summary[4]} s against {median} s computed");
+
+        /* THE ESTIMATOR CHOICE. This clause used to require the 95th percentile to EQUAL the maximum, which
+           was half the comment's stated reason for taking the maximum and was written to expire once the
+           population grew. It expired (#3166): at 57 readings the 95th sits below the maximum, the decision
+           was re-taken, and the surviving reason — a scheduling exclusion may accept no exceedance over its
+           own record — does not reference the population's size, so there is nothing left for an expiry to
+           watch. What replaces it is stricter about what the prose may claim: both percentiles and both
+           gaps, derived by nearest rank from the published list rather than restated. */
         var percentile = Read("the percentile decision");
         Require(percentile[0] == population.Length,
             $"stated sample size {percentile[0]} against {population.Length} listed");
-        Require(NearestRank(sorted, 95) == max,
-            $"the 95th percentile of {Join(sorted)} is {NearestRank(sorted, 95)} s and no longer the "
-            + $"{max} s maximum, so the comment's stated reason for taking the maximum rather than a "
-            + "percentile has expired. RE-TAKE the decision (issue #3101 records the trade) rather than "
-            + "editing this assertion — that is what this pin is for");
-        Require(percentile[1] == NearestRank(sorted, 90),
-            $"stated 90th percentile {percentile[1]} s against {NearestRank(sorted, 90)} s computed");
-        Require(percentile[2] == max - NearestRank(sorted, 90),
-            $"stated gap {percentile[2]} s against {max - NearestRank(sorted, 90)} s derived");
+        Require(percentile[1] == NearestRank(sorted, 95),
+            $"stated 95th percentile {percentile[1]} s against {NearestRank(sorted, 95)} s computed");
+        Require(percentile[2] == NearestRank(sorted, 90),
+            $"stated 90th percentile {percentile[2]} s against {NearestRank(sorted, 90)} s computed");
+        Require(percentile[3] == max - NearestRank(sorted, 95),
+            $"stated 95th-percentile gap {percentile[3]} s against {max - NearestRank(sorted, 95)} s derived");
+        Require(percentile[4] == max - NearestRank(sorted, 90),
+            $"stated 90th-percentile gap {percentile[4]} s against {max - NearestRank(sorted, 90)} s derived");
+
+        /* And the divergence the paragraph is ABOUT, as an inequality rather than as prose: if a high
+           percentile ever coincided with the maximum again the sample-size argument would be available
+           once more, and re-taking the decision on the cost argument alone would no longer be the whole
+           story. Stated so a coincidence has to be noticed rather than sat on. */
+        Require(NearestRank(sorted, 95) < max,
+            $"the 95th percentile of {Join(sorted)} is back at the {max} s maximum, so the paragraph's "
+            + "premise — that the two answers have diverged — is false and the sample-size half of the "
+            + "estimator argument is live again. Re-read #3101's trade rather than editing this assertion");
 
         var low = Read("the low the grid is deliberately not sized against");
         Require(low[0] == min, $"stated low {low[0]} s against {min} s listed");
@@ -685,10 +759,17 @@ public sealed class RefreshCeilingProvenancePinTests
         var statedShareTenths = live[4] * 10 + live[5];
         var statedPastWatch10 = live[6] * 10 + live[7];
 
-        Require(measured10 > Ceiling * 10,
-            $"the measured maximum {measured10 / 10}.{measured10 % 10} s is at or below the {Ceiling} s "
-            + "recorded ceiling, so a paragraph stating it as an envelope NARROWER than the population's "
-            + "clearance is describing something that is not the case");
+        /* The two now COINCIDE, because the constant is the maximum of a census that includes this day
+           rather than of a sample that predated it (#3166). #3119 required the measured maximum to be
+           strictly ABOVE the ceiling, which was the whole reason that paragraph existed; equality is what
+           says the census has closed that gap. A measured day ABOVE the ceiling would mean the census has
+           been overtaken and the constant is stale again; BELOW would mean the constant was not taken from
+           this population at all. */
+        Require(measured10 / 10 == Ceiling,
+            $"the measured maximum {measured10 / 10}.{measured10 % 10} s no longer truncates to the "
+            + $"{Ceiling} s recorded ceiling. Above it, the census this constant was derived from has been "
+            + "overtaken and it needs re-deriving; below it, this paragraph is quoting a day the constant "
+            + "was not taken from");
 
         /* THE VERDICT, from the SHIPPED classifier and ABOVE the arithmetic, because Verify is fail-fast:
            a maximum restated low enough to change its band trips the margin equality below on the way
@@ -741,9 +822,13 @@ public sealed class RefreshCeilingProvenancePinTests
         var excluded = Read("the excluded run's duration");
         Require(ended - started == excluded[0],
             $"the quoted run spans {ended - started} s, not the {excluded[0]} s stated for it");
-        Require(excluded[0] > Ceiling,
-            $"the excluded run's {excluded[0]} s is no longer above the {Ceiling} s population maximum, so "
-            + "the prose's \"slower than the largest reading\" is false");
+        /* The excluded run now sits INSIDE the population's range, which is what the prose says and is the
+           reason its duration-based disqualification was dropped (#3166). Held as an inequality rather than
+           left as prose: if it rose back above the maximum, "inside the post-boundary range" would be false
+           and the paragraph would need the earlier argument back. */
+        Require(excluded[0] < Ceiling,
+            $"the excluded run's {excluded[0]} s is at or above the {Ceiling} s population maximum again, so "
+            + "the prose's \"sits INSIDE the post-boundary range\" is false");
 
         var boundary = Read("the boundary timestamp");
         Require(ended - Seconds(boundary[0], boundary[1], boundary[2]) == 1,
@@ -755,12 +840,20 @@ public sealed class RefreshCeilingProvenancePinTests
             $"stated ratio {ratio[0]}.{ratio[1]}x against {excluded[0] * 100 / Ceiling / 100}."
             + $"{excluded[0] * 100 / Ceiling % 100}x derived from {excluded[0]} s over {Ceiling} s");
 
-        /* The snapshot readings stay out of the admissible population, HOWEVER MANY of them there are. */
+        /* THE SNAPSHOT READINGS ARE MEMBERS of the census population, HOWEVER MANY of them there are, and
+           that is the inversion of what this clause used to require (#3166). Disjointness was a property of
+           the SAMPLE the population used to be, not of the rule: the self-metrics snapshot reads this job's
+           last run, so a census of the job contains whatever it reported. Containment is the same evidence
+           read the right way round, and it fails toward the more useful label - a quoted reading that is NOT
+           in the census means the unfiltered series is reporting a run the status-verified census does not
+           have, which is an anomaly in the reads rather than a tidiness problem in the prose. */
         var snapshot = Read("the inadmissible snapshot readings");
         Require(snapshot.Length > 0, "the inadmissible snapshot readings parsed to nothing");
-        Require(!snapshot.Intersect(population).Any(),
-            $"an unfiltered snapshot reading appears in the status-verified population {Join(sorted)}, so "
-            + "the two populations have been run together");
+        Require(snapshot.All(reading => population.Contains(reading)),
+            $"a quoted snapshot reading is absent from the census population {Join(sorted)}. The snapshot "
+            + "series reads this job's last run and the population is a census of every run since the "
+            + "boundary, so a reading with no member to match either came from a different job, or the "
+            + "population is not the census it says it is");
 
         /* THE CLOSING SCOPE, which is what stops that list reading as a complete enumeration of an open
            set. The series it quotes gains a reading every hour, so an unscoped list is a frozen enumeration
@@ -781,16 +874,17 @@ public sealed class RefreshCeilingProvenancePinTests
             + "enumeration and keep only the rule, which is the timeless part and the paragraph's real "
             + "subject");
 
-        /* CompressionPhaseMinutes' exclude-whole reasoning: the ceiling in minutes, the guard band against
-           it, and the minutes the exclusion declines to recover. */
-        Require(Ceiling * 10 % 60 == 0,
-            "the ceiling is no longer an exact tenth of a minute, so the occupancy figure cannot be stated to "
-            + "one decimal");
+        /* CompressionPhaseMinutes' exclude-whole reasoning: the ceiling against the slot, the guard band
+           against it, and the minutes the exclusion declines to recover.
+
+           IN SECONDS, not tenths of a minute (#3166). The old form stated the occupancy as a tenth of a
+           minute, which is only faithful while the ceiling is a multiple of six seconds; 896 is not, and a
+           check demanding that divisibility would make an honest measurement unstateable rather than
+           catching anything. Seconds against seconds is exact for every value the constant can take, so
+           this cannot expire for a reason that has nothing to do with the grid. */
         var occupancy = Read("the exclude-whole occupancy sentence");
-        Require(occupancy[0] == Ceiling / 60, $"stated whole minutes {occupancy[0]} against {Ceiling / 60}");
-        Require(occupancy[1] == Ceiling * 10 / 60 % 10,
-            $"stated tenth of a minute {occupancy[1]} against {Ceiling * 10 / 60 % 10}");
-        Require(occupancy[2] == SlotMinutes, $"stated slot {occupancy[2]} minutes against {SlotMinutes}");
+        Require(occupancy[0] == Ceiling, $"stated occupancy {occupancy[0]} s against {Ceiling} s");
+        Require(occupancy[1] == Slot, $"stated slot {occupancy[1]} s against {Slot} s");
 
         var minutesInsideTheRefresh = (Ceiling + 59) / 60;
         var band = Read("the guard-band arithmetic the exclusion rests on");
@@ -857,9 +951,11 @@ public sealed class RefreshCeilingProvenancePinTests
 
     /// <summary>
     /// The clean post-boundary population: both published lists, concatenated. Read from the two patterns
-    /// rather than from one, because the comment publishes them separately — the boundary day's tail is a
-    /// census of that day and the days after it are a sample, and collapsing the two into a single list in
-    /// the prose would erase a distinction the estimator's stated limitation rests on.
+    /// rather than from one, because the comment publishes them separately — the boundary day's tail is one
+    /// partial day and the days after it are whole ones, which is the split the per-day trend the comment
+    /// states is read off. Both halves are now censuses (#3166); the sample-versus-census distinction the
+    /// split originally carried is retired, and the split is kept because it is what makes the boundary
+    /// day's nine runs identifiable as a tail rather than a day.
     /// </summary>
     private static int[] CleanPopulation(string prose) =>
         Numbers(prose, "the boundary day's tail")

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -133,9 +133,11 @@ public sealed class TimescaleContinuousAggregateTests
     /// retention re-materialized roughly three quarters of the hypertable every hour. Measured on the
     /// production store: the heaviest hourly refresh ran 3,301-6,330 s against its own 1-hour cadence — 118-175%
     /// of it, so each run started into the tail of the last — while rows arriving per hour FELL ~3x. On the
-    /// narrowed window the same refresh finishes well inside one phase slot, which is what makes the overlap
-    /// structurally impossible rather than merely absent. The figure and its derivation live on
-    /// TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds rather than being restated here.</para>
+    /// narrowed window the same refresh finishes inside one phase slot, which is what makes the overlap
+    /// structurally impossible rather than merely absent — by 4 s of a 900 s slot as of #3166's census, so
+    /// "inside" is now the whole of the claim and "well inside" is no longer available. The figure and its
+    /// derivation live on TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds rather than being
+    /// restated here.</para>
     ///
     /// <para>Asserted for EVERY hourly view rather than the heavy one alone: the defect was a shared default,
     /// so a fix that reached only the aggregate named in the incident would leave twelve behind.</para>

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2291,7 +2291,7 @@ LIMIT 1", connection))
            comment reads as unconditional to whoever finds it next. Raising the recorded ceiling past the
            slot width therefore has to FAIL here rather than be renumbered through, because past that
            point the refresh runs into its neighbour and the grid needs redesigning. */
-        Assert.Equal(594, TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds);
+        Assert.Equal(896, TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds);
         Assert.Equal(140, TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds);
         Assert.True(
             TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds < TimescaleSupport.RefreshPhaseStepMinutes * 60,
@@ -2472,7 +2472,15 @@ LIMIT 1", connection))
     /// and the watch line sits ABOVE it — so a live reading in the warning band is this job exceeding its own
     /// recorded range rather than a restatement of the figure the compression grid is sized against. The five
     /// readings taken during #3044's review all classify INSIDE too, which is the anti-crying-wolf half; the
-    /// largest of them, at 66.0% of the slot, IS the recorded ceiling.</para>
+    /// largest of them, at 66.0% of the slot, was the recorded ceiling when the record was sixteen runs
+    /// long.</para>
+    ///
+    /// <para><b>The ceiling assertion below now FAILS, on the census re-derivation of #3166, and it is left
+    /// exactly as written.</b> At 896 s the figure the grid is sized against classifies
+    /// <c>ApproachingSlot</c> and sits 146 s ABOVE the watch line, so the relationship this test is named
+    /// for has inverted. Restoring it means moving the watch line, moving the slot, or making the refresh
+    /// cheaper — a scheduling decision (#3035, #3044, #3107) — and re-typing the expected band here is the
+    /// one change that would hide it while deciding nothing.</para>
     ///
     /// <para>Both boundaries are pinned inclusive on purpose: the wall matches the build-time assertion's
     /// <c>&lt;</c>, so a value AT the slot width fails both.</para>
@@ -2610,10 +2618,14 @@ LIMIT 1", connection))
             TimescaleSupport.HeaviestHourlyRefreshView,
             TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds);
 
-        /* The recorded ceiling: 66.0% of the slot, 306 s clear, and inside the routine band. */
+        /* The recorded ceiling: 99.6% of the slot and 4 s clear (#3166's census re-derivation). The BAND
+           assertion below is left as it was written and now FAILS, which is the point of having it: a
+           sizing figure that classifies as a warning is the grid's precondition going, and renumbering the
+           expected band to match would be the one edit that makes the failure disappear without changing
+           anything about the store. */
         Assert.Equal(TimescaleSupport.RefreshSlotHeadroom.InsideSlot, atTheCeiling.Headroom);
-        Assert.Equal(306, atTheCeiling.ClearOfSlotSeconds);
-        Assert.Equal(66.0, atTheCeiling.PercentOfSlot, 1);
+        Assert.Equal(4, atTheCeiling.ClearOfSlotSeconds);
+        Assert.Equal(99.6, atTheCeiling.PercentOfSlot, 1);
 
         /* The watch line, which is where APPROACHING starts: 83.3% of the slot, 150 s clear. */
         var atTheWatchLine = new HeaviestRefreshSlotReading(
@@ -2773,11 +2785,11 @@ LIMIT 1", connection))
             "the slot watch no longer fires before #2136's default cadence warning, so it adds no lead time");
 
         /* And the evidence that #2136 does not know this job's size, as a number rather than as prose:
-           the recorded ceiling is 16.5% of the same cadence, while the clamp in DarlingAlertSettings is
-           justified on "the production worst runs ~7% of cadence" — 252 s, under half of it. Pinned so the
-           doc comment's claim cannot quietly stop being true. */
+           the recorded ceiling is 24.9% of the same cadence, while the clamp in DarlingAlertSettings is
+           justified on "the production worst runs ~7% of cadence" — 252 s, well under half of it. Pinned so
+           the doc comment's claim cannot quietly stop being true. */
         Assert.Equal(
-            16.5,
+            24.9,
             100.0 * TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds / hourlyCadenceSeconds,
             1);
         Assert.True(

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2385,6 +2385,16 @@ LIMIT 1", connection))
     /// refresh by a wide margin is satisfied by almost anything, so the minute that WOULD violate it is
     /// computed and shown to violate it. Without that, a check that had stopped measuring the right quantity
     /// would still be green.</para>
+    ///
+    /// <para><b>The GRID half of this test still passes and the WATCH-LINE half now FAILS, on #3166's census
+    /// re-derivation, and the two conditions are left exactly as written.</b> The grid is genuinely clear: at
+    /// a 896 s ceiling the nearest compression minute is still 1,320 s past the heaviest refresh's start and
+    /// the discriminating minute is still excluded, so nothing overruns anything. What is false is
+    /// <c>ceiling &lt; RefreshSlotWarningSeconds</c>, and the 26%-gap literal derived from it — the sizing
+    /// figure is 146 s ABOVE the line, so the watch now reports the grid's own sizing rather than anything
+    /// new. Restoring the ordering means moving the line, moving the slot, or making the refresh cheaper,
+    /// which is a scheduling decision (#3035, #3044, #3107); re-typing either condition here is the only
+    /// edit that makes the failure go away while changing nothing about the store.</para>
     /// </summary>
     [Fact]
     public void NoCompressionMinuteStartsWhileTheHeaviestRefreshIsStillRunning()
@@ -2558,6 +2568,14 @@ LIMIT 1", connection))
     /// <para>The lead-time leg cuts the OTHER way and is asserted in that direction, because a reader
     /// checking the rejection is owed the fact that it does not help: the lower line leaves MORE room
     /// between itself and the slot, so it warns earlier rather than later.</para>
+    ///
+    /// <para><b>Half of that rejection now FAILS, on #3166's census re-derivation, and both conditions are
+    /// left exactly as written.</b> The recorded ceiling is still at or past the 480 s alternative, so the
+    /// alternative is still the lower of the two lines — but at 896 s the ceiling warns under the CHOSEN
+    /// line too, so the chosen line rejects the alternative on a property it has itself stopped having, and
+    /// the classifier no longer bands the ceiling <c>InsideSlot</c>. That is the ordering paragraph above
+    /// doing what it says: one of the two constants moved, so the five-sixths decision genuinely has to be
+    /// re-taken (#3044, #3107) rather than restated here.</para>
     /// </summary>
     [Fact]
     public void TheRejectedWatchLineAlternative_SitsBelowTheRecordedCeiling_WhileTheChosenLineSitsAbove()
@@ -2652,6 +2670,13 @@ LIMIT 1", connection))
         TimescaleSupport.LogHeaviestRefreshSlotHeadroom(null, quiet);
         Assert.Equal("(no log lines captured)", quiet.Joined);
 
+        /* THE ROUTINE-BAND CASE IS FED THE RECORDED CEILING, and after #3166's census re-derivation that
+           reading logs Warning rather than Debug — so this assertion FAILS and is left exactly as written.
+           It is the same inversion as the band pins: a sizing figure the product's own watch line calls a
+           warning cannot also be the example of a routine reading. Re-pointing this case at a lower literal
+           would keep the level table covered while quietly dropping the claim that the grid's own figure is
+           routine, which is the claim worth losing loudly. The remedy is the slot or the fraction (#3035,
+           #3044, #3107). */
         var inside = new CapturingTestLogger();
         TimescaleSupport.LogHeaviestRefreshSlotHeadroom(
             new HeaviestRefreshSlotReading(

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1889,8 +1889,11 @@ WITH NO DATA";
     /// run's own completion a fraction of a second later, in which case the boundary and that run's
     /// exclusion are ONE OBSERVATION and cannot corroborate each other. That is NOT asserted as settled in
     /// either direction. What would settle it is a record of the ALTER independent of the job history, and
-    /// none has been found — and nothing above needs one, because the exclusion rule is positional and the
-    /// excluded run is disqualified by its duration alone.</para>
+    /// none has been found — and nothing above needs one, because the exclusion rule is positional. It used
+    /// to say "and the excluded run is disqualified by its duration alone", which was the belt to the
+    /// boundary's braces; that belt is gone with the census, since 864 s is now an ordinary member of the
+    /// post-boundary range. The circularity is therefore no better corroborated than it was and no worse:
+    /// a positional rule needs no second reason, which is why it was chosen over one.</para>
     ///
     /// <para><b>And the rule that keeps a whole SERIES out of this constant, stated as a rule because the
     /// series keeps growing.</b> The hourly self-metrics snapshot

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1573,7 +1573,8 @@ WITH NO DATA";
     /// hypertable rather than with ingest. Measured on the production store: the heaviest hourly refresh
     /// (<see cref="QueryStoreStatsIntervalHourlyView"/>) ran 3,301-6,330 s against a 1-hour cadence —
     /// <b>118-175% of its own schedule interval</b> — while rows arriving per hour FELL ~3x over the same
-    /// period. Narrowed to 1 day the same refresh finishes <b>well inside one phase slot</b>, and the figure
+    /// period. Narrowed to 1 day the same refresh finishes <b>inside one phase slot</b> — by 4 s of 900 as of
+    /// #3166's census, so the margin is no longer part of the claim — and the figure
     /// with its derivation is on <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> rather than
     /// restated here — a percentage of cadence written twice goes stale in one of the two places. The
     /// direction of that measurement is the whole argument: duration tracking window size while ingest moves the other way is

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1793,44 +1793,87 @@ WITH NO DATA";
     /// published below and TimescaleSupportTests holds the grid clear of it, so the value and the method
     /// cannot drift apart without a red test.</para>
     ///
+    /// <para><b>THE READ IS A CENSUS, and that is what changed (#3166).</b> Every run of this job since the
+    /// boundary, one row per run, from <c>timescaledb_information.job_history</c> — the read this comment
+    /// used to NAME as the one that would settle the sampling qualifier, now performed. That view carries a
+    /// <c>succeeded</c> column on this store because <c>DarlingManagedPostgres.BuildConfAppend</c> turns
+    /// <c>timescaledb.enable_job_execution_logging</c> on (#1681). Read at <c>2026-09-08 01:37Z</c>, so the
+    /// window is one that has ENDED and stays true rather than a scope read against a clock a doc comment
+    /// does not have. Each side of the boundary, since a bound is only as good as what it excludes: <b>304
+    /// runs</b> at or before it, median <b>1081.7 s</b>, maximum <b>13300.7 s</b>; <b>57 runs</b> after it,
+    /// median <b>418.3 s</b>, maximum <b>896.1 s</b>. Not one post-boundary run failed or was left without a
+    /// finish time, so the <c>succeeded</c> filter removes nothing from the span and the census is the whole
+    /// of it rather than a status-selected part.</para>
+    ///
     /// <para><b>THE POPULATION ITSELF, published so the estimator can be recomputed rather than taken on
     /// trust.</b> The boundary day's tail, every run that day after the boundary: <c>194, 222, 225, 335,
-    /// 594, 465, 359, 293, 355</c> seconds. The days after it: <c>219, 225, 299, 376, 418, 546, 515</c>
-    /// seconds. Together <b>16 runs</b> spanning <b>194 s to 594 s</b>, mean <b>352.5 s</b>, median
-    /// <b>345 s</b> — every one of them below <see cref="RefreshSlotWarningSeconds"/>.</para>
+    /// 594, 465, 359, 293, 355</c> seconds. The days after it: <c>347, 342, 348, 286, 368, 362, 320, 252,
+    /// 219, 225, 299, 376, 418, 546, 515, 473, 530, 523, 676, 778, 666, 705, 702, 599, 534, 479, 387, 373,
+    /// 391, 413, 356, 336, 395, 418, 386, 460, 591, 722, 570, 812, 641, 739, 830, 871, 786, 896, 815,
+    /// 681</c> seconds. Together <b>57 runs</b> spanning <b>194 s to 896 s</b>, totalling <b>27799 s</b>,
+    /// median <b>418 s</b> — and <b>7</b> of them at or past <see cref="RefreshSlotWarningSeconds"/>, where
+    /// the sixteen-run sample this population replaces had none.</para>
+    ///
+    /// <para><b>A TOTAL rather than a mean, and the reason is that a mean of this population is not
+    /// exactly stateable.</b> 27799 s over 57 runs is 487.7017… s, so any one-decimal figure for it would be
+    /// a rounded claim wearing an exact one's clothes — the same defect the occupancy figure below was
+    /// restated to avoid. The total is exact, it is checked against the published list, and it makes every
+    /// individual reading load-bearing in the same way the mean did: a single digit moved anywhere in the
+    /// list changes it.</para>
     ///
     /// <para><b>MAXIMUM, NOT A PERCENTILE PLUS MARGIN — decided rather than defaulted, and the trade stated
     /// because the two answers diverge as the population grows.</b> What this constant sizes is a SCHEDULING
     /// exclusion, and the cost of undersizing it is one lock convoy (#3012's measured harm) that no later
     /// run amortises. A percentile is a statement about an ACCEPTED RATE OF EXCEEDANCE, and the rate this
-    /// bound may accept over the record it is derived from is zero — so the estimator is the maximum. The
-    /// sample size says the same thing from the other end: by nearest rank over <b>16 readings</b> the 95th
-    /// percentile IS the largest of them, and the 90th is <b>546 s</b>, only <b>48 s</b> below it, so a
-    /// percentile buys no headroom here and only discards the readings the bound exists for. No margin is
-    /// added on top either: the clearance is <see cref="RefreshPhaseSlotSeconds"/> minus this value, stated
-    /// where it is used, so a reader sees a bound and its margin as two numbers instead of one padded
-    /// one.</para>
+    /// bound may accept over the record it is derived from is zero — so the estimator is the maximum. No
+    /// margin is added on top either: the clearance is <see cref="RefreshPhaseSlotSeconds"/> minus this
+    /// value, stated where it is used, so a reader sees a bound and its margin as two numbers instead of
+    /// one padded one.</para>
     ///
-    /// <para><b>What would change that answer, written down so it is not re-reasoned from scratch.</b> A
-    /// population large enough for a high percentile to sit meaningfully below the maximum — which this one
-    /// is not, and the pin on the 95th goes red when it becomes so — or this maximum ceasing to be a lower
-    /// bound on the truth. The second is the live limitation, and it is a property of the READ rather than
-    /// of the estimator: the boundary day's runs are a census of that day after the boundary, while the days
-    /// after it are a SAMPLE, because the sweep that reads this and the refresh that produces it tick on
-    /// independent anchors (see <see cref="HeaviestRefreshRuntimeSql"/>). So the figure bounds the runs that
-    /// were OBSERVED. The census read that would drop that qualifier exists and is named rather than left
-    /// implied: <c>timescaledb_information.job_history</c>, whose <c>succeeded</c> column this store has
-    /// because <c>DarlingManagedPostgres.BuildConfAppend</c> turns
-    /// <c>timescaledb.enable_job_execution_logging</c> on (#1681) — read as every run since the boundary
-    /// rather than sampled, giving count, median and maximum each side of it.</para>
+    /// <para><b>THE SAMPLE-SIZE HALF OF THAT ARGUMENT HAS EXPIRED, which is exactly what it was written to
+    /// do (#3101, #3166).</b> At sixteen readings the 95th percentile WAS the maximum by nearest rank, so a
+    /// percentile bought no headroom and the two answers agreed. They no longer do: by nearest rank over
+    /// <b>57 readings</b> the 95th percentile is <b>830 s</b> and the 90th is <b>786 s</b>, <b>66 s</b> and
+    /// <b>110 s</b> below the maximum. So the decision is RE-TAKEN rather than inherited, and it comes out
+    /// the same way on the half that never depended on the sample size: one lock convoy is not amortised by
+    /// the runs that did fit, so a bound on a scheduling exclusion may accept no exceedance over its own
+    /// record, and a 95th percentile is a promise to be wrong three times in every sixty runs. What is gone
+    /// with the sample-size half is its EXPIRY: a reason that does not reference the population's size has
+    /// nothing left to expire, so this paragraph now pins both percentiles and both gaps as readings that
+    /// TRACK the population instead of as a coincidence that ends.</para>
+    ///
+    /// <para><b>What would change that answer, written down so it is not re-reasoned from scratch — and
+    /// both of the things it named have now happened.</b> The two triggers recorded were a population large
+    /// enough for a high percentile to sit meaningfully below the maximum, and this maximum ceasing to be a
+    /// lower bound on the truth. The first fired at 57 readings and the estimator paragraph above re-takes
+    /// the decision it forced. The second fired too, and it was a property of the READ rather than of the
+    /// estimator: the sixteen-run record mixed a census of the boundary day's tail with a SAMPLE of the days
+    /// after it, because the sweep that read it and the refresh that produced it tick on independent anchors
+    /// (see <see cref="HeaviestRefreshRuntimeSql"/>), so that figure bounded the runs which happened to be
+    /// OBSERVED. The census read named as the fix has been done and its result is this constant, so the
+    /// qualifier is retired rather than restated.</para>
+    ///
+    /// <para><b>WHAT REPLACES IT IS A TREND, and that is a different kind of limitation from a sampling
+    /// one.</b> Per closed day, the maximum of this job's runs went <b>594 s</b> over the boundary day's
+    /// nine remaining runs, <b>778 s</b> over the twenty-two runs of the day after, and <b>896 s</b> over
+    /// the twenty-four runs of the day after that. A census removes the "as observed" caveat and puts
+    /// nothing in its place: the population is closed at a stated instant and it grows, so this maximum is
+    /// the largest run the job has been RECORDED to make and not a ceiling on what it will make next. What
+    /// that means for the grid is stated below and is deliberately not decided here — the value is a
+    /// measurement, and the slot it has to fit inside is a scheduling choice.</para>
     ///
     /// <para><b>THE RUN THE EXCLUSION RULE REMOVES, recorded because a figure that looks like a ceiling and
     /// is not one is how the wrong number gets cited.</b> One run, <c>13:30:00</c> to <c>13:44:24</c> on the
-    /// boundary day, 864 s, excluded for starting before the boundary — and disqualified independently of
-    /// any timestamp, by the durations alone: it is <b>3.8x</b> faster than the fastest run the 3-day window
-    /// ever produced (3,301 s, of a 3,301-6,330 s band) and <b>1.45x</b> slower than the largest reading in
-    /// the population above. Too fast for one regime and too slow for the other, so it is a sample of
-    /// neither and can bound neither. Why it is that fast is NOT established — the plausible candidate is
+    /// boundary day, 864 s, excluded for starting before the boundary. It is still <b>3.8x</b> faster than
+    /// the fastest run the 3-day window ever produced (3,301 s, of a 3,301-6,330 s band), so it remains no
+    /// sample of the pre-narrowing regime — but the other half of that argument is GONE. At <b>0.96x</b> of
+    /// the largest reading in the population above it now sits INSIDE the post-boundary range instead of
+    /// 1.45x past it, and an ordinary member of a distribution cannot be disqualified for belonging to
+    /// neither. Which is why the rule is POSITIONAL and always was: this run is out because it STARTED
+    /// before the boundary, and nothing about its duration does any of that work. The duration-based
+    /// disqualification the sixteen-run record leaned on was an artefact of a population whose maximum was
+    /// 302 s lower, and recording that it expired is the whole point of stating a rule rather than a
+    /// verdict. Why it is that fast is NOT established — the plausible candidate is
     /// that the 6,330 s run before it had already cleared most of the backlog — and it is recorded as
     /// unexplained precisely so the low figure is not read as evidence that the narrowing had partly taken
     /// effect.</para>
@@ -1857,11 +1900,18 @@ WITH NO DATA";
     /// reading from it may set this constant — a statement about the SOURCE, deliberately not about any
     /// particular reading, because that series gains one every hour this job runs and an enumeration of it
     /// would be stale within the hour. The complete set of snapshot readings up to <c>04:20Z</c>
-    /// (342 s, 348 s, 286 s) says the series stayed flat, which is corroboration and nothing more. Note the
-    /// scope has to CLOSE the population, not merely date it: "up to 04:20Z" is a window that has ended and
-    /// will still be true next year, where "the readings so far" carries a scope and rots anyway, because a
-    /// doc comment has no timestamp of its own to be read relative to. They are kept out of the population
-    /// above for the rule's sake rather than for tidiness.</para>
+    /// (342 s, 348 s, 286 s) says the series stayed flat, which is corroboration and nothing more — and
+    /// all three are now IN the census population above. <b>That is worth stating, because the sixteen-run
+    /// record held these three to being DISJOINT from it, and the reversal is not a defect in either
+    /// figure.</b> Disjointness held only while the published population was a SAMPLE of this job; against
+    /// a CENSUS of the same job it cannot hold at all, because a snapshot of a job's last run reports a
+    /// duration the census contains by construction. So the values were never what made these readings
+    /// inadmissible and a test on them was measuring the sample's incompleteness: the rule is about which
+    /// SOURCE may set this constant, and that is checked against the shipped SQL of all three reads. Note
+    /// the scope has to CLOSE the population, not merely date it: "up to 04:20Z" is a window that has ended
+    /// and will still be true next year, where "the readings so far" carries a scope and rots anyway,
+    /// because a doc comment has no timestamp of its own to be read relative to. They are kept out of the
+    /// population above for the rule's sake rather than for tidiness.</para>
     ///
     /// <para><b>Why the grid is sized against the high figure and not the low.</b> A slot chosen against the
     /// 194 s low would be correct only at the load it was chosen at, and before the narrowing this job ran
@@ -1881,29 +1931,45 @@ WITH NO DATA";
     /// overlap at all.</para>
     ///
     /// <para><b>So: the small-residual reading is conditional on how long this job runs, and what
-    /// invalidates it is that runtime approaching <see cref="RefreshPhaseStepMinutes"/> x 60.</b> At 594 s
-    /// against a 900-second slot the margin is 306 seconds — the clearance the population above carries, a
+    /// invalidates it is that runtime approaching <see cref="RefreshPhaseStepMinutes"/> x 60.</b> At 896 s
+    /// against a 900-second slot the margin is 4 seconds — the clearance the population above carries, a
     /// property of that closed record rather than of current load; the heaviest
     /// slot is excluded WHOLE rather than guarded on the guard band being shorter than the refresh rather
     /// than on the refresh filling the slot (see <see cref="CompressionPhaseMinutes"/>). A value at or past
     /// the slot width is asserted as a failure rather than accommodated: past that point the refresh runs
     /// into its neighbour and the grid needs redesigning, not renumbering.</para>
     ///
-    /// <para><b>THE LIVE ENVELOPE, taken from the census read named above and stated apart from that
-    /// clearance because the two describe different populations (#3119).</b> Over <c>2026-09-06</c> — one
-    /// closed day, its 22 runs read from <c>timescaledb_information.job_history</c> at one row per run —
-    /// this job's maximum was <b>778.4 s</b>. That leaves <b>121.6 s</b> of the slot, <b>13.5%</b> of it,
-    /// and sits <b>28.4 s</b> PAST <see cref="RefreshSlotWarningSeconds"/>, which
-    /// <see cref="ClassifyRefreshSlotHeadroom"/> bands
-    /// <see cref="RefreshSlotHeadroom.ApproachingSlot"/>. Short of the slot width, so the grid's
-    /// precondition holds and this is not the failure the paragraph above asserts — but the residual is D
-    /// wide and D is that maximum, so "completes well inside its slot" is a description of the closed
-    /// population and not of that day. RefreshCeilingProvenancePinTests derives every figure stated against
-    /// that maximum from the grid's own constants and takes the band from the shipped classifier, so a
-    /// moved grid step moves them all and a reading that stopped classifying as a warning goes red rather
-    /// than sitting here as prose.</para>
+    /// <para><b>THE LIVE ENVELOPE, which the census has now COLLAPSED onto that clearance rather than
+    /// leaving beside it (#3119, #3166).</b> Over <c>2026-09-07</c> — one closed day, its 24 runs read from
+    /// <c>timescaledb_information.job_history</c> at one row per run — this job's maximum was
+    /// <b>896.1 s</b>. That leaves <b>3.9 s</b> of the slot, <b>0.4%</b> of it, and sits <b>146.1 s</b>
+    /// PAST <see cref="RefreshSlotWarningSeconds"/>, which <see cref="ClassifyRefreshSlotHeadroom"/> bands
+    /// <see cref="RefreshSlotHeadroom.ApproachingSlot"/>. #3119 had to state these figures apart from the
+    /// clearance because the constant was the maximum of a SAMPLE and the census exceeded it; now that the
+    /// constant IS the census maximum, the two describe the same population and agree to the second. What
+    /// remains is the reading itself: short of the slot width, so the grid's stated precondition still
+    /// holds and this is not yet the failure the paragraph above asserts — but the residual is D wide and D
+    /// is that maximum, so nothing here can be described as completing well inside its slot.
+    /// RefreshCeilingProvenancePinTests derives every figure stated against that maximum from the grid's own
+    /// constants and takes the band from the shipped classifier, so a moved grid step moves them all and a
+    /// reading that stopped classifying as a warning goes red rather than sitting here as prose.</para>
+    ///
+    /// <para><b>AND THE CONSEQUENCE THAT IS NOT THIS CONSTANT'S TO SETTLE, said here rather than left for a
+    /// reader to derive (#3166).</b> A sizing figure of 896 s is <b>ABOVE</b>
+    /// <see cref="RefreshSlotWarningSeconds"/>, so <see cref="ClassifyRefreshSlotHeadroom"/> bands the
+    /// grid's own sizing figure as <see cref="RefreshSlotHeadroom.ApproachingSlot"/> — a warning. Every
+    /// assertion that held the grid CLEAR of this constant is therefore false, in TimescaleSupportTests and
+    /// in the population clause of RefreshCeilingProvenancePinTests both, and those failures are the checks
+    /// doing their job rather than literals left behind: <see cref="RefreshSlotWarningSeconds"/>'s own
+    /// summary pre-registered this exact outcome. They are NOT widened here. What the arithmetic says and
+    /// where it stops: a 15-minute slot leaves 4 s of clearance against a measured maximum that rose 302 s
+    /// in two days, and restoring the five-sixths watch line's lead time above a 896 s figure needs a slot
+    /// of at least 1,076 s — 18 minutes, which 60 does not divide, so the grid would gain slots of unequal
+    /// width or lose one of its four. Which of those, or whether the refresh is made cheaper instead, is a
+    /// scheduling decision (#3035, #3044, #3107) and is deliberately not taken by re-deriving a
+    /// measurement.</para>
     /// </summary>
-    public const int HeaviestHourlyRefreshObservedCeilingSeconds = 594;
+    public const int HeaviestHourlyRefreshObservedCeilingSeconds = 896;
 
     /// <summary>
     /// The slot width in seconds — the bound
@@ -1948,15 +2014,22 @@ WITH NO DATA";
     /// out and is not offered as if it did: a line further below the slot warns EARLIER, so the comparison
     /// against the ceiling has to carry the decision on its own.</para>
     ///
-    /// <para><b>This line sits ABOVE <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>, and that is
-    /// what makes a crossing mean something.</b> 750 s is <b>26% above</b> the maximum of the closed
-    /// population that constant is derived from, so a reading in this band is not "approaching a known
-    /// ceiling" — it is past the whole of the record the compression grid is sized against, which is a
-    /// different signal calling for a different response. The band is reachable and not hypothetical: the
-    /// live envelope on <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> puts a measured run past
-    /// this line, stated there and not restated here so the figures have one home. The relationship is what
-    /// is pinned, not the two numbers: a ceiling that rose past this line would put the grid's own sizing
-    /// figure inside the warning band, and the pin says so rather than leaving a reader to notice.</para>
+    /// <para><b>This line was chosen to sit ABOVE <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>,
+    /// because that ordering is what makes a crossing mean something — and the ordering has now INVERTED
+    /// (#3166).</b> While the constant was the maximum of a sixteen-run sample, 750 s sat 26% above it, so a
+    /// reading in this band was not "approaching a known ceiling" but past the whole of the record the
+    /// compression grid was sized against: a different signal calling for a different response. Re-derived
+    /// from a census, that constant is <b>896 s</b>, which is 146 s ABOVE this line, so
+    /// <see cref="ClassifyRefreshSlotHeadroom"/> now bands the grid's own sizing figure a warning and this
+    /// line reports the sizing rather than anything new. That is precisely the case the previous version of
+    /// this paragraph pre-registered — "a ceiling that rose past this line would put the grid's own sizing
+    /// figure inside the warning band, and the pin says so rather than leaving a reader to notice" — and
+    /// the pins in TimescaleSupportTests say so now, in the only way that is any use: by going RED rather
+    /// than by being renumbered to agree. <b>Nothing here re-justifies the five sixths against the new
+    /// figure, and that is deliberate.</b> Restoring the ordering means moving this line up, moving
+    /// <see cref="RefreshPhaseSlotSeconds"/> up, or making the refresh cheaper; the first two are the same
+    /// grid decision (#3035, #3044, #3107) and the third is not a threshold at all. A measurement is not a
+    /// mandate to pick one, so the fraction is left where it was and the inversion is left visible.</para>
     /// </summary>
     public const int RefreshSlotWarningSeconds = RefreshPhaseSlotSeconds * 5 / 6;
 
@@ -2070,14 +2143,19 @@ WITH NO DATA";
     /// change would be INTRODUCING, not removing, so the grid keeps the spread and takes only the drift away.</para>
     ///
     /// <para><b>Why the heaviest slot is excluded whole rather than guarded.</b>
-    /// <see cref="HeaviestHourlyRefreshView"/> occupies 9.9 of the 15 minutes in its slot and the
+    /// <see cref="HeaviestHourlyRefreshView"/> occupies 896 of the 900 seconds in its slot and the
     /// <see cref="CompressionPhaseGuardMinutes"/> band is 7, so applying the ordinary band to this slot would
-    /// admit 3 minutes that sit INSIDE the refresh — the band is the wrong size for it, which is the
+    /// admit 8 minutes that sit INSIDE the refresh — the band is the wrong size for it, which is the
     /// arithmetic the exclusion rests on and the reason widening the band is not the alternative. The other
-    /// 5 minutes of the slot are past the refresh and are left on the table deliberately: recovering them
-    /// means sizing a band for one slot against a bound whose population is 16 readings and still moving
-    /// (194 s to 594 s within the clean regime), which is #3035's exclude-versus-guard decision to reopen
-    /// and not a renumbering.
+    /// 0 minutes of the slot are past the refresh, so the exclusion no longer declines to recover anything:
+    /// there is nothing there to recover, and the question of sizing a band for one slot against a bound
+    /// whose population is 57 readings and still moving
+    /// (194 s to 896 s within the clean regime) has answered itself for as long as that stays true —
+    /// #3035's exclude-versus-guard decision is not reopened by it and is certainly not a renumbering.
+    /// Stated in SECONDS against the slot in seconds, because the occupancy is only exactly stateable to a
+    /// tenth of a minute while the ceiling happens to be a multiple of six seconds, and 896 is not: a
+    /// figure that has to be rounded to stay in its unit is a rounded claim wearing an exact one's
+    /// clothes.
     /// Excluding the slot is also what keeps the remaining minutes far from the only refresh that can reach
     /// forward: the nearest is a full slot past the heaviest one, and the furthest is 59 minutes past
     /// it.</para>
@@ -4304,9 +4382,9 @@ AND   js.last_run_status = 'Success'";
     /// <para><b>That the two lines coincide is a coincidence of two independent decisions, and the clearest
     /// evidence is that #2136 does not know this job's size.</b> Its clamp is justified in
     /// <c>DarlingAlertSettings</c> on the grounds that "the production worst runs ~7% of cadence" — 252 s —
-    /// while <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> here records 594 s, which is <b>16.5%
+    /// while <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> here records 896 s, which is <b>24.9%
     /// of the same 3,600 s cadence</b> — so the line #2136 lands on is calibrated as though this job ran
-    /// under half its actual length, and nothing connects the two numbers. #2136's own remedy text —
+    /// under a third of its actual length, and nothing connects the two numbers. #2136's own remedy text —
     /// "extend the job's schedule_interval" —
     /// is actively wrong for this one, because <see cref="HourlyRefreshScheduleInterval"/> is also the
     /// <c>end_offset</c> and widening it changes what the aggregate materializes without touching the slot.
@@ -4672,7 +4750,7 @@ public sealed record HeaviestRefreshSlotReading(string View, double LastRunSecon
     /// clamping would report every breach as a dead heat.</summary>
     public double ClearOfSlotSeconds => TimescaleSupport.RefreshPhaseSlotSeconds - LastRunSeconds;
 
-    /// <summary>This reading as a percentage of the slot — 66.0% for the recorded ceiling
+    /// <summary>This reading as a percentage of the slot — 99.6% for the recorded ceiling
     /// (<see cref="TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds"/>), which is the margin the
     /// #3044 watch is stated against.</summary>
     public double PercentOfSlot => 100.0 * LastRunSeconds / TimescaleSupport.RefreshPhaseSlotSeconds;


### PR DESCRIPTION
Closes #3166.

`HeaviestHourlyRefreshObservedCeilingSeconds` was **594 s**, the maximum of a 16-run record the comment itself described as half census and half sample. The comment also named the read that would settle that: `timescaledb_information.job_history`, every run since the boundary rather than sampled. That read has been done, and the constant is now **896 s**.

## The census

One row per run for job `policy_refresh_continuous_aggregate` / `query_store_stats_interval_hourly` on the store that carries this workload, read at `2026-09-08 01:37Z` over `timescaledb_information.job_history` (TimescaleDB 2.28.1, PostgreSQL 18.4, `timescaledb.enable_job_execution_logging = on`). Boundary `2026-09-05 13:44:23`, exclusion positional as recorded.

| side of the boundary | runs | median | maximum |
|---|---|---|---|
| at or before | 304 | 1081.7 s | 13300.7 s |
| after | **57** | **418.3 s** | **896.1 s** |

Zero post-boundary runs failed and none is missing a finish time, so the `succeeded` filter removes nothing from the span — the census is the whole of it rather than a status-selected part.

The read reproduces the published record exactly where they overlap, which is what says the method is the same one: the nine boundary-day values (`194, 222, 225, 335, 594, 465, 359, 293, 355`) and the seven "days after" values (`219, 225, 299, 376, 418, 546, 515`) come back digit for digit, and the sampled seven turn out to be seven consecutive runs of 2026-09-06 with fifteen more either side of them that the sample never saw. #3119's separately-read closed day (2026-09-06, 22 runs, maximum 778.4 s) also reproduces.

The population is republished in full — 9 + 48 — so the estimator is still recomputable rather than trusted. Range 194–896 s, total 27799 s, median 418 s.

## The estimator is unchanged and the decision was re-taken rather than inherited

The doc's reason for the maximum had two halves, and one was written to expire. At 16 readings the 95th percentile by nearest rank *was* the maximum, so a percentile bought no headroom. At 57 it is **830 s**, 66 s below the maximum, and the 90th is **786 s**, 110 s below. `RefreshCeilingProvenancePinTests` went red on exactly that clause, which is what it was for. The decision comes out the same way on the half that never referenced the sample size — a scheduling exclusion may accept no exceedance over its own record, and a 95th percentile is a promise to be wrong three times in sixty runs — so the estimator stays the maximum and the expiring clause is gone with the argument it guarded. There is no replacement expiry, because a reason independent of `n` has nothing left to expire; both percentiles and both gaps are now pinned as readings that track the population.

## Three arguments in the old derivation expired with the sample, and none was re-argued to fit

- **The mean is not exactly stateable.** 27799 s over 57 runs is 487.7017… s. The prose carries the exact **total** instead, which is a strictly stronger pin — a bump to any middle-ranked reading moves neither the range nor the median, and the total is what sees it.
- **The excluded run is no longer an outlier.** 864 s is **0.96x** of the census maximum, inside the post-boundary range rather than 1.45x past it, so the duration-based disqualification is dead. That was always an artefact of a population whose maximum was 302 s lower; the rule is positional and always was.
- **The snapshot readings are no longer disjoint from the population — they cannot be.** All three (342, 348, 286 s) are census members, because the self-metrics snapshot reads this job's last run and a census contains every run. Disjointness was a property of the *sample*, so that pin was measuring the sample's incompleteness rather than the rule. It is inverted to **containment**, which is the same evidence read the right way round and fails toward the more useful label: a quoted reading with no census run behind it means the two reads disagree about what the job did. The rule the paragraph is actually about — which SOURCE may set the constant — stays where it was already load-bearing, against the shipped SQL of all three reads.
- Occupancy moves from tenths of a minute to **seconds** (896 of 900): a tenth of a minute is only exact while the ceiling is a multiple of six seconds, and demanding that a measurement be divisible makes an honest figure unstateable rather than catching a drift.

## The consequence, stated and not settled here

`RefreshPhaseSlotSeconds` is 900. Clearance is slot minus ceiling: **306 s before, 4 s now**. The compression grid's spatial clearance survives — the nearest phase minute is 1320 s past the heaviest slot's start, and the discriminating minute `:14` is still excluded — so nothing has overrun a slot.

What broke is the **watch line ordering**. `RefreshSlotWarningSeconds` is 750, and 896 is 146 s ABOVE it, so `ClassifyRefreshSlotHeadroom` bands the grid's own sizing figure `ApproachingSlot`. Seven of the 57 census readings are already at or past that line, where the 16-run record had none. `RefreshSlotWarningSeconds`' own summary pre-registered this: *"a ceiling that rose past this line would put the grid's own sizing figure inside the warning band, and the pin says so rather than leaving a reader to notice."*

**Six test methods are therefore RED, and every condition is left exactly as written.**

| file | method | condition |
|---|---|---|
| `RefreshCeilingProvenancePinTests` | `TheDerivedFiguresAreExactlyStateable_AndTheConstantIsThePopulationMaximum` | a population reading is at or past the watch line; and `Ceiling < WatchLine` |
| `TimescaleSupportTests` | `NoCompressionMinuteStartsWhileTheHeaviestRefreshIsStillRunning` | `ceiling < RefreshSlotWarningSeconds`; `Assert.Equal(26, (watch - ceiling) * 100 / ceiling)` (now -16) |
| `TimescaleSupportTests` | `TheRefreshSlotClassifier_BandsTheLiveReadings_AndKeepsTheWatchLineAboveTheRecordedCeiling` | `ClassifyRefreshSlotHeadroom(ceiling) == InsideSlot` (now `ApproachingSlot`); `ceiling < watch` |
| `TimescaleSupportTests` | `TheRejectedWatchLineAlternative_SitsBelowTheRecordedCeiling_WhileTheChosenLineSitsAbove` | same two |
| `TimescaleSupportTests` | `TheRefreshSlotReading_CarriesItsOwnVerdict_AndReportsOverrunAsNegativeHeadroom` | `atTheCeiling.Headroom == InsideSlot` |
| `TimescaleSupportTests` | `TheRefreshSlotLogLine_IsLeveledByBand_AndSaysNothingWithoutAReading` | the line at the ceiling is `Warning:`, not `Debug:` |

Two failure MESSAGES in the pin file were re-pointed, because the reason they gave — "the doc comment claims otherwise" — is no longer why they matter now that the comment states the crossings plainly. Both conditions are byte-identical, so the tests still go red on the same input.

**What the arithmetic says about the slot, and where it stops.** Restoring the five-sixths line above 896 s needs a slot of at least **1076 s** — 18 minutes, which 60 does not divide, so the grid would gain slots of unequal width or lose one of its four. Moving the fraction instead, or making the refresh cheaper, are the other two routes. Choosing among them is a scheduling decision (#3035, #3044, #3107) and is deliberately not taken by re-deriving a measurement.

## Trend, not calibration

The daily maximum went **594 s** (boundary-day tail, 9 runs) → **778 s** (2026-09-06, 22 runs) → **896 s** (2026-09-07, 24 runs). #3166 listed 702 / 871 / 815 s; the census found a **896.1 s** run at 2026-09-07 23:00 that the issue did not have, so the readings in the issue were not the ceiling. A census removes the "as observed" caveat and puts nothing in its place — the population is closed at a stated instant and it grows.

## Verification

`RefreshCeilingProvenancePinTests` is pure and reads the real `TimescaleSupport.cs` through `[CallerFilePath]`, so it was compiled unmodified into a `net10.0` console harness behind a minimal xUnit shim and run: **8 of 9 pass**, including the full derivation `Verify` and the one-number-at-a-time drift sweep over every captured figure; the 9th is the watch-line row above. Red-first proven by reverting the constant to 594 in a committed tree, confirming `EveryDerivationClaim_...` fails on `max == Ceiling`, and restoring via `git checkout --`. The red list in the table was produced by a second harness that evaluates each ceiling-dependent condition against the real Storage assembly rather than by reading the assertions.

## CHANGELOG

Not edited here — entry text is in the lane report for the coordinator to batch.
