### PR TITLE
Make an alert-history row state its channel, so alert_sent is only ever a delivery outcome (#3169)

### DIFF
--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -285,6 +285,8 @@ public sealed class AlertDeliveryChannelTests
     [InlineData(true, AlertDelivery.ChannelEmail, null, AlertDeliveryStatus.Delivered)]
     [InlineData(true, AlertDelivery.ChannelWebhook, null, AlertDeliveryStatus.Delivered)]
     [InlineData(true, AlertDelivery.ChannelEmailAndWebhook, null, AlertDeliveryStatus.Delivered)]
+    [InlineData(true, AlertDelivery.ChannelTray, null, AlertDeliveryStatus.NoChannel)]
+    [InlineData(false, AlertDelivery.ChannelTray, null, AlertDeliveryStatus.Logged)]
     public void Describe_OnADarlingStore_DiscriminatesEveryDisposition(
         bool sent, string channel, string? sendError, string expected)
         => Assert.Equal(expected, AlertDeliveryStatus.Describe(sent, channel, sendError, trayChannelPresent: false));
@@ -318,9 +320,12 @@ public sealed class AlertDeliveryChannelTests
     {
         var status = AlertDeliveryStatus.Describe(false, AlertDelivery.ChannelTray, null, trayChannelPresent: false);
 
-        Assert.Equal(AlertDeliveryStatus.NotSent, status);
+        /* #2781's word for it, adopted rather than replaced with a second one. It claims nothing in either
+           direction, which is the only honest reading of a row whose state cannot be recovered. */
+        Assert.Equal(AlertDeliveryStatus.Logged, status);
         Assert.NotEqual(AlertDeliveryStatus.NoChannelConfigured, status);
         Assert.NotEqual(AlertDeliveryStatus.Shown, status);
+        Assert.NotEqual(AlertDeliveryStatus.Delivered, status);
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -106,19 +106,44 @@ public sealed class AlertDeliveryChannelTests
             var delivery = AlertDelivery.FromFanout(result, muted, tray);
             checked_++;
 
+            /* One-directional. The converse is false by design: an attempted email that threw is
+               ChannelEmail with Sent false and its error attached. */
             if (delivery.Sent)
             {
                 Assert.Contains(delivery.Channel, delivering);
-            }
-            else
-            {
-                Assert.DoesNotContain(delivery.Channel, delivering);
             }
         }
 
         /* The count IS the claim that the enumeration is the whole domain: 2^4 result bools x muted x
            trayChannelPresent. A shrunken loop would otherwise pass by covering less. */
         Assert.Equal(64, checked_);
+    }
+
+    /// <summary>
+    /// The decode-critical half of the invariant, stated on its own rather than left as a corollary: no
+    /// <c>Sent</c> row lands on a channel that did not deliver. This is precisely what makes
+    /// <c>alert_sent = true</c> with <c>notification_type = 'tray'</c> unreachable for a new row, and so
+    /// what licenses <see cref="TheLegacyResolutionSignature_DecodesToNoChannel"/> to read that signature
+    /// as the resolution builder's old constant.
+    /// </summary>
+    [Fact]
+    public void NoSentRow_LandsOnANonDeliveringChannel()
+    {
+        string[] nonDelivering =
+        {
+            AlertDelivery.ChannelTray, AlertDelivery.ChannelNotApplicable,
+            AlertDelivery.ChannelNoneConfigured, AlertDelivery.ChannelMuted, AlertDelivery.ChannelUndelivered,
+        };
+
+        foreach (var (result, muted, tray) in EveryFanoutCase())
+        {
+            var delivery = AlertDelivery.FromFanout(result, muted, tray);
+
+            if (delivery.Sent)
+            {
+                Assert.DoesNotContain(delivery.Channel, nonDelivering);
+            }
+        }
     }
 
     /// <summary><c>Sent</c> is exactly "a channel delivered", with no other contributor.</summary>

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -336,14 +336,7 @@ public sealed class AlertDeliveryChannelTests
     [Fact]
     public void Describe_OnADarlingStore_NeverSaysShown()
     {
-        string[] everyChannel =
-        {
-            AlertDelivery.ChannelNotApplicable, AlertDelivery.ChannelNoneConfigured, AlertDelivery.ChannelMuted,
-            AlertDelivery.ChannelTray, AlertDelivery.ChannelUndelivered, AlertDelivery.ChannelEmail,
-            AlertDelivery.ChannelWebhook, AlertDelivery.ChannelEmailAndWebhook, "", "toast",
-        };
-
-        foreach (var channel in everyChannel)
+        foreach (var channel in EveryStoredChannelValue())
         {
             foreach (var sent in new[] { false, true })
             {
@@ -396,6 +389,41 @@ public sealed class AlertDeliveryChannelTests
         }
     }
 
+    /// <summary>
+    /// <b>The per-SKU divergence is exactly one cell, and this says which.</b> Over every
+    /// (channel, sent, send_error) combination the column can hold, the two SKUs' renderings differ for
+    /// <c>tray</c> with <c>alert_sent = false</c> and nothing else — "Shown" where a toast really was shown,
+    /// #2781's "Logged" where the producer had no tray.
+    ///
+    /// <para>Stated as a count rather than as prose because "there is a deliberate divergence" is not a
+    /// falsifiable claim and this is: widening it, or collapsing it, fails here. A test that merely checked
+    /// the one known cell would pass while a second divergence appeared beside it.</para>
+    /// </summary>
+    [Fact]
+    public void TheTwoSkus_DivergeOnExactlyOneStoredCombination()
+    {
+        var diverging = new List<string>();
+
+        foreach (var channel in EveryStoredChannelValue())
+        {
+            foreach (var sent in new[] { false, true })
+            {
+                foreach (var error in new string?[] { null, "relay refused" })
+                {
+                    var headless = AlertDeliveryStatus.Describe(sent, channel, error, producerHadTrayChannel: false);
+                    var withTray = AlertDeliveryStatus.Describe(sent, channel, error, producerHadTrayChannel: true);
+
+                    if (headless != withTray)
+                    {
+                        diverging.Add($"{channel}/sent={sent}/error={(error is null ? "null" : "set")}");
+                    }
+                }
+            }
+        }
+
+        Assert.Equal(new[] { $"{AlertDelivery.ChannelTray}/sent=False/error=null" }, diverging.ToArray());
+    }
+
     /* ─────────────── the hatch stays where it was put ─────────────── */
 
     /// <summary>
@@ -442,6 +470,17 @@ public sealed class AlertDeliveryChannelTests
     }
 
     /* ─────────────── helpers ─────────────── */
+
+    /// <summary>
+    /// Every value <c>notification_type</c> can hold: the declared taxonomy, plus the two shapes a stored
+    /// row can carry that the taxonomy does not name — an empty string and a value written by a version
+    /// that had a channel this one does not. The reading code must be total over the column, not just over
+    /// the constants.
+    /// </summary>
+    private static IEnumerable<string> EveryStoredChannelValue()
+        => AlertDelivery.StateCarryingChannels
+            .Concat(AlertDelivery.DeliveringChannels)
+            .Concat(new[] { "", "toast" });
 
     private static string Describe(AlertDelivery delivery)
         => AlertDeliveryStatus.Describe(delivery.Sent, delivery.Channel, delivery.SendError, producerHadTrayChannel: false);

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -289,7 +289,7 @@ public sealed class AlertDeliveryChannelTests
     [InlineData(false, AlertDelivery.ChannelTray, null, AlertDeliveryStatus.Logged)]
     public void Describe_OnADarlingStore_DiscriminatesEveryDisposition(
         bool sent, string channel, string? sendError, string expected)
-        => Assert.Equal(expected, AlertDeliveryStatus.Describe(sent, channel, sendError, trayChannelPresent: false));
+        => Assert.Equal(expected, AlertDeliveryStatus.Describe(sent, channel, sendError, producerHadTrayChannel: false));
 
     /// <summary>
     /// <b>The one legacy signature that can be decoded.</b> <c>alert_sent = true</c> with
@@ -302,9 +302,9 @@ public sealed class AlertDeliveryChannelTests
     public void TheLegacyResolutionSignature_DecodesToNoChannel()
     {
         Assert.Equal(AlertDeliveryStatus.NoChannel,
-            AlertDeliveryStatus.Describe(true, AlertDelivery.ChannelTray, null, trayChannelPresent: false));
+            AlertDeliveryStatus.Describe(true, AlertDelivery.ChannelTray, null, producerHadTrayChannel: false));
         Assert.Equal(AlertDeliveryStatus.NoChannel,
-            AlertDeliveryStatus.Describe(true, AlertDelivery.ChannelTray, null, trayChannelPresent: true));
+            AlertDeliveryStatus.Describe(true, AlertDelivery.ChannelTray, null, producerHadTrayChannel: true));
     }
 
     /// <summary>
@@ -318,7 +318,7 @@ public sealed class AlertDeliveryChannelTests
     [Fact]
     public void TheLegacyDetectedSignature_IsNotReinterpreted()
     {
-        var status = AlertDeliveryStatus.Describe(false, AlertDelivery.ChannelTray, null, trayChannelPresent: false);
+        var status = AlertDeliveryStatus.Describe(false, AlertDelivery.ChannelTray, null, producerHadTrayChannel: false);
 
         /* #2781's word for it, adopted rather than replaced with a second one. It claims nothing in either
            direction, which is the only honest reading of a row whose state cannot be recovered. */
@@ -351,7 +351,7 @@ public sealed class AlertDeliveryChannelTests
                 {
                     Assert.NotEqual(
                         AlertDeliveryStatus.Shown,
-                        AlertDeliveryStatus.Describe(sent, channel, error, trayChannelPresent: false));
+                        AlertDeliveryStatus.Describe(sent, channel, error, producerHadTrayChannel: false));
                 }
             }
         }
@@ -391,7 +391,7 @@ public sealed class AlertDeliveryChannelTests
             };
 
             Assert.Equal(
-                AlertDeliveryStatus.Describe(sent, channel, error, trayChannelPresent: false),
+                AlertDeliveryStatus.Describe(sent, channel, error, producerHadTrayChannel: false),
                 row.StatusDisplay);
         }
     }
@@ -444,7 +444,7 @@ public sealed class AlertDeliveryChannelTests
     /* ─────────────── helpers ─────────────── */
 
     private static string Describe(AlertDelivery delivery)
