### PR TITLE
Size pg_index_bloat's ceiling and cycle budget against the measured block rate, not an assumed one (#3164)

### DIFF
--- a/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
@@ -478,8 +478,16 @@ public class PgIndexBloatCollectorDefinitionTests
     /// "unmeasured" and "healthy" that <c>skipped_reason</c> exists to prevent, reintroduced one level up.</para>
     ///
     /// <para>Pinned as an inequality rather than as equality: raising the cycle budget above the ceiling is
-    /// a legitimate tuning move once a SUCCESS row supplies a real duration, and this must not stand in the
-    /// way of it. Only the floor is load-bearing.</para>
+    /// a legitimate tuning move, and this must not stand in the way of it. Only the floor is
+    /// load-bearing.</para>
+    ///
+    /// <para><b>This pin is not sufficient on its own, which #3164 is what established.</b> While
+    /// <c>budget &gt;= ceiling</c> holds, <see cref="TheCycleBudget_FitsTheDeadline_AtTheMeasuredBlockRate"/>
+    /// covers the CEILING's deadline cost for free — a near-ceiling index cannot cost more than the budget
+    /// it sits under. That transitive coverage disappears the moment anyone decouples the two, and its
+    /// disappearance is silent, so the ceiling now carries its own deadline assertion in
+    /// <see cref="ThePerIndexCeiling_FitsTheDeadline_OnItsOwn"/> rather than inheriting one from this
+    /// inequality.</para>
     /// </summary>
     [Fact]
     public void TheCycleBudget_IsNeverBelowThePerIndexCeiling()
@@ -501,31 +509,81 @@ public class PgIndexBloatCollectorDefinitionTests
     /// orders of magnitude, and that is the arithmetic error that a per-byte argument cannot see.</para>
     ///
     /// <para><b>Half the deadline, not all of it.</b> The remainder pays for the catalog scan, connection
-    /// setup, and the tail index admitted while the running total was still just under budget — that index
-    /// is charged for itself, so the last admission can be almost a whole index past the point where the
-    /// budget was nearly spent.</para>
+    /// setup, and being wrong about the rate — which is the whole of the margin, deliberately, since
+    /// <see cref="PgIndexBloatCollector.MeasuredBlocksPerSecond"/> is now what was measured rather than a
+    /// figure shaded downwards. Spending the margin in two places would leave neither meaning anything.</para>
     ///
-    /// <para>The rate is an assumption and is named as one. This pin does not make it true; it makes
-    /// raising the budget state a rate, and makes raising the rate state why.</para>
+    /// <para><b>The rate is a measurement now, and this pin is what made the trigger fire (#3164).</b> The
+    /// figure was an assumed 2,000 blocks/s; the first SUCCESS row this collector ever produced put it at
+    /// ~1,013, and this assertion is what turned that into a required budget change rather than a note —
+    /// 2 GiB is 262,144 blocks, which at the measured rate is 259 s against a 150 s allowance. Its own
+    /// failure text named the two exits, "lower the budget, or argue the rate up and say on what
+    /// measurement", and the measurement argued it DOWN. The pin does not make the rate true; it makes the
+    /// budget answerable to it.</para>
     /// </summary>
     [Fact]
-    public void TheCycleBudget_FitsTheDeadline_AtThePessimisticBlockRate()
+    public void TheCycleBudget_FitsTheDeadline_AtTheMeasuredBlockRate()
     {
         var deadlineSeconds = PgIndexBloatCollector.Instance.CommandTimeoutSecondsOverride;
 
         Assert.NotNull(deadlineSeconds);
 
         var blocks = PgIndexBloatCollector.CycleMeasureBudgetBytes / PgIndexBloatCollector.BlockSizeBytes;
-        var seconds = blocks / (double)PgIndexBloatCollector.PessimisticBlocksPerSecond;
+        var seconds = blocks / (double)PgIndexBloatCollector.MeasuredBlocksPerSecond;
         var allowed = deadlineSeconds.Value / 2.0;
 
         Assert.True(
             seconds <= allowed,
             $"a full cycle budget of {PgIndexBloatCollector.CycleMeasureBudgetBytes} bytes is {blocks} "
-            + $"blocks, which at {PgIndexBloatCollector.PessimisticBlocksPerSecond} blocks/s takes "
+            + $"blocks, which at {PgIndexBloatCollector.MeasuredBlocksPerSecond} blocks/s takes "
             + $"{seconds:F0}s — past the {allowed:F0}s that leaves half of the {deadlineSeconds}s command "
             + "deadline for everything else. Lower the budget, or argue the rate up and say on what "
             + "measurement");
+    }
+
+    /// <summary>
+    /// The PER-INDEX CEILING has to fit the deadline on its own, because one index just under it is the
+    /// largest amount of work a single statement can be asked to do.
+    ///
+    /// <para><b>Why this is not redundant with
+    /// <see cref="TheCycleBudget_FitsTheDeadline_AtTheMeasuredBlockRate"/>.</b> Today the two are the same
+    /// arithmetic, because <see cref="TheCycleBudget_IsNeverBelowThePerIndexCeiling"/> forces
+    /// <c>budget &gt;= ceiling</c> and a near-ceiling index therefore cannot cost more than the budget it
+    /// sits under. That makes the ceiling's deadline cost covered TRANSITIVELY — and the transitive route
+    /// runs through an inequality whose own doc invites it to be relaxed. Decouple the two and the ceiling
+    /// silently loses the only assertion its cost ever had, with every other pin still green.</para>
+    ///
+    /// <para><b>It is also the assertion that decides the decoupling question, which is why #3164 added it
+    /// rather than filing it.</b> #3153 deferred decoupling the budget from the ceiling — an unconditional
+    /// first-admission rule plus a deadline constraint restated as a SUM — so that the budget could fall to
+    /// fit a slower rate while the ceiling stayed at 2 GiB. This pin is what shows that goal to be
+    /// unreachable: at the measured rate a 2 GiB ceiling is 259 s in one statement, so it fails this
+    /// assertion before a budget is chosen at all, and <c>ceiling + budget &lt;= allowance</c> has no
+    /// solution. The binding constraint was never the ordering between the two figures; it was the
+    /// ceiling's own deadline cost, which equal values had been hiding.</para>
+    ///
+    /// <para>Written against the ceiling and the deadline rather than against the budget, so it stays
+    /// meaningful under a decoupling instead of quietly becoming a second copy of the budget pin.</para>
+    /// </summary>
+    [Fact]
+    public void ThePerIndexCeiling_FitsTheDeadline_OnItsOwn()
+    {
+        var deadlineSeconds = PgIndexBloatCollector.Instance.CommandTimeoutSecondsOverride;
+
+        Assert.NotNull(deadlineSeconds);
+
+        var blocks = PgIndexBloatCollector.MeasureCeilingBytes / PgIndexBloatCollector.BlockSizeBytes;
+        var seconds = blocks / (double)PgIndexBloatCollector.MeasuredBlocksPerSecond;
+        var allowed = deadlineSeconds.Value / 2.0;
+
+        Assert.True(
+            seconds <= allowed,
+            $"one index just under the {PgIndexBloatCollector.MeasureCeilingBytes}-byte per-index ceiling "
+            + $"is {blocks} blocks, which at {PgIndexBloatCollector.MeasuredBlocksPerSecond} blocks/s takes "
+            + $"{seconds:F0}s in a SINGLE statement — past the {allowed:F0}s that leaves half of the "
+            + $"{deadlineSeconds}s command deadline for everything else. No cycle budget can fix this: the "
+            + "ceiling is what one statement can be asked to read. Lower the ceiling, or argue the rate up "
+            + "and say on what measurement");
     }
 
     /* ---------------- rotation (#3153) ---------------- */