-        => AlertDeliveryStatus.Describe(delivery.Sent, delivery.Channel, delivery.SendError, trayChannelPresent: false);
+        => AlertDeliveryStatus.Describe(delivery.Sent, delivery.Channel, delivery.SendError, producerHadTrayChannel: false);
 
     private static EmailFanoutResult Fanout(
         bool emailAttempted = false, bool emailSent = false, string? sendError = null,

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -37,9 +37,12 @@ public sealed class AlertDeliveryChannelTests
     /// <summary>
     /// The defect itself. <c>BuildResolutionRecord</c> was the only construction site in non-test code that
     /// named <c>AlertSent:</c> explicitly, and it said <c>true</c> — documented as meaning "a resolution has
-    /// no send channel", not "something was delivered". Measured on three live stores on 2026-09-08: every
-    /// one of 5,683 <c>alert_sent = true</c> rows carried a resolution title, and no channel was configured
-    /// on any of them, so not one of those <c>true</c>s was a delivery.
+    /// no send channel", not "something was delivered". Measured across three live stores on 2026-09-08:
+    /// 32,546 stored rows, 5,246 of them <c>alert_sent = true</c>, and no send channel configured on any of
+    /// the three — so not one of those <c>true</c>s was a delivery. In the seven-day window where the census
+    /// was broken down per metric (11,521 rows, 2,391 of them <c>true</c>), every single <c>true</c> row
+    /// carried a resolution title. The per-metric breakdown is what supports that last claim, so it is
+    /// stated for the window it was measured in rather than for all 5,246.
     /// </summary>
     [Fact]
     public void TheResolutionRecord_StatesNoChannel_RatherThanClaimingDelivery()
@@ -239,7 +242,7 @@ public sealed class AlertDeliveryChannelTests
     /// <summary>
     /// Both Darling producers state <c>trayChannelPresent: false</c>. The named argument is what makes a
     /// transposition a compile error rather than a silent flip, and this is what makes ADDING a producer
-    /// that forgets the answer a red test rather than 32,000 more untrue rows.
+    /// that forgets the answer a red test rather than another storeful of untrue rows.
     /// </summary>
     [Fact]
     public void BothDarlingProducers_DeclareNoTrayChannel()
@@ -312,8 +315,8 @@ public sealed class AlertDeliveryChannelTests
     /// throttled and failed-webhook alike, and nothing in the row separates them, so it gets an
     /// outcome-only label that makes no claim about configuration. Reading it as
     /// <see cref="AlertDeliveryStatus.NoChannelConfigured"/> would be asserting the new semantics over rows
-    /// written before them — every existing row on all three stores predates this change, and 8,085 of them
-    /// in one seven-day window are exactly this shape.
+    /// written before them — every existing row on all three stores predates this change, and on the busiest
+    /// of them 8,085 rows in a single seven-day window are exactly this shape.
     /// </summary>
     [Fact]
     public void TheLegacyDetectedSignature_IsNotReinterpreted()

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using PerformanceMonitor.Alerting;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Viewer;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3169: <c>config_alert_log.alert_sent</c> meant "delivered" on a fired row and "no send channel
+/// applies" on a resolution row, so <c>false</c> could not be told from never-attempted and no aggregate
+/// over the column meant anything.
+///
+/// <para>These pin the Darling half: the resolution record states its channel instead of claiming a
+/// delivery, the headless service never writes a <c>tray</c> row, and the Viewer's status column renders
+/// through the one shared describer both SKUs use. Lite's half — including that its stored values are
+/// UNCHANGED — is <c>Lite.Tests.AlertDeliveryChannelTests</c>.</para>
+/// </summary>
+public sealed class AlertDeliveryChannelTests
+{
+    /* ─────────────── the resolution record: a stated channel, not a claimed delivery ─────────────── */
+
+    /// <summary>
+    /// The defect itself. <c>BuildResolutionRecord</c> was the only construction site in non-test code that
+    /// named <c>AlertSent:</c> explicitly, and it said <c>true</c> — documented as meaning "a resolution has
+    /// no send channel", not "something was delivered". Measured on three live stores on 2026-09-08: every
+    /// one of 5,683 <c>alert_sent = true</c> rows carried a resolution title, and no channel was configured
+    /// on any of them, so not one of those <c>true</c>s was a delivery.
+    /// </summary>
+    [Fact]
+    public void TheResolutionRecord_StatesNoChannel_RatherThanClaimingDelivery()
+    {
+        var record = DarlingSelfAlertEvaluator.BuildResolutionRecord(
+            new AlertResolution("7", "Srv", "High CPU", "CPU Resolved", "back under the threshold"));
+
+        Assert.False(record.AlertSent);
+        Assert.Equal(AlertDelivery.ChannelNotApplicable, record.NotificationType);
+        Assert.Null(record.SendError);
+    }
+
+    /// <summary>
+    /// The pairing <c>BuildResolutionRecord</c> exists for, pinned separately from the boolean so a repair
+    /// of the boolean cannot quietly cost it: an operator reviewing history must still see "Detected" then
+    /// "Cleared" as a pair, which means the row is still written, still carries the resolution title, and
+    /// still classifies as resolved.
+    /// </summary>
+    [Fact]
+    public void TheResolutionRecord_StillPairsWithItsDetection()
+    {
+        var record = DarlingSelfAlertEvaluator.BuildResolutionRecord(
+            new AlertResolution("7", "Srv", "Blocking Detected", "Blocking Cleared", "no blocking"));
+
+        Assert.Equal("Blocking Cleared", record.MetricName);
+        Assert.True(AlertMetricClassifier.IsResolution(record.MetricName));
+        Assert.Equal("resolved", record.CurrentValueText);
+        Assert.Equal("no blocking", record.DetailText);
+    }
+
+    /// <summary>A row with no channel is never a delivered row, whatever else is true of it.</summary>
+    [Fact]
+    public void NoChannelApplies_IsNeverSent()
+    {
+        var delivery = AlertDelivery.NoChannelApplies();
+
+        Assert.False(delivery.Sent);
+        Assert.Equal(AlertDelivery.ChannelNotApplicable, delivery.Channel);
+        Assert.Null(delivery.SendError);
+    }
+
+    /* ─────────────── the invariant that makes alert_sent decodable again ─────────────── */
+
+    /// <summary>
+    /// <b>Sent implies a named delivering channel</b>, over the WHOLE input domain rather than the
+    /// combinations the send core happens to produce. Enumerating every route to a violation is the point:
+    /// <c>EmailFanoutResult</c> carries four independent bools, and an <c>EmailSent</c> without an
+    /// <c>EmailAttempted</c> — which the send core never emits but the type freely represents — would
+    /// otherwise report a delivery on a channel that never named itself, putting a <c>true</c> back
+    /// alongside <c>tray</c> and re-breaking the legacy decode in
+    /// <see cref="TheLegacyResolutionSignature_DecodesToNoChannel"/>.
+    /// </summary>
+    [Fact]
+    public void EverySentDisposition_NamesADeliveringChannel()
+    {
+        var delivering = new[]
+        {
+            AlertDelivery.ChannelEmail, AlertDelivery.ChannelWebhook, AlertDelivery.ChannelEmailAndWebhook,
+        };
+
+        var checked_ = 0;
+        foreach (var (result, muted, tray) in EveryFanoutCase())
+        {
+            var delivery = AlertDelivery.FromFanout(result, muted, tray);
+            checked_++;
+
+            if (delivery.Sent)
+            {
+                Assert.Contains(delivery.Channel, delivering);
+            }
+            else
+            {
+                Assert.DoesNotContain(delivery.Channel, delivering);
+            }
+        }
+
+        /* The count IS the claim that the enumeration is the whole domain: 2^4 result bools x muted x
+           trayChannelPresent. A shrunken loop would otherwise pass by covering less. */
+        Assert.Equal(64, checked_);
+    }
+
+    /// <summary><c>Sent</c> is exactly "a channel delivered", with no other contributor.</summary>
+    [Fact]
+    public void Sent_IsEmailSentOrWebhookSent_AndNothingElse()
+    {
+        foreach (var (result, muted, tray) in EveryFanoutCase())
+        {
+            Assert.Equal(
+                result.EmailSent || result.WebhookSent,
+                AlertDelivery.FromFanout(result, muted, tray).Sent);
+        }
+    }
+
+    /* ─────────────── the three states that used to be one `false` ─────────────── */
+
+    /// <summary>
+    /// The state every fired alert on Erik's three live stores is actually in, and the one the column could
+    /// not express: no SMTP and no webhook configured, so nothing was attempted. Measured 2026-09-08 —
+    /// all nine channel flags empty in <c>config_notification</c> on all three, never edited since seed —
+    /// which is why these rows' <c>false</c> was correct all along and still told a reader nothing.
+    /// </summary>
+    [Fact]
+    public void WithNoChannelConfigured_TheDispositionSaysSo()
+    {
+        var delivery = AlertDelivery.FromFanout(
+            Fanout(anyChannelConfigured: false), muted: false, trayChannelPresent: false);
+
+        Assert.False(delivery.Sent);
+        Assert.Equal(AlertDelivery.ChannelNoneConfigured, delivery.Channel);
+    }
+
+    /// <summary>
+    /// Configured, consulted, nothing delivered — a throttled send or a webhook post that came back
+    /// unsuccessful. Distinct from <see cref="AlertDelivery.ChannelNoneConfigured"/>, which is the whole
+    /// point: the two want different operator responses and used to arrive identically.
+    /// </summary>
+    [Fact]
+    public void WithAChannelConfiguredAndNothingDelivered_TheDispositionIsUndelivered()
+    {
+        var delivery = AlertDelivery.FromFanout(
+            Fanout(anyChannelConfigured: true), muted: false, trayChannelPresent: false);
+
+        Assert.False(delivery.Sent);
+        Assert.Equal(AlertDelivery.ChannelUndelivered, delivery.Channel);
+    }
+
+    /// <summary>An attempt that threw keeps its error, and reads as a failure rather than as an absence.</summary>
+    [Fact]
+    public void AnAttemptThatFailed_KeepsItsErrorAndReadsAsFailed()
+    {
+        var delivery = AlertDelivery.FromFanout(
+            Fanout(emailAttempted: true, sendError: "relay refused", anyChannelConfigured: true),
+            muted: false, trayChannelPresent: false);
+
+        Assert.False(delivery.Sent);
+        Assert.Equal(AlertDelivery.ChannelEmail, delivery.Channel);
+        Assert.Equal("relay refused", delivery.SendError);
+        Assert.Equal(AlertDeliveryStatus.Failed, Describe(delivery));
+    }
+
+    /// <summary>A muted alert is still recorded, and says the channels were suppressed rather than absent.</summary>
+    [Fact]
+    public void AMutedAlert_SaysSuppressed_NotUnconfigured()
+    {
+        var delivery = AlertDelivery.FromFanout(
+            Fanout(anyChannelConfigured: true), muted: true, trayChannelPresent: false);
+
+        Assert.Equal(AlertDelivery.ChannelMuted, delivery.Channel);
+        Assert.Equal(AlertDeliveryStatus.Muted, Describe(delivery));
+    }
+
+    /* ─────────────── the deliberate per-SKU divergence, asserted ─────────────── */
+
+    /// <summary>
+    /// <b>The headless service has no tray, so it never writes a tray row.</b> Not a style choice: there is
+    /// no tray icon and no toast code anywhere under the Darling service, yet all 32,546 rows across the
+    /// three live stores carried <c>notification_type = 'tray'</c> — a UI event that cannot occur —
+    /// because both Darling producers had copied Lite's taxonomy comment along with its tray fallback.
+    /// Asserted here rather than left to the comment, so the answer is remade if a producer is added.
+    /// </summary>
+    [Fact]
+    public void TheHeadlessService_NeverWritesATrayRow()
+    {
+        foreach (var (result, muted, _) in EveryFanoutCase())
+        {
+            Assert.NotEqual(
+                AlertDelivery.ChannelTray,
+                AlertDelivery.FromFanout(result, muted, trayChannelPresent: false).Channel);
+        }
+    }
+
+    /// <summary>
+    /// Both Darling producers state <c>trayChannelPresent: false</c>. The named argument is what makes a
+    /// transposition a compile error rather than a silent flip, and this is what makes ADDING a producer
+    /// that forgets the answer a red test rather than 32,000 more untrue rows.
+    /// </summary>
+    [Fact]
+    public void BothDarlingProducers_DeclareNoTrayChannel()
+    {
+        string[] producers =
+        {
+            "Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs",
+            "Darling/PerformanceMonitor.Darling.Service/DarlingFindingAlertSender.cs",
+        };
+
+        foreach (var relative in producers)
+        {
+            var text = File.ReadAllText(RepoPath(relative));
+            Assert.Contains("trayChannelPresent: false", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("trayChannelPresent: true", text, StringComparison.Ordinal);
+        }
+
+        /* Every FromFanout call under the Darling tree is one of those two, so the pair above is the
+           whole population rather than a sample of it. */
+        var callers = SourceFilesUnder("Darling")
+            .Where(f => File.ReadAllText(f).Contains("AlertDelivery.FromFanout(", StringComparison.Ordinal))
+            .Where(f => !f.Contains("Darling.Tests", StringComparison.Ordinal))
+            .Select(f => f.Replace('\\', '/'))
+            .ToList();
+
+        Assert.Equal(2, callers.Count);
+        Assert.All(callers, c => Assert.Contains("PerformanceMonitor.Darling.Service", c, StringComparison.Ordinal));
+    }
+
+    /* ─────────────── the read side: one vocabulary, and old rows left alone ─────────────── */
+
+    /// <summary>
+    /// Every disposition renders as something an operator can act on, and no two states that want different
+    /// responses collapse onto one label.
+    /// </summary>
+    [Theory]
+    [InlineData(false, AlertDelivery.ChannelNotApplicable, null, AlertDeliveryStatus.NoChannel)]
+    [InlineData(false, AlertDelivery.ChannelNoneConfigured, null, AlertDeliveryStatus.NoChannelConfigured)]
+    [InlineData(false, AlertDelivery.ChannelUndelivered, null, AlertDeliveryStatus.NotSent)]
+    [InlineData(false, AlertDelivery.ChannelMuted, null, AlertDeliveryStatus.Muted)]
+    [InlineData(false, AlertDelivery.ChannelEmail, "relay refused", AlertDeliveryStatus.Failed)]
+    [InlineData(false, AlertDelivery.ChannelEmail, null, AlertDeliveryStatus.NotSent)]
+    [InlineData(true, AlertDelivery.ChannelEmail, null, AlertDeliveryStatus.Delivered)]
+    [InlineData(true, AlertDelivery.ChannelWebhook, null, AlertDeliveryStatus.Delivered)]
+    [InlineData(true, AlertDelivery.ChannelEmailAndWebhook, null, AlertDeliveryStatus.Delivered)]
+    public void Describe_OnADarlingStore_DiscriminatesEveryDisposition(
+        bool sent, string channel, string? sendError, string expected)
+        => Assert.Equal(expected, AlertDeliveryStatus.Describe(sent, channel, sendError, trayChannelPresent: false));
+
+    /// <summary>
+    /// <b>The one legacy signature that can be decoded.</b> <c>alert_sent = true</c> with
+    /// <c>notification_type = 'tray'</c> is unreachable for a new row —
+    /// <see cref="EverySentDisposition_NamesADeliveringChannel"/> is what holds that — and it is what the
+    /// resolution builder's hardcoded constant wrote, on either SKU, because that builder is shared. So it
+    /// renders as what it always meant rather than as a delivery that never happened.
+    /// </summary>
+    [Fact]
+    public void TheLegacyResolutionSignature_DecodesToNoChannel()
+    {
+        Assert.Equal(AlertDeliveryStatus.NoChannel,
+            AlertDeliveryStatus.Describe(true, AlertDelivery.ChannelTray, null, trayChannelPresent: false));
+        Assert.Equal(AlertDeliveryStatus.NoChannel,
+            AlertDeliveryStatus.Describe(true, AlertDelivery.ChannelTray, null, trayChannelPresent: true));
+    }
+
+    /// <summary>
+    /// <b>And the one that is NOT decoded.</b> A legacy <c>false</c> + <c>tray</c> covers no-channel,
+    /// throttled and failed-webhook alike, and nothing in the row separates them, so it gets an
+    /// outcome-only label that makes no claim about configuration. Reading it as
+    /// <see cref="AlertDeliveryStatus.NoChannelConfigured"/> would be asserting the new semantics over rows
+    /// written before them — every existing row on all three stores predates this change, and 8,085 of them
+    /// in one seven-day window are exactly this shape.
+    /// </summary>
+    [Fact]
+    public void TheLegacyDetectedSignature_IsNotReinterpreted()
+    {
+        var status = AlertDeliveryStatus.Describe(false, AlertDelivery.ChannelTray, null, trayChannelPresent: false);
+
+        Assert.Equal(AlertDeliveryStatus.NotSent, status);
+        Assert.NotEqual(AlertDeliveryStatus.NoChannelConfigured, status);
+        Assert.NotEqual(AlertDeliveryStatus.Shown, status);
+    }
+
+    /// <summary>
+    /// The Darling Viewer said "Shown" for every fired alert and "Delivered" for every resolution, because
+    /// its copy of the renderer branched on <c>notification_type == "email"</c> and, with no SMTP
+    /// configured, that arm never ran. Nothing a Darling store can hold may read as a UI event now.
+    /// </summary>
+    [Fact]
+    public void Describe_OnADarlingStore_NeverSaysShown()
+    {
+        string[] everyChannel =
+        {
+            AlertDelivery.ChannelNotApplicable, AlertDelivery.ChannelNoneConfigured, AlertDelivery.ChannelMuted,
+            AlertDelivery.ChannelTray, AlertDelivery.ChannelUndelivered, AlertDelivery.ChannelEmail,
+            AlertDelivery.ChannelWebhook, AlertDelivery.ChannelEmailAndWebhook, "", "toast",
+        };
+
+        foreach (var channel in everyChannel)
+        {
+            foreach (var sent in new[] { false, true })
+            {
+                foreach (var error in new[] { null, "relay refused" })
+                {
+                    Assert.NotEqual(
+                        AlertDeliveryStatus.Shown,
+                        AlertDeliveryStatus.Describe(sent, channel, error, trayChannelPresent: false));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The Viewer's grid column IS the shared describer's answer, not a copy that agrees today. If a local
+    /// copy is reintroduced it drifts the moment the describer changes, and this goes red.
+    /// </summary>
+    [Fact]
+    public void TheViewerRow_RendersThroughTheSharedDescriber()
+    {
+        var cases = new (bool Sent, string Channel, string? Error)[]
+        {
+            (false, AlertDelivery.ChannelNotApplicable, null),
+            (false, AlertDelivery.ChannelNoneConfigured, null),
+            (false, AlertDelivery.ChannelUndelivered, null),
+            (false, AlertDelivery.ChannelMuted, null),
+            (false, AlertDelivery.ChannelEmail, "relay refused"),
+            (true, AlertDelivery.ChannelEmailAndWebhook, null),
+            (true, AlertDelivery.ChannelTray, null),
+            (false, AlertDelivery.ChannelTray, null),
+        };
+
+        foreach (var (sent, channel, error) in cases)
+        {
+            var row = new ViewerAlertRow
+            {
+                AlertTime = new DateTime(2026, 9, 8, 1, 0, 0, DateTimeKind.Utc),
+                MetricName = "High CPU",
+                CurrentValue = 92,
+                ThresholdValue = 90,
+                AlertSent = sent,
+                NotificationType = channel,
+                SendError = error,
+                Muted = false,
+            };
+
+            Assert.Equal(
+                AlertDeliveryStatus.Describe(sent, channel, error, trayChannelPresent: false),
+                row.StatusDisplay);
+        }
+    }
+
+    /* ─────────────── the hatch stays where it was put ─────────────── */
+
+    /// <summary>
+    /// <c>FromLegacyStoredColumns</c> is the only way left to hand-write a disposition, and it exists for
+    /// the deprecated Dashboard SKU, whose 26 callers pass an already-decided pair as method parameters.
+    /// It is <c>internal</c>, but <c>InternalsVisibleTo</c> on the Notifications project also admits Lite
+    /// and both SKUs' test projects — so the boundary is asserted rather than assumed. A live producer
+    /// reaching for it fails here instead of quietly reintroducing #3169.
+    /// </summary>
+    [Fact]
+    public void TheLegacyHatch_HasExactlyOneProductionCaller()
+    {
+        var root = RepoRoot();
+        var callers = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(file);
+            if (!text.Contains("FromLegacyStoredColumns", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var relative = Path.GetRelativePath(root, file).Replace('\\', '/');
+
+            /* Its own declaration, and test code deliberately storing an arbitrary column triple, are not
+               producers. Everything else is. */
+            if (relative == "PerformanceMonitor.Notifications/AlertDelivery.cs"
+                || relative.Contains(".Tests/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            callers.Add(relative);
+        }
+
+        Assert.Equal(new[] { "deprecated/Dashboard/Services/EmailAlertService.cs" }, callers.OrderBy(c => c).ToArray());
+    }
+
+    /* ─────────────── helpers ─────────────── */
+
+    private static string Describe(AlertDelivery delivery)
+        => AlertDeliveryStatus.Describe(delivery.Sent, delivery.Channel, delivery.SendError, trayChannelPresent: false);
+
+    private static EmailFanoutResult Fanout(
+        bool emailAttempted = false, bool emailSent = false, string? sendError = null,
+        bool webhookSent = false, bool anyChannelConfigured = false)
+        => new(emailAttempted, emailSent, sendError, webhookSent, anyChannelConfigured);
+
+    /// <summary>
+    /// Every representable <c>EmailFanoutResult</c> shape crossed with both callers' answers — 64 cases.
+    /// <c>SendError</c> is not part of the cross-product because no arm branches on it; the failure path is
+    /// covered by <see cref="AnAttemptThatFailed_KeepsItsErrorAndReadsAsFailed"/>.
+    /// </summary>
+    private static IEnumerable<(EmailFanoutResult Result, bool Muted, bool Tray)> EveryFanoutCase()
+    {
+        foreach (var emailAttempted in new[] { false, true })
+        foreach (var emailSent in new[] { false, true })
+        foreach (var webhookSent in new[] { false, true })
+        foreach (var anyConfigured in new[] { false, true })
+        foreach (var muted in new[] { false, true })
+        foreach (var tray in new[] { false, true })
+        {
+            yield return (
+                new EmailFanoutResult(emailAttempted, emailSent, null, webhookSent, anyConfigured),
+                muted, tray);
+        }
+    }
+
+    private static IEnumerable<string> SourceFilesUnder(string relativeDirectory)
+        => Directory.EnumerateFiles(Path.Combine(RepoRoot(), relativeDirectory), "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+    private static string RepoPath(string relative) => Path.Combine(RepoRoot(), relative);
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+        => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", ".."));
+}

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -117,9 +117,10 @@ public sealed class AlertDeliveryChannelTests
             }
         }
 
-        /* The count IS the claim that the enumeration is the whole domain: 2^4 result bools x muted x
-           trayChannelPresent. A shrunken loop would otherwise pass by covering less. */
-        Assert.Equal(64, checked_);
+        /* The count IS the claim that the enumeration is the whole domain: 2^4 result bools x send_error
+           present-or-not x muted x trayChannelPresent. A shrunken loop would otherwise pass by covering
+           less. */
+        Assert.Equal(128, checked_);
     }
 
     /// <summary>
@@ -158,6 +159,37 @@ public sealed class AlertDeliveryChannelTests
             Assert.Equal(
                 result.EmailSent || result.WebhookSent,
                 AlertDelivery.FromFanout(result, muted, tray).Sent);
+        }
+    }
+
+    /// <summary>
+    /// <b>No state-carrying channel can carry a <c>send_error</c>.</b> Over the whole input domain, a
+    /// non-null error implies <see cref="AlertDelivery.DeliveringChannels"/> — because the error can only
+    /// come from the SMTP attempt, so its presence is itself email involvement.
+    ///
+    /// <para>This is what licenses two surfaces to check in different orders. The web dashboard tests
+    /// <c>send_error</c> before its state lookup; <see cref="AlertDeliveryStatus.Describe"/> tests the state
+    /// channels first. Equivalent, but only because the two cases can never co-occur — which the review of
+    /// this change correctly noted was true of the reachable subset rather than of the type. It is now true
+    /// of the type.</para>
+    ///
+    /// <para>Residual, stated rather than papered over: a row PERSISTED by an earlier version could still
+    /// hold a state channel beside an error, and the two surfaces would label it differently. No producer
+    /// can write one, and none of the 32,546 rows on the three live stores carries a non-null
+    /// <c>send_error</c> at all.</para>
+    /// </summary>
+    [Fact]
+    public void NoStateCarryingChannel_CanCarryASendError()
+    {
+        foreach (var (result, muted, tray) in EveryFanoutCase())
+        {
+            var delivery = AlertDelivery.FromFanout(result, muted, tray);
+
+            if (delivery.SendError is not null)
+            {
+                Assert.Contains(delivery.Channel, AlertDelivery.DeliveringChannels);
+                Assert.DoesNotContain(delivery.Channel, AlertDelivery.StateCarryingChannels);
+            }
         }
     }
 
@@ -494,9 +526,10 @@ public sealed class AlertDeliveryChannelTests
         => new(emailAttempted, emailSent, sendError, webhookSent, anyChannelConfigured);
 
     /// <summary>
-    /// Every representable <c>EmailFanoutResult</c> shape crossed with both callers' answers — 64 cases.
-    /// <c>SendError</c> is not part of the cross-product because no arm branches on it; the failure path is
-    /// covered by <see cref="AnAttemptThatFailed_KeepsItsErrorAndReadsAsFailed"/>.
+    /// Every representable <c>EmailFanoutResult</c> shape crossed with both callers' answers — 128 cases.
+    /// <c>SendError</c> is in the cross-product because an arm DOES branch on it: it counts as email
+    /// involvement, which is what makes
+    /// <see cref="NoStateCarryingChannel_CanCarryASendError"/> hold over the whole domain.
     /// </summary>
     private static IEnumerable<(EmailFanoutResult Result, bool Muted, bool Tray)> EveryFanoutCase()
     {
@@ -504,11 +537,12 @@ public sealed class AlertDeliveryChannelTests
         foreach (var emailSent in new[] { false, true })
         foreach (var webhookSent in new[] { false, true })
         foreach (var anyConfigured in new[] { false, true })
+        foreach (var sendError in new string?[] { null, "relay refused" })
         foreach (var muted in new[] { false, true })
         foreach (var tray in new[] { false, true })
         {
             yield return (
-                new EmailFanoutResult(emailAttempted, emailSent, null, webhookSent, anyConfigured),
+                new EmailFanoutResult(emailAttempted, emailSent, sendError, webhookSent, anyConfigured),
                 muted, tray);
         }
     }

--- a/Darling/Darling.Tests/AlertTrayStatusLoggedTests.cs
+++ b/Darling/Darling.Tests/AlertTrayStatusLoggedTests.cs
@@ -7,41 +7,207 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
+using PerformanceMonitor.Notifications;
 using Xunit;
 
 namespace Darling.Tests;
 
 /// <summary>
-/// #2814 (follow-on to #2781): the Darling web is headless (no system tray), so a <c>"tray"</c> alert - Lite's
-/// delivered-without-email taxonomy - was never delivered on this surface and must read a single neutral
-/// "Logged", NOT a Sent/Not-sent derived from <c>alert_sent</c> (which the engine sets inconsistently: clears
-/// true, problems false). Both status collapses - <c>statusCell</c> (alerts.js) and <c>alertStatusText</c>
-/// (triage.js) - carry the rule, and the pages document that they stay in lockstep, so this pins both. No JS
-/// runner in this repo, so it scans the frontend source the way the composer drift guards do.
+/// #2814 (follow-on to #2781): the Darling web is headless (no system tray), so a <c>"tray"</c> alert -
+/// Lite's delivered-without-email taxonomy - was never delivered on this surface and must read a single
+/// neutral "Logged", NOT a Sent/Not-sent derived from <c>alert_sent</c>. No JS runner in this repo, so this
+/// scans the frontend source the way the composer drift guards do.
+///
+/// <para>#3169 fixed the cause rather than this surface's reading of it. <c>alert_sent</c> no longer means
+/// "no channel applies" on a resolution row, and <c>notification_type</c> now NAMES the state, so a headless
+/// store records <c>unconfigured</c> / <c>none</c> where it used to borrow Lite's <c>tray</c>. Those values
+/// reach these pages, and with no handling they would fall straight through to the very <c>alert_sent</c>
+/// collapse #2814 removed - so the guard grew rather than being deleted.</para>
+///
+/// <para><b>What changed about the guard itself.</b> It used to scan for a
+/// <c>notification_type === "tray"</c> branch, for the string "Logged" somewhere in the file, and for
+/// <c>IndexOf("alert_sent")</c> preceding the branch. All three were satisfiable without the behaviour
+/// holding: any mention of <c>alert_sent</c> anywhere anchored the ordering check, and a page pairing every
+/// label with the wrong state would still have contained both strings. The mapping now lives in ONE
+/// parseable declaration - <c>ALERT_STATE_LABELS</c> in <c>util.js</c>, which both pages read through
+/// <c>alertDeliveryState</c> - and this file parses that object and compares it to
+/// <see cref="AlertDeliveryStatus"/>'s constants key by key. A cross-language parity pin on the seam rather
+/// than a text search, which is the shape the repo's other cross-surface guards use.</para>
 /// </summary>
 public class AlertTrayStatusLoggedTests
 {
+    /// <summary>
+    /// The label each state-carrying channel owes an operator. The KEYS are not listed here - they come from
+    /// <see cref="AlertDelivery.StateCarryingChannels"/>, so adding a state to the C# taxonomy without
+    /// teaching the web dashboard about it fails
+    /// <see cref="EveryChannelConstant_IsClassified_AndEveryStateHasALabel"/> rather than silently shipping
+    /// a third vocabulary.
+    /// </summary>
+    private static readonly Dictionary<string, string> ExpectedStateLabels = new(StringComparer.Ordinal)
+    {
+        [AlertDelivery.ChannelNotApplicable] = AlertDeliveryStatus.NoChannel,
+        [AlertDelivery.ChannelNoneConfigured] = AlertDeliveryStatus.NoChannelConfigured,
+        [AlertDelivery.ChannelMuted] = AlertDeliveryStatus.Muted,
+        [AlertDelivery.ChannelUndelivered] = AlertDeliveryStatus.NotSent,
+        [AlertDelivery.ChannelTray] = AlertDeliveryStatus.Logged,
+    };
+
+    /// <summary>
+    /// Every <c>Channel*</c> constant on <see cref="AlertDelivery"/> is classified as either state-carrying
+    /// or delivering, the two lists are a partition, and this file has a label for every state-carrying one.
+    ///
+    /// <para>This is the reach property. Without it a new channel constant would be invisible to every check
+    /// below - absent from both lists, absent from the web dashboard's map, and rendered by whatever
+    /// fallback happened to catch it. Reflection over the constants is what makes "did anyone classify
+    /// this?" answerable, instead of trusting that whoever added it also came here.</para>
+    /// </summary>
+    [Fact]
+    public void EveryChannelConstant_IsClassified_AndEveryStateHasALabel()
+    {
+        var constants = typeof(AlertDelivery)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            .Where(f => f.Name.StartsWith("Channel", StringComparison.Ordinal))
+            .Select(f => (f.Name, Value: (string)f.GetRawConstantValue()!))
+            .ToList();
+
+        Assert.NotEmpty(constants);
+
+        var classified = AlertDelivery.StateCarryingChannels
+            .Concat(AlertDelivery.DeliveringChannels)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Empty(constants.Where(c => !classified.Contains(c.Value)).Select(c => c.Name));
+
+        /* The two lists are a partition, not two overlapping opinions. */
+        Assert.Empty(AlertDelivery.StateCarryingChannels
+            .Intersect(AlertDelivery.DeliveringChannels, StringComparer.Ordinal));
+
+        Assert.Equal(
+            AlertDelivery.StateCarryingChannels.OrderBy(c => c, StringComparer.Ordinal).ToArray(),
+            ExpectedStateLabels.Keys.OrderBy(c => c, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// The web dashboard's <c>ALERT_STATE_LABELS</c> is exactly the shared taxonomy, key for key and label
+    /// for label. Three surfaces render this column and only two of them can share code, so this is the
+    /// join for the third.
+    /// </summary>
+    [Fact]
+    public void TheWebDashboardsStateLabels_MatchTheSharedConstants()
+    {
+        var actual = ParseStateLabels(FrontendSource("util.js"));
+
+        Assert.Equal(
+            ExpectedStateLabels.OrderBy(kv => kv.Key, StringComparer.Ordinal).ToArray(),
+            actual.OrderBy(kv => kv.Key, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// Both pages route through the shared lookup, and they do it BEFORE their own <c>alert_sent</c>
+    /// collapse - otherwise a state-carrying row falls into the Sent/Not-sent reading #2814 removed and
+    /// #3169 made avoidable.
+    ///
+    /// <para>The collapse is located by its full branch text, <c>(a.alert_sent)</c>, rather than by the
+    /// first mention of <c>alert_sent</c> anywhere. The predecessor pin used the latter, and a composite
+    /// condition reading <c>a.alert_sent &amp;&amp; a.notification_type === "tray"</c> would have anchored
+    /// it - reporting the collapse as coming first and passing on a page that had lost every state
+    /// branch.</para>
+    /// </summary>
     [Theory]
     [InlineData("pages/alerts.js")]
     [InlineData("pages/triage.js")]
-    public void TrayAlert_RendersLogged_NotSentOrNotSent(string relPath)
+    public void BothPages_ConsultTheSharedLookup_BeforeTheAlertSentCollapse(string relPath)
     {
         var src = FrontendSource(relPath);
 
-        // The tray branch exists and maps to "Logged".
-        Assert.Matches(new Regex(@"notification_type\s*===\s*""tray"""), src);
-        Assert.Contains("\"Logged\"", src, StringComparison.Ordinal);
+        var lookup = src.IndexOf("alertDeliveryState(a)", StringComparison.Ordinal);
+        var collapse = src.IndexOf("(a.alert_sent)", StringComparison.Ordinal);
 
-        // The tray check must sit BEFORE the alert_sent -> Sent/Not-sent collapse, or a tray alert would still
-        // fall through to the misleading Sent/Not-sent. (Guards the ordering, not just the presence.)
-        var trayIdx = src.IndexOf("=== \"tray\"", StringComparison.Ordinal);
-        var sentIdx = src.IndexOf("alert_sent", StringComparison.Ordinal);
-        Assert.True(trayIdx >= 0, $"{relPath}: tray branch not found");
-        Assert.True(sentIdx >= 0, $"{relPath}: alert_sent branch not found");
-        Assert.True(trayIdx < sentIdx, $"{relPath}: the tray->Logged branch must precede the alert_sent collapse");
+        Assert.True(lookup >= 0, $"{relPath}: the shared lookup is never called");
+        Assert.True(collapse >= 0, $"{relPath}: the bare alert_sent collapse was not found - was it renamed?");
+        Assert.True(
+            lookup < collapse,
+            $"{relPath}: the state lookup must precede the alert_sent collapse, or the row falls into it");
+    }
+
+    /// <summary>
+    /// The one legacy signature that decodes lives in the shared lookup, once: <c>alert_sent</c> true
+    /// alongside <c>tray</c> is unreachable for a row written after #3169 - a row that delivered names its
+    /// channel - so it can only be the resolution builder's old hardcoded true, which meant "no send channel
+    /// applies" and never meant a delivery.
+    /// </summary>
+    [Fact]
+    public void TheLegacyResolutionSignature_IsDecodedOnceInTheSharedLookup()
+    {
+        Assert.Matches(
+            new Regex(@"a\.alert_sent\s*&&\s*a\.notification_type\s*===\s*""tray"""),
+            FrontendSource("util.js"));
+
+        /* And neither page keeps a second copy of it, which is what "in lockstep" used to mean here. */
+        foreach (var relPath in new[] { "pages/alerts.js", "pages/triage.js" })
+        {
+            Assert.DoesNotContain("=== \"tray\"", FrontendSource(relPath), StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The channel chip names a real channel only - "No channel configured (unconfigured)" is the shape this
+    /// prevents - and it derives its exclusions from the shared map rather than listing them again.
+    /// </summary>
+    [Fact]
+    public void TheChannelChip_NamesARealChannelOnly()
+    {
+        var src = FrontendSource("pages/alerts.js");
+
+        Assert.Contains("new Set(Object.keys(ALERT_STATE_LABELS))", src, StringComparison.Ordinal);
+        Assert.Contains("!STATE_ONLY_CHANNELS.has(a.notification_type)", src, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Parses the <c>ALERT_STATE_LABELS</c> object literal out of <c>util.js</c>. Deliberately strict: every
+    /// line inside the literal must be a flat <c>key: "value",</c> pair, so a form this cannot read fails
+    /// loudly instead of yielding a short dictionary that would make
+    /// <see cref="TheWebDashboardsStateLabels_MatchTheSharedConstants"/> pass by comparing less.
+    /// </summary>
+    private static Dictionary<string, string> ParseStateLabels(string util)
+    {
+        var open = util.IndexOf("export const ALERT_STATE_LABELS = {", StringComparison.Ordinal);
+        Assert.True(open >= 0, "util.js: ALERT_STATE_LABELS was not found");
+
+        var close = util.IndexOf("};", open, StringComparison.Ordinal);
+        Assert.True(close > open, "util.js: ALERT_STATE_LABELS is not a closed object literal");
+
+        var body = util.Substring(open, close - open);
+        body = body.Substring(body.IndexOf('{') + 1);
+
+        var pairs = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var rawLine in body.Split('\n'))
+        {
+            var line = rawLine.Trim().TrimEnd('\r');
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            var match = Regex.Match(line, @"^""?(?<key>[A-Za-z0-9_+]+)""?\s*:\s*""(?<label>[^""]*)"",$");
+            Assert.True(
+                match.Success,
+                "util.js: ALERT_STATE_LABELS carries a line this parser cannot read, so the parity check "
+                + $"would silently compare fewer keys: {line}");
+
+            pairs[match.Groups["key"].Value] = match.Groups["label"].Value;
+        }
+
+        Assert.NotEmpty(pairs);
+        return pairs;
     }
 
     private static string FrontendSource(string relPath, [CallerFilePath] string thisFile = "")

--- a/Darling/Darling.Tests/DarlingAlertingTests.cs
+++ b/Darling/Darling.Tests/DarlingAlertingTests.cs
@@ -381,7 +381,7 @@ WHERE server_id = $1 AND metric_name = $2", connection))
             await historyStore.RecordAlertAsync(new AlertHistoryRecord(
                 TestServerKey, TestServerName, metricName,
                 "92%", "90%", 92, 90,
-                AlertSent: true, NotificationType: "tray", SendError: null,
+                Delivery: AlertDelivery.NoChannelApplies(),
                 Muted: false, DetailText: null, ContextJson: ContextFor("walnut")));
 
             await Task.Delay(TimeSpan.FromMilliseconds(50), ct); /* force a distinguishable alert_time */
@@ -389,7 +389,7 @@ WHERE server_id = $1 AND metric_name = $2", connection))
             await historyStore.RecordAlertAsync(new AlertHistoryRecord(
                 TestServerKey, TestServerName, metricName,
                 "95%", "90%", 95, 90,
-                AlertSent: true, NotificationType: "tray", SendError: null,
+                Delivery: AlertDelivery.NoChannelApplies(),
                 Muted: false, DetailText: null, ContextJson: ContextFor("cashew")));
 
             var walnutSeed = await historyStore.GetLastAlertTimeAsync(TestServerKey, metricName, dedupKey: "walnut");

--- a/Darling/Darling.Tests/DarlingAlertingTests.cs
+++ b/Darling/Darling.Tests/DarlingAlertingTests.cs
@@ -292,7 +292,10 @@ WHERE server_id = $1 AND metric_name = 'Deadlocks Detected'", connection))
                 read.Parameters.AddWithValue(TestServerId);
                 using var reader = await read.ExecuteReaderAsync(ct);
                 Assert.True(await reader.ReadAsync(ct), "config_alert_log row missing for the deadlock fire");
-                Assert.Equal("tray", reader.GetString(0)); /* Lite's taxonomy: no email/webhook attempted */
+                /* #3169: the state this assertion's own comment already described. The headless service has
+                   no tray, so a fired alert with nothing configured says "unconfigured" rather than borrowing
+                   Lite's tray fallback. */
+                Assert.Equal(AlertDelivery.ChannelNoneConfigured, reader.GetString(0));
                 Assert.False(reader.GetBoolean(1));
                 Assert.False(reader.GetBoolean(2));
                 Assert.Contains("DedupKey", reader.GetString(3), StringComparison.Ordinal);

--- a/Darling/Darling.Tests/DarlingDeliveryModeTests.cs
+++ b/Darling/Darling.Tests/DarlingDeliveryModeTests.cs
@@ -99,7 +99,8 @@ public sealed class DarlingDeliveryModeTests
         /* One combined summary row, carrying the server-level numerics. */
         var record = Assert.Single(history.Records);
         Assert.Equal("Deadlocks Detected", record.MetricName);
-        Assert.Equal("tray", record.NotificationType); // no channel configured
+        /* #3169: says "no channel configured" instead of leaving it to this comment. */
+        Assert.Equal(AlertDelivery.ChannelNoneConfigured, record.NotificationType);
         Assert.Equal(3, record.NumericCurrentValue);
     }
 

--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -333,8 +333,9 @@ public sealed class DarlingSelfAlertTests
         await e.ApplyCollectionStoppedAsync(ServerId, Name, stopped: false, "", Ct);
         var resumed = Assert.Single(h.History.Records);
         Assert.Equal("Collection Resumed", resumed.MetricName);
-        Assert.True(resumed.AlertSent);
-        Assert.Equal("tray", resumed.NotificationType);
+        /* #3169: a resolution has no send channel, and says so rather than claiming a delivery. */
+        Assert.False(resumed.AlertSent);
+        Assert.Equal(AlertDelivery.ChannelNotApplicable, resumed.NotificationType);
         Assert.Single(h.Deliverer.Outcomes); /* only the original fire went to the deliverer */
 
         /* Still healthy on the next sweep — no duplicate resumed row (resolution is edge-triggered too). */
@@ -430,8 +431,8 @@ public sealed class DarlingSelfAlertTests
         await e.ApplyAgentNotRunningAsync(ServerId, Name, agentRunningFresh: true, agentEverSeenRunning: true, Ct);
         var restarted = Assert.Single(h.History.Records);
         Assert.Equal("Agent Restarted", restarted.MetricName);
-        Assert.True(restarted.AlertSent);
-        Assert.Equal("tray", restarted.NotificationType);
+        Assert.False(restarted.AlertSent);
+        Assert.Equal(AlertDelivery.ChannelNotApplicable, restarted.NotificationType);
         Assert.Single(h.Deliverer.Outcomes);
 
         /* Still running on the next sweep — no duplicate resolution (edge-triggered). */
@@ -902,8 +903,8 @@ public sealed class DarlingSelfAlertTests
         await e.ApplyDiskPressureAsync(50 * Gib, 100 * Gib, null, Ct);
         var resolved = Assert.Single(h.History.Records);
         Assert.Equal("Store Disk Pressure Resolved", resolved.MetricName);
-        Assert.True(resolved.AlertSent);
-        Assert.Equal("tray", resolved.NotificationType);
+        Assert.False(resolved.AlertSent);
+        Assert.Equal(AlertDelivery.ChannelNotApplicable, resolved.NotificationType);
         Assert.Single(h.Deliverer.Outcomes);   /* only the original fire went to the deliverer */
 
         /* Still healthy on the next sweep — no duplicate resolved row (resolution is edge-triggered too). */
@@ -1205,7 +1206,7 @@ public sealed class DarlingSelfAlertTests
         await e.ApplyCompressionJobsStuckAsync(Stuck(), rearm.Delegate, Ct);
         var resolved = Assert.Single(h.History.Records);
         Assert.Equal("Compression Job Recovered", resolved.MetricName);
-        Assert.True(resolved.AlertSent);
+        Assert.False(resolved.AlertSent); /* #3169: a resolution has no send channel to have used */
         Assert.Contains("running on schedule again", resolved.DetailText, StringComparison.Ordinal);
 
         /* Still healthy next check — no duplicate resolution (edge-triggered), and a re-stuck job would be a
@@ -1990,8 +1991,8 @@ public sealed class DarlingSelfAlertTests
         Assert.Equal(Name, record.ServerName);
         Assert.Equal("CPU Resolved", record.MetricName);           /* the "…Resolved/Cleared" title, Dashboard shape */
         Assert.Equal($"{Name}: Total CPU back to 12%", record.DetailText);
-        Assert.True(record.AlertSent);
-        Assert.Equal("tray", record.NotificationType);
+        Assert.False(record.AlertSent);
+        Assert.Equal(AlertDelivery.ChannelNotApplicable, record.NotificationType);
         Assert.Null(record.SendError);
         Assert.False(record.Muted);
     }
@@ -2025,7 +2026,7 @@ public sealed class DarlingSelfAlertTests
         await engine.EvaluateServerAsync(new AlertServerSnapshot(Key, Name, IsOnline: true, 10, 10, false, false), Ct);
         var resolved = Assert.Single(history.Records);
         Assert.Equal("CPU Resolved", resolved.MetricName);
-        Assert.Equal("tray", resolved.NotificationType);
+        Assert.Equal(AlertDelivery.ChannelNotApplicable, resolved.NotificationType);
     }
 
     private sealed class StubReadAdapter : IAlertReadAdapter

--- a/Darling/Darling.Tests/ServerPageTabsTests.cs
+++ b/Darling/Darling.Tests/ServerPageTabsTests.cs
@@ -481,13 +481,22 @@ public sealed class ServerPageTabsTests
         Assert.DoesNotContain("errorStrip(res.message)", serverTabs, StringComparison.Ordinal);
         Assert.DoesNotContain("errorStrip(trend.message)", serverTabs, StringComparison.Ordinal);
 
-        /* #2781 on BOTH surfaces that render the status cell. */
+        /* #2781 on BOTH surfaces that render the status cell, in the generalized form #3169 gave it: the
+           surface-less channel is no longer just "tray" but every value that carries a STATE rather than
+           naming a channel, and both pages route through the one shared lookup in util.js instead of each
+           testing a literal. Asserted as the claim rather than as the old `!== "tray"` text, because that
+           text is now absent while the behaviour it stood for is strictly wider. What the values ARE, and
+           that they agree with the desktop surfaces' constants, is Darling.Tests.AlertTrayStatusLoggedTests. */
         var alerts = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "alerts.js"));
-        Assert.Contains("a.notification_type !== \"tray\"", alerts, StringComparison.Ordinal);
+        Assert.Contains("!STATE_ONLY_CHANNELS.has(a.notification_type)", alerts, StringComparison.Ordinal);
+        Assert.Contains(
+            PerformanceMonitor.Notifications.AlertDelivery.ChannelTray,
+            PerformanceMonitor.Notifications.AlertDelivery.StateCarryingChannels);
+
         var triage = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "triage.js"));
-        Assert.Contains("a.notification_type !== \"tray\"", triage, StringComparison.Ordinal);
+        Assert.Contains("alertDeliveryState(a)", triage, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/ViewerWave3Tests.cs
+++ b/Darling/Darling.Tests/ViewerWave3Tests.cs
@@ -298,15 +298,35 @@ public sealed class ViewerWave3DisplayTests
         Assert.Equal("0.00", AlertRow(metric: "Store Disk Pressure", current: 0).CurrentValueDisplay);
     }
 
+    /// <summary>
+    /// #3169: the status column no longer mirrors Lite's channel mapping, and the two <c>tray</c> rows are
+    /// why. This SKU's store is written by the HEADLESS service, which has no tray and no toast code, so a
+    /// stored <c>tray</c> claims a UI event that cannot have happened — the reading #2781/#2814 already
+    /// removed on the web surface and this grid still had. Both surfaces now share one description with the
+    /// SKU's tray answer passed in.
+    ///
+    /// <para><c>true</c> alongside <c>tray</c> reads "No channel": it is unreachable for a new row, so it
+    /// can only be the resolution builder's old hardcoded constant. <c>false</c> alongside <c>tray</c> gets
+    /// #2781's neutral "Logged", because it merges no-channel, throttled and failed-webhook and nothing in
+    /// the row separates them — decoding it would be asserting the new semantics over old rows.</para>
+    /// </summary>
     [Theory]
-    [InlineData("email", true, null, "Sent")]
+    [InlineData("email", true, null, "Delivered")]
     [InlineData("email", false, "smtp exploded", "Failed")]
     [InlineData("email", false, null, "Not sent")]
-    [InlineData("tray", true, null, "Delivered")]
-    [InlineData("tray", false, null, "Shown")]
-    public void StatusDisplay_MirrorsLitesChannelMapping(string notif, bool sent, string? error, string expected)
+    [InlineData("webhook", true, null, "Delivered")]
+    [InlineData("email+webhook", true, null, "Delivered")]
+    [InlineData("none", false, null, "No channel")]
+    [InlineData("unconfigured", false, null, "No channel configured")]
+    [InlineData("undelivered", false, null, "Not sent")]
+    [InlineData("muted", false, null, "Muted")]
+    [InlineData("tray", true, null, "No channel")]
+    [InlineData("tray", false, null, "Logged")]
+    public void StatusDisplay_NamesTheChannelState_AndNeverClaimsATrayThisSkuLacks(
+        string notif, bool sent, string? error, string expected)
     {
         Assert.Equal(expected, AlertRow(notificationType: notif, alertSent: sent, sendError: error).StatusDisplay);
+        Assert.NotEqual("Shown", AlertRow(notificationType: notif, alertSent: sent, sendError: error).StatusDisplay);
     }
 
     [Fact]
@@ -559,7 +579,9 @@ public sealed class ViewerWave3LivePostgresTests
             Assert.Equal("High CPU", row.MetricName);
             Assert.Equal("95.5%", row.CurrentValueDisplay);
             Assert.Equal("tray", row.NotificationType);
-            Assert.Equal("Shown", row.StatusDisplay);
+            /* #3169: a pre-change row on a headless store, read conservatively — #2781's neutral label,
+               not the "Shown" this grid used to render for a surface with no tray. */
+            Assert.Equal("Logged", row.StatusDisplay);
             /* The read carries the raw context_json (the #1140 dedup fingerprint) through unchanged. */
             Assert.NotNull(row.ContextJson);
             Assert.Contains("DedupKey", row.ContextJson, StringComparison.Ordinal);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
@@ -143,21 +143,11 @@ public sealed class DarlingAlertDeliverer : IAlertDeliverer
             outcome.MetricName, outcome.ServerName, currentValue, outcome.ThresholdValue,
             outcome.ServerKey, context, attemptChannels: !outcome.Muted);
 
-        /* Lite's single-row notification_type taxonomy (EmailAlertService.cs:68-80):
-           muted → "muted"; email attempted → "email"; webhook delivery upgrades to
-           "email+webhook"/"webhook"; otherwise "tray". */
-        var notificationType = outcome.Muted ? "muted" : "tray";
-        if (result.EmailAttempted)
-        {
-            notificationType = "email";
-        }
-
-        var sent = result.EmailSent;
-        if (result.WebhookSent)
-        {
-            notificationType = notificationType == "email" ? "email+webhook" : "webhook";
-            sent = true;
-        }
+        /* trayChannelPresent: false — this is the HEADLESS service. It has no tray icon and no toast
+           code, so the taxonomy's "tray" fallback (which is Lite's, and truthful there) would assert a UI
+           event that cannot occur here. Without a channel configured a fired alert is reported as
+           "unconfigured", which is the state an operator can act on. */
+        var delivery = AlertDelivery.FromFanout(result, outcome.Muted, trayChannelPresent: false);
 
         /* Always log the alert, regardless of channel status (EmailAlertService.cs:82-94). */
         string? contextJson = context is not null ? AlertContextSerializer.Serialize(context) : null;
@@ -165,7 +155,7 @@ public sealed class DarlingAlertDeliverer : IAlertDeliverer
             outcome.ServerKey, outcome.ServerName, outcome.MetricName,
             currentValue, outcome.ThresholdValue,
             numericCurrentValue, numericThresholdValue,
-            sent, notificationType, result.SendError,
+            delivery,
             outcome.Muted, detailText, contextJson));
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
@@ -21,9 +21,14 @@ namespace PerformanceMonitor.Darling.Service;
 /// (when SMTP is configured and outside the per-fingerprint cooldown) and fans out to the shared
 /// <see cref="WebhookAlertService"/> (Teams/Slack), then ONE combined <c>config_alert_log</c> row
 /// is written per fired alert regardless of channel outcome — including muted alerts (flagged
-/// muted, channels skipped) and alerts with no channel configured at all (recorded as 'tray',
-/// Lite's taxonomy for delivered-without-email; the headless smoke asserts this row exists).
+/// muted, channels skipped) and alerts with no channel configured at all, whose row states
+/// <see cref="AlertDelivery.ChannelNoneConfigured"/> (the headless smoke asserts the row exists).
 /// Never throws — a dead SMTP server or Postgres store must not abort the engine's sweep.
+///
+/// <para>The row's disposition comes from <see cref="AlertDelivery.FromFanout"/> with
+/// <c>trayChannelPresent: false</c>. This service is headless: it has no tray icon and no toast code, so
+/// Lite's <c>tray</c> fallback — which is truthful there, where the deliverer really does show a balloon —
+/// would assert a UI event that cannot occur here (#3169).</para>
 ///
 /// <para>Delivery-mode fan-out (Lite/Dashboard parity): the effective mode is the shared
 /// <see cref="AlertDeliveryModeResolver"/> of a per-server override (#1236,

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingFindingAlertSender.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingFindingAlertSender.cs
@@ -20,9 +20,11 @@ namespace PerformanceMonitor.Darling.Service;
 /// the same <see cref="EmailSendCore"/>/webhook flow <see cref="DarlingAlertDeliverer"/>
 /// already uses (same branding, same settings, same PG history store): the core attempts
 /// email + fans out to Teams/Slack, then ONE combined <c>config_alert_log</c> row is written
-/// per finding alert regardless of channel outcome (no channel configured → recorded as
-/// 'tray', Lite's delivered-without-email taxonomy), with the finding's numeric
+/// per finding alert regardless of channel outcome (no channel configured → the row states
+/// <see cref="AlertDelivery.ChannelNoneConfigured"/>), with the finding's numeric
 /// severity/threshold and detail text persisted like Lite's row. Never throws.
+/// <see cref="AlertDelivery.FromFanout"/> is called with <c>trayChannelPresent: false</c> for the same
+/// reason <see cref="DarlingAlertDeliverer"/> does: this service is headless and has no tray (#3169).
 ///
 /// <para>
 /// A separate class from <see cref="DarlingAlertDeliverer"/> (where Lite folds both surfaces

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingFindingAlertSender.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingFindingAlertSender.cs
@@ -80,21 +80,8 @@ public sealed class DarlingFindingAlertSender : IFindingAlertSender
                 alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue,
                 alert.ServerId, alert.Context, attemptChannels: true);
 
-            /* Lite's single-row notification_type taxonomy (EmailAlertService.cs): email
-               attempted → "email"; webhook delivery upgrades to "email+webhook"/"webhook";
-               otherwise "tray". */
-            var notificationType = "tray";
-            if (result.EmailAttempted)
-            {
-                notificationType = "email";
-            }
-
-            var sent = result.EmailSent;
-            if (result.WebhookSent)
-            {
-                notificationType = notificationType == "email" ? "email+webhook" : "webhook";
-                sent = true;
-            }
+            /* trayChannelPresent: false — the headless service has no tray; see DarlingAlertDeliverer. */
+            var delivery = AlertDelivery.FromFanout(result, muted: false, trayChannelPresent: false);
 
             /* Always log the alert, regardless of channel status — the structured context
                persists as JSON alongside the flat detail_text, the numeric severity/threshold
@@ -104,7 +91,7 @@ public sealed class DarlingFindingAlertSender : IFindingAlertSender
                 alert.ServerId, alert.ServerName, alert.MetricName,
                 alert.CurrentValue, alert.ThresholdValue,
                 alert.Severity, alert.NotifyThreshold,
-                sent, notificationType, result.SendError,
+                delivery,
                 false, alert.DetailText, contextJson));
         }
         catch (Exception ex)

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -2326,14 +2326,21 @@ ORDER BY ag_name, database_name, replica_server_name", connection) { CommandTime
     /// Dashboard's explicit "…Cleared/Resolved/Restored" <c>RecordAlert</c> rows. Used by BOTH this
     /// evaluator's self-alert recoveries (Collection Resumed / Capture Restored) and the shared alert
     /// engine's resolution callback (CPU Resolved, Blocking Cleared, …) so an operator reviewing alert
-    /// history sees the paired "Detected" then "Cleared" entries. Never email/webhook (a resolution has no
-    /// send channel — the deliverer's fire path is untouched): recorded as a delivered tray/history row.
+    /// history sees the paired "Detected" then "Cleared" entries. Never email/webhook: a resolution has no
+    /// send channel, and the deliverer's fire path is untouched.
+    ///
+    /// <para>That "no send channel" is stated by <see cref="AlertDelivery.NoChannelApplies"/> rather than
+    /// spelled as a delivered row. Saying it with <c>AlertSent: true</c> made <c>alert_sent</c> mean
+    /// "delivered" on a fired row and "no channel applies" here, so a reader could not tell the two senses
+    /// apart and no aggregate over the column meant anything — the delivered fraction rose with the number
+    /// of resolutions. The pairing this method exists for is unaffected: the row is still written, still
+    /// carries the resolution title, and still reads as resolved.</para>
     /// </summary>
     public static AlertHistoryRecord BuildResolutionRecord(AlertResolution resolution) => new(
         resolution.ServerKey, resolution.ServerName, resolution.Title,
         CurrentValueText: "resolved", ThresholdValueText: "",
         NumericCurrentValue: null, NumericThresholdValue: null,
-        AlertSent: true, NotificationType: "tray", SendError: null,
+        Delivery: AlertDelivery.NoChannelApplies(),
         Muted: false, DetailText: resolution.Message, ContextJson: null);
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/alerts.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/alerts.js
@@ -15,8 +15,14 @@
  * "Story:/Severity:/Confidence:" findings render as labeled fields).
  */
 
-import { el, mount, readTool, buildQuery, loadingStrip, errorStrip, emptyStrip, disclosure } from "../util.js";
+import { el, mount, readTool, buildQuery, loadingStrip, errorStrip, emptyStrip, disclosure,
+         ALERT_STATE_LABELS, alertDeliveryState } from "../util.js";
 import { VIZ } from "../panels.js";
+
+/* #3169: the state-carrying notification_type values, derived from the one shared map rather than listed a
+   second time. The status label already carries each of them, so the channel chip beside it must not repeat
+   them - "No channel configured (unconfigured)" is the shape this prevents. */
+const STATE_ONLY_CHANNELS = new Set(Object.keys(ALERT_STATE_LABELS));
 
 const ALERT_COLUMNS = [
   { key: "alert_time", label: "Time", format: "time" },
@@ -44,6 +50,7 @@ function triageCell(a) {
    meaningless delivery channel (#2781). A real channel (email / webhook / email+webhook) still renders. */
 function statusCell(a) {
   let glyph, label, sev;
+  const stateLabel = alertDeliveryState(a);
   if (a.muted) {
     glyph = "⊘";
     label = "Muted";
@@ -52,19 +59,19 @@ function statusCell(a) {
     glyph = "✕";
     label = "Delivery failed";
     sev = "Critical";
-  } else if (a.notification_type === "tray") {
-    /* #2814: the Darling web is headless — there is no system tray — so a "tray" alert (Lite's
-       delivered-without-email taxonomy) was never delivered anywhere on this surface; it was only logged.
-       Show a single neutral "Logged" rather than a Sent/Not-sent derived from alert_sent, which the alert
-       engine sets inconsistently across paths (clears true, problems false) and which reads backwards here
-       ("notified you it cleared but not that it broke"). A real channel (email/webhook) keeps Sent/Not-sent
-       below. Extends #2781, which already dropped the meaningless "tray" channel label. */
+  } else if (stateLabel !== null) {
+    /* #3169: the row states a delivery STATE rather than naming a channel — no channel applies to it, none
+       is configured, it was muted, or a channel was consulted and nothing landed. One neutral glyph and
+       severity for all of them: whether an unconfigured deployment is a problem is the operator's call, not
+       this page's. The label and the legacy decode both live in util.js, shared with triage.js and pinned
+       against the WPF surfaces' constants. Extends #2781/#2814, which established the reading for the
+       headless "tray" row that #3169 then stopped the service writing. */
     glyph = "•";
-    label = "Logged";
+    label = stateLabel;
     sev = "Unknown";
   } else if (a.alert_sent) {
     glyph = "✓";
-    label = "Sent";
+    label = "Delivered";
     sev = "Healthy";
   } else {
     glyph = "•";
@@ -74,7 +81,10 @@ function statusCell(a) {
   return el("span", { class: "status-cell sev-" + sev, title: a.send_error || null }, [
     el("span", { class: "glyph", text: glyph }),
     el("span", { text: label }),
-    a.notification_type && a.notification_type !== "tray" ? el("span", { class: "channel", text: a.notification_type }) : null,
+    /* The channel chip names a real channel only. The state-carrying values are already in the label
+       above, so repeating them would read as "No channel configured (unconfigured)". */
+    a.notification_type && !STATE_ONLY_CHANNELS.has(a.notification_type)
+      ? el("span", { class: "channel", text: a.notification_type }) : null,
   ]);
 }
 

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/triage.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/triage.js
@@ -20,7 +20,8 @@
  * every cell go through the shared builders; nothing touches innerHTML.
  */
 
-import { el, mount, apiGet, buildQuery, loadingStrip, errorStrip, emptyStrip, noticeStrip, localTime, fmtNum } from "../util.js";
+import { el, mount, apiGet, buildQuery, loadingStrip, errorStrip, emptyStrip, noticeStrip, localTime, fmtNum,
+         alertDeliveryState } from "../util.js";
 import { VIZ } from "../panels.js";
 import { suggestViz, deriveVizConfig } from "../derive.js";
 
@@ -31,12 +32,13 @@ import { suggestViz, deriveVizConfig } from "../derive.js";
 function alertStatusText(a) {
   if (a.muted) return "Muted";
   if (a.send_error) return "Delivery failed: " + a.send_error;
-  /* #2814: headless has no tray, so a "tray" alert was only logged, never delivered — a single neutral
-     "Logged", kept in lockstep with statusCell in alerts.js (see the note there). A real channel keeps
-     Sent/Not-sent below. */
-  if (a.notification_type === "tray") return "Logged";
-  const channel = a.notification_type && a.notification_type !== "tray" ? " (" + a.notification_type + ")" : "";
-  if (a.alert_sent) return "Sent" + channel;
+  /* #3169: a row that states a delivery STATE rather than naming a channel, including the one legacy
+     signature that decodes. Same shared lookup statusCell in alerts.js uses, which is what keeps the two
+     in lockstep now instead of a comment asking them to be. */
+  const state = alertDeliveryState(a);
+  if (state !== null) return state;
+  const channel = a.notification_type ? " (" + a.notification_type + ")" : "";
+  if (a.alert_sent) return "Delivered" + channel;
   return "Not sent";
 }
 

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/util.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/util.js
@@ -391,6 +391,40 @@ async function classifyResponse(resp) {
   return { kind: "data", data: body };
 }
 
+/* ── alert delivery state (#3169) ──────────────────────────────────────────────────────────────────
+ * A config_alert_log row's notification_type either NAMES A CHANNEL (email / webhook / email+webhook)
+ * or STATES A DELIVERY STATE. The state values are listed here once, with the label every surface owes
+ * them, because there are three surfaces: this web dashboard, the WPF Darling Viewer and Lite's grid.
+ * The other two share PerformanceMonitor.Notifications.AlertDeliveryStatus; JS cannot call it, so this is
+ * the restatement, and Darling.Tests.AlertTrayStatusLoggedTests parses THIS OBJECT and compares it to
+ * those constants rather than scanning the branch text it used to.
+ *
+ * "tray" is a state here rather than a channel because this surface is HEADLESS - no system tray, no toast
+ * code - so a stored tray row records nothing that happened. #2781/#2814 established that and chose
+ * "Logged"; #3169 stopped the service writing it at all, so only rows recorded before then reach it.
+ */
+export const ALERT_STATE_LABELS = {
+  none: "No channel",
+  unconfigured: "No channel configured",
+  muted: "Muted",
+  undelivered: "Not sent",
+  tray: "Logged",
+};
+
+/**
+ * The delivery state of an alert-history row, or null when its notification_type names a real channel and
+ * the caller should fall through to its own sent/failed handling.
+ *
+ * Carries the one legacy signature that decodes: alert_sent true alongside "tray" is unreachable for a row
+ * written after #3169 - a row that delivered names its channel - so it can only be the resolution builder's
+ * old hardcoded true, which meant "no send channel applies" and never meant a delivery.
+ */
+export function alertDeliveryState(a) {
+  if (a.alert_sent && a.notification_type === "tray") return ALERT_STATE_LABELS.none;
+  if (a.alert_sent) return null;
+  return ALERT_STATE_LABELS[a.notification_type] || null;
+}
+
 /** GET a read-only tool by its MCP name with query-string params. */
 export function readTool(tool, params) {
   return apiGet("/api/read/" + tool + buildQuery(params));

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertHistory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertHistory.cs
@@ -65,14 +65,17 @@ public sealed class ViewerAlertRow
 
     /// <summary>
     /// The operator-facing delivery status, from the one shared renderer both SKUs use.
-    /// <c>trayChannelPresent: false</c>: the Darling store is written by the HEADLESS service, which has no
+    /// <c>producerHadTrayChannel: false</c>: this store is written by the HEADLESS service, which has no
     /// tray and no toast code, so a stored <c>tray</c> asserts nothing that happened and must not read as
     /// "Shown". The copy this replaces did read it that way, and with no SMTP configured its email arm
     /// never ran — so every fired alert showed as "Shown" and every resolution as "Delivered", neither of
     /// which had occurred.
+    ///
+    /// <para>The answer is about the PRODUCER, not this app: the viewer has its own
+    /// <c>AlertToastCoordinator</c> and does raise toasts, but it did not write these rows.</para>
     /// </summary>
     public string StatusDisplay =>
-        AlertDeliveryStatus.Describe(AlertSent, NotificationType, SendError, trayChannelPresent: false);
+        AlertDeliveryStatus.Describe(AlertSent, NotificationType, SendError, producerHadTrayChannel: false);
 
     public bool IsResolved => AlertMetricClassifier.IsResolution(MetricName);
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertHistory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertHistory.cs
@@ -12,13 +12,15 @@ using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
 /// One Alerts-tab row over <c>config_alert_log</c>, mirroring Lite's <c>AlertHistoryRow</c>
 /// (Lite/Services/LocalDataService.AlertHistory.cs): the same metric-keyed value formatting
-/// (#1134), the same email-vs-tray <see cref="StatusDisplay"/>, and the shared
+/// (#1134), the same shared <see cref="AlertDeliveryStatus.Describe"/> behind
+/// <see cref="StatusDisplay"/> (differing only in the tray answer each SKU gives it), and the shared
 /// <see cref="AlertMetricClassifier"/> for critical/warning/resolved row emphasis. Carries
 /// <see cref="ServerId"/> + <see cref="ServerName"/> so the all-servers Alert History surface (W2a)
 /// can show a Server column and key the dismiss write on (alert_time, server_id, metric_name).
@@ -61,19 +63,16 @@ public sealed class ViewerAlertRow
 
     public string ThresholdValueDisplay => AlertMetricClassifier.FormatHistoryValue(MetricName, ThresholdValue);
 
-    /// <summary>Email rows show send outcome; tray/other rows show shown-vs-delivered (Lite's mapping).</summary>
-    public string StatusDisplay
-    {
-        get
-        {
-            if (NotificationType == "email")
-            {
-                return AlertSent ? "Sent" : (!string.IsNullOrEmpty(SendError) ? "Failed" : "Not sent");
-            }
-
-            return AlertSent ? "Delivered" : "Shown";
-        }
-    }
+    /// <summary>
+    /// The operator-facing delivery status, from the one shared renderer both SKUs use.
+    /// <c>trayChannelPresent: false</c>: the Darling store is written by the HEADLESS service, which has no
+    /// tray and no toast code, so a stored <c>tray</c> asserts nothing that happened and must not read as
+    /// "Shown". The copy this replaces did read it that way, and with no SMTP configured its email arm
+    /// never ran — so every fired alert showed as "Shown" and every resolution as "Delivered", neither of
+    /// which had occurred.
+    /// </summary>
+    public string StatusDisplay =>
+        AlertDeliveryStatus.Describe(AlertSent, NotificationType, SendError, trayChannelPresent: false);
 
     public bool IsResolved => AlertMetricClassifier.IsResolution(MetricName);
 

--- a/Lite.Tests/AlertDeliveryChannelTests.cs
+++ b/Lite.Tests/AlertDeliveryChannelTests.cs
@@ -59,15 +59,23 @@ public sealed class AlertDeliveryChannelTests
     }
 
     /// <summary>
-    /// Over every representable send outcome, Lite's shared derivation agrees with the hand-written one it
-    /// replaced — so no Lite row's <c>alert_sent</c> or <c>notification_type</c> changes value.
-    ///
-    /// <para>The one combination excluded is <c>EmailSent</c> without <c>EmailAttempted</c>, which the send
-    /// core cannot produce and where the two derivations deliberately DISAGREE: the old one reported a send
-    /// on <c>tray</c>, and the new one names the email channel, which is what
-    /// <c>Darling.Tests.AlertDeliveryChannelTests.EverySentDisposition_NamesADeliveringChannel</c> requires.
-    /// Excluding it is a stated carve-out rather than a silent one — <see cref="TheOneDisagreement_IsTheImpossibleCombination"/>
-    /// pins that it is the ONLY disagreement, so this test cannot be weakened by widening the exclusion.</para>
+    /// The two <c>EmailFanoutResult</c> shapes <c>EmailSendCore</c> cannot emit: a send without an attempt,
+    /// and a muted alert carrying any channel outcome (the caller passes <c>attemptChannels: !muted</c>, so
+    /// every attempt is gated off). Both are representable, so the shared derivation must still be
+    /// well-defined on them and deliberately differs from the derivation it replaced there — the old one
+    /// would put a <c>Sent</c> row onto <c>tray</c> or <c>muted</c>, which is what
+    /// <c>Darling.Tests.AlertDeliveryChannelTests.EverySentDisposition_NamesADeliveringChannel</c> forbids.
+    /// Neither is reachable, so excluding them from the parity comparison costs nothing real.
+    /// </summary>
+    private static bool Unreachable(EmailFanoutResult result, bool muted)
+        => (result.EmailSent && !result.EmailAttempted)
+        || (muted && (result.EmailAttempted || result.EmailSent || result.WebhookSent));
+
+    /// <summary>
+    /// Over every send outcome the core can actually produce, Lite's shared derivation agrees with the
+    /// hand-written one it replaced — so no Lite row's <c>alert_sent</c> or <c>notification_type</c> changes
+    /// value. <see cref="EveryDisagreement_IsAnUnreachableCombination"/> pins that the exclusion is exactly
+    /// <see cref="Unreachable"/> and nothing more, so this cannot be weakened by widening it.
     /// </summary>
     [Fact]
     public void LiteDispositions_AreUnchangedFromTheHandWrittenDerivation()
@@ -76,7 +84,7 @@ public sealed class AlertDeliveryChannelTests
 
         foreach (var (result, muted) in EveryFanoutCase())
         {
-            if (result.EmailSent && !result.EmailAttempted)
+            if (Unreachable(result, muted))
             {
                 continue;
             }
@@ -89,18 +97,19 @@ public sealed class AlertDeliveryChannelTests
             Assert.Equal(expected.NotificationType, actual.Channel);
         }
 
-        /* 2^4 result bools x muted = 32, less the 8 cases carrying the impossible EmailSent-without-attempt. */
-        Assert.Equal(24, compared);
+        /* 2^4 result bools x muted = 32 representable, of which 14 are reachable: EmailSent implies
+           EmailAttempted (3 of the 4 email shapes), and muted forces every outcome false. */
+        Assert.Equal(14, compared);
     }
 
     /// <summary>
-    /// The carve-out above is exactly the impossible combination and nothing else. Without this, widening
-    /// the <c>continue</c> would make the parity claim pass by comparing less.
+    /// Every disagreement with the old derivation is one of the unreachable shapes. Without this, widening
+    /// the exclusion above would make the parity claim pass by comparing less.
     /// </summary>
     [Fact]
-    public void TheOneDisagreement_IsTheImpossibleCombination()
+    public void EveryDisagreement_IsAnUnreachableCombination()
     {
-        var disagreements = new List<EmailFanoutResult>();
+        var disagreements = new List<(EmailFanoutResult Result, bool Muted)>();
 
         foreach (var (result, muted) in EveryFanoutCase())
         {
@@ -109,12 +118,12 @@ public sealed class AlertDeliveryChannelTests
 
             if (expected.Sent != actual.Sent || expected.NotificationType != actual.Channel)
             {
-                disagreements.Add(result);
+                disagreements.Add((result, muted));
             }
         }
 
         Assert.NotEmpty(disagreements);
-        Assert.All(disagreements, r => Assert.True(r.EmailSent && !r.EmailAttempted));
+        Assert.All(disagreements, c => Assert.True(Unreachable(c.Result, c.Muted)));
     }
 
     /// <summary>

--- a/Lite.Tests/AlertDeliveryChannelTests.cs
+++ b/Lite.Tests/AlertDeliveryChannelTests.cs
@@ -141,7 +141,7 @@ public sealed class AlertDeliveryChannelTests
         Assert.False(delivery.Sent);
         Assert.Equal(
             AlertDeliveryStatus.Shown,
-            AlertDeliveryStatus.Describe(delivery.Sent, delivery.Channel, delivery.SendError, trayChannelPresent: true));
+            AlertDeliveryStatus.Describe(delivery.Sent, delivery.Channel, delivery.SendError, producerHadTrayChannel: true));
     }
 
     /// <summary>
@@ -206,7 +206,7 @@ public sealed class AlertDeliveryChannelTests
             };
 
             Assert.Equal(
-                AlertDeliveryStatus.Describe(sent, channel, error, trayChannelPresent: true),
+                AlertDeliveryStatus.Describe(sent, channel, error, producerHadTrayChannel: true),
                 row.StatusDisplay);
         }
     }
@@ -220,9 +220,9 @@ public sealed class AlertDeliveryChannelTests
     public void TheLegacyResolutionSignature_DecodesToNoChannel_OnALiteStoreToo()
     {
         Assert.Equal(AlertDeliveryStatus.NoChannel,
-            AlertDeliveryStatus.Describe(true, AlertDelivery.ChannelTray, null, trayChannelPresent: true));
+            AlertDeliveryStatus.Describe(true, AlertDelivery.ChannelTray, null, producerHadTrayChannel: true));
         Assert.Equal(AlertDeliveryStatus.Shown,
-            AlertDeliveryStatus.Describe(false, AlertDelivery.ChannelTray, null, trayChannelPresent: true));
+            AlertDeliveryStatus.Describe(false, AlertDelivery.ChannelTray, null, producerHadTrayChannel: true));
     }
 
     /* ─────────────── where AnyChannelConfigured comes from ─────────────── */

--- a/Lite.Tests/AlertDeliveryChannelTests.cs
+++ b/Lite.Tests/AlertDeliveryChannelTests.cs
@@ -59,17 +59,29 @@ public sealed class AlertDeliveryChannelTests
     }
 
     /// <summary>
-    /// The two <c>EmailFanoutResult</c> shapes <c>EmailSendCore</c> cannot emit: a send without an attempt,
-    /// and a muted alert carrying any channel outcome (the caller passes <c>attemptChannels: !muted</c>, so
-    /// every attempt is gated off). Both are representable, so the shared derivation must still be
-    /// well-defined on them and deliberately differs from the derivation it replaced there — the old one
-    /// would put a <c>Sent</c> row onto <c>tray</c> or <c>muted</c>, which is what
-    /// <c>Darling.Tests.AlertDeliveryChannelTests.EverySentDisposition_NamesADeliveringChannel</c> forbids.
-    /// Neither is reachable, so excluding them from the parity comparison costs nothing real.
+    /// The <c>EmailFanoutResult</c> shapes <c>EmailSendCore</c> cannot emit. All three come from the same
+    /// place — <c>attemptChannels: !muted</c> gates every attempt, and both <c>EmailSent</c> and
+    /// <c>SendError</c> are set only inside the branch that has already set <c>EmailAttempted</c>:
+    ///
+    /// <list type="bullet">
+    /// <item>a send without an attempt</item>
+    /// <item>an error without an attempt</item>
+    /// <item>a muted alert carrying any channel outcome or error</item>
+    /// </list>
+    ///
+    /// <para>All are representable, so the shared derivation must still be well-defined on them, and it
+    /// deliberately differs from the derivation it replaced there — the old one would put a <c>Sent</c> row
+    /// onto <c>tray</c> or <c>muted</c>, or an error onto a state-carrying channel, which
+    /// <c>Darling.Tests.AlertDeliveryChannelTests</c>'s domain-wide pins forbid. None is reachable, so
+    /// excluding them from the parity comparison costs nothing real, and
+    /// <see cref="EveryDisagreement_IsAnUnreachableCombination"/> holds the exclusion to exactly this
+    /// predicate.</para>
     /// </summary>
     private static bool Unreachable(EmailFanoutResult result, bool muted)
         => (result.EmailSent && !result.EmailAttempted)
-        || (muted && (result.EmailAttempted || result.EmailSent || result.WebhookSent));
+        || (result.SendError is not null && !result.EmailAttempted)
+        || (muted && (result.EmailAttempted || result.EmailSent || result.WebhookSent
+                      || result.SendError is not null));
 
     /// <summary>
     /// Over every send outcome the core can actually produce, Lite's shared derivation agrees with the
@@ -97,9 +109,10 @@ public sealed class AlertDeliveryChannelTests
             Assert.Equal(expected.NotificationType, actual.Channel);
         }
 
-        /* 2^4 result bools x muted = 32 representable, of which 14 are reachable: EmailSent implies
-           EmailAttempted (3 of the 4 email shapes), and muted forces every outcome false. */
-        Assert.Equal(14, compared);
+        /* 64 representable (2^4 result bools x send_error present-or-not x muted), of which 22 are
+           reachable. The figure is derived from Unreachable() rather than asserted independently — see
+           TheReachableCount_FollowsFromThePredicate, which is what stops it drifting into a magic number. */
+        Assert.Equal(ReachableCaseCount(), compared);
     }
 
     /// <summary>
@@ -266,10 +279,28 @@ public sealed class AlertDeliveryChannelTests
         foreach (var emailSent in new[] { false, true })
         foreach (var webhookSent in new[] { false, true })
         foreach (var anyConfigured in new[] { false, true })
+        foreach (var sendError in new string?[] { null, "relay refused" })
         foreach (var muted in new[] { false, true })
         {
-            yield return (new EmailFanoutResult(emailAttempted, emailSent, null, webhookSent, anyConfigured), muted);
+            yield return (
+                new EmailFanoutResult(emailAttempted, emailSent, sendError, webhookSent, anyConfigured),
+                muted);
         }
+    }
+
+    private static int ReachableCaseCount()
+        => EveryFanoutCase().Count(c => !Unreachable(c.Result, c.Muted));
+
+    /// <summary>
+    /// The reachable count is 22 of 64. Pinned separately from the parity comparison so a widened
+    /// <see cref="Unreachable"/> cannot make that comparison pass by excluding more: the parity test asserts
+    /// it compared <see cref="ReachableCaseCount"/> cases, and this asserts what that number is.
+    /// </summary>
+    [Fact]
+    public void TheReachableCount_FollowsFromThePredicate()
+    {
+        Assert.Equal(64, EveryFanoutCase().Count());
+        Assert.Equal(22, ReachableCaseCount());
     }
 
     private static string RepoPath(string relative) => Path.Combine(RepoRoot(), relative);