--- a/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
@@ -514,6 +514,20 @@ public class PgIndexBloatCollectorDefinitionTests
     /// <see cref="PgIndexBloatCollector.MeasuredBlocksPerSecond"/> is now what was measured rather than a
     /// figure shaded downwards. Spending the margin in two places would leave neither meaning anything.</para>
     ///
+    /// <para><b>One thing this reserve does NOT cover, corrected rather than quietly rewritten (#3164).</b>
+    /// This paragraph used to say the remainder also paid for "the tail index admitted while the running
+    /// total was still just under budget — that index is charged for itself, so the last admission can be
+    /// almost a whole index past the point where the budget was nearly spent." That describes a gate of the
+    /// form <c>total BEFORE this row &lt;= budget</c>, and the shipped gate is not that one:
+    /// <c>measured_bytes_through_here</c> is a window sum over
+    /// <c>ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW</c>, so it INCLUDES the row being tested, and
+    /// <c>measured_bytes_through_here &lt;= budget</c> admits the tail index only if it fits in the
+    /// headroom that is left. Prefix sums are non-decreasing, so the admitted set is a prefix and the total
+    /// read is bounded by the budget exactly — there is no overshoot to reserve against. Worth stating
+    /// because the wrong version made the reserve look like it was covering a 2x read, which would have
+    /// left the actual rate error uncovered; and because the same property is what lets a SUCCESS row's
+    /// duration bound the block rate from above at all.</para>
+    ///
     /// <para><b>The rate is a measurement now, and this pin is what made the trigger fire (#3164).</b> The
     /// figure was an assumed 2,000 blocks/s; the first SUCCESS row this collector ever produced put it at
     /// ~1,013, and this assertion is what turned that into a required budget change rather than a note —
@@ -612,6 +626,16 @@ public class PgIndexBloatCollectorDefinitionTests
     /// matches nothing is the shape that reports success for having looked. The two figures this change is
     /// about are additionally required BY NAME, so the census shrinking to one of them is red rather than
     /// quietly narrower.</para>
+    ///
+    /// <para><b>The filter is every <c>long</c> constant, not every one whose name ends in
+    /// <c>Bytes</c>.</b> The suffix would read more precisely and fails the wrong way: a byte bound added
+    /// under some other name escapes the census and is never checked, which is green and wrong. Taking
+    /// every <c>long</c> means an unrelated <c>long</c> constant added later gets asserted against the
+    /// deadline as well — noisy and wrong, which someone has to come and look at. Given the choice, fail
+    /// toward the label that costs attention rather than the one that costs coverage. The <c>int</c>
+    /// constants on this type (<c>BlockSizeBytes</c>, <c>MeasuredBlocksPerSecond</c>,
+    /// <c>MaxSplicedCursors</c>) are excluded by the type test, which is why the suffix is not needed to
+    /// keep <c>BlockSizeBytes</c> out of a census of byte BOUNDS.</para>
     /// </summary>
     [Fact]
     public void EveryDeclaredByteBound_FitsTheDeadline_CensusedFromTheType()

--- a/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Lite.Tests.Helpers;
@@ -584,6 +585,68 @@ public class PgIndexBloatCollectorDefinitionTests
             + $"{deadlineSeconds}s command deadline for everything else. No cycle budget can fix this: the "
             + "ceiling is what one statement can be asked to read. Lower the ceiling, or argue the rate up "
             + "and say on what measurement");
+    }
+
+    /// <summary>
+    /// EVERY byte bound this collector declares fits the deadline, with the population of bounds CENSUSED
+    /// FROM THE TYPE rather than typed out here.
+    ///
+    /// <para><b>Why the census, when two pins above already do this arithmetic.</b> Because those two name
+    /// their subject inline, and a pin's subject is the one thing it cannot check about itself. Mutating
+    /// <see cref="ThePerIndexCeiling_FitsTheDeadline_OnItsOwn"/> to read
+    /// <c>CycleMeasureBudgetBytes</c> instead of <c>MeasureCeilingBytes</c> — one token — leaves all of
+    /// this file green while the ceiling's deadline cost goes unasserted, because the two figures are
+    /// currently EQUAL. That is not a hypothetical: equal values are precisely what
+    /// <see cref="TheCycleBudget_IsNeverBelowThePerIndexCeiling"/> is documented as preferring, so the two
+    /// pins are arithmetically indistinguishable for as long as this collector is correct, and become
+    /// distinguishable only in the decoupled state where one of them is supposed to fire.</para>
+    ///
+    /// <para>So the ceiling's coverage is made independent of any hand-typed subject: the bounds are read
+    /// off the type's own public constants, and each is required to fit the same allowance. A third byte
+    /// bound added later is covered without anyone remembering to add a pin, which is the case a
+    /// hand-written list gets wrong.</para>
+    ///
+    /// <para><b>It cannot pass vacuously.</b> An empty census is asserted against — if these constants ever
+    /// stop being <c>public const long</c> (made <c>static readonly</c>, moved to a settings type, renamed
+    /// out of the filter) the reflection returns nothing, and a reflection-driven check that silently
+    /// matches nothing is the shape that reports success for having looked. The two figures this change is
+    /// about are additionally required BY NAME, so the census shrinking to one of them is red rather than
+    /// quietly narrower.</para>
+    /// </summary>
+    [Fact]
+    public void EveryDeclaredByteBound_FitsTheDeadline_CensusedFromTheType()
+    {
+        var deadlineSeconds = PgIndexBloatCollector.Instance.CommandTimeoutSecondsOverride;
+
+        Assert.NotNull(deadlineSeconds);
+
+        var allowed = deadlineSeconds.Value / 2.0;
+
+        var bounds = typeof(PgIndexBloatCollector)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(long))
+            .ToDictionary(f => f.Name, f => (long)f.GetRawConstantValue()!, StringComparer.Ordinal);
+
+        Assert.NotEmpty(bounds);
+
+        foreach (var required in new[] { "MeasureCeilingBytes", "CycleMeasureBudgetBytes" })
+        {
+            Assert.Contains(required, bounds.Keys);
+        }
+
+        foreach (var (name, bytes) in bounds)
+        {
+            var blocks = bytes / PgIndexBloatCollector.BlockSizeBytes;
+            var seconds = blocks / (double)PgIndexBloatCollector.MeasuredBlocksPerSecond;
+
+            Assert.True(
+                seconds <= allowed,
+                $"{name} is {bytes} bytes = {blocks} blocks, which at "
+                + $"{PgIndexBloatCollector.MeasuredBlocksPerSecond} blocks/s takes {seconds:F0}s — past "
+                + $"the {allowed:F0}s that leaves half of the {deadlineSeconds}s command deadline for "
+                + "everything else. Every byte bound here bounds work inside ONE statement under ONE "
+                + "deadline, so each has to fit it on its own");
+        }
     }
 
     /* ---------------- rotation (#3153) ---------------- */

--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -160,6 +160,16 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     /// but that row's duration and the shipped gate. The rate derived from the bytes that run actually
     /// measured is ~1,013 blocks/s, and it is the figure kept here.</para>
     ///
+    /// <para><b>What the denominator actually contains, because the name says "blocks per second" and
+    /// this is not a pure I/O rate.</b> <c>sql_duration_ms</c> on a <see cref="RunsPerDatabase"/> collector
+    /// is the SUM across databases of connect + execute + drain, so the figure below is blocks divided by
+    /// everything the statement spent, not by <c>pgstatindex</c> time alone — and the run it comes from
+    /// swept two databases, one of which failed fast on a missing extension. Every one of those terms
+    /// inflates the denominator, so the true per-block read rate is FASTER than this. That is the right
+    /// direction and the right quantity: what this constant feeds is a comparison against a command
+    /// deadline, and the deadline covers connect and drain too. A pure I/O rate would understate the
+    /// budget's real cost by exactly the terms it left out.</para>
+    ///
     /// <para><b>What this figure does NOT rest on.</b> n = 1 — one run, one target, one night. Two numbers
     /// elsewhere in this type read like corroboration and are not: <see cref="MeasureCeilingBytes"/>' "about
     /// 11 hours" for the over-ceiling set and "roughly an hour" for its largest member are this same rate

--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -92,6 +92,17 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     /// Indexes at or above this many bytes are recorded but NEVER measured — permanently, not this cycle.
     /// The read is proportional to index size, so this bounds what any single index can cost.
     ///
+    /// <para><b>It is the DEADLINE that sets this figure, and that only became visible once the block rate
+    /// was measured (#3164).</b> One index just under this ceiling is the largest amount of work a single
+    /// statement can be asked to do, so the ceiling has to fit the deadline on its own — at
+    /// <see cref="MeasuredBlocksPerSecond"/>, 1 GiB is 131,072 blocks and about 129 s, inside the 150 s
+    /// that leaves half of <see cref="CommandTimeoutSecondsOverride"/> for everything else.
+    /// <c>ThePerIndexCeiling_FitsTheDeadline_OnItsOwn</c> asserts that directly rather than leaving it to
+    /// be inherited from the lockstep below, because the lockstep is exactly what a future decoupling
+    /// would remove. At the measured rate a 2 GiB ceiling is 259 s in one statement — past the whole
+    /// allowance on a single index — which is why this ceiling could not stay where it was whatever the
+    /// cycle budget did.</para>
+    ///
     /// <para>It moves in lockstep with <see cref="CycleMeasureBudgetBytes"/>, because the cycle budget may
     /// never sit below it: the band between the two would be indexes that are legitimate candidates,
     /// earn no "too large" reason, and yet exceed the whole cycle on their own first row every run.
@@ -99,20 +110,24 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     /// stall the ROTATION CURSOR rather than merely mislabel one index, which is a strictly worse
     /// failure. See <see cref="CycleMeasureBudgetBytes"/> for the argument in full.</para>
     ///