--- a/Lite.Tests/AlertDeliveryChannelTests.cs
+++ b/Lite.Tests/AlertDeliveryChannelTests.cs
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging.Abstractions;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// #3169, Lite's half. Darling's is <c>Darling.Tests.AlertDeliveryChannelTests</c>, which pins the
+/// resolution record and the headless service's no-tray answer.
+///
+/// <para><b>Lite is not the defective SKU here, and the load-bearing claim is that nothing about what it
+/// stores changed.</b> The taxonomy was written out by hand in three producers, of which Lite's was the
+/// original and the only truthful one: its deliverer really does show a styled balloon for every non-muted
+/// alert on the same call that records the row, so a stored <c>tray</c> means what it says. Collapsing the
+/// three copies into one shared derivation therefore has to leave Lite's output byte-identical, and
+/// <see cref="LiteDispositions_AreUnchangedFromTheHandWrittenDerivation"/> is what says so — over the whole
+/// input domain, against the derivation it replaced, rather than at a handful of sampled points.</para>
+/// </summary>
+public sealed class AlertDeliveryChannelTests
+{
+    /* ─────────────── the parity claim: Lite's stored values did not move ─────────────── */
+
+    /// <summary>
+    /// The pre-#3169 derivation, transcribed from the three copies it existed in (Lite's
+    /// <c>EmailAlertService</c>, Darling's <c>DarlingAlertDeliverer</c> and <c>DarlingFindingAlertSender</c>
+    /// — identical but for the muted arm the finding sender does not need). Kept here as the reference
+    /// Lite's new output is compared against.
+    /// </summary>
+    private static (bool Sent, string NotificationType) HandWrittenDerivation(EmailFanoutResult result, bool muted)
+    {
+        var notificationType = muted ? "muted" : "tray";
+        if (result.EmailAttempted)
+        {
+            notificationType = "email";
+        }
+
+        var sent = result.EmailSent;
+        if (result.WebhookSent)
+        {
+            notificationType = notificationType == "email" ? "email+webhook" : "webhook";
+            sent = true;
+        }
+
+        return (sent, notificationType);
+    }
+
+    /// <summary>
+    /// Over every representable send outcome, Lite's shared derivation agrees with the hand-written one it
+    /// replaced — so no Lite row's <c>alert_sent</c> or <c>notification_type</c> changes value.
+    ///
+    /// <para>The one combination excluded is <c>EmailSent</c> without <c>EmailAttempted</c>, which the send
+    /// core cannot produce and where the two derivations deliberately DISAGREE: the old one reported a send
+    /// on <c>tray</c>, and the new one names the email channel, which is what
+    /// <c>Darling.Tests.AlertDeliveryChannelTests.EverySentDisposition_NamesADeliveringChannel</c> requires.
+    /// Excluding it is a stated carve-out rather than a silent one — <see cref="TheOneDisagreement_IsTheImpossibleCombination"/>
+    /// pins that it is the ONLY disagreement, so this test cannot be weakened by widening the exclusion.</para>
+    /// </summary>
+    [Fact]
+    public void LiteDispositions_AreUnchangedFromTheHandWrittenDerivation()
+    {
+        var compared = 0;
+
+        foreach (var (result, muted) in EveryFanoutCase())
+        {
+            if (result.EmailSent && !result.EmailAttempted)
+            {
+                continue;
+            }
+
+            var expected = HandWrittenDerivation(result, muted);
+            var actual = AlertDelivery.FromFanout(result, muted, trayChannelPresent: true);
+            compared++;
+
+            Assert.Equal(expected.Sent, actual.Sent);
+            Assert.Equal(expected.NotificationType, actual.Channel);
+        }
+
+        /* 2^4 result bools x muted = 32, less the 8 cases carrying the impossible EmailSent-without-attempt. */
+        Assert.Equal(24, compared);
+    }
+
+    /// <summary>
+    /// The carve-out above is exactly the impossible combination and nothing else. Without this, widening
+    /// the <c>continue</c> would make the parity claim pass by comparing less.
+    /// </summary>
+    [Fact]
+    public void TheOneDisagreement_IsTheImpossibleCombination()
+    {
+        var disagreements = new List<EmailFanoutResult>();
+
+        foreach (var (result, muted) in EveryFanoutCase())
+        {
+            var expected = HandWrittenDerivation(result, muted);
+            var actual = AlertDelivery.FromFanout(result, muted, trayChannelPresent: true);
+
+            if (expected.Sent != actual.Sent || expected.NotificationType != actual.Channel)
+            {
+                disagreements.Add(result);
+            }
+        }
+
+        Assert.NotEmpty(disagreements);
+        Assert.All(disagreements, r => Assert.True(r.EmailSent && !r.EmailAttempted));
+    }
+
+    /// <summary>
+    /// Lite has a tray, so it writes one — and its status column still reads "Shown", which is a true
+    /// statement there. The Darling Viewer's twin pin requires the opposite for the same stored value.
+    /// </summary>
+    [Fact]
+    public void LiteWritesTray_BecauseItHasOne()
+    {
+        var delivery = AlertDelivery.FromFanout(
+            new EmailFanoutResult(false, false, null, false, AnyChannelConfigured: false),
+            muted: false, trayChannelPresent: true);
+
+        Assert.Equal(AlertDelivery.ChannelTray, delivery.Channel);
+        Assert.False(delivery.Sent);
+        Assert.Equal(
+            AlertDeliveryStatus.Shown,
+            AlertDeliveryStatus.Describe(delivery.Sent, delivery.Channel, delivery.SendError, trayChannelPresent: true));
+    }
+
+    /// <summary>
+    /// Lite's producer states <c>trayChannelPresent: true</c> — the named argument, so the answer cannot be
+    /// flipped by a positional edit, and the divergence from Darling is declared at the call site rather
+    /// than inferred.
+    /// </summary>
+    [Fact]
+    public void TheLiteProducer_DeclaresItsTrayChannel()
+    {
+        var text = File.ReadAllText(RepoPath("Lite/Services/EmailAlertService.cs"));
+
+        Assert.Contains("trayChannelPresent: true", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("trayChannelPresent: false", text, StringComparison.Ordinal);
+
+        /* And it is the only FromFanout caller under Lite, so that one file is the whole population. */
+        var callers = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot(), "Lite"), "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(f => File.ReadAllText(f).Contains("AlertDelivery.FromFanout(", StringComparison.Ordinal))
+            .Select(f => Path.GetRelativePath(RepoRoot(), f).Replace('\\', '/'))
+            .ToArray();
+
+        Assert.Equal(new[] { "Lite/Services/EmailAlertService.cs" }, callers);
+    }
+
+    /* ─────────────── the read side ─────────────── */
+
+    /// <summary>
+    /// Lite's grid column IS the shared describer's answer. The copy it replaces rendered the same
+    /// <c>false</c> as "Not sent" on its email arm and "Shown" on the other, which is how one boolean came
+    /// to have two vocabularies.
+    /// </summary>
+    [Fact]
+    public void TheLiteRow_RendersThroughTheSharedDescriber()
+    {
+        var cases = new (bool Sent, string Channel, string? Error)[]
+        {
+            (false, AlertDelivery.ChannelNotApplicable, null),
+            (false, AlertDelivery.ChannelNoneConfigured, null),
+            (false, AlertDelivery.ChannelUndelivered, null),
+            (false, AlertDelivery.ChannelMuted, null),
+            (false, AlertDelivery.ChannelEmail, "relay refused"),
+            (false, AlertDelivery.ChannelEmail, null),
+            (true, AlertDelivery.ChannelEmailAndWebhook, null),
+            (true, AlertDelivery.ChannelTray, null),
+            (false, AlertDelivery.ChannelTray, null),
+        };
+
+        foreach (var (sent, channel, error) in cases)
+        {
+            var row = new AlertHistoryRow
+            {
+                AlertTime = new DateTime(2026, 9, 8, 1, 0, 0, DateTimeKind.Utc),
+                MetricName = "High CPU",
+                CurrentValue = 92,
+                ThresholdValue = 90,
+                AlertSent = sent,
+                NotificationType = channel,
+                SendError = error,
+            };
+
+            Assert.Equal(
+                AlertDeliveryStatus.Describe(sent, channel, error, trayChannelPresent: true),
+                row.StatusDisplay);
+        }
+    }
+
+    /// <summary>
+    /// The legacy resolution signature decodes the same on a Lite store, because the resolution builder is
+    /// shared code: <c>true</c> alongside <c>tray</c> was that builder's constant on either SKU, and Lite's
+    /// own tray rows are <c>false</c>.
+    /// </summary>
+    [Fact]
+    public void TheLegacyResolutionSignature_DecodesToNoChannel_OnALiteStoreToo()
+    {
+        Assert.Equal(AlertDeliveryStatus.NoChannel,
+            AlertDeliveryStatus.Describe(true, AlertDelivery.ChannelTray, null, trayChannelPresent: true));
+        Assert.Equal(AlertDeliveryStatus.Shown,
+            AlertDeliveryStatus.Describe(false, AlertDelivery.ChannelTray, null, trayChannelPresent: true));
+    }
+
+    /* ─────────────── where AnyChannelConfigured comes from ─────────────── */
+
+    /// <summary>
+    /// Each webhook channel on its own makes the deployment "configured". The disjunction and the fan-out's
+    /// own four if-conditions are the same four expressions, so a channel added to one is added to both —
+    /// but each is pinned individually here, because a disjunction that silently dropped a term would
+    /// report "no channel configured" for a deployment that has one, and that is the reading an operator
+    /// would act on.
+    /// </summary>
+    [Theory]
+    [InlineData("teams")]
+    [InlineData("slack")]
+    [InlineData("generic")]
+    [InlineData("pagerduty")]
+    public void AnyWebhookConfigured_IsTrueForEachChannelAlone(string channel)
+    {
+        var settings = new OneChannelSettings(channel);
+        var service = new WebhookAlertService(
+            settings, new AlertBranding("Lite", null), NullLogger<WebhookAlertService>.Instance);
+
+        Assert.True(service.AnyWebhookConfigured);
+    }
+
+    /// <summary>And false when nothing is set — the state all three of Erik's live stores are in.</summary>
+    [Fact]
+    public void AnyWebhookConfigured_IsFalseWithNothingSet()
+    {
+        var service = new WebhookAlertService(
+            new OneChannelSettings("none"), new AlertBranding("Lite", null), NullLogger<WebhookAlertService>.Instance);
+
+        Assert.False(service.AnyWebhookConfigured);
+    }
+
+    /* ─────────────── helpers ─────────────── */
+
+    private static IEnumerable<(EmailFanoutResult Result, bool Muted)> EveryFanoutCase()
+    {
+        foreach (var emailAttempted in new[] { false, true })
+        foreach (var emailSent in new[] { false, true })
+        foreach (var webhookSent in new[] { false, true })
+        foreach (var anyConfigured in new[] { false, true })
+        foreach (var muted in new[] { false, true })
+        {
+            yield return (new EmailFanoutResult(emailAttempted, emailSent, null, webhookSent, anyConfigured), muted);
+        }
+    }
+
+    private static string RepoPath(string relative) => Path.Combine(RepoRoot(), relative);
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+        => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, ".."));
+
+    /// <summary>An <see cref="IAlertSettings"/> with exactly one channel populated.</summary>
+    private sealed class OneChannelSettings : IAlertSettings
+    {
+        private readonly string _channel;
+
+        public OneChannelSettings(string channel) => _channel = channel;
+
+        public bool SmtpEnabled => false;
+        public string SmtpServer => "";
+        public int SmtpPort => 25;
+        public bool SmtpUseSsl => false;
+        public string SmtpUsername => "";
+        public string SmtpFromAddress => "";
+        public string SmtpRecipients => "";
+        public string? GetSmtpPassword() => null;
+        public int EmailCooldownMinutes => 15;
+
+        public bool TeamsWebhookEnabled => _channel == "teams";
+        public string TeamsWebhookUrl => _channel == "teams" ? "https://example.invalid/teams" : "";
+        public string TeamsProxyAddress => "";
+
+        public bool SlackWebhookEnabled => _channel == "slack";
+        public string SlackWebhookUrl => _channel == "slack" ? "https://example.invalid/slack" : "";
+        public string SlackProxyAddress => "";
+
+        public bool GenericWebhookEnabled => _channel == "generic";
+        public string GenericWebhookUrl => _channel == "generic" ? "https://example.invalid/generic" : "";
+        public string GenericWebhookHeadersJson => "";
+        public string GenericWebhookBodyTemplate => "";
+        public string GenericWebhookProxyAddress => "";
+
+        public bool PagerDutyEnabled => _channel == "pagerduty";
+        public string PagerDutyRoutingKey => _channel == "pagerduty" ? "routing-key-placeholder" : "";
+        public bool PagerDutyUseEuRegion => false;
+        public string PagerDutyProxyAddress => "";
+
+        public double AnalysisNotifySeverity => 1.5;
+        public int AnalysisNotifyCooldownMinutes => 360;
+        public string TriageBaseUrl => "";
+    }
+
+}

--- a/Lite.Tests/StoreRoundTripTests.cs
+++ b/Lite.Tests/StoreRoundTripTests.cs
@@ -56,7 +56,10 @@ public class StoreRoundTripTests : IClassFixture<SharedDuckDbFixture>, IDisposab
             ServerId: "7", ServerName: "Srv", MetricName: "CPU",
             CurrentValueText: "92.5%", ThresholdValueText: "80%",
             NumericCurrentValue: null, NumericThresholdValue: null,
-            AlertSent: true, NotificationType: "email", SendError: null,
+            Delivery: AlertDelivery.FromFanout(
+                new EmailFanoutResult(EmailAttempted: true, EmailSent: true, SendError: null,
+                                      WebhookSent: false, AnyChannelConfigured: true),
+                muted: false, trayChannelPresent: true),
             Muted: false, DetailText: "detail text", ContextJson: "{\"k\":1}"));
 
         var after = DateTime.UtcNow;
@@ -89,7 +92,10 @@ public class StoreRoundTripTests : IClassFixture<SharedDuckDbFixture>, IDisposab
             ServerId: "7", ServerName: "Srv", MetricName: "High CPU",
             CurrentValueText: "87% (Total CPU)", ThresholdValueText: "80%",
             NumericCurrentValue: null, NumericThresholdValue: null,
-            AlertSent: true, NotificationType: "toast", SendError: null,
+            Delivery: AlertDelivery.FromFanout(
+                new EmailFanoutResult(EmailAttempted: true, EmailSent: true, SendError: null,
+                                      WebhookSent: false, AnyChannelConfigured: true),
+                muted: false, trayChannelPresent: true),
             Muted: false, DetailText: null, ContextJson: null));
 
         var row = await ReadSingleAlertRowAsync();
@@ -108,7 +114,10 @@ public class StoreRoundTripTests : IClassFixture<SharedDuckDbFixture>, IDisposab
             ServerId: "1", ServerName: "Srv", MetricName: "Analysis",
             CurrentValueText: "not-a-number", ThresholdValueText: "also-bad",
             NumericCurrentValue: 1.8, NumericThresholdValue: 1.5,
-            AlertSent: false, NotificationType: "tray", SendError: null,
+            Delivery: AlertDelivery.FromFanout(
+                new EmailFanoutResult(EmailAttempted: false, EmailSent: false, SendError: null,
+                                      WebhookSent: false, AnyChannelConfigured: false),
+                muted: false, trayChannelPresent: true),
             Muted: false, DetailText: null, ContextJson: null));
 
         var row = await ReadSingleAlertRowAsync();
@@ -368,15 +377,20 @@ public class StoreRoundTripTests : IClassFixture<SharedDuckDbFixture>, IDisposab
         Assert.Equal("live-1", loaded[0].Id);
     }
 
+    /* These two exercise the cooldown-seed filters' notification_type predicates, so they need to store
+       an arbitrary column triple rather than one a producer would derive — the same reason the deprecated
+       SKU's hatch exists. */
+#pragma warning disable CS0618
     private static Task RecordAsync(IAlertHistoryStore store, string serverId, string metric, string type, string? error)
         => store.RecordAlertAsync(new AlertHistoryRecord(
             serverId, "Srv", metric, "90", "80", 90, 80,
-            true, type, error, false, null, null));
+            AlertDelivery.FromLegacyStoredColumns(true, type, error), false, null, null));
 
     private static Task RecordWithContextAsync(IAlertHistoryStore store, string serverId, string metric, string type, string? contextJson)
         => store.RecordAlertAsync(new AlertHistoryRecord(
             serverId, "Srv", metric, "90", "80", 90, 80,
-            true, type, null, false, null, contextJson));
+            AlertDelivery.FromLegacyStoredColumns(true, type, null), false, null, contextJson));
+#pragma warning restore CS0618
 
     /// <summary>Real serialized #1140 context carrying a single incident with the given dedup key.</summary>
     private static string JsonWith(string dedupKey)

--- a/Lite/Services/EmailAlertService.cs
+++ b/Lite/Services/EmailAlertService.cs
@@ -65,19 +65,12 @@ public class EmailAlertService : IFindingAlertSender
             var result = await _core.TrySendAsync(
                 metricName, serverName, currentValue, thresholdValue, serverId.ToString(), context, attemptChannels: !muted);
 