-    /// <para><b>Over-ceiling indexes are a terminal state, and the row says so.</b> On the first
-    /// production target 43 indexes sat above this ceiling, holding 311 GB — 68% of that instance's index
-    /// footprint, mean 7.4 GB, largest 27 GB. At the rate that target's own SUCCESS row measured, reading
-    /// that set is about 11 hours and its largest member alone is roughly an hour in one statement, so no
-    /// per-statement deadline this product could plausibly set reaches them: <c>pgstatindex</c> is the
-    /// wrong instrument for them rather than a mis-tuned one. Raising the ceiling does not help, and an
-    /// estimator is not available — <c>pg_stats</c> returns zero rows to a <c>pg_monitor</c>-only login
-    /// (see the type header). So their reason states PERMANENCE instead of implying a deferral, and points
-    /// at what does cover them: <see cref="PgIndexUsageStatsCollector"/> runs on the same target at the
-    /// same daily cadence with the same retention, needs no extension, records <c>index_bytes</c> and
-    /// <c>table_bytes</c> per index, and covers all 43 — an index growing while its table's row count does
-    /// not is itself a bloat signal, and it is already collected.</para>
+    /// <para><b>Over-ceiling indexes are a terminal state, and the row says so.</b> Measured on the first
+    /// production target AT A 2 GiB CEILING, 43 indexes sat above it holding 311 GB — 68% of that
+    /// instance's index footprint, mean 7.4 GB, largest 27 GB. That census belongs to the ceiling it was
+    /// taken at: this ceiling is lower, so the terminal set is LARGER by however many indexes fall between
+    /// the two, and that count has not been measured — the store holding that target was not reachable for
+    /// #3164. What is measured is the direction and the mechanism, not a new count. At
+    /// <see cref="MeasuredBlocksPerSecond"/> the 311 GB set is about 11 hours of reading and its largest
+    /// member alone is roughly an hour in one statement, so no per-statement deadline this product could
+    /// plausibly set reaches them: <c>pgstatindex</c> is the wrong instrument for them rather than a
+    /// mis-tuned one. Raising the ceiling does not help, and an estimator is not available —
+    /// <c>pg_stats</c> returns zero rows to a <c>pg_monitor</c>-only login (see the type header). So their
+    /// reason states PERMANENCE instead of implying a deferral, and points at what does cover them:
+    /// <see cref="PgIndexUsageStatsCollector"/> runs on the same target at the same daily cadence with the
+    /// same retention, needs no extension, records <c>index_bytes</c> and <c>table_bytes</c> per index, and
+    /// covers every one of them whatever this ceiling is — an index growing while its table's row count
+    /// does not is itself a bloat signal, and it is already collected.</para>
     /// </summary>
-    public const long MeasureCeilingBytes = 2L * 1024 * 1024 * 1024;
+    public const long MeasureCeilingBytes = 1L * 1024 * 1024 * 1024;
 
     /// <summary>
     /// PostgreSQL's block size. <c>pgstatindex</c> is charged per BLOCK rather than per byte, so this is
@@ -125,8 +140,8 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     public const int BlockSizeBytes = 8192;
 
     /// <summary>
-    /// The block rate <see cref="CycleMeasureBudgetBytes"/> is sized against, and the reason the budget is
-    /// a small number rather than a large one.
+    /// The block rate <see cref="CycleMeasureBudgetBytes"/> and <see cref="MeasureCeilingBytes"/> are both
+    /// sized against, and the reason each is a small number rather than a large one.
     ///
     /// <para><b>Why a block rate and not a byte throughput.</b> <c>pgstatindex</c> walks the index one
     /// block at a time through the buffer manager with no prefetch, so its cost is a count of
@@ -134,12 +149,40 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     /// each miss is a round trip, so per-block LATENCY sets the rate and a sequential-throughput figure
     /// overstates it by orders of magnitude.</para>
     ///
-    /// <para>This value is an assumption, not a measurement — no SUCCESS row has ever supplied a duration
-    /// for this collector — so it is deliberately pessimistic, and
-    /// <c>TheCycleBudget_FitsTheDeadline_AtThePessimisticBlockRate</c> pins the budget, the deadline and
-    /// this rate together so that raising any one of them has to argue against the other two.</para>
+    /// <para><b>This is now a MEASUREMENT, and it came in at roughly HALF the figure that preceded it
+    /// (#3164).</b> The figure here used to be an assumption of 2,000 blocks/s, named pessimistic and
+    /// carrying no measurement, because none existed. One does now: the first SUCCESS row this collector
+    /// has ever produced recorded <c>collection_log.sql_duration_ms</c> of <b>252,940 ms</b>, which is the
+    /// instrument <see cref="CycleMeasureBudgetBytes"/> pre-registered for exactly this decision. That run
+    /// executed under a 2 GiB cycle budget, and the gate admits an index only when the running total
+    /// THROUGH that index is still within budget, so the bytes it read cannot have exceeded the budget —
+    /// which bounds the rate from above at 262,144 blocks / 252.94 s = <b>1,036 blocks/s</b> using nothing
+    /// but that row's duration and the shipped gate. The rate derived from the bytes that run actually
+    /// measured is ~1,013 blocks/s, and it is the figure kept here.</para>
+    ///
+    /// <para><b>What this figure does NOT rest on.</b> n = 1 — one run, one target, one night. Two numbers
+    /// elsewhere in this type read like corroboration and are not: <see cref="MeasureCeilingBytes"/>' "about
+    /// 11 hours" for the over-ceiling set and "roughly an hour" for its largest member are this same rate
+    /// restated at coarse precision, not independent derivations. So the only independent check on the
+    /// figure below is the 1,036 blocks/s upper bound above, which agrees on the order and on the
+    /// direction. The three-significant-figure value is kept rather than rounded because rounding it would
+    /// invent a margin, and the margin belongs in ONE place — see the next paragraph.</para>
+    ///
+    /// <para><b>The safety margin is the half-deadline allowance, and it must not be double-counted here.</b>
+    /// <c>TheCycleBudget_FitsTheDeadline_AtTheMeasuredBlockRate</c> compares the budget against HALF of
+    /// <see cref="CommandTimeoutSecondsOverride"/>, so a run whose rate comes in materially below this
+    /// figure still has the other half of the deadline to finish in. Shading this constant below the
+    /// measurement as well would spend that headroom twice and make neither figure mean anything. One
+    /// number, one meaning: this one is what was measured, and the allowance is what pays for being wrong
+    /// about it.</para>
+    ///
+    /// <para><b>What would justify moving it.</b> A DISTRIBUTION rather than another single row — several
+    /// SUCCESS rows across cache states and instance load, because per-block latency on network-attached
+    /// storage is the rate-setter and a single sample of it is not a rate. A measurement LOWER than this
+    /// reds the deadline pins and brings the budget and the ceiling down again; that is the mechanism
+    /// working rather than a problem, and it is the same trigger that produced this change.</para>
     /// </summary>
-    public const int PessimisticBlocksPerSecond = 2_000;
+    public const int MeasuredBlocksPerSecond = 1_013;
 
     /// <summary>
     /// How many bytes of index ONE ATTEMPT will measure in total, largest first. Independent of
@@ -153,19 +196,25 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     /// The deadline is per statement, so that is the right granularity for the bound, but it is not a
     /// bound on a sweep.</para>
     ///
-    /// <para><b>Why 2 GB.</b> Not from a throughput measurement — none exists for this collector, and a
-    /// deadline-cut run bounds only its own duration, never a rate. It is derived instead from the cost
-    /// model in <see cref="PessimisticBlocksPerSecond"/>: 2 GB is 262,144 blocks, which at 2,000
-    /// blocks/s is about 131 seconds, inside half of
-    /// <see cref="CommandTimeoutSecondsOverride"/>. The remaining headroom pays for the catalog scan,
-    /// connection setup, and the tail index admitted while the running total was still just under
-    /// budget.</para>
+    /// <para><b>Why 1 GiB, and why it used to be 2.</b> Derived from the cost model in
+    /// <see cref="MeasuredBlocksPerSecond"/>: 1 GiB is 131,072 blocks, which at 1,013 blocks/s is about
+    /// 129 seconds, inside half of <see cref="CommandTimeoutSecondsOverride"/>. The remaining headroom
+    /// pays for the catalog scan, connection setup, and being wrong about the rate. The figure was 2 GiB
+    /// while the rate was an ASSUMED 2,000 blocks/s; the same arithmetic at the measured 1,013 puts 2 GiB
+    /// at 259 seconds, past the whole allowance, so the budget came down rather than the allowance going
+    /// up (#3164).</para>
     ///
-    /// <para><b>What would justify raising it.</b> A SUCCESS row's own
-    /// <c>collection_log.sql_duration_ms</c> (#2997), which is a measured rate for this instance and
-    /// this index population rather than the assumed one above. Until such a row exists, every value
-    /// here is an argument rather than a measurement, and the small end of the argument is the one that
-    /// produces the row.</para>
+    /// <para><b>The measurement that decided it is the one this comment used to ask for.</b> The line
+    /// here previously read "until a SUCCESS row exists, every value here is an argument rather than a
+    /// measurement, and the small end of the argument is the one that produces the row" — and that is
+    /// what happened: the small end produced a row, the row supplied a rate, and the rate argued the
+    /// budget DOWN. So the trigger fired as pre-registered rather than being overruled.</para>
+    ///
+    /// <para><b>What would justify raising it now.</b> Not another single SUCCESS row — a distribution of
+    /// them, for the reason given in <see cref="MeasuredBlocksPerSecond"/>: one sample of a
+    /// latency-bound rate is not a rate. Raising the command deadline is the other arithmetic route and
+    /// is deliberately not taken here; see <see cref="CommandTimeoutSecondsOverride"/> for what it
+    /// would and would not cost.</para>
     ///
     /// <para><b>It must never drop BELOW <see cref="MeasureCeilingBytes"/>, and that it equals it is a
     /// floor rather than a coincidence.</b> A cycle budget under the per-index ceiling opens a band
@@ -185,9 +234,22 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     /// sitting at the cursor is admitted by neither gate, so the cycle measures NOTHING, records the pass
     /// as complete, wraps to the largest index, and arrives back at the same band index — the collector
     /// stops measuring anything at all, on every index, permanently. The band used to mislabel one index;
-    /// it now stops the whole mechanism. Decoupling the two therefore needs an unconditional
-    /// first-admission rule and a deadline constraint restated as a SUM (<c>ceiling + budget</c>) rather
-    /// than an ordering, which is a separate change with its own arithmetic to argue.</para>
+    /// it now stops the whole mechanism.</para>
+    ///
+    /// <para><b>Decoupling the two would not have helped here, and the arithmetic is what says so
+    /// (#3164).</b> The route #3153 left open was an unconditional first-admission rule plus the deadline
+    /// constraint restated as a SUM (<c>ceiling + budget</c>) rather than an ordering, whose whole point
+    /// was to let the budget fall to fit a slower rate while the ceiling stayed at 2 GiB. At the measured
+    /// rate that goal is unreachable by any budget: 2 GiB is 262,144 blocks and about 259 s in ONE
+    /// statement, so the ceiling alone is already past the 150 s allowance before a budget is chosen, and
+    /// <c>ceiling + budget &lt;= allowance</c> has no solution at all. So the binding constraint was never
+    /// the ordering between these two figures — it was the ceiling's own deadline cost, which the lockstep
+    /// had been hiding by making the two numbers equal. Once the ceiling comes down to fit the deadline,
+    /// setting the budget equal to it satisfies everything with no new mechanism, and decoupling would
+    /// only permit the one direction (<c>budget &lt; ceiling</c>) that reopens the band. The transitive
+    /// coverage is also the reason <c>ThePerIndexCeiling_FitsTheDeadline_OnItsOwn</c> now exists: while
+    /// <c>budget &gt;= ceiling</c> holds, a deadline pin on the budget covers the ceiling for free, so a
+    /// decoupling would silently remove the only assertion the ceiling's cost had.</para>
     ///
     /// <para><b>Accepted consequence.</b> An index at or above the ceiling is reported at its size with
     /// the ceiling's own reason and is never measured — on a large target that includes the biggest and
@@ -198,12 +260,33 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     ///
     /// <para><b>What this bound does NOT buy.</b> Coverage is not budget-limited; before #3153 it was
     /// memory-limited, and now it is CADENCE-limited. A complete pass over the first production target's