-            /* Combine the channel outcomes into Lite's single-row notification_type taxonomy:
-               muted → "muted"; email attempted → "email"; webhook delivery upgrades to
-               "email+webhook"/"webhook"; otherwise "tray". */
-            var notificationType = muted ? "muted" : "tray";
-            if (result.EmailAttempted)
-                notificationType = "email";
-
-            var sent = result.EmailSent;
-            if (result.WebhookSent)
-            {
-                notificationType = notificationType == "email" ? "email+webhook" : "webhook";
-                sent = true;
-            }
+            /* trayChannelPresent: true — LiteAlertDeliverer.DeliverAsync shows a styled balloon for every
+               non-muted alert on the same call that reaches here, so a stored "tray" really does mean a
+               toast was shown. This is Lite's half of the deliberate per-SKU divergence; the headless
+               Darling service passes false because it has no tray at all. Lite's stored values are
+               unchanged by the shared derivation. */
+            var delivery = AlertDelivery.FromFanout(result, muted, trayChannelPresent: true);
 
             /* Always log the alert, regardless of email status. The numeric current/threshold
                resolution happens in the store (it owns the DuckDB DOUBLE columns); the record
@@ -90,7 +83,7 @@ public class EmailAlertService : IFindingAlertSender
                 serverId.ToString(), serverName, metricName,
                 currentValue, thresholdValue,
                 numericCurrentValue, numericThresholdValue,
-                sent, notificationType, result.SendError,
+                delivery,
                 muted, detailText, contextJson));
         }
         catch (Exception ex)

--- a/Lite/Services/LocalDataService.AlertHistory.cs
+++ b/Lite/Services/LocalDataService.AlertHistory.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 using PerformanceMonitorLite.Database;
 
 namespace PerformanceMonitorLite.Services;
@@ -454,15 +455,14 @@ public class AlertHistoryRow
     public string CurrentValueDisplay => AlertMetricClassifier.FormatHistoryValue(MetricName, CurrentValue);
     public string ThresholdValueDisplay => AlertMetricClassifier.FormatHistoryValue(MetricName, ThresholdValue);
 
-    public string StatusDisplay
-    {
-        get
-        {
-            if (NotificationType == "email")
-                return AlertSent ? "Sent" : (!string.IsNullOrEmpty(SendError) ? "Failed" : "Not sent");
-            return AlertSent ? "Delivered" : "Shown";
-        }
-    }
+    /// <summary>
+    /// The operator-facing delivery status, from the one shared renderer both SKUs use. Lite passes
+    /// <c>trayChannelPresent: true</c> because <c>LiteAlertDeliverer.DeliverAsync</c> really does show a
+    /// styled balloon for every non-muted alert, so a stored <c>tray</c> is a truthful "Shown" here. The
+    /// Darling Viewer passes false; see <see cref="AlertDeliveryStatus.Describe"/>.
+    /// </summary>
+    public string StatusDisplay =>
+        AlertDeliveryStatus.Describe(AlertSent, NotificationType, SendError, trayChannelPresent: true);
 
     public bool IsResolved => AlertMetricClassifier.IsResolution(MetricName);
     public bool IsCritical => AlertMetricClassifier.IsCritical(MetricName);

--- a/Lite/Services/LocalDataService.AlertHistory.cs
+++ b/Lite/Services/LocalDataService.AlertHistory.cs
@@ -462,7 +462,7 @@ public class AlertHistoryRow
     /// Darling Viewer passes false; see <see cref="AlertDeliveryStatus.Describe"/>.
     /// </summary>
     public string StatusDisplay =>
-        AlertDeliveryStatus.Describe(AlertSent, NotificationType, SendError, trayChannelPresent: true);
+        AlertDeliveryStatus.Describe(AlertSent, NotificationType, SendError, producerHadTrayChannel: true);
 
     public bool IsResolved => AlertMetricClassifier.IsResolution(MetricName);
     public bool IsCritical => AlertMetricClassifier.IsCritical(MetricName);

--- a/PerformanceMonitor.Notifications/AlertDelivery.cs
+++ b/PerformanceMonitor.Notifications/AlertDelivery.cs
@@ -211,11 +211,19 @@ public static class AlertDeliveryStatus
     /// <param name="sent">The row's <c>alert_sent</c>.</param>
     /// <param name="channel">The row's <c>notification_type</c>.</param>
     /// <param name="sendError">The row's <c>send_error</c>.</param>
-    /// <param name="trayChannelPresent">Whether the SKU reading this store has a tray channel — the read
-    /// side of <see cref="AlertDelivery.FromFanout"/>'s parameter of the same name, and required for the
-    /// same reason. <b>Lite: true.</b> <b>The Darling Viewer: false.</b> A stored <c>tray</c> is a
-    /// truthful "a toast was shown" on a Lite store and means nothing at all on a headless Darling one, so
-    /// one renderer cannot label it without being told which store it is reading.</param>
+    /// <param name="producerHadTrayChannel">
+    /// Whether the SKU that WROTE this store records a tray channel — the read side of
+    /// <see cref="AlertDelivery.FromFanout"/>'s <c>trayChannelPresent</c>, and required for the same
+    /// reason: a stored <c>tray</c> is a truthful "a toast was shown" on a Lite store and means nothing at
+    /// all on a headless Darling one, so one renderer cannot label it without being told which store it is
+    /// reading. <b>Lite: true.</b> <b>The Darling Viewer: false.</b>
+    ///
+    /// <para>Named for the PRODUCER rather than the reader on purpose. The Darling Viewer has an
+    /// <c>AlertToastCoordinator</c> and does raise its own toasts, so "does this SKU have a tray" is true
+    /// of the reader and false of the writer, and the value here is about the writer. Getting that backwards
+    /// would make the Viewer render "Shown" for 32,546 rows recorded by a service with no tray, which is the
+    /// exact reading this change removes.</para>
+    /// </param>
     /// <remarks>
     /// <para><b>Rows written before this taxonomy are read conservatively, not reinterpreted.</b> The one
     /// legacy signature that can be decoded is <c>alert_sent = true</c> with
@@ -225,13 +233,13 @@ public static class AlertDeliveryStatus
     /// hardcoded constant. It renders as <see cref="NoChannel"/>, which is what it always meant — on either
     /// SKU, because that builder is shared code.</para>
     ///
-    /// <para>A legacy <c>alert_sent = false</c> with <c>tray</c> is NOT decoded on a store whose SKU has no
+    /// <para>A legacy <c>alert_sent = false</c> with <c>tray</c> is NOT decoded on a store whose producer had no
     /// tray. It covers a store with no channel configured, a throttled send, and a failed webhook post, and
     /// nothing in the row separates them — the whole reason this change exists. It renders
     /// <see cref="Logged"/>, which is #2781's word for it and claims nothing in either direction. New rows
     /// say which of those they are.</para>
     /// </remarks>
-    public static string Describe(bool sent, string? channel, string? sendError, bool trayChannelPresent)
+    public static string Describe(bool sent, string? channel, string? sendError, bool producerHadTrayChannel)
     {
         if (channel == AlertDelivery.ChannelNotApplicable)
         {
@@ -265,12 +273,12 @@ public static class AlertDeliveryStatus
             return NoChannelConfigured;
         }
 
-        /* Lite's tray toast is a real delivery to a real channel. On a store written by a SKU with no tray
+        /* Lite's tray toast is a real delivery to a real channel. On a store whose producer had no tray
            the same stored value carries no information at all, so it gets #2781's neutral "Logged" — the
            label the web surface already chose for this exact row, rather than a second word for it. */
         if (channel == AlertDelivery.ChannelTray)
         {
-            return trayChannelPresent ? Shown : Logged;
+            return producerHadTrayChannel ? Shown : Logged;
         }
 
         return NotSent;

--- a/PerformanceMonitor.Notifications/AlertDelivery.cs
+++ b/PerformanceMonitor.Notifications/AlertDelivery.cs
@@ -181,7 +181,14 @@ public sealed record AlertDelivery
            Below the delivering arms the order preserves the derivation this replaces: muted beats tray
            (Lite shows no toast for a muted alert), and tray beats the configuration arms so a Lite row's
            stored value is unchanged whether or not SMTP happens to be set up. */
-        var emailInvolved = result.EmailAttempted || result.EmailSent;
+        /* SendError counts as email involvement. It is only ever set by the SMTP attempt — the webhook
+           fan-out reports one bool for four channels and no error, which IAlertHistoryStore documents — so
+           its presence IS the email channel having been used. Reading it here is what makes "a non-null
+           send_error implies a delivering channel" hold over the whole input domain rather than over the
+           shapes the send core emits, and that is what lets the web dashboard test send_error BEFORE the
+           state lookup while AlertDeliveryStatus.Describe tests the state channels first: the orders differ
+           and are equivalent, because no state-carrying channel can carry an error. */
+        var emailInvolved = result.EmailAttempted || result.EmailSent || result.SendError is not null;
 
         var channel =
             result.WebhookSent && emailInvolved ? ChannelEmailAndWebhook

--- a/PerformanceMonitor.Notifications/AlertDelivery.cs
+++ b/PerformanceMonitor.Notifications/AlertDelivery.cs
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Notifications;
+
+/// <summary>
+/// What was attempted for one alert, on which channel, with what outcome — the value
+/// <see cref="AlertHistoryRecord"/> persists into <c>alert_sent</c> / <c>notification_type</c> /
+/// <c>send_error</c>.
+///
+/// <para><b>Why a value and not three fields.</b> <c>alert_sent</c> alone answers two different questions
+/// depending on which producer wrote the row: on a fired alert it is a delivery measurement from the
+/// deliverer, and on a resolution row it was a hardcoded <c>true</c> standing for "no send channel applies
+/// to a resolution". A reader given the boolean cannot tell which sense it holds, so no aggregate over the
+/// column means anything — the delivered fraction reads healthy in exact proportion to how many resolutions
+/// occurred. <see cref="Channel"/> states which channel the row is about, so "no channel applies" is a
+/// named state rather than a <c>true</c> meaning something else, and <see cref="Sent"/> is only ever a
+/// measurement.</para>
+///
+/// <para><b>Factory-only, on purpose.</b> The constructor is private and neither property is settable, so
+/// there is no <c>with</c> expression and no way to hand-write a <see cref="Sent"/> of <c>true</c>. Every
+/// row's disposition comes from <see cref="FromFanout"/> (a real send attempt) or
+/// <see cref="NoChannelApplies"/> (a row that has no channel by design). Before this type the derivation
+/// was written out by hand in three producers — Lite's <c>EmailAlertService</c>, Darling's
+/// <c>DarlingAlertDeliverer</c> and Darling's <c>DarlingFindingAlertSender</c>, each carrying a comment
+/// pointing at one of the others as the definition — and nothing held the three copies equal.</para>
+/// </summary>
+public sealed record AlertDelivery
+{
+    /// <summary>No send channel applies to this row at all — a resolution row, which exists to pair with
+    /// its "Detected" entry in history and was never a candidate for delivery. Distinct from
+    /// <see cref="ChannelNoneConfigured"/>, which means a channel WOULD have applied and none is set up.</summary>
+    public const string ChannelNotApplicable = "none";
+
+    /// <summary>A channel applied to this alert, and no channel is configured on this store, so nothing
+    /// was attempted. The honest reading of a headless deployment with empty SMTP and webhook settings.</summary>
+    public const string ChannelNoneConfigured = "unconfigured";
+
+    /// <summary>A mute rule suppressed the channels. The row is still recorded, flagged muted.</summary>
+    public const string ChannelMuted = "muted";
+
+    /// <summary>The Lite tray toast — a real channel that really received the alert, and the reason
+    /// <c>tray</c> exists in this taxonomy at all. Only a SKU that has a tray may write it; see
+    /// <see cref="FromFanout"/>'s <c>trayChannelPresent</c>.</summary>
+    public const string ChannelTray = "tray";
+
+    /// <summary>At least one channel was configured and consulted, and none of them delivered — a
+    /// cooldown-throttled send, or a webhook post that came back unsuccessful. Replaces the reading that
+    /// used to fall into <see cref="ChannelTray"/> on a SKU with no tray.</summary>
+    public const string ChannelUndelivered = "undelivered";
+
+    public const string ChannelEmail = "email";
+    public const string ChannelWebhook = "webhook";
+    public const string ChannelEmailAndWebhook = "email+webhook";
+
+    private AlertDelivery(bool sent, string channel, string? sendError)
+    {
+        Sent = sent;
+        Channel = channel;
+        SendError = sendError;
+    }
+
+    /// <summary>Whether a channel actually delivered this alert. A measurement on every row — never a
+    /// stand-in for anything else. Persisted as <c>alert_sent</c>.</summary>
+    public bool Sent { get; }
+
+    /// <summary>Which channel this row is about, from the constants above. Persisted as
+    /// <c>notification_type</c>. The field that carries "no channel applies" so <see cref="Sent"/> does
+    /// not have to.</summary>
+    public string Channel { get; }
+
+    /// <summary>The email send error, when the SMTP attempt threw. Null on every other disposition —
+    /// including a configured webhook whose post failed, which <c>EmailFanoutResult</c> does not report
+    /// (see <see cref="FromFanout"/>).</summary>
+    public string? SendError { get; }
+
+    /// <summary>
+    /// The row has no send channel by design. Used by the resolution-record builder, whose rows exist so
+    /// an operator reviewing history sees "Detected" then "Cleared" as a pair and which were never
+    /// candidates for email or webhook.
+    ///
+    /// <para><see cref="Sent"/> is <c>false</c> here, where the hand-written record it replaces said
+    /// <c>true</c>. The <c>true</c> was not a claim that anything was delivered; the state it meant is now
+    /// in <see cref="Channel"/>, which is where a reader can act on it.</para>
+    /// </summary>
+    public static AlertDelivery NoChannelApplies() => new(false, ChannelNotApplicable, null);
+
+    /// <summary>
+    /// A disposition rebuilt from three already-computed column values. <b>The deprecated Dashboard SKU's
+    /// only.</b>
+    ///
+    /// <para>It exists because that SKU's <c>EmailAlertService.RecordAlert</c> takes the pair as method
+    /// PARAMETERS from 26 call sites, each hand-computing it — which is this issue's defect, in a SKU that
+    /// is not shipped, writes to its own JSON store, and has its own display. Converting those 26 sites
+    /// would be churn in dead code and would fix nothing an operator can see. Deliberately
+    /// <c>internal</c>, so no live producer can reach it, and
+    /// <c>Darling.Tests.AlertDeliveryChannelTests.TheLegacyHatch_HasExactlyOneProductionCaller</c> pins
+    /// that it stays that way — an <c>internal</c> member is visible to Lite as well as to the deprecated
+    /// SKU, so the boundary is asserted rather than assumed.</para>
+    /// </summary>
+    [Obsolete("Deprecated Dashboard SKU only. Live producers use FromFanout or NoChannelApplies.", error: false)]
+    internal static AlertDelivery FromLegacyStoredColumns(bool sent, string channel, string? sendError) =>
+        new(sent, channel, sendError);
+
+    /// <summary>
+    /// The disposition of a real send attempt, from what the shared send core reports.
+    /// </summary>
+    /// <param name="result">What <c>EmailSendCore.TrySendAsync</c> did.</param>
+    /// <param name="muted">Whether a mute rule suppressed the channels — the caller passed
+    /// <c>attemptChannels: !muted</c>, so a muted result is all-false by construction.</param>
+    /// <param name="trayChannelPresent">
+    /// Whether this SKU has a tray channel that received the alert. <b>Lite: true</b> — its deliverer shows
+    /// a styled balloon for every non-muted alert on the same call that records the row, so
+    /// <see cref="ChannelTray"/> is a truthful statement there. <b>Darling: false</b> — the headless service
+    /// has no tray and no toast code at all, so a <c>tray</c> row on a Darling store asserted a UI event
+    /// that cannot occur. This is a deliberate per-SKU divergence, not an oversight, and each SKU's tests
+    /// pin its own answer.
+    /// </param>
+    /// <remarks>
+    /// <para><b>Invariant:</b> <see cref="Sent"/> implies <see cref="Channel"/> is one of
+    /// <see cref="ChannelEmail"/>, <see cref="ChannelWebhook"/>, <see cref="ChannelEmailAndWebhook"/> — a
+    /// delivering channel names itself. That holds over the whole <c>EmailFanoutResult</c> domain, not just
+    /// the combinations the send core happens to produce, which is why the email arm tests
+    /// <c>EmailSent</c> as well as <c>EmailAttempted</c>: those are two independent bools on the result
+    /// type, and an <c>EmailSent</c> without an <c>EmailAttempted</c> would otherwise report a send on a
+    /// channel that never named itself. The invariant is what lets a reader decode the one legacy signature
+    /// this change leaves behind — see <c>AlertDeliveryStatus.Describe</c>.</para>
+    ///
+    /// <para><b>A configured webhook that failed reads as <see cref="ChannelUndelivered"/>, not
+    /// <see cref="ChannelEmail"/>-style failure.</b> <c>EmailFanoutResult.SendError</c> tracks the EMAIL
+    /// channel only — <c>WebhookAlertService.TrySendWebhookAlertsAsync</c> collapses every per-channel
+    /// outcome into one bool — so a webhook post that came back unsuccessful is reported here as
+    /// "configured, nothing delivered" with a null error. That is honest but coarse, and it is a live
+    /// delivery gap on any store that configures a webhook.</para>
+    /// </remarks>
+    public static AlertDelivery FromFanout(EmailFanoutResult result, bool muted, bool trayChannelPresent)
+    {
+        var sent = result.EmailSent || result.WebhookSent;
+
+        /* Ordered so the email arm outranks the tray fallback, matching the derivation this replaces. The
+           muted and unconfigured arms cannot be reached with a channel outcome to report: muted means the
+           caller passed attemptChannels: false, and AnyChannelConfigured comes from the very gates that
+           decide whether anything is attempted, so both imply an all-false result. */
+        var channel =
+            muted ? ChannelMuted
+            : result.EmailAttempted || result.EmailSent ? ChannelEmail
+            : trayChannelPresent ? ChannelTray
+            : !result.AnyChannelConfigured ? ChannelNoneConfigured
+            : ChannelUndelivered;
+
+        if (result.WebhookSent)
+        {
+            channel = channel == ChannelEmail ? ChannelEmailAndWebhook : ChannelWebhook;
+        }
+
+        return new AlertDelivery(sent, channel, result.SendError);
+    }
+}
+
+/// <summary>
+/// The one rendering of a stored alert-history row's delivery status, shared by Lite's
+/// <c>AlertHistoryRow</c> and the Darling Viewer's, which each carried their own copy of it.
+///
+/// <para>The copies branched on <c>notification_type == "email"</c> and rendered the same <c>false</c> as
+/// "Not sent" on one arm and "Shown" on the other. With no SMTP configured the email arm never ran, so
+/// every fired alert rendered "Shown" and every resolution rendered "Delivered" — a UI event that cannot
+/// happen on a headless service, and a delivery that never occurred.</para>
+/// </summary>
+public static class AlertDeliveryStatus
+{
+    /// <summary>What to show an operator for a stored row.</summary>
+    /// <param name="sent">The row's <c>alert_sent</c>.</param>
+    /// <param name="channel">The row's <c>notification_type</c>.</param>
+    /// <param name="sendError">The row's <c>send_error</c>.</param>
+    /// <param name="trayChannelPresent">Whether the SKU reading this store has a tray channel — the read
+    /// side of <see cref="AlertDelivery.FromFanout"/>'s parameter of the same name, and required for the
+    /// same reason. <b>Lite: true.</b> <b>The Darling Viewer: false.</b> A stored <c>tray</c> is a
+    /// truthful "a toast was shown" on a Lite store and means nothing at all on a headless Darling one, so
+    /// one renderer cannot label it without being told which store it is reading.</param>
+    /// <remarks>
+    /// <para><b>Rows written before this taxonomy are read conservatively, not reinterpreted.</b> The one
+    /// legacy signature that can be decoded is <c>alert_sent = true</c> with
+    /// <c>notification_type = 'tray'</c>: <see cref="AlertDelivery.FromFanout"/>'s invariant says a
+    /// delivering channel names itself, and every producer that ever wrote this column derived the pair the
+    /// same way, so a <c>true</c> alongside <c>tray</c> can only have come from the resolution builder's
+    /// hardcoded constant. It renders as <see cref="NoChannel"/>, which is what it always meant — on either
+    /// SKU, because that builder is shared code.</para>
+    ///
+    /// <para>A legacy <c>alert_sent = false</c> with <c>tray</c> is NOT decoded on a store whose SKU has no
+    /// tray. It covers a store with no channel configured, a throttled send, and a failed webhook post, and
+    /// nothing in the row separates them — the whole reason this change exists. It renders
+    /// <see cref="NotSent"/>, a statement about outcome that makes no claim about configuration. New rows
+    /// say which of those they are.</para>
+    /// </remarks>
+    public static string Describe(bool sent, string? channel, string? sendError, bool trayChannelPresent)
+    {
+        if (channel == AlertDelivery.ChannelNotApplicable)
+        {
+            return NoChannel;
+        }
+
+        /* The legacy resolution signature. Unreachable for a new row: Sent implies a named delivering
+           channel, so nothing can write true alongside tray again. */
+        if (sent && channel == AlertDelivery.ChannelTray)
+        {
+            return NoChannel;
+        }
+
+        if (sent)
+        {
+            return Delivered;
+        }
+
+        if (!string.IsNullOrEmpty(sendError))
+        {
+            return Failed;
+        }
+
+        if (channel == AlertDelivery.ChannelMuted)
+        {
+            return Muted;
+        }
+
+        if (channel == AlertDelivery.ChannelNoneConfigured)
+        {
+            return NoChannelConfigured;
+        }
+
+        /* Lite's tray toast is a real delivery to a real channel; on a store written by a SKU with no
+           tray, the same stored value carries no information and gets the outcome-only label. */
+        if (channel == AlertDelivery.ChannelTray && trayChannelPresent)
+        {
+            return Shown;
+        }
+
+        return NotSent;
+    }
+
+    public const string NoChannel = "No channel";
+    public const string NoChannelConfigured = "No channel configured";
+    public const string Delivered = "Delivered";
+    public const string Failed = "Failed";
+    public const string Muted = "Muted";
+    public const string Shown = "Shown";
+    public const string NotSent = "Not sent";
+}