-    /// 2,457 measurable indexes is a fixed ~19.6M blocks however it is spread, so at one statement per day
-    /// a full pass takes months. Rotation converts "never" into "eventually"; how long "eventually" is, is
-    /// set by how much <c>pgstatindex</c> time per day is acceptable on a production instance and by
-    /// nothing else. That is a scheduling decision, not a number this constant can express.</para>
+    /// 2,457 measurable indexes was a fixed ~19.6M blocks however it was spread, so at one statement per
+    /// day a full pass takes months. Rotation converts "never" into "eventually"; how long "eventually"
+    /// is, is set by how much <c>pgstatindex</c> time per day is acceptable on a production instance and
+    /// by nothing else. That is a scheduling decision, not a number this constant can express.</para>
+    ///
+    /// <para><b>What halving it cost, stated in the unit it is paid in (#3164).</b> Pass length is
+    /// measurable blocks divided by this budget, so halving the budget at most DOUBLES the pass: ~75
+    /// cycles became at most ~150, and at the 1,440-minute cadence in <c>CollectorScheduleDefaults</c>
+    /// that is at most ~150 days rather than ~75. "At most", because the same change lowered
+    /// <see cref="MeasureCeilingBytes"/>, which removes the indexes between the old and new ceilings from
+    /// the measurable set entirely — a smaller numerator against the halved denominator, so the true pass
+    /// length lands somewhere below the doubling. How far below depends on how much of that target's
+    /// ~150 GB of measurable index sits between 1 and 2 GiB, and that has not been measured. The cadence
+    /// is deliberately NOT touched in the same change: lowering the budget lengthens the pass, so moving
+    /// both at once would conflate two effects and leave neither figure meaning anything. It is re-derived
+    /// from whatever this budget is, separately.</para>
+    ///
+    /// <para><b>Why slower coverage is the right thing to pay.</b> A budget that overruns its deadline
+    /// produces NO ROW AT ALL — strictly worse than a smaller budget that completes, and it is also the
+    /// state that produces no <c>sql_duration_ms</c> to measure the next decision from. The one SUCCESS
+    /// row this collector has ever produced spent 84% of its deadline, so the margin being defended here
+    /// is real rather than theoretical. Before #3153 a smaller budget cost REACHABILITY — the same
+    /// largest indexes were re-selected every cycle and anything below the cut was never measured — and
+    /// rotation is what converted that cost into a rate. Paying in coverage rate is only an option at all
+    /// because rotation exists.</para>
     /// </summary>
-    public const long CycleMeasureBudgetBytes = 2L * 1024 * 1024 * 1024;
+    public const long CycleMeasureBudgetBytes = 1L * 1024 * 1024 * 1024;
 
     /// <summary>
     /// Prefix of the per-database rotation cursor key in <c>collector_state</c> (V44, primary key
@@ -575,7 +658,7 @@ ORDER BY k.index_bytes DESC";
         NULL::bigint                    AS cursor_bytes,
         NULL::bigint                    AS cursor_oid";
 
-    private const string CeilingLiteral = "2147483648";
+    private const string CeilingLiteral = "1073741824";
 
     /* The upper bound on how many indexes one attempt will MEASURE, largest first: 200 indexes OR
        CycleMeasureBudgetBytes, whichever comes first. The byte figure is the one that binds on any
@@ -584,7 +667,7 @@ ORDER BY k.index_bytes DESC";
 
     /* Kept in the C# type system as well as in the SQL literal so a reader has one authoritative
        figure and TheBudgetLiterals_AgreeWithTheirConstants can pin that the two agree. */
-    private const string CycleByteBudgetLiteral = "2147483648";
+    private const string CycleByteBudgetLiteral = "1073741824";
 
     /// <summary>
     /// Five minutes, because even a bounded cycle of pages is real work and a slow single index
@@ -602,6 +685,23 @@ ORDER BY k.index_bytes DESC";
     /// while it scans, so it gets no reprieve from that and the deadline does fire - which is why
     /// the failures arrive as <c>Exception while reading from stream</c>, the transport's own words
     /// for a read that ran out of time.</para>
+    ///
+    /// <para><b>Raising it is the other way to make the arithmetic work, and it is NOTHING to do with a
+    /// 120-second wall clock (#3164).</b> That objection was checked and does not apply: 120 s is not a
+    /// product-wide budget but the value three SQL Server collectors chose for
+    /// <see cref="PerItemWallClockBudget"/>, the opt-in per-item budget #2673 added, whose base default is
+    /// <c>null</c> and which <c>query_store</c> already sets to 600 s — longer than this deadline. This
+    /// collector does not override it, so no wall clock bounds it at all and this figure is its only
+    /// deadline. A per-collector budget above 300 s is therefore established rather than novel.</para>
+    ///
+    /// <para><b>It is still not the move, for reasons that are about cost rather than mechanism.</b> The
+    /// figure that would fit a 2 GiB ceiling at the measured rate is ~518 s, so this would sit at over
+    /// eight minutes of <c>pgstatindex</c> in one statement against a production instance — and because
+    /// this is a backstop rather than a bound, it is also eight minutes that a MIS-BUDGETED run spends
+    /// before reporting nothing. It would be sized to make one n=1 measurement fit rather than derived
+    /// from anything, which is the move the budget's own pin exists to prevent. And it would leave
+    /// <see cref="MeasuredBlocksPerSecond"/> wrong, which is the actual defect. Raising it needs its own
+    /// argument about acceptable occupancy of a production instance, made on its own terms.</para>
     /// </summary>
     public override int? CommandTimeoutSecondsOverride => 300;
 


### PR DESCRIPTION
Fixes #3164.

`PgIndexBloatCollector.PessimisticBlocksPerSecond` was `2_000` with no measurement behind it. The name asserted pessimism and the value was optimistic by roughly 2x: the first SUCCESS row this collector has ever produced puts the real rate at **~1,013 blocks/s**. `MeasuredBlocksPerSecond` replaces it at 1,013, and `MeasureCeilingBytes` and `CycleMeasureBudgetBytes` both drop from 2 GiB to 1 GiB.

## The rate, and the instrument that produced each number