--- a/PerformanceMonitor.Notifications/AlertDelivery.cs
+++ b/PerformanceMonitor.Notifications/AlertDelivery.cs
@@ -175,8 +175,8 @@ public sealed record AlertDelivery
            domain and not merely over the shapes the send core emits. Ordering muted ahead of them read
            naturally — a muted alert attempts nothing — but it let a Sent row be labelled "muted", which
            puts a true back onto a non-delivering channel and breaks the legacy decode. Both routes to that
-           are unreachable in practice (attemptChannels: !muted gates every attempt), and neither is
-           unrepresentable, which is the difference that matters.
+           are unreachable in practice (attemptChannels: !muted gates every attempt), and both are
+           representable in the type, which is the difference that matters.
 
            Below the delivering arms the order preserves the derivation this replaces: muted beats tray
            (Lite shows no toast for a muted alert), and tray beats the configuration arms so a Lite row's

--- a/PerformanceMonitor.Notifications/AlertDelivery.cs
+++ b/PerformanceMonitor.Notifications/AlertDelivery.cs
@@ -126,12 +126,17 @@ public sealed record AlertDelivery
     /// <remarks>
     /// <para><b>Invariant:</b> <see cref="Sent"/> implies <see cref="Channel"/> is one of
     /// <see cref="ChannelEmail"/>, <see cref="ChannelWebhook"/>, <see cref="ChannelEmailAndWebhook"/> — a
-    /// delivering channel names itself. That holds over the whole <c>EmailFanoutResult</c> domain, not just
-    /// the combinations the send core happens to produce, which is why the email arm tests
-    /// <c>EmailSent</c> as well as <c>EmailAttempted</c>: those are two independent bools on the result
-    /// type, and an <c>EmailSent</c> without an <c>EmailAttempted</c> would otherwise report a send on a
-    /// channel that never named itself. The invariant is what lets a reader decode the one legacy signature
-    /// this change leaves behind — see <c>AlertDeliveryStatus.Describe</c>.</para>
+    /// channel that delivered names itself. One-directional on purpose: the converse is false and should
+    /// be, because an attempted email that threw is <see cref="ChannelEmail"/> with <see cref="Sent"/>
+    /// false and its error attached.</para>
+    ///
+    /// <para>It holds over the whole <c>EmailFanoutResult</c> domain rather than over the shapes the send
+    /// core emits, which is what the ordering below is for and why the email arm reads <c>EmailSent</c> as
+    /// well as <c>EmailAttempted</c>: the result's four bools are independent, and the two combinations the
+    /// send core cannot produce (an <c>EmailSent</c> without an <c>EmailAttempted</c>, and a muted result
+    /// carrying any channel outcome) would each otherwise put a <c>Sent</c> row onto a non-delivering
+    /// channel. The invariant is what lets a reader decode the one legacy signature this change leaves
+    /// behind — see <c>AlertDeliveryStatus.Describe</c>.</para>
     ///
     /// <para><b>A configured webhook that failed reads as <see cref="ChannelUndelivered"/>, not
     /// <see cref="ChannelEmail"/>-style failure.</b> <c>EmailFanoutResult.SendError</c> tracks the EMAIL
@@ -144,21 +149,26 @@ public sealed record AlertDelivery
     {
         var sent = result.EmailSent || result.WebhookSent;
 
-        /* Ordered so the email arm outranks the tray fallback, matching the derivation this replaces. The
-           muted and unconfigured arms cannot be reached with a channel outcome to report: muted means the
-           caller passed attemptChannels: false, and AnyChannelConfigured comes from the very gates that
-           decide whether anything is attempted, so both imply an all-false result. */
+        /* The channels that carry an outcome are tested FIRST, so the invariant holds over the whole input
+           domain and not merely over the shapes the send core emits. Ordering muted ahead of them read
+           naturally — a muted alert attempts nothing — but it let a Sent row be labelled "muted", which
+           puts a true back onto a non-delivering channel and breaks the legacy decode. Both routes to that
+           are unreachable in practice (attemptChannels: !muted gates every attempt), and neither is
+           unrepresentable, which is the difference that matters.
+
+           Below the delivering arms the order preserves the derivation this replaces: muted beats tray
+           (Lite shows no toast for a muted alert), and tray beats the configuration arms so a Lite row's
+           stored value is unchanged whether or not SMTP happens to be set up. */
+        var emailInvolved = result.EmailAttempted || result.EmailSent;
+
         var channel =
-            muted ? ChannelMuted
-            : result.EmailAttempted || result.EmailSent ? ChannelEmail
+            result.WebhookSent && emailInvolved ? ChannelEmailAndWebhook
+            : result.WebhookSent ? ChannelWebhook
+            : emailInvolved ? ChannelEmail
+            : muted ? ChannelMuted
             : trayChannelPresent ? ChannelTray
             : !result.AnyChannelConfigured ? ChannelNoneConfigured
             : ChannelUndelivered;
-
-        if (result.WebhookSent)
-        {
-            channel = channel == ChannelEmail ? ChannelEmailAndWebhook : ChannelWebhook;
-        }
 
         return new AlertDelivery(sent, channel, result.SendError);
     }

--- a/PerformanceMonitor.Notifications/AlertDelivery.cs
+++ b/PerformanceMonitor.Notifications/AlertDelivery.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 
 namespace PerformanceMonitor.Notifications;
 
@@ -59,6 +60,27 @@ public sealed record AlertDelivery
     public const string ChannelEmail = "email";
     public const string ChannelWebhook = "webhook";
     public const string ChannelEmailAndWebhook = "email+webhook";
+
+    /// <summary>
+    /// The channel values that state a delivery STATE rather than naming a channel that carried the alert.
+    /// Declared rather than left implicit in the reading code, because three surfaces need the answer — the
+    /// two WPF grids through <see cref="AlertDeliveryStatus"/>, and the headless web dashboard, which
+    /// restates it in <c>util.js</c> and is pinned against this list.
+    /// </summary>
+    public static IReadOnlyList<string> StateCarryingChannels { get; } = new[]
+    {
+        ChannelNotApplicable, ChannelNoneConfigured, ChannelMuted, ChannelUndelivered, ChannelTray,
+    };
+
+    /// <summary>
+    /// The channel values that name a channel the alert actually went out on. <see cref="Sent"/> implies
+    /// one of these; the converse does not hold, because an attempted email that threw is
+    /// <see cref="ChannelEmail"/> with <see cref="Sent"/> false.
+    /// </summary>
+    public static IReadOnlyList<string> DeliveringChannels { get; } = new[]
+    {
+        ChannelEmail, ChannelWebhook, ChannelEmailAndWebhook,
+    };
 
     private AlertDelivery(bool sent, string channel, string? sendError)
     {
@@ -206,7 +228,7 @@ public static class AlertDeliveryStatus
     /// <para>A legacy <c>alert_sent = false</c> with <c>tray</c> is NOT decoded on a store whose SKU has no
     /// tray. It covers a store with no channel configured, a throttled send, and a failed webhook post, and
     /// nothing in the row separates them — the whole reason this change exists. It renders
-    /// <see cref="NotSent"/>, a statement about outcome that makes no claim about configuration. New rows
+    /// <see cref="Logged"/>, which is #2781's word for it and claims nothing in either direction. New rows
     /// say which of those they are.</para>
     /// </remarks>
     public static string Describe(bool sent, string? channel, string? sendError, bool trayChannelPresent)
@@ -243,11 +265,12 @@ public static class AlertDeliveryStatus
             return NoChannelConfigured;
         }
 
-        /* Lite's tray toast is a real delivery to a real channel; on a store written by a SKU with no
-           tray, the same stored value carries no information and gets the outcome-only label. */
-        if (channel == AlertDelivery.ChannelTray && trayChannelPresent)
+        /* Lite's tray toast is a real delivery to a real channel. On a store written by a SKU with no tray
+           the same stored value carries no information at all, so it gets #2781's neutral "Logged" — the
+           label the web surface already chose for this exact row, rather than a second word for it. */
+        if (channel == AlertDelivery.ChannelTray)
         {
-            return Shown;
+            return trayChannelPresent ? Shown : Logged;
         }
 
         return NotSent;
@@ -259,5 +282,11 @@ public static class AlertDeliveryStatus
     public const string Failed = "Failed";
     public const string Muted = "Muted";
     public const string Shown = "Shown";
+
+    /// <summary>#2781/#2814's label for a stored <c>tray</c> row on a surface with no tray: a history row
+    /// was written and no channel was involved, with no claim either way. Reached only by rows written
+    /// before this taxonomy, since a SKU without a tray no longer records one.</summary>
+    public const string Logged = "Logged";
+
     public const string NotSent = "Not sent";
 }

--- a/PerformanceMonitor.Notifications/EmailSendCore.cs
+++ b/PerformanceMonitor.Notifications/EmailSendCore.cs
@@ -83,12 +83,19 @@ public sealed class EmailSendCore
         bool emailSent = false;
         string? sendError = null;
 
-        /* Attempt email delivery if SMTP is fully configured */
-        if (attemptChannels &&
+        /* The SMTP gate, hoisted so the same expression both decides whether email is attempted and
+           answers "is any channel configured at all". A restatement of it somewhere else would be free to
+           drift; a reader of the result needs the answer from the code that consults the settings. */
+        var smtpConfigured =
             _settings.SmtpEnabled &&
             !string.IsNullOrWhiteSpace(_settings.SmtpServer) &&
             !string.IsNullOrWhiteSpace(_settings.SmtpFromAddress) &&
-            !string.IsNullOrWhiteSpace(_settings.SmtpRecipients))
+            !string.IsNullOrWhiteSpace(_settings.SmtpRecipients);
+
+        var anyChannelConfigured = smtpConfigured || _webhookAlertService.AnyWebhookConfigured;
+
+        /* Attempt email delivery if SMTP is fully configured */
+        if (attemptChannels && smtpConfigured)
         {
             /* #1154: per-fingerprint cooldown. Send if any incident in this alert is outside its
                window (a distinct fingerprint is not throttled by an unrelated prior incident);
@@ -147,7 +154,7 @@ public sealed class EmailSendCore
                 metricName, serverName, currentValue, thresholdValue, serverId, context);
         }
 
-        return new EmailFanoutResult(emailAttempted, emailSent, sendError, webhookSent);
+        return new EmailFanoutResult(emailAttempted, emailSent, sendError, webhookSent, anyChannelConfigured);
     }
 
     /// <summary>Gets email delivery health summary (consecutive failures + last error).</summary>
@@ -233,10 +240,20 @@ public sealed class EmailSendCore
 /// <summary>
 /// What <see cref="EmailSendCore.TrySendAsync"/> did, so the per-app shell can record its
 /// alert-history rows: whether email was attempted (configured + outside cooldown), whether
-/// it actually sent, any send error, and whether a webhook was delivered.
+/// it actually sent, any send error, whether a webhook was delivered, and whether any channel
+/// was configured to attempt in the first place.
 /// </summary>
+/// <param name="AnyChannelConfigured">
+/// Whether SMTP or at least one webhook is configured on this deployment. Reported by the send core
+/// rather than derived by the caller because it comes from the very gates that decide what gets
+/// attempted, and it is the only thing that separates "nothing is set up" from "something is set up and
+/// this alert did not go out" — two states that otherwise both arrive as an all-false result with a null
+/// error. Note it is answered from configuration, so <c>attemptChannels: false</c> (a muted alert) still
+/// reports it truthfully.
+/// </param>
 public readonly record struct EmailFanoutResult(
     bool EmailAttempted,
     bool EmailSent,
     string? SendError,
-    bool WebhookSent);
+    bool WebhookSent,
+    bool AnyChannelConfigured);

--- a/PerformanceMonitor.Notifications/IAlertHistoryStore.cs
+++ b/PerformanceMonitor.Notifications/IAlertHistoryStore.cs
@@ -79,10 +79,26 @@ public interface IAlertHistoryStore
 /// One alert event to persist. Carries both the display strings (Dashboard
 /// persists these verbatim) and the optional resolved numerics (Lite persists
 /// these into DOUBLE columns, falling back to parsing the display text).
+///
+/// <para>The delivery disposition arrives as one <see cref="AlertDelivery"/> rather than as a loose
+/// <c>bool</c> + two strings. A producer cannot then state a send outcome without stating the channel it
+/// belongs to, cannot transpose the two strings past the compiler, and — because
+/// <see cref="AlertDelivery"/> has no public constructor — cannot hand-write a delivered row at all. The
+/// three column-shaped members below are projections for the store writers, which are unchanged.</para>
 /// </summary>
 public sealed record AlertHistoryRecord(
     string  ServerId, string ServerName, string MetricName,
     string  CurrentValueText, string ThresholdValueText,    // Dashboard persists these
     double? NumericCurrentValue, double? NumericThresholdValue, // Lite persists these
-    bool    AlertSent, string NotificationType, string? SendError,
-    bool    Muted, string? DetailText, string? ContextJson);
+    AlertDelivery Delivery,
+    bool    Muted, string? DetailText, string? ContextJson)
+{
+    /// <summary>The <c>alert_sent</c> column. A delivery measurement on every row.</summary>
+    public bool AlertSent => Delivery.Sent;
+
+    /// <summary>The <c>notification_type</c> column — which channel the row is about.</summary>
+    public string NotificationType => Delivery.Channel;
+
+    /// <summary>The <c>send_error</c> column.</summary>
+    public string? SendError => Delivery.SendError;
+}

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -111,6 +111,30 @@ public class WebhookAlertService
     /// Sends webhook alerts to all configured channels (Teams and/or Slack).
     /// Respects the email cooldown setting for throttling. Never throws.
     /// </summary>
+    /* The four per-channel configuration gates, named so the fan-out's own if-conditions and
+       AnyWebhookConfigured are the SAME expressions rather than two lists that have to be kept in step.
+       Adding a channel and forgetting the disjunction would otherwise report "nothing configured" for a
+       deployment that has one. */
+    private bool TeamsConfigured =>
+        _settings.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(_settings.TeamsWebhookUrl);
+
+    private bool SlackConfigured =>
+        _settings.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(_settings.SlackWebhookUrl);
+
+    private bool GenericConfigured =>
+        _settings.GenericWebhookEnabled && !string.IsNullOrWhiteSpace(_settings.GenericWebhookUrl);
+
+    private bool PagerDutyConfigured =>
+        _settings.PagerDutyEnabled && !string.IsNullOrWhiteSpace(_settings.PagerDutyRoutingKey);
+
+    /// <summary>
+    /// Whether any webhook channel is configured, so a caller can tell "no channel is set up" from "a
+    /// channel is set up and this alert did not go out". Answers from configuration only — it never
+    /// consults a cooldown and never attempts anything.
+    /// </summary>
+    public bool AnyWebhookConfigured =>
+        TeamsConfigured || SlackConfigured || GenericConfigured || PagerDutyConfigured;
+
     public async Task<bool> TrySendWebhookAlertsAsync(
         string metricName,
         string serverName,
@@ -147,22 +171,22 @@ public class WebhookAlertService
                 _settings.TriageBaseUrl, serverName, metricName, DateTime.UtcNow,
                 DerivePagerDutyDedupKey(string.IsNullOrEmpty(serverId) ? serverName : serverId, metricName, context));
 
-            if (_settings.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(_settings.TeamsWebhookUrl))
+            if (TeamsConfigured)
             {
                 sent |= await TrySendTeamsAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl);
             }
 
-            if (_settings.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(_settings.SlackWebhookUrl))
+            if (SlackConfigured)
             {
                 sent |= await TrySendSlackAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl);
             }
 
-            if (_settings.GenericWebhookEnabled && !string.IsNullOrWhiteSpace(_settings.GenericWebhookUrl))
+            if (GenericConfigured)
             {
                 sent |= await TrySendGenericAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, context, triageUrl);
             }
 
-            if (_settings.PagerDutyEnabled && !string.IsNullOrWhiteSpace(_settings.PagerDutyRoutingKey))
+            if (PagerDutyConfigured)
             {
                 sent |= await TrySendPagerDutyAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, context, triageUrl);
             }

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -107,10 +107,6 @@ public class WebhookAlertService
                     historyStore.GetLastWebhookSentUtcAsync(serverId, metricName, dedupKey));
     }
 
-    /// <summary>
-    /// Sends webhook alerts to all configured channels (Teams and/or Slack).
-    /// Respects the email cooldown setting for throttling. Never throws.
-    /// </summary>
     /* The four per-channel configuration gates, named so the fan-out's own if-conditions and
        AnyWebhookConfigured are the SAME expressions rather than two lists that have to be kept in step.
        Adding a channel and forgetting the disjunction would otherwise report "nothing configured" for a
@@ -135,6 +131,10 @@ public class WebhookAlertService
     public bool AnyWebhookConfigured =>
         TeamsConfigured || SlackConfigured || GenericConfigured || PagerDutyConfigured;
 
+    /// <summary>
+    /// Sends webhook alerts to all configured channels (Teams and/or Slack).
+    /// Respects the email cooldown setting for throttling. Never throws.
+    /// </summary>
     public async Task<bool> TrySendWebhookAlertsAsync(
         string metricName,
         string serverName,

--- a/deprecated/Dashboard.Tests/DashboardAlertHistoryValueTests.cs
+++ b/deprecated/Dashboard.Tests/DashboardAlertHistoryValueTests.cs
@@ -151,7 +151,7 @@ public class DashboardAlertHistoryValueTests
             serverId, "Srv", "Capture Down",
             CurrentValueText: "Blocking and Deadlock", ThresholdValueText: "session running",
             NumericCurrentValue: null, NumericThresholdValue: null,
-            AlertSent: true, NotificationType: "tray", SendError: null,
+            Delivery: LegacyTrayDelivery(),
             Muted: false, DetailText: null, ContextJson: null));
 
         var row = Assert.Single(store.GetAlertHistory(200), e => e.ServerId == serverId);
@@ -178,7 +178,7 @@ public class DashboardAlertHistoryValueTests
             CurrentValueText: "no collection in 47m", ThresholdValueText: "collecting",
             /* Numerics deliberately supplied AND deliberately expected to be ignored. */
             NumericCurrentValue: 47, NumericThresholdValue: 30,
-            AlertSent: true, NotificationType: "tray", SendError: null,
+            Delivery: LegacyTrayDelivery(),
             Muted: false, DetailText: null, ContextJson: null));
 
         var row = Assert.Single(store.GetAlertHistory(200), e => e.ServerId == serverId);
@@ -201,4 +201,11 @@ public class DashboardAlertHistoryValueTests
         var dashboardRow = new AlertLogEntry { MetricName = "Capture Down", CurrentValue = "Blocking and Deadlock" };
         Assert.IsType<string>(dashboardRow.CurrentValue);
     }
+
+    /* The deprecated SKU records a hand-decided disposition; its 26 production callers do the same, so its
+       tests state one too rather than deriving it. */
+#pragma warning disable CS0618
+    private static AlertDelivery LegacyTrayDelivery() =>
+        AlertDelivery.FromLegacyStoredColumns(true, "tray", null);
+#pragma warning restore CS0618
 }

--- a/deprecated/Dashboard.Tests/JsonAlertHistoryStoreDedupKeyTests.cs
+++ b/deprecated/Dashboard.Tests/JsonAlertHistoryStoreDedupKeyTests.cs
@@ -45,7 +45,9 @@ public class JsonAlertHistoryStoreDedupKeyTests
     private static Task RecordAsync(JsonAlertHistoryStore store, string serverId, string metric, string type, string? contextJson)
         => store.RecordAlertAsync(new AlertHistoryRecord(
             serverId, "Srv", metric, "4", "1", null, null,
-            AlertSent: true, NotificationType: type, SendError: null,
+#pragma warning disable CS0618
+            Delivery: AlertDelivery.FromLegacyStoredColumns(true, type, null),
+#pragma warning restore CS0618
             Muted: false, DetailText: null, ContextJson: contextJson));
 
     [Fact]

--- a/deprecated/Dashboard.Tests/JsonAlertHistoryStoreMutedFilterTests.cs
+++ b/deprecated/Dashboard.Tests/JsonAlertHistoryStoreMutedFilterTests.cs
@@ -39,7 +39,9 @@ public class JsonAlertHistoryStoreMutedFilterTests
     private static Task RecordAsync(JsonAlertHistoryStore store, string serverId, string metric, bool muted)
         => store.RecordAlertAsync(new AlertHistoryRecord(
             serverId, "Srv", metric, "4", "1", null, null,
-            AlertSent: !muted, NotificationType: muted ? "muted" : "tray", SendError: null,
+#pragma warning disable CS0618
+            Delivery: AlertDelivery.FromLegacyStoredColumns(!muted, muted ? "muted" : "tray", null),
+#pragma warning restore CS0618
             Muted: muted, DetailText: null, ContextJson: null));
 
     [Fact]

--- a/deprecated/Dashboard/Services/EmailAlertService.cs
+++ b/deprecated/Dashboard/Services/EmailAlertService.cs
@@ -98,11 +98,17 @@ namespace PerformanceMonitorDashboard.Services
             string notificationType, string? sendError = null, bool muted = false, string? detailText = null,
             string? contextJson = null)
         {
+            /* This SKU is deprecated and its 26 callers each hand-compute the alertSent/notificationType
+               pair, so the disposition arrives already decided rather than derived. FromLegacyStoredColumns
+               is internal and exists for exactly this call. */
+#pragma warning disable CS0618
+            var delivery = AlertDelivery.FromLegacyStoredColumns(alertSent, notificationType, sendError);
+#pragma warning restore CS0618
             _historyStore.RecordAlertAsync(new AlertHistoryRecord(
                 serverId, serverName, metricName,
                 currentValue, thresholdValue,
                 null, null,
-                alertSent, notificationType, sendError,
+                delivery,
                 muted, detailText, contextJson)).GetAwaiter().GetResult();
         }
 