The instrument `CycleMeasureBudgetBytes`' own summary pre-registered is a SUCCESS row's `collection_log.sql_duration_ms` (#2997). One exists: a **252,940 ms** SUCCESS row, 2,500 rows collected, the first this collector has ever produced on any target.

That row alone bounds the rate from above with no further data. The gate admits an index only when the running total *through* that index is still within budget, so the admitted set is a prefix and the bytes a run reads cannot exceed the budget — and that run's budget was 2 GiB. So the rate is at most `262,144 blocks / 252.94 s` = **1,036 blocks/s**, i.e. at most 52% of the assumed 2,000. The ~1,013 figure derived from the bytes that run actually measured sits just under that bound, so the issue's number is confirmed rather than merely repeated.

**The denominator is not pgstatindex time alone, and that matters for reading the constant.** `sql_duration_ms` on a `RunsPerDatabase` collector is the sum across databases of connect + execute + drain, and that run swept two databases, one of which failed fast on a missing extension. Every one of those terms inflates the denominator, so the true per-block read rate is *faster* than this figure. That is the safe direction and the right quantity: what the constant feeds is a comparison against a command deadline, and the deadline covers connect and drain too — a pure I/O rate would understate the budget's real cost by exactly the terms it left out. The constant's doc says so, because "blocks per second" reads like a pure I/O rate and is not one.

Three things about provenance, because two of them read like corroboration and are not:

- **`MeasureCeilingBytes`' "about 11 hours" for the over-ceiling set and "roughly an hour" for its largest member are this same rate restated at coarse precision**, not independent derivations. 311 GiB at 1,013 blocks/s is 11.2 h; 27 GiB is 58 min. Citing them as agreement would be citing one measurement three times.
- **n = 1.** One run, one target, one night. The only independent check is the 1,036 blocks/s upper bound above, which agrees on the order and the direction.
- **`get_store_metrics` produced none of the figures here.** Its background-job series samples one reading an hour and its daily point is the day's *last*, so it cannot answer a maximum question (#3119). The duration above came from a `collection_log` read (wide window, `truncated: false`); the ceiling/census figures are the collector's own committed doc comments.

The run also spent **84% of its 300 s deadline**, against a pin that allows half. That falsifies the pin's premise directly, before any rate arithmetic.

## Why the ceiling had to move, and why the decoupling #3153 deferred could not have saved it

#3164 recommends the decoupling #3153 left undone — an unconditional first-admission rule plus the deadline constraint restated as a **sum** (`ceiling + budget`) — so the budget could fall to fit the real rate while the ceiling stayed at 2 GiB. **That goal is unreachable at the measured rate, and the arithmetic is one line.**

One index just under the ceiling is the largest amount of work a single statement can be asked to do. At 1,013 blocks/s, 2 GiB is 262,144 blocks and **259 s in one statement** — past the entire 150 s allowance *before a budget is chosen at all*. `ceiling + budget <= allowance` therefore has no solution with a 2 GiB ceiling, and neither does `max(ceiling, budget) <= allowance`. The binding constraint was never the ordering between the two figures; it was the ceiling's own deadline cost, which equal values had been hiding.

So the ceiling comes down regardless of what the budget does. Once it does, setting the budget equal to it satisfies every constraint with no new mechanism, and decoupling would only permit the one direction (`budget < ceiling`) that reopens the band. 1 GiB is 131,072 blocks and ~129 s, inside the 150 s allowance with 21 s of margin — it absorbs a further 14% rate degradation (it breaches at 874 blocks/s), and it is off the edge of its own plausible range rather than at it.

## How the band-emptiness floor survives

By construction, and unchanged: `CycleMeasureBudgetBytes == MeasureCeilingBytes == 1 GiB`, so `budget >= ceiling` still holds and `TheCycleBudget_IsNeverBelowThePerIndexCeiling` is green without modification. There is no band between the two figures, because there is no gap.

#3163's liveness guarantee is untouched for the same reason. Because `budget >= ceiling`, the first sub-ceiling candidate at or below the rotation cursor is still admitted unconditionally — its own size is under the ceiling, hence under the budget, so it is the first FILTERed row in the window frame and `measured_bytes_through_here` for it equals its own size, which cannot already have exceeded the budget. The cursor therefore still advances by at least one index every cycle, which is what makes "a later run in this pass reaches this index" a fact. Nothing about this change touches the gate's shape, the four reason arms, the cursor, or the prune.

## The other arithmetic route, investigated rather than assumed

#3164 asks that raising `CommandTimeoutSecondsOverride` above 300 s not be taken without first establishing how it coexists with "the 120-second whole-server wall-clock budget that abandons cycles". **Established: they do not interact, because that budget does not apply to this collector.**

120 s is not a product-wide constant. It is the value three SQL Server collectors (`procedure_stats`, `query_stats`, `plan_correction`) chose for `ICollectorSchemaInfo.PerItemWallClockBudget`, the opt-in per-item budget #2673 added. `CollectorDefinitionBase.PerItemWallClockBudget` defaults to `null`; `query_store` already sets **600 s**, longer than this deadline. `PgIndexBloatCollector` does not override it at all, so `StartItemBudget` returns null, the item token *is* the cancellation token, and no wall clock bounds this collector. A per-collector budget above 300 s is established precedent, not novel.

**It is still not the move**, for reasons about cost rather than mechanism, and they are now recorded on `CommandTimeoutSecondsOverride`: ~518 s would fit 2 GiB, which is over eight minutes of `pgstatindex` in one statement against a production instance — and because the deadline is a backstop rather than a bound, it is also eight minutes a *mis-budgeted* run spends before reporting nothing. It would be sized to make one n=1 measurement fit, which is the move the budget's own pin exists to prevent. And it would leave the rate constant wrong, which is the actual defect.

## A second correction, stated rather than quietly rewritten: what the half-deadline reserve covers

`TheCycleBudget_FitsTheDeadline_...`' doc said the reserve paid for the catalog scan, connection setup, **and** "the tail index admitted while the running total was still just under budget — that index is charged for itself, so the last admission can be almost a whole index past the point where the budget was nearly spent."

That describes a gate of the form `total BEFORE this row <= budget`. The shipped gate is not that shape: `measured_bytes_through_here` is a window sum over `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`, so it **includes** the row being tested, and `measured_bytes_through_here <= budget` admits the tail index only if it fits in the headroom left. Prefix sums are non-decreasing, so the admitted set is a prefix and the total read is bounded by the budget **exactly**. There is no overshoot to reserve against.

Two reasons this is worth a paragraph rather than a silent edit. The wrong version made the reserve look as though it were covering a possible ~2x read, which would leave the actual rate error — the thing that just went wrong — uncovered. And the same prefix property is what lets a SUCCESS row's duration bound the block rate from above at all, so the upper bound above rests on it.

The reserve's job is now stated as being wrong about the rate, and only that.

## Cadence is deliberately not touched

Coverage is cadence-limited after #3153. Lowering the budget makes passes longer, so moving both at once would conflate two effects and leave neither figure meaning anything. The cadence stays at the 1,440 minutes in `CollectorScheduleDefaults` and gets re-derived from whatever the budget is, separately.

## What this costs

**Coverage rate: at most 2x.** Pass length is measurable blocks over the budget, so halving the budget at most doubles the pass — ~75 cycles becomes at most ~150, and at a daily cadence at most ~150 days rather than ~75. "At most", because the same change lowers the ceiling, which removes the indexes between the old and new ceilings from the measurable set entirely: a smaller numerator against the halved denominator, so the true figure lands below the doubling.

**Permanently lost: the indexes between 1 and 2 GiB.** Over-ceiling indexes are terminal, so these move from "measurable, eventually" to "recorded but never measured". **How many there are on the real target is not measured** — see below. The old census of 43 indexes / 311 GB is a figure *at a 2 GiB ceiling*, so it is now restated in the doc as belonging to the ceiling it was taken at rather than left attached to a ceiling it no longer describes. What is claimed is the direction and the mechanism, not a new count.

Their `skipped_reason` already states permanence rather than implying deferral, and already names `pg_index_usage_stats` as what carries their size trend instead — same target, same daily cadence, same retention, no extension needed, and it covers them whatever this ceiling is.

## Evidence

`Lite.Tests` cannot execute on macOS, so the pins were run by compiling **the actual `Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs`** (unmodified, plus its real `CollectorDefinitionTestFakes.cs`) into a `net10.0` console harness against a minimal xUnit shim, and reflecting over `[Fact]`. Baseline on the committed tree: **35 ran, 35 passed**. CI is the arbiter; this is what was checkable locally.

**Red first.** Changing only `PessimisticBlocksPerSecond` from 2,000 to 1,013 and touching nothing else reds `TheCycleBudget_FitsTheDeadline_AtThePessimisticBlockRate` with its own failure text: *"a full cycle budget of 2147483648 bytes is 262144 blocks, which at 1013 blocks/s takes 259s — past the 150s..."*

**Nine mutations, each confirmed applied by `git diff --numstat` before the run, each restored afterwards with the tree verified clean.** Anchor counts asserted at 1 before every edit.

| mutation | caught by |
|---|---|
| rate 1,013 → 800 (slower than measured) | both deadline pins, and the census pin |
| **ceiling back to 2 GiB, budget stays 1 GiB** — the decoupled state | `ThePerIndexCeiling_FitsTheDeadline_OnItsOwn`, `TheCycleBudget_IsNeverBelowThePerIndexCeiling`, `TheBudgetLiterals_AgreeWithTheirConstants` |
| budget back to 2 GiB, ceiling stays 1 GiB | `TheCycleBudget_FitsTheDeadline_AtTheMeasuredBlockRate`, `TheBudgetLiterals_AgreeWithTheirConstants` |
| `CeilingLiteral` left at the old 2 GiB SQL value | `TheBudgetLiterals_AgreeWithTheirConstants` |
| `CycleByteBudgetLiteral` left at the old 2 GiB SQL value | `TheBudgetLiterals_AgreeWithTheirConstants` |
| the ceiling pin reads the BUDGET instead of the CEILING | **initially NOTHING.** See below |
| the ceiling pin reads the budget **and** the ceiling goes to 2 GiB | `EveryDeclaredByteBound_FitsTheDeadline_CensusedFromTheType`, naming `MeasureCeilingBytes` |
| census filter changed to match nothing | its `Assert.NotEmpty` |
| census filter matches nothing **and** the non-empty assertion removed | its required-by-name check |

### The uncaught mutation, and the pin it produced

Mutating `ThePerIndexCeiling_FitsTheDeadline_OnItsOwn` to read `CycleMeasureBudgetBytes` instead of `MeasureCeilingBytes` is one token, and left **all 34 pins green**. A pin's subject is the one thing it cannot check about itself, and here the two figures are *equal* — which is exactly the value `TheCycleBudget_IsNeverBelowThePerIndexCeiling` documents as preferred. So the two pins are arithmetically indistinguishable for as long as this collector is correct, and diverge only in the decoupled state one of them exists to catch.

`EveryDeclaredByteBound_FitsTheDeadline_CensusedFromTheType` removes the hand-typed subject: it reads the bounds off the type's own `public const long` fields and requires each to fit the same allowance, so the ceiling's coverage no longer depends on any single pin naming it, and a third byte bound added later is covered without anyone remembering. It asserts a non-empty census and requires both figures **by name**, because a reflection filter that matches nothing reports success for having looked — and those two guards catch different mutations, as the last two rows above show.

`ThePerIndexCeiling_FitsTheDeadline_OnItsOwn` stays, because it is where the decoupling argument is written down; it is no longer where the coverage lives.

The census filter takes every `long` constant rather than every name ending in `Bytes`. The suffix reads more precisely and fails the wrong way — a byte bound added under some other name escapes the census and is never checked, which is green and wrong — whereas the broad filter means an unrelated `long` added later gets asserted against the deadline too, which is noisy and wrong and someone has to come and look at it. Fail toward the label that costs attention, not the one that costs coverage. The population today is exactly `MeasureCeilingBytes` and `CycleMeasureBudgetBytes`: the type's other constants are `int` (`BlockSizeBytes`, `MeasuredBlocksPerSecond`, `MaxSplicedCursors`) or `string`, and neither base class declares any.

## Not verified

- **The count and byte share of indexes between 1 and 2 GiB on the real target**, which is the permanent loss this change accepts. It needs the pgmonitor store, and the AWS SSO token expired mid-session (`Token has expired and refresh failed`) with no `darling-pgmon` MCP in this session — so neither route was available. `aws` is not classifier-blocked here; the token is expired, which is a credential path not pursued. An inbox request is filed.
- **The ~1,013 figure's own arithmetic.** The bytes that run measured come from another lane's store read; what is independently re-derived here is the ≤1,036 blocks/s upper bound from the row's duration and the shipped gate.
- **The rate as a distribution.** n=1. A lower measurement will red these pins and bring the figures down again, which is the mechanism working.
- **Whether a post-#3163 (rotation-era) run has landed.** The 252,940 ms row ran on a pre-rotation build, so it measured a top-of-census prefix rather than a rotating slice. That does not affect the rate — the gate's byte bound was the same 2 GiB — but it means no rotation-era duration exists yet.

## No issue is referenced by a claim I did not check

`CHANGELOG.md:926` contains the digits "1,013" in an unrelated Query Store row-count context. It is a numeral collision, not a second sighting of this rate.