### PR DESCRIPTION
Closes #3169.

## The severity question first: no send channel is configured on any store

#3169 could not establish whether the `alert_sent: false` rows were undelivered alerts about live problems, because `get_alert_settings` does not report SMTP/webhook configuration. It is answerable read-only from the store, because the channel configuration lives there — `config.config_notification`, single `id = 1` row, read by `StoreConfigProvider.ReadNotificationAsync`.

Read via `psql` over SSM on all three Darling boxes, as booleans only so no credential or webhook URL was retrieved:

| store | SMTP | Teams | Slack | generic | PagerDuty | `modified_at` | oldest alert row |
|---|---|---|---|---|---|---|---|
| use2 | not set | not set | not set | not set | not set | 2026-07-18 00:45 | 2026-07-18 04:12 |
| use1 | not set | not set | not set | not set | not set | 2026-08-17 16:46 | 2026-08-17 16:55 |
| pgmonitor | not set | not set | not set | not set | not set | 2026-08-19 08:37 | 2026-08-28 20:36 |

Every SMTP field empty (host, from, recipients, encrypted password) and every webhook field empty (Teams, Slack, generic, PagerDuty routing key) on all three — eight independent fields, plus the derived SMTP-enabled predicate false. Each `modified_at` is its provisioning stamp, so the row has never been edited since seed on any of them.

**So this is not a live delivery gap.** Every `alert_sent: false` on a fired alert is correct: nothing is configured, so nothing could have been delivered. The defect is purely semantic, and the scope here is smaller than the issue's "what was attempted, on which channel" direction implies — no new column, no migration rung, no store change.

## The measured split

Full `GROUP BY` over `config.config_alert_log`, seven days, no `LIMIT` and no `dismissed` filter.

| store | rows in window | detection flavour | resolution flavour | `send_error` non-null | distinct `notification_type`, all time |
|---|---|---|---|---|---|
| use2 | 655 | 345, all `false` | 310, all `true` | 0 | `tray` only (13,455 rows) |
| use1 | 9,655 | 8,085, all `false` | 1,570, all `true` | 0 | `tray` only (15,425 rows) |
| pgmonitor | 1,211 | 700, all `false` | 511, all `true` | 0 | `tray` only (3,666 rows) |

Fleet totals for the window: **11,521 rows, 9,130 `false` and 2,391 `true`**. All time: 32,546 rows, 27,300 `false` and 5,246 `true`. Each store's per-metric census sums exactly to its own window total and the three reconcile to the fleet figure, which is the cross-check that the enumeration is complete rather than truncated. `notification_type` takes exactly one value across all 32,546 stored rows on the three stores, so the issue's note that it does not discriminate is measured, not inferred.

**Instrument and its limits.** These come from `psql` on each box, not from `get_alert_history`. That MCP read is `ORDER BY alert_time DESC LIMIT $3` with `dismissed = FALSE`, so it returns a newest-first truncated tail — a 50-row default over a 30-hour window is why the original observation covered about an hour once collector-cost-regression rows saturated it. Its ceilings are `limit` 1000 (`McpHelpers.MaxTop`) and `hours_back` 168; it also cannot see dismissed rows at all, so a census through it would silently omit them. The `psql` read has none of those bounds. What it does not cover: retention. The oldest row on each store is that store's provisioning date, so a seven-day window is representative of current behaviour but says nothing about a period when a channel might have been configured — and no such period is visible in `modified_at`.

**One finding that corrects the issue's framing.** The split is not cleanly by flavour. `Server Restored` — a recovery — carries `alert_sent = false`, because it fires through `DarlingSelfAlertEvaluator`'s `FireAsync` (`DarlingSelfAlertEvaluator.cs:935` on `dev` at `a01c7d2d0`) rather than through `BuildResolutionRecord`, while `Store Job Cadence Recovered` and `Forced Plan Failing Resolved` carry `true`. So a reader cannot recover the boolean's sense from the row's flavour either; there is no side channel that decodes it.

## What the column actually collapsed

Reading `EmailSendCore.TrySendAsync` and `WebhookAlertService.TrySendWebhookAlertsAsync`, `alert_sent = false` with `send_error = null` covers more than the issue's three states:

1. no channel configured, so nothing attempted — the state all three stores are in
2. SMTP configured but the per-fingerprint cooldown suppressed this send
3. muted, so the channels were skipped — partly discriminated, by `notification_type = 'muted'`
4. **a configured webhook whose post came back unsuccessful.** `EmailFanoutResult.SendError` tracks the email channel only, which `IAlertHistoryStore` documents, and the webhook fan-out collapses four channels into one `bool`. A failed webhook is therefore byte-identical to "nothing configured"

and `true` covers a delivery (a measurement) or `BuildResolutionRecord`'s constant (not one).

## The seam

`AlertHistoryRecord` takes one factory-only `AlertDelivery` in place of `bool AlertSent, string NotificationType, string? SendError`. `AlertSent` / `NotificationType` / `SendError` remain as projections, so `PgAlertHistoryStore` and `DuckDbAlertHistoryStore` are untouched and the persisted shape is unchanged.

- `AlertDelivery.NoChannelApplies()` — `Sent = false`, `Channel = "none"`. What `BuildResolutionRecord` now uses. `alert_sent` is a delivery outcome on every row, so an aggregate over it means something.
- `AlertDelivery.FromFanout(result, muted, trayChannelPresent)` — the single copy of a taxonomy that was **hand-written in three producers**, each commenting a pointer at one of the others as its definition, with nothing holding the three equal. It adds `"unconfigured"` (a channel applied and none is set up) and `"undelivered"` (configured, consulted, nothing landed), fed by a new `EmailFanoutResult.AnyChannelConfigured` that the send core reports from the very gates that decide what gets attempted, rather than from a restatement a caller could drift.

The constructor is private and no property is settable, so there is no `with` expression and **no way to hand-write a delivered row**. The record's arity change made the compiler enumerate every producer: `CS1729`/`CS1739` at exactly five sites — `DarlingAlertDeliverer.cs:164`, `DarlingFindingAlertSender.cs:103`, `DarlingSelfAlertEvaluator.cs:2336`, `Lite/Services/EmailAlertService.cs:89`, `deprecated/Dashboard/Services/EmailAlertService.cs:101` — which matches the source census exactly.

### How the three states are discriminated

`notification_type` was the right field and already existed; it carried `tray` for both flavours because that is Lite's fallback, copied into a SKU that has no tray. It now names the state: `none` (no channel by design) / `unconfigured` (none set up) / `muted` (suppressed) / `undelivered` (consulted, nothing landed) / `email`, `webhook`, `email+webhook` (delivered or attempted, with `send_error` splitting attempted-and-threw). `alert_sent` carries only the outcome.

### The deliberate per-SKU divergence, asserted

**Lite has a tray channel. The headless Darling service does not** — no tray icon, no toast code anywhere under it — and yet every one of those 32,546 rows claimed one.

**This is not a new observation, and the credit belongs to #2781/#2814.** Those issues established it and fixed it *on the web dashboard*: `wwwroot/js/pages/alerts.js` and `triage.js` special-case `notification_type === "tray"` to a neutral "Logged", and #2814's own test comment says why — `alert_sent`, "which the engine sets inconsistently: clears true, problems false". So the mechanism #3169 describes was already written down in this repo, as a workaround on one reader.

What those issues did not do is fix the write side, or the other two readers. `DarlingAlertDeliverer` and `DarlingFindingAlertSender` had each copied Lite's taxonomy comment along with its tray fallback into a SKU with no tray, and the WPF Darling Viewer's grid kept rendering "Shown"/"Delivered". So there were three vocabularies for one column, not two.

`LiteAlertDeliverer.DeliverAsync` shows a styled balloon for every non-muted alert on the same call that records the row, so Lite's stored `tray` is truthful; Darling's asserted a UI event that cannot occur. `trayChannelPresent` is a required, named argument on both the write and the read side, `false` at both Darling producers and `true` at Lite's, pinned per SKU with a source scan proving those are the whole population of callers.

### The third surface, which this would otherwise have regressed

The web dashboard's tray branch matches `"tray"` alone, so after the write-side change a resolution row (`none`) and a fired alert with nothing configured (`unconfigured`) would both have fallen straight through to the `alert_sent` collapse #2814 removed — rendering "Not sent (none)" for "CPU Resolved". Found while reading the pins the change broke, and independently flagged by the review bot.

The state-to-label map and the legacy decode now live once, in `util.js`'s `ALERT_STATE_LABELS` / `alertDeliveryState`, and both pages read them — so "in lockstep", which those two pages previously asked for in a comment, is now structural. `AlertDelivery` declares `StateCarryingChannels` and `DeliveringChannels`, and `AlertTrayStatusLoggedTests` **parses that map and compares it to `AlertDeliveryStatus`'s constants key by key**, with a reflection pin that every `Channel*` constant is in exactly one of the two lists.

That replaces a guard that could not fail in the ways it mattered: it asserted a `"tray"` branch existed, that the string "Logged" appeared *somewhere in the file*, and that `IndexOf("alert_sent")` preceded the branch. A page pairing every label with the wrong state satisfied all three — and an intermediate version of this change introduced a composite `a.alert_sent && a.notification_type === "tray"` condition that would have anchored the ordering check and let it pass on a page with no state branches at all.

**"Logged" is #2781's word, adopted rather than replaced.** A legacy `tray` row on a headless store renders "Logged" on all three surfaces; on Lite it still renders "Shown", because a toast really was shown there.

`Lite.Tests.AlertDeliveryChannelTests.LiteDispositions_AreUnchangedFromTheHandWrittenDerivation` compares the shared derivation against the derivation it replaced over every reachable input, so **no Lite row's stored values change**.

### The read side

`StatusDisplay` existed verbatim in both SKUs, branching on `notification_type == "email"` and rendering the same `false` as "Not sent" on one arm and "Shown" on the other. With no SMTP configured the email arm never ran, so on all three stores the Darling Viewer showed **"Shown" for every fired alert and "Delivered" for every resolution** — a UI event that cannot happen on a headless service, and a delivery that never occurred. Both now call one shared `AlertDeliveryStatus.Describe`.

## What happens to existing history

Nothing is rewritten and no row is reinterpreted as though the new semantics applied to it.

- `alert_sent = true` with `notification_type = 'tray'` renders as **"No channel"**. This is a decode, not a reinterpretation: `Sent` implies a channel that names itself, so no producer can write that pair again, and all four producers that ever wrote this column derived it the same way — it is `BuildResolutionRecord`'s constant and nothing else. Corroborated on the live data, but only as far as the data goes: the per-metric census covers a seven-day window — 11,521 rows, 2,391 of them `true` — and every `true` row in it carries a resolution title. The all-time figure (5,246 `true` of 32,546) was read grouped by `notification_type` only, so it does not carry the per-metric claim, and none of it comes from a store that had a channel configured. The pin is what holds the decode; the data only fails to contradict it.
- `alert_sent = false` with `notification_type = 'tray'` is **not** decoded. On a Darling store it renders "Not sent" — a statement about outcome that makes no claim about configuration — because it covers no-channel, throttled and failed-webhook alike and nothing in the row separates them. Reading it as "No channel configured" would be exactly the silent reinterpretation to avoid. New rows say which they are. On a Lite store it still renders "Shown", which was and remains true there.

### Blast radius of changing what `alert_sent` holds

Nothing keys on it. Both stores' cooldown seeds filter on `notification_type` — `IN ('email', 'email+webhook')` for the email seed, `IN ('webhook', 'email+webhook')` for the webhook one — and `GetLastAlertTimeAsync` is unfiltered, so no seed reads `alert_sent`, and none of the three new values appears in either `IN` list. The resolution rows never seeded a cooldown before this change either, because they were `tray`. Its only consumers are the four read surfaces: both SKUs' grid column, the two `get_alert_history` MCP tools, and `DarlingTriageEndpoint`. The three machine-readable ones already emit `notification_type` beside `alert_sent`, so they discriminate the new states with no change.

## Evidence

Every pin was mutation-tested; each mutation was confirmed applied by `git diff --numstat` before running, and each landed on the pin that claims the thing it broke.

| # | mutation | red |
|---|---|---|
| 1 | `NoChannelApplies()` returns `true` + `tray` (the original defect) | resolution-record pins |
| 2 | email arm drops `\|\| EmailSent` | the delivering-channel invariant, both forms |
| 3 | drop the `unconfigured` arm | no-channel-configured pin |
| 4 | `Describe` drops the per-SKU tray guard | "a Darling store never renders Shown", legacy-detected pin |
| 5 | `Describe` drops the legacy `true`+`tray` decode | legacy-resolution pin |
| 6 | `AnyWebhookConfigured` drops the PagerDuty term | the per-channel pin for PagerDuty |
| 7 | `unconfigured` outranks `tray` | Lite's unchanged-values pin |
| 8 | a Darling producer claims a tray channel | the producer source scan |
| 9 | two state labels swapped in the JS map | the cross-language parity pin — **the case the predecessor guard's co-presence check could not see** |
| 10 | a state key dropped from the JS map | the same parity pin |
| 11 | a new `Channel*` constant nobody classified | the reflection reach pin |
| 12 | the shared lookup moved after the `alert_sent` collapse | the ordering pin, on `triage.js` |
| 13 | a page reintroduces its own tray comparison | the no-second-copy pin |
| 14 | the per-SKU divergence collapsed (Lite loses its truthful "Shown") | the divergence-count pin, and Lite's tray pin |
| 15 | a second per-SKU divergence introduced beside the known one | the divergence-count pin, naming both cells |
| 16 | `emailInvolved` stops reading `SendError` (order-equivalence made contingent again) | the send-error pin, 8 rows |
| 17 | the Lite parity carve-out narrowed by one clause | the derived-reachable-count pin (26, not 22) plus the parity comparison |

Mutation 17 is worth reporting for how it failed first. Run against the shipped `Lite.Tests` predicate it changed nothing, because my local harness kept its **own copy** of that predicate — the exact "derive it from the shipped artifact, not a copy" failure, in the instrument rather than in the code. The harness now mirrors the shipped two-pin structure (the comparison asserts it covered the *derived* reachable count; a separate pin asserts that count is 22), and the mutation then reds three checks. Either pin alone is satisfiable by a widened or narrowed carve-out; together they are not.

The 64-case enumeration over every representable `EmailFanoutResult` **found a real defect in the first draft**: ordering the muted arm ahead of the channels that carry an outcome let a `Sent` row be labelled `muted`, which puts a `true` back onto a non-delivering channel and breaks the legacy decode. Unreachable in practice, representable in the type. It is the second commit here.

`Lite.Tests`/`Darling.Tests` target `net10.0-windows` and cannot run on macOS; the shared logic, `BuildResolutionRecord` (invoked by reflection — the evaluator is `internal`) and every source/JS scan were run locally against the real build in a throwaway `net10.0` harness, 42 checks, all passing. That is what all 13 mutations were measured with. The two SKUs' `StatusDisplay` properties live in WPF projects and are CI's to run.

### CI, round by round

| check | round 1 (`c398ba4`) | round 2 (`7b36c88`) | round 3 (`6c0274e`) |
|---|---|---|---|
| `check-branches` | pass 4s | pass 4s | see below |
| `description-drift` | pass 9s | pass 6s | |
| `Darling Linux build` | pass 1m43s | pass 1m34s | |
| `Darling whole-tree guards` | pass 15s | **cancelled** (03:05:26→03:05:34, superseded) | |
| `Darling PostgreSQL tests` | **fail 4m32s** (step 12, Run Darling PG tests) | **fail 3m57s** (same step) | |
| `build` | **fail 9m50s** (step 14, Run Darling tests) | **fail 8m12s** (same step) | |
| `review` | pass 11m27s | pass 5m44s | |
| `verify` | pass 11m47s | pass 6m8s | |

Seven or eight checks per round, never one — so not the stacked-PR trap. Round 2's `Darling whole-tree guards` is a **`cancelled`**, not a pass: it starts after `build` and round 3's push superseded it eight seconds in.

`build`'s per-suite lines are the load-bearing evidence for the parity claim:

| suite | round 1 | round 2 | round 4 |
|---|---|---|---|
| `Lite.Tests` | 3,501 total, **0 failed** | 3,501 total, **0 failed** | 3,501 total, **0 failed** |
| `Dashboard.Tests` | 782 total, **0 failed** | 782 total, **0 failed** | 782 total, **0 failed** |
| `Darling.Tests` | 8,103 total, 10 failed | 8,115 total, 1 failed | **8,116 total, 0 failed** |

**Not one Lite assertion changed.** The only pre-existing Lite test file in the diff is `StoreRoundTripTests.cs`, and only its `AlertHistoryRecord` construction sites — the record's arity changed, so they had to. No `Assert.` line in Lite moved, and Lite's 3,501 pass. That is a stronger statement than the parity pin alone: Lite's stored values and its rendered column really are unchanged.

**On confirming the new tests executed.** This repo's runner prints no per-test `Passed` lines, so a grep by test name returns nothing and proves nothing — the judgement is `Failed: 0` plus `Not Run: 0`. What ties that to *my* tests is the total: `Darling.Tests` went 8,115 → **8,116** between round 2 and round 4, and the diff across that span adds exactly one `[Fact]` and no other test attribute. The suite is counting my additions, so its zero covers them. I did not attempt a baseline from `dev`: the most recent green `dev` `build` took the docs fast path and skipped every test step, which is a green that ran nothing.

### The pins that held the old semantics

Round 1's 10 Darling failures (12 in the PG job, which additionally runs two live-Postgres tests) were every place the old meaning was written down. Each is re-decided, not weakened:

- `DarlingSelfAlertTests` (6) — resolution rows asserting `AlertSent == true` and `"tray"`
- `DarlingDeliveryModeTests:102` — `Assert.Equal("tray", record.NotificationType); // no channel configured`. **The comment beside the assertion already said what the value now says.** So did `DarlingAlertingTests:295`'s `/* Lite's taxonomy: no email/webhook attempted */`
- `ViewerWave3Tests` — the theory named `StatusDisplay_MirrorsLitesChannelMapping`, whose name was the defect: mirroring Lite is exactly what a SKU with no tray must not do. Renamed, and extended from 5 cases to 11
- `ViewerWave3LivePostgresTests` — a live-Postgres row asserting `"Shown"`

Round 2's single failure was #2781's own chip-drop pin, asserting the literal `a.notification_type !== "tray"` on both pages — text that is now absent while the behaviour it stood for is strictly wider. Rewritten to assert the claim.

I found that one from CI rather than locally, so afterwards I swept it properly: every distinctive string literal the JS diff removed, grepped across both test trees, plus a read of every test that reads `util.js` / `alerts.js` / `triage.js` (`RollupTileDescriptionTests`, `FleetPageAttentionFilterTests`, `DarlingWebAssetsTests`, `ChartWindowDomainTests`, `DailySummaryHealthFormatTests`). Nothing else depends on a literal this removes.

The `review` check passed in both rounds. Its bot found the same three stale-pin sets independently, verified the 64/14-case enumerations by hand, and flagged the web-dashboard regression. Its sharpest point — that `AlertTrayStatusLoggedTests` "only checks source-text patterns, not the actual rendered value, so it still passes even though the behavior it guards has changed underneath it" — is what the parity rewrite answers.

## Left undone, deliberately

**A configured webhook that fails is still indistinguishable from an unconfigured one** — `WebhookAlertService.TrySendWebhookAlertsAsync` returns one `bool` for four channels and `send_error` covers only email, so the new `undelivered` state merges "throttled" with "webhook post failed". Fixing it means per-channel attempt-and-error reporting through `EmailFanoutResult`, which is a live-delivery change with no observable effect on any current store, since no webhook is configured anywhere. Shipping the half an operator can see today and naming this one rather than folding it in.

The **deprecated Dashboard** SKU's `RecordAlert` takes the already-decided pair as method parameters from 26 call sites, which is this same defect in a SKU that is not shipped, writes to its own JSON store, and has its own display. Those 26 sites are unchanged; they go through an `internal`, `[Obsolete]` `FromLegacyStoredColumns`, and `TheLegacyHatch_HasExactlyOneProductionCaller` pins that the deprecated call site stays its only production caller — `InternalsVisibleTo` on the Notifications project also admits Lite, so the boundary is asserted rather than assumed.

## CHANGELOG entry text (not committed)

**Deliberately not committed**, not an oversight: every lane appends to the same `[Unreleased]` block, so a
per-PR edit is a guaranteed conflict with whichever lane merges first. The convention here is that the lane
reports the text and it is folded in centrally. Raised by the review bot, so stating it rather than leaving
it to look like a gap.

```
- **Alert history states which channel a row is about (#3169).** `config_alert_log.alert_sent` meant
  "delivered" on a fired row and "no send channel applies" on a resolution row, so `false` could not be
  told from never-attempted and no aggregate over the column meant anything. An alert-history row now
  carries one factory-only delivery value: `notification_type` names the state — no channel applies, none
  configured, muted, consulted-but-undelivered, or the channel that delivered — and `alert_sent` is only
  ever a delivery outcome. The headless service no longer records a tray notification it has no way to
  show, which #2781/#2814 had worked around on the web dashboard alone. All three surfaces that render the
  status column now share one vocabulary: the two desktop grids through one description, and the web
  dashboard through a single state-to-label map pinned against it. Existing rows are not rewritten — a
  pre-change resolution row reads as "No channel", and a pre-change fired row keeps a label that claims
  nothing rather than being reinterpreted under the new semantics.
```
