### PR TITLE
Watch a compression run against the clearance its own minute has, and record why the midnight burst is accepted rather than moved

### DIFF
--- a/Darling/Darling.Tests/CommentFilterAdoptionTests.cs
+++ b/Darling/Darling.Tests/CommentFilterAdoptionTests.cs
@@ -80,7 +80,7 @@ public sealed class CommentFilterAdoptionTests
     /// <see cref="AnalysisPassTokenThreadingTests"/> gives: the way a wildcard grows is that nobody has to
     /// name a new entry.
     ///
-    /// <para>Four kinds live here and they are not the same kind. Four <b>collect</b> a doc-comment run,
+    /// <para>Four kinds live here and they are not the same kind. Five <b>collect</b> a doc-comment run,
     /// where the prefix is what defines the run. One reads a <b>stated, measured</b> bound off a named file.
     /// One filters <b>SQL</b>, which the C# walk cannot help with. One <b>demonstrates</b> the shape on an
     /// arranged fixture, which is this file.</para>
@@ -103,6 +103,19 @@ public sealed class CommentFilterAdoptionTests
 
         ["Lite.Tests/AnalysisPassTokenThreadingTests.cs"] =
             "COLLECTS a doc run. The Lite twin of the above, same helper, same reason.",
+
+        ["Darling.Tests/CompressionClearanceWatchTests.cs"] =
+            "COLLECTS a doc run. DocProseWithMap walks the contiguous /// run above a named declaration for "
+            + "the same reason RefreshCeilingProvenancePinTests does - the figures being pinned live only in "
+            + "comments, so asking for the walker would leave nothing to read - and additionally returns a "
+            + "per-character map back into the source, which is what the drift sweep splices a bumped numeral "
+            + "through. Stated bound, and it is TWO: the walk STOPS at the first line that is not /// "
+            + "-prefixed, so a block comment between the run and its declaration truncates it, which is loud "
+            + "because the collected prose is then asserted to open at <summary>. And the map is exact only "
+            + "where the normalisation introduces no character - it strips <b> tags and folds dashes, neither "
+            + "of which yields a DIGIT, and digits are the only thing a pin here reads. The splice asserts "
+            + "the source span equals the captured text, so a numeral wrapped across two /// lines fails "
+            + "loudly rather than being partially replaced.",
 
         ["Darling.Tests/DocCommentHygieneTests.cs"] =
             "COLLECTS a doc run. DocRuns groups contiguous /// lines into the run that documents one member, "

--- a/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
+++ b/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
@@ -464,6 +464,82 @@ public sealed class CompressionClearanceWatchTests
             string.Create(CultureInfo.InvariantCulture, $":{assigned:00}"), drifted.Joined, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The enum's declaration ORDER is its severity order, which <c>IsTighter</c> relies on to rank a band
+    /// against a band. Pinned rather than left as a property of how the members happen to be written: a
+    /// reordering would silently invert the summary's choice of which policy to name.
+    /// </summary>
+    [Fact]
+    public void TheClearanceBands_AreDeclaredInSeverityOrder()
+    {
+        Assert.True(
+            TimescaleSupport.CompressionClearanceBand.InsideClearance
+                < TimescaleSupport.CompressionClearanceBand.ApproachingRefresh,
+            "InsideClearance no longer sorts below ApproachingRefresh");
+        Assert.True(
+            TimescaleSupport.CompressionClearanceBand.ApproachingRefresh
+                < TimescaleSupport.CompressionClearanceBand.RefreshOverrun,
+            "ApproachingRefresh no longer sorts below RefreshOverrun");
+    }
+
+    /// <summary>
+    /// The per-tick summary names the WORST reading, and the case that proves it is the one whose share of
+    /// its clearance cannot be computed at all: a drifted policy on a minute an hourly refresh also starts
+    /// on has ZERO clearance, so <see cref="CompressionActivity.PercentOfClearance"/> is null there.
+    ///
+    /// <para><b>Why this case and not a merely-large one.</b> Ranking by the share with a missing value
+    /// defaulted to zero ranks that policy BELOW a routine reading — the worst geometry the grid can produce,
+    /// passed over by the line documented as carrying the tightest reading. A large-but-finite overrun would
+    /// rank correctly under either rule, so it cannot tell the two apart. Raised by review.</para>
+    /// </summary>
+    [Fact]
+    public void ThePerTickSummary_NamesAZeroClearanceOverrun_OverAnyRoutineReading()
+    {
+        var refreshStart = TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.HourlyRefreshPhaseOrder[0]);
+        Assert.Equal(0, TimescaleSupport.CompressionMinuteClearanceSeconds(refreshStart));
+
+        var worst = ChunkCloseReadings[0].Hypertable;
+        var drifted = Reading(worst, refreshStart, seconds: 5d);
+
+        /* The premise: its share really is unavailable, so the two ranking rules genuinely differ here. */
+        Assert.Null(drifted.PercentOfClearance);
+        Assert.Equal(TimescaleSupport.CompressionClearanceBand.RefreshOverrun, drifted.ClearanceBand);
+
+        /* A routine companion with a REAL and non-trivial share, so a rule that defaults the missing one to
+           zero would pick this one. */
+        var routine = ChunkCloseReadings[2].Hypertable;
+        Assert.True(TimescaleSupport.TryCompressionPhaseMinutesFor(routine, out var routineMinute));
+        var companion = Reading(
+            routine,
+            routineMinute,
+            seconds: TimescaleSupport.CompressionMinuteClearanceSeconds(routineMinute) / 2d);
+
+        Assert.NotNull(companion.PercentOfClearance);
+        Assert.True(
+            companion.PercentOfClearance > 0d,
+            "the routine companion's share is not positive, so it cannot out-rank a zero defaulted from null "
+            + "and this case cannot tell the two rules apart");
+        Assert.Equal(TimescaleSupport.CompressionClearanceBand.InsideClearance, companion.ClearanceBand);
+
+        /* Both orders of arrival, because a comparator can be right in one and wrong in the other. */
+        foreach (var tick in new[]
+                 {
+                     new[] { companion, drifted },
+                     new[] { drifted, companion },
+                 })
+        {
+            var logger = new CapturingTestLogger();
+            TimescaleSupport.LogCompressionActivity(tick, DateTime.UtcNow, logger);
+
+            var summary = logger.Joined
+                .Split(" | ", StringSplitOptions.None)
+                .Single(line => line.Contains("tightest compression clearance", StringComparison.Ordinal));
+
+            Assert.Contains(worst, summary, StringComparison.Ordinal);
+            Assert.DoesNotContain(routine, summary, StringComparison.Ordinal);
+        }
+    }
+
     private static CompressionActivity Reading(string hypertable, int startMinute, double seconds) =>
         new(
             hypertable,

--- a/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
+++ b/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
@@ -452,16 +452,55 @@ public sealed class CompressionClearanceWatchTests
             new[] { Reading("a_table_this_product_does_not_own", 59, 5_000d) }, DateTime.UtcNow, foreignOnly);
         Assert.DoesNotContain("clearance", foreignOnly.Joined, StringComparison.Ordinal);
 
-        /* The drift line names BOTH minutes, because "off its slot" without the two numbers cannot be acted
-           on. */
-        TimescaleSupport.TryCompressionPhaseMinutesFor(hypertable, out var assigned);
+        /* THE OFF-PHASE REPORT IS ONE LINE FOR THE STORE, and the case that establishes it is the one the
+           condition actually produces: a job catalog too old to expose fixed_schedule/initial_start fails the
+           phased read on every start, so EVERY policy is off phase at once and stays that way. Per-hypertable
+           this branch was one Information line per hypertable per hour, indefinitely, on exactly that store.
+           Raised by review. */
+        var everyPolicyDrifted = TimescaleSupport.CompressionPhaseOrder
+            .Where(table => TimescaleSupport.TryCompressionPhaseMinutesFor(table, out var assignedMinute)
+                && assignedMinute != tightest)
+            .Select(table => Reading(table, tightest, seconds: 0.5d))
+            .ToArray();
+
+        Assert.True(
+            everyPolicyDrifted.Length > 1,
+            "fewer than two policies are off their assigned minute in this arrangement, so 'one line not N' "
+            + "is vacuous");
+
         var drifted = new CapturingTestLogger();
-        TimescaleSupport.LogCompressionActivity(
-            new[] { Reading(hypertable, tightest, 0.5d) }, DateTime.UtcNow, drifted);
+        TimescaleSupport.LogCompressionActivity(everyPolicyDrifted, DateTime.UtcNow, drifted);
+
+        var driftLines = drifted.Joined
+            .Split(" | ", StringSplitOptions.None)
+            .Where(line => line.Contains("other than the one the phase grid assigns", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Single(driftLines);
+        Assert.StartsWith("Information:", driftLines[0], StringComparison.Ordinal);
+
+        /* It carries the COUNT out of the on-grid total, plus one worked example's two minutes - "off its
+           slot" without the numbers cannot be acted on. */
         Assert.Contains(
-            string.Create(CultureInfo.InvariantCulture, $":{tightest:00}"), drifted.Joined, StringComparison.Ordinal);
+            string.Create(CultureInfo.InvariantCulture, $"{everyPolicyDrifted.Length} of {everyPolicyDrifted.Length}"),
+            driftLines[0],
+            StringComparison.Ordinal);
         Assert.Contains(
-            string.Create(CultureInfo.InvariantCulture, $":{assigned:00}"), drifted.Joined, StringComparison.Ordinal);
+            string.Create(CultureInfo.InvariantCulture, $":{tightest:00}"), driftLines[0], StringComparison.Ordinal);
+
+        /* And it is SILENT when every policy is on its assigned minute, so a healthy store pays nothing. */
+        var onPhaseTick = TimescaleSupport.CompressionPhaseOrder
+            .Select(table =>
+            {
+                TimescaleSupport.TryCompressionPhaseMinutesFor(table, out var assignedMinute);
+                return Reading(table, assignedMinute, seconds: 0.5d);
+            })
+            .ToArray();
+
+        var quietDrift = new CapturingTestLogger();
+        TimescaleSupport.LogCompressionActivity(onPhaseTick, DateTime.UtcNow, quietDrift);
+        Assert.DoesNotContain(
+            "other than the one the phase grid assigns", quietDrift.Joined, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
+++ b/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
@@ -587,6 +587,93 @@ public sealed class CompressionClearanceWatchTests
         }
     }
 
+    /// <summary>
+    /// The RENDERED line for a zero-clearance reading cannot read as a low percentage, and cannot be confused
+    /// with a near-instant run that had the whole band to spare.
+    ///
+    /// <para><b>Why the pin is on the output and not on the selection.</b> The selection was already right —
+    /// <c>IsTighter</c> treats a missing share as maximally tight, and a test asserting it picks the
+    /// zero-clearance policy passes with the defect present. The defect was in the REPORTING: the share was
+    /// then printed with a zero default, so the one case with no room at all rendered "0.0%", byte-identical
+    /// to a 0.1 s run with eighteen minutes spare. Every other reading in this watch gets more alarming as it
+    /// gets worse; that one wrapped around to look best, and an operator scanning the share would skip it.
+    /// A pin on the selection cannot see any of that. Raised by review.</para>
+    ///
+    /// <para>The comparison is made on the SHARES extracted from each rendering rather than on the whole
+    /// text, because the two lines differ in their clearance figure anyway — under the defect they differed
+    /// there while agreeing on the number a reader actually scans.</para>
+    /// </summary>
+    [Fact]
+    public void AZeroClearanceReading_CannotRenderAsALowPercentage_AndDiffersFromANearInstantRun()
+    {
+        var refreshStart = TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.HourlyRefreshPhaseOrder[0]);
+        Assert.Equal(0, TimescaleSupport.CompressionMinuteClearanceSeconds(refreshStart));
+
+        var hypertable = ChunkCloseReadings[0].Hypertable;
+        Assert.True(TimescaleSupport.TryCompressionPhaseMinutesFor(hypertable, out var assigned));
+
+        var roomy = TimescaleSupport.CompressionMinuteClearanceSeconds(assigned);
+        Assert.True(roomy > 0, "the comparison minute has no clearance either, so this case cannot contrast");
+
+        /* THE PREMISE, asserted before anything is rendered: the share really is unavailable in one and
+           available in the other, so the two rendering rules genuinely differ here. */
+        var sinkReading = Reading(hypertable, refreshStart, seconds: 5d);
+        var nearInstantReading = Reading(hypertable, assigned, seconds: 0.1d);
+        Assert.Null(sinkReading.PercentOfClearance);
+        Assert.NotNull(nearInstantReading.PercentOfClearance);
+
+        var sink = Render(sinkReading);
+        var nearInstant = Render(nearInstantReading);
+
+        var sinkShares = Percentages(sink);
+        var nearInstantShares = Percentages(nearInstant);
+
+        /* The near-instant run DOES render a share. Without this the comparison below could pass because
+           neither side rendered one. */
+        Assert.NotEmpty(nearInstantShares);
+
+        /* No share the sink case renders may read as low. Vacuous on its own when the case renders none at
+           all, which is why the distinct token is required next. */
+        Assert.All(
+            sinkShares,
+            share => Assert.True(
+                share >= 100d,
+                $"a zero-clearance reading rendered {share}% — the one case with no room at all must not "
+                + "render as a low percentage, because that is the most reassuring thing the format can say"));
+
+        Assert.Contains("NO CLEARANCE", sink, StringComparison.Ordinal);
+        Assert.Contains("UNDEFINED rather than low", sink, StringComparison.Ordinal);
+
+        /* THE DISCRIMINATOR. Under the defect both renderings carried the same "0.0%" and this is what saw
+           it; the two clauses above would also have fired, so the pin is covered three ways. */
+        Assert.NotEqual(nearInstantShares, sinkShares);
+
+        /* It is a DIFFERENT FINDING, not the same one with an awkward number: a policy on a refresh's own
+           minute means the phase grid was never applied to it, so the chunk-close reasoning would point at
+           the wrong lever. */
+        Assert.Contains("Warning:", sink, StringComparison.Ordinal);
+        Assert.Contains("the phase grid was never applied", sink, StringComparison.Ordinal);
+        Assert.DoesNotContain("chunk close", sink, StringComparison.Ordinal);
+
+        /* And the ordinary overrun keeps that finding, so the two cases are not merged into one message. */
+        var ordinary = Render(Reading(hypertable, assigned, seconds: roomy + 1d));
+        Assert.Contains("chunk close", ordinary, StringComparison.Ordinal);
+        Assert.NotEmpty(Percentages(ordinary));
+    }
+
+    private static string Render(params CompressionActivity[] tick)
+    {
+        var logger = new CapturingTestLogger();
+        TimescaleSupport.LogCompressionActivity(tick, DateTime.UtcNow, logger);
+        return logger.Joined;
+    }
+
+    /// <summary>Every percentage the rendering states, as numbers — the figure a reader actually scans.</summary>
+    private static double[] Percentages(string rendered) =>
+        Regex.Matches(rendered, @"([0-9]+(?:\.[0-9]+)?)%")
+            .Select(match => double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture))
+            .ToArray();
+
     private static CompressionActivity Reading(string hypertable, int startMinute, double seconds) =>
         new(
             hypertable,

--- a/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
+++ b/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
@@ -1,0 +1,964 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The #3112 compression-clearance watch: a compression run's duration against the space the minute it
+/// started on had before the next hourly refresh.
+///
+/// <para><b>What this covers that nothing else did.</b> #3174's grid derives the compression band's WIDTH
+/// from a count and asserts the band is clear of every refresh START. Neither of those is a statement about
+/// how long a compression RUN takes, and the daily chunk close is a runtime event: every hypertable's newest
+/// chunk becomes eligible at the same UTC midnight, so one tick a day carries a full day's rewrite. The two
+/// instruments that look as though they cover it do not — #2136's cadence knob judges the run against the
+/// hour, and #1778's activity line reports only runs still in progress — so the assertions here are the
+/// first over that geometry.</para>
+///
+/// <para><b>Derive, don't restate.</b> No expected minute, clearance, watch line or percentage below is
+/// written down. Each comes from <see cref="TimescaleSupport.CompressionPhaseMinutes"/>,
+/// <see cref="TimescaleSupport.HourlyRefreshPhaseOrder"/> or the shipped classifier, so a re-derived grid
+/// moves every expectation with it instead of leaving a literal that used to be right. The only literals
+/// are the three QUOTED chunk-close readings, which derive from nothing here and are named as
+/// measurements.</para>
+/// </summary>
+public sealed class CompressionClearanceWatchTests
+{
+    /// <summary>
+    /// The three compression runtimes read in the <c>2026-09-08 00:00Z</c> hour on ONE store, from
+    /// <c>collect.store_metrics</c>' hourly <c>background_job</c> snapshot — a last-run reading, so no
+    /// maximum question is answered by them (#3119).
+    ///
+    /// <para>Quoted evidence, not a derived quantity: nothing in the product can know them, so they carry no
+    /// derivation and are used only as inputs. What is asserted about them is what the SHIPPED classifier
+    /// says when it is handed them at the minutes the shipped grid puts those hypertables on.</para>
+    /// </summary>
+    private static readonly (string Hypertable, double Seconds)[] ChunkCloseReadings =
+    {
+        ("query_store_stats", 552d),
+        ("query_stats", 360d),
+        ("query_snapshots", 198d),
+    };
+
+    private static int[] RefreshStartMinutes() =>
+        TimescaleSupport.HourlyRefreshPhaseOrder.Select(TimescaleSupport.RefreshPhaseMinutesFor).ToArray();
+
+    /// <summary>
+    /// The clearance is the distance forward round the hour to the NEAREST refresh start, and it is
+    /// established as a property rather than by re-running the same loop: no refresh start is closer than
+    /// the reported clearance, one refresh start is at EXACTLY it, and no refresh start falls strictly
+    /// inside the span it claims to be clear.
+    ///
+    /// <para>The third clause is what a re-implementation of the rule would not add. A function returning
+    /// the distance to the FURTHEST refresh start satisfies "some start is at exactly this distance" and
+    /// fails only here.</para>
+    /// </summary>
+    [Fact]
+    public void TheClearance_IsTheDistanceToTheNearestRefreshStart_AndNothingStartsInsideIt()
+    {
+        var cadence = TimescaleSupport.MinutesInHourlyCadence;
+        var starts = RefreshStartMinutes();
+
+        Assert.NotEmpty(starts);
+        Assert.NotEmpty(TimescaleSupport.CompressionPhaseMinutes);
+
+        foreach (var minute in TimescaleSupport.CompressionPhaseMinutes)
+        {
+            var clearance = TimescaleSupport.CompressionMinuteClearanceMinutes(minute);
+
+            Assert.True(
+                clearance > 0,
+                $"compression minute :{minute:00} reports {clearance} minutes of clearance, so a refresh "
+                + "starts on the same minute a compression policy does — CompressionPhaseMinutes and this "
+                + "function disagree about the grid");
+
+            var distances = starts.Select(start => (start - minute + cadence) % cadence).ToArray();
+
+            Assert.All(
+                distances,
+                distance => Assert.True(
+                    distance >= clearance,
+                    $"a refresh starts {distance} minutes after :{minute:00}, closer than the {clearance} "
+                    + "minutes of clearance reported for it"));
+
+            Assert.Contains(clearance, distances);
+
+            /* The span is CLEAR, not merely bounded: nothing starts strictly inside it. */
+            Assert.DoesNotContain(distances, distance => distance > 0 && distance < clearance);
+        }
+    }
+
+    /// <summary>
+    /// The band's clearance falls one minute per minute across it, from its widest first minute to exactly
+    /// one <see cref="TimescaleSupport.LightRefreshStepMinutes"/> step on its last — and that last minute is
+    /// OCCUPIED, which is what makes the one-step clearance a permanent feature of the grid rather than an
+    /// arrangement that happens to be tight.
+    /// </summary>
+    [Fact]
+    public void TheBand_NarrowsToOneLightRefreshStep_AndItsTightestMinuteCarriesAPolicy()
+    {
+        var minutes = TimescaleSupport.CompressionPhaseMinutes;
+        var widest = TimescaleSupport.CompressionMinuteClearanceSeconds(minutes[0]);
+        var narrowest = TimescaleSupport.CompressionMinuteClearanceSeconds(minutes[^1]);
+
+        Assert.Equal(TimescaleSupport.LightRefreshStepMinutes * 60, narrowest);
+        Assert.True(
+            widest > narrowest,
+            $"the band's first minute has {widest}s of clearance and its last has {narrowest}s — a band that "
+            + "does not narrow is not the contiguous tail band this watch is written over");
+
+        /* Strictly monotonic, which is the property that makes "the last minute is the tightest" true rather
+           than merely observed at today's widths. */
+        for (var index = 1; index < minutes.Count; index++)
+        {
+            Assert.True(
+                TimescaleSupport.CompressionMinuteClearanceSeconds(minutes[index])
+                    < TimescaleSupport.CompressionMinuteClearanceSeconds(minutes[index - 1]),
+                $"clearance did not fall from :{minutes[index - 1]:00} to :{minutes[index]:00}");
+        }
+
+        var onTheTightestMinute = TimescaleSupport.CompressionPhaseOrder
+            .Where(table => TimescaleSupport.TryCompressionPhaseMinutesFor(table, out var assigned)
+                && assigned == minutes[^1])
+            .ToArray();
+
+        Assert.NotEmpty(onTheTightestMinute);
+    }
+
+    /// <summary>
+    /// Both classifier boundaries are inclusive, and the middle band is non-empty at EVERY minute in the
+    /// band — a watch fraction of one would collapse it and leave the approaching case green while it had
+    /// stopped existing.
+    /// </summary>
+    [Fact]
+    public void TheClassifier_IsInclusiveAtBothWalls_AndTheApproachingBandIsNeverEmpty()
+    {
+        foreach (var minute in TimescaleSupport.CompressionPhaseMinutes)
+        {
+            var clearance = TimescaleSupport.CompressionMinuteClearanceSeconds(minute);
+            var watch = TimescaleSupport.CompressionClearanceWatchSeconds(minute);
+
+            Assert.True(
+                watch < clearance,
+                $"the watch line for :{minute:00} is {watch}s against {clearance}s of clearance, so the "
+                + "approaching band is empty and every reading is either routine or an overrun");
+            Assert.True(watch > 0, $"the watch line for :{minute:00} is {watch}s, so it cannot be reached");
+
+            Assert.Equal(
+                TimescaleSupport.CompressionClearanceBand.RefreshOverrun,
+                TimescaleSupport.ClassifyCompressionClearance(clearance, minute));
+            Assert.Equal(
+                TimescaleSupport.CompressionClearanceBand.ApproachingRefresh,
+                TimescaleSupport.ClassifyCompressionClearance(watch, minute));
+            Assert.Equal(
+                TimescaleSupport.CompressionClearanceBand.InsideClearance,
+                TimescaleSupport.ClassifyCompressionClearance(watch - 1, minute));
+        }
+    }
+
+    /// <summary>
+    /// An impossible reading costs the LINE and never the sweep that carries it — the same posture
+    /// <see cref="TimescaleSupport.ClassifyRefreshSlotHeadroom"/> takes — and the minute is modular, because
+    /// minute-of-hour arithmetic is.
+    /// </summary>
+    [Fact]
+    public void TheClassifier_TreatsImpossibleReadingsAsRoutine_AndTheMinuteIsModular()
+    {
+        var minute = TimescaleSupport.CompressionPhaseMinutes[^1];
+
+        Assert.Equal(
+            TimescaleSupport.CompressionClearanceBand.InsideClearance,
+            TimescaleSupport.ClassifyCompressionClearance(double.NaN, minute));
+        Assert.Equal(
+            TimescaleSupport.CompressionClearanceBand.InsideClearance,
+            TimescaleSupport.ClassifyCompressionClearance(-1d, minute));
+
+        var cadence = TimescaleSupport.MinutesInHourlyCadence;
+        Assert.Equal(
+            TimescaleSupport.CompressionMinuteClearanceSeconds(minute),
+            TimescaleSupport.CompressionMinuteClearanceSeconds(minute + cadence));
+        Assert.Equal(
+            TimescaleSupport.CompressionMinuteClearanceSeconds(minute),
+            TimescaleSupport.CompressionMinuteClearanceSeconds(minute - cadence));
+
+        /* A minute that IS a refresh start has ZERO clearance, so any positive run on it is already an
+           overrun. That is not a band-minute case — it is the drifted-policy case, where a job the converge
+           could not put on a fixed schedule discovers eligibility wherever its own runtime carried it. */
+        var refreshStart = TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.HourlyRefreshPhaseOrder[0]);
+        Assert.Equal(0, TimescaleSupport.CompressionMinuteClearanceSeconds(refreshStart));
+        Assert.Equal(
+            TimescaleSupport.CompressionClearanceBand.RefreshOverrun,
+            TimescaleSupport.ClassifyCompressionClearance(1d, refreshStart));
+    }
+
+    /// <summary>
+    /// The one lead-time fraction, applied to two different widths. Both watch lines are re-derived over
+    /// <see cref="TimescaleSupport.WindowWatchLeadNumerator"/> and the source carries no second copy of the
+    /// literal — the failure a shared fraction exists to prevent is the two lines drifting apart, which two
+    /// independent literals produce silently.
+    /// </summary>
+    [Fact]
+    public void TheWatchFraction_IsSharedByBothWatches_AndTheSourceCarriesNoSecondLiteral()
+    {
+        var numerator = TimescaleSupport.WindowWatchLeadNumerator;
+        var denominator = TimescaleSupport.WindowWatchLeadDenominator;
+
+        Assert.True(
+            numerator > 0 && numerator < denominator,
+            $"the watch fraction is {numerator}/{denominator}, which is not a lead time inside a window");
+
+        Assert.Equal(
+            TimescaleSupport.RefreshPhaseSlotSeconds * numerator / denominator,
+            TimescaleSupport.RefreshSlotWarningSeconds);
+
+        foreach (var minute in TimescaleSupport.CompressionPhaseMinutes)
+        {
+            Assert.Equal(
+                TimescaleSupport.CompressionMinuteClearanceSeconds(minute) * numerator / denominator,
+                TimescaleSupport.CompressionClearanceWatchSeconds(minute));
+        }
+
+        /* THE WALKER, not a regex over the raw file (#2913/#2925). Both remaining copies of this fraction
+           in TimescaleSupport.cs are DOC PROSE — one quotes the arithmetic that produced 1,077 s, the other
+           states the rule this test enforces — and a scan of the raw text counts them as second
+           implementations. A hand-rolled masker is how three separate attempts at this shape got three
+           different wrong answers, so the shared one is used. */
+        var code = CSharpSourceWalker.StripCommentsAndStrings(ReadTimescaleSupportSource());
+
+        /* The stripper kept CODE, which is what stops this being a guard over an empty string: a
+           StripCommentsAndStrings that returned nothing would make the search below vacuously clean. */
+        Assert.Contains("RefreshSlotWarningSeconds", code, StringComparison.Ordinal);
+        Assert.Contains("WindowWatchLeadNumerator", code, StringComparison.Ordinal);
+
+        /* Whitespace-collapsed, so the search catches '* 5 / 6' and '*5/6' alike — a spacing variant is the
+           obvious way past a literal search and it is the same defect. */
+        var dense = new string(code.Where(character => !char.IsWhiteSpace(character)).ToArray());
+        var literal = string.Create(CultureInfo.InvariantCulture, $"*{numerator}/{denominator}");
+        var occurrences = CountOccurrences(dense, literal);
+
+        Assert.True(
+            occurrences == 0,
+            $"TimescaleSupport.cs's CODE carries {occurrences} copies of the raw '{literal}' fraction. Both "
+            + "watch lines are derived over WindowWatchLeadNumerator/Denominator precisely so there is one "
+            + "lead-time choice; a literal restores two, and two drift.");
+    }
+
+    /// <summary>
+    /// The measured chunk-close readings against the grid this file ships: each is inside the clearance of
+    /// the minute its hypertable holds, and by how much is derived rather than stated.
+    ///
+    /// <para><b>Non-vacuous by assertion.</b> A grid that put every policy an hour from the next refresh
+    /// would make "inside the clearance" true of any reading at all, so the case requires each reading to be
+    /// a real fraction of its clearance before the verdict means anything.</para>
+    /// </summary>
+    [Fact]
+    public void TheMeasuredChunkCloseReadings_AreInsideTheClearanceTheShippedGridGivesThem()
+    {
+        foreach (var (hypertable, seconds) in ChunkCloseReadings)
+        {
+            Assert.True(
+                TimescaleSupport.TryCompressionPhaseMinutesFor(hypertable, out var minute),
+                $"{hypertable} is not on the compression phase grid, so this reading cannot be placed — it "
+                + "left the collector catalog, and the paragraph quoting it has to move with it");
+
+            var clearance = TimescaleSupport.CompressionMinuteClearanceSeconds(minute);
+            var share = 100.0 * seconds / clearance;
+
+            Assert.InRange(share, 1d, 99d);
+
+            Assert.Equal(
+                TimescaleSupport.CompressionClearanceBand.InsideClearance,
+                TimescaleSupport.ClassifyCompressionClearance(seconds, minute));
+        }
+    }
+
+    /// <summary>
+    /// The clearance is measured from where the run ACTUALLY started, not from where the grid puts the
+    /// policy — the two differ on exactly the store state the converge documents as its degraded path, and
+    /// on that store the assigned minute is a fiction.
+    /// </summary>
+    [Fact]
+    public void TheClearance_IsMeasuredFromTheObservedStart_NotFromTheAssignedMinute()
+    {
+        var hypertable = ChunkCloseReadings[0].Hypertable;
+        Assert.True(TimescaleSupport.TryCompressionPhaseMinutesFor(hypertable, out var assigned));
+
+        var tightest = TimescaleSupport.CompressionPhaseMinutes[^1];
+        Assert.NotEqual(assigned, tightest);
+
+        var drifted = Reading(hypertable, startMinute: tightest, seconds: ChunkCloseReadings[0].Seconds);
+
+        Assert.Equal(assigned, drifted.AssignedPhaseMinute);
+        Assert.Equal(tightest, drifted.ObservedStartMinute);
+        Assert.Equal(tightest, drifted.ClearanceMinute);
+        Assert.Equal(TimescaleSupport.CompressionMinuteClearanceSeconds(tightest), drifted.ClearanceSeconds);
+        Assert.True(drifted.OffAssignedPhase);
+
+        /* The verdict follows the observed minute too, and it INVERTS against the assigned one — which is
+           what says the choice of minute is load-bearing rather than cosmetic. */
+        Assert.Equal(TimescaleSupport.CompressionClearanceBand.RefreshOverrun, drifted.ClearanceBand);
+        Assert.Equal(
+            TimescaleSupport.CompressionClearanceBand.InsideClearance,
+            TimescaleSupport.ClassifyCompressionClearance(ChunkCloseReadings[0].Seconds, assigned));
+
+        var onPhase = Reading(hypertable, startMinute: assigned, seconds: ChunkCloseReadings[0].Seconds);
+        Assert.False(onPhase.OffAssignedPhase);
+        Assert.Equal(assigned, onPhase.ClearanceMinute);
+        Assert.Equal(TimescaleSupport.CompressionClearanceBand.InsideClearance, onPhase.ClearanceBand);
+    }
+
+    /// <summary>
+    /// A reading this product has no standing to judge produces NO verdict — never a synthesized
+    /// <see cref="TimescaleSupport.CompressionClearanceBand.InsideClearance"/>, which reads as "measured and
+    /// fine" for something not measured at all. Three ways to have no standing: a foreign hypertable, no
+    /// completed run, and the never-ran sentinel start.
+    /// </summary>
+    [Fact]
+    public void AReadingWithoutStanding_ProducesNoVerdictRatherThanAPassingOne()
+    {
+        var foreign = Reading("a_table_this_product_does_not_own", startMinute: 59, seconds: 5_000d);
+        Assert.Null(foreign.AssignedPhaseMinute);
+        Assert.Null(foreign.ClearanceMinute);
+        Assert.Null(foreign.ClearanceSeconds);
+        Assert.Null(foreign.ClearanceBand);
+        Assert.Null(foreign.ClearOfRefreshSeconds);
+        Assert.False(foreign.OffAssignedPhase);
+
+        var hypertable = ChunkCloseReadings[0].Hypertable;
+        Assert.True(TimescaleSupport.TryCompressionPhaseMinutesFor(hypertable, out var assigned));
+
+        var noRun = new CompressionActivity(hypertable, "Scheduled", null, null, 0L);
+        Assert.Null(noRun.ObservedStartMinute);
+        Assert.Equal(assigned, noRun.ClearanceMinute);
+        Assert.Null(noRun.ClearanceBand);
+        Assert.False(noRun.OffAssignedPhase);
+
+        /* #1760's sentinel: TimescaleDB's never-ran marker maps to DateTime.MinValue, whose MINUTE is 0 —
+           a perfectly plausible minute, which is exactly why it has to be rejected by identity rather than
+           by range. Minute 0 is a refresh start, so a sentinel read as a start would report zero clearance
+           and call every first run an overrun. */
+        var sentinel = new CompressionActivity(
+            hypertable, "Running", DateTime.MinValue, TimeSpan.FromSeconds(1d), 0L);
+        Assert.Null(sentinel.ObservedStartMinute);
+        Assert.Equal(assigned, sentinel.ClearanceMinute);
+        Assert.Equal(
+            TimescaleSupport.CompressionClearanceBand.InsideClearance, sentinel.ClearanceBand);
+    }
+
+    /// <summary>
+    /// Clearance left over goes NEGATIVE past the wall rather than clamping, and the percentage is over the
+    /// clearance rather than over the hour — clamping would report every overrun as a dead heat, and the
+    /// hour is the denominator #2136 already uses and the one that misses this by a factor.
+    /// </summary>
+    [Fact]
+    public void TheOverrunIsReportedAsNegativeClearance_AndTheShareIsOverTheClearance()
+    {
+        var hypertable = ChunkCloseReadings[0].Hypertable;
+        var tightest = TimescaleSupport.CompressionPhaseMinutes[^1];
+        var clearance = TimescaleSupport.CompressionMinuteClearanceSeconds(tightest);
+        var overrunBy = clearance / TimescaleSupport.WindowWatchLeadDenominator;
+
+        Assert.True(
+            overrunBy > 0,
+            "the derived overrun is zero, so this case is vacuous — the tightest clearance has collapsed "
+            + "below the watch fraction's own denominator");
+
+        var through = Reading(hypertable, startMinute: tightest, seconds: clearance + overrunBy);
+
+        Assert.Equal(TimescaleSupport.CompressionClearanceBand.RefreshOverrun, through.ClearanceBand);
+        Assert.Equal(-overrunBy, through.ClearOfRefreshSeconds);
+        Assert.True(
+            through.ClearOfRefreshSeconds < 0,
+            "clearance past the wall is not negative, so the overrun clamps instead of reporting how far "
+            + "through the next refresh's start the run went");
+
+        Assert.Equal(
+            100.0 * (clearance + overrunBy) / clearance,
+            through.PercentOfClearance!.Value,
+            3);
+        Assert.True(
+            through.PercentOfClearance > 100d,
+            "an overrun reports at or under 100% of its clearance, so the share is being taken over "
+            + "something wider than the wall");
+    }
+
+    /// <summary>
+    /// The line is leveled by band, and the routine band costs ONE line for the whole store rather than one
+    /// per policy — the discipline #1778's own summary states, which seventy hourly Debug lines would
+    /// break.
+    /// </summary>
+    [Fact]
+    public void TheClearanceLine_IsLeveledByBand_AndTheRoutineBandIsOneLineForTheWholeStore()
+    {
+        var routine = new CapturingTestLogger();
+        var everyPolicy = TimescaleSupport.CompressionPhaseOrder
+            .Select(table =>
+            {
+                TimescaleSupport.TryCompressionPhaseMinutesFor(table, out var minute);
+                return Reading(table, minute, seconds: 0.5d);
+            })
+            .ToArray();
+
+        Assert.True(everyPolicy.Length > 1, "the catalog has one hypertable, so 'one line not N' is vacuous");
+        TimescaleSupport.LogCompressionActivity(everyPolicy, DateTime.UtcNow, routine);
+
+        var clearanceLines = routine.Joined
+            .Split(" | ", StringSplitOptions.None)
+            .Where(line => line.Contains("clearance", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Single(clearanceLines);
+        Assert.StartsWith("Debug:", clearanceLines[0], StringComparison.Ordinal);
+
+        var hypertable = ChunkCloseReadings[0].Hypertable;
+        var tightest = TimescaleSupport.CompressionPhaseMinutes[^1];
+        var clearance = TimescaleSupport.CompressionMinuteClearanceSeconds(tightest);
+
+        var overrun = new CapturingTestLogger();
+        TimescaleSupport.LogCompressionActivity(
+            new[] { Reading(hypertable, tightest, clearance) }, DateTime.UtcNow, overrun);
+        Assert.Contains("Warning:", overrun.Joined, StringComparison.Ordinal);
+        Assert.Contains(hypertable, overrun.Joined, StringComparison.Ordinal);
+        Assert.Contains("AccessExclusiveLock", overrun.Joined, StringComparison.Ordinal);
+        Assert.Contains("#3112", overrun.Joined, StringComparison.Ordinal);
+
+        var approaching = new CapturingTestLogger();
+        TimescaleSupport.LogCompressionActivity(
+            new[] { Reading(hypertable, tightest, TimescaleSupport.CompressionClearanceWatchSeconds(tightest)) },
+            DateTime.UtcNow,
+            approaching);
+        Assert.Contains("Information:", approaching.Joined, StringComparison.Ordinal);
+        Assert.DoesNotContain("Warning:", approaching.Joined, StringComparison.Ordinal);
+
+        /* A store of nothing but FOREIGN hypertables says nothing about clearance at all — not a routine
+           all-clear over tables whose minutes this code did not choose. */
+        var foreignOnly = new CapturingTestLogger();
+        TimescaleSupport.LogCompressionActivity(
+            new[] { Reading("a_table_this_product_does_not_own", 59, 5_000d) }, DateTime.UtcNow, foreignOnly);
+        Assert.DoesNotContain("clearance", foreignOnly.Joined, StringComparison.Ordinal);
+
+        /* The drift line names BOTH minutes, because "off its slot" without the two numbers cannot be acted
+           on. */
+        TimescaleSupport.TryCompressionPhaseMinutesFor(hypertable, out var assigned);
+        var drifted = new CapturingTestLogger();
+        TimescaleSupport.LogCompressionActivity(
+            new[] { Reading(hypertable, tightest, 0.5d) }, DateTime.UtcNow, drifted);
+        Assert.Contains(
+            string.Create(CultureInfo.InvariantCulture, $":{tightest:00}"), drifted.Joined, StringComparison.Ordinal);
+        Assert.Contains(
+            string.Create(CultureInfo.InvariantCulture, $":{assigned:00}"), drifted.Joined, StringComparison.Ordinal);
+    }
+
+    private static CompressionActivity Reading(string hypertable, int startMinute, double seconds) =>
+        new(
+            hypertable,
+            "Scheduled",
+            new DateTime(2026, 9, 8, 0, startMinute, 0, DateTimeKind.Utc),
+            TimeSpan.FromSeconds(seconds),
+            0L);
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var at = haystack.IndexOf(needle, StringComparison.Ordinal);
+
+        while (at >= 0)
+        {
+            count++;
+            at = haystack.IndexOf(needle, at + needle.Length, StringComparison.Ordinal);
+        }
+
+        return count;
+    }
+
+    private static string ReadTimescaleSupportSource([CallerFilePath] string thisFile = "")
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(thisFile)!, "..", "PerformanceMonitor.Darling.Storage", "TimescaleSupport.cs"));
+
+        Assert.True(File.Exists(path),
+            $"TimescaleSupport.cs was not found at '{path}'. This guard scans the REAL file (resolved from "
+            + "[CallerFilePath], so there is no copy to go stale); restore the path rather than pointing it "
+            + "at a fixture.");
+        return File.ReadAllText(path);
+    }
+
+    /* ─────────────── the prose pins over the members this file's watch is stated on ─────────────── */
+
+    /// <summary>
+    /// Marks a verification failure caused by a PATTERN no longer matching, so
+    /// <see cref="EveryClearancePin_ReportsAnInjectedDrift"/> can tell "the pin caught the drift" from "the
+    /// pin went blind" — which are otherwise the same exception, and the second of which would let the sweep
+    /// report success for a guard that had stopped seeing anything. Borrowed shape from
+    /// <c>RefreshCeilingProvenancePinTests</c>, which is where this discipline is argued at length.
+    /// </summary>
+    private const string ParseMiss = "CLEARANCE PIN PARSE MISS";
+
+    private const string ClearanceDeclaration =
+        "public static int CompressionMinuteClearanceMinutes(int minute)";
+
+    private const string WatchFractionDeclaration =
+        "public const int WindowWatchLeadNumerator";
+
+    private const string CompressionMinutesDeclaration =
+        "public static readonly IReadOnlyList<int> CompressionPhaseMinutes";
+
+    private static string DeclarationFor(string pin) => pin switch
+    {
+        "the cadence knob's line against the tightest clearance" => ClearanceDeclaration,
+        "the quoted reading as a share of cadence" => ClearanceDeclaration,
+        "the band's clearance range" => ClearanceDeclaration,
+        "the largest hypertable's placement" => ClearanceDeclaration,
+        "the tightest large placement" => ClearanceDeclaration,
+        "the previous grid's clearances against the quoted readings" => ClearanceDeclaration,
+        "the shipped grid's shares" => ClearanceDeclaration,
+        "the watch fraction as a percent" => WatchFractionDeclaration,
+        "the lead the tightest clearance buys" => WatchFractionDeclaration,
+        "the spread #3174 held constant" => CompressionMinutesDeclaration,
+        "the shipped grid's clearances for the measured three" => CompressionMinutesDeclaration,
+        _ => throw new ArgumentOutOfRangeException(nameof(pin), pin, "no declaration registered for this pin"),
+    };
+
+    /// <summary>
+    /// Every numeral the doc runs above those three members state, paired with the pattern that reads it out
+    /// of the SHIPPED file. Each is arithmetic over the grid's own constants or over a quoted reading the same
+    /// sentence names, so none of them is a value a reader has to trust.
+    ///
+    /// <para>Patterns are written against <see cref="DocProseFor"/>'s NORMALISED output, so they carry a
+    /// plain hyphen and no <c>&lt;b&gt;</c> tags — bolding a figure or switching an em dash for a hyphen must
+    /// not be able to break a pin for a reason that has nothing to do with what it guards.</para>
+    ///
+    /// <para>Every group is <c>[0-9]+</c> rather than <c>[0-9]</c>, for the reason the sibling file states:
+    /// <see cref="EveryClearancePin_ReportsAnInjectedDrift"/> bumps a captured number width-preservingly, so
+    /// a group holding a 9 comes back two digits wide and a one-digit group would then stop matching — which
+    /// the sweep would report as a broken pattern rather than as a caught drift.</para>
+    /// </summary>
+    private static IEnumerable<(string Name, string Pattern, bool DriftSwept)> Pins()
+    {
+        yield return (
+            "the cadence knob's line against the tightest clearance",
+            @"puts the line at ([0-9]+) s of a ([0-9,]+) s hour, while the wall a compression run actually faces is its own minute's clearance, as little as ([0-9]+) s\. That is FIFTEEN times too high",
+            true);
+
+        yield return (
+            "the quoted reading as a share of cadence",
+            @"the ([0-9]+) s chunk-close run measured below reads ([0-9]+)\.([0-9]+)% of cadence",
+            true);
+
+        yield return (
+            "the band's clearance range",
+            @"([0-9,]+) s on its first minute down to ([0-9]+) s on its last",
+            true);
+
+        yield return (
+            "the largest hypertable's placement",
+            @"sits at :([0-9]+) with ([0-9,]+) s, and <c>procedure_stats</c>",
+            true);
+
+        yield return (
+            "the tightest large placement",
+            @"<c>procedure_stats</c> sits at :([0-9]+) with ([0-9,]+) s",
+            true);
+
+        /* NOT drift-swept, and the reason is the one the sibling file states for its own quoted series: these
+           three are MEASUREMENTS. Nothing in the code can know them, so bumping a digit only produces another
+           number the code cannot contradict - a +1 changes neither the "ran past its clearance" verdict nor
+           the rounded percentage below. What IS checked is what the paragraph actually claims about them:
+           that each exceeds the clearance the same sentence states, and that each divides into the share the
+           shipped grid gives it. Material drift is caught by the second of those; a single digit is not, and
+           saying so is better than a flag that implies otherwise. */
+        yield return (
+            "the previous grid's clearances against the quoted readings",
+            @"read at ([0-9]+) s \(<c>query_stats</c>\), ([0-9]+) s \(<c>query_snapshots</c>\) and ([0-9]+) s \(<c>query_store_stats</c>\)",
+            false);
+
+        yield return (
+            "the shipped grid's shares",
+            @"the same three hold <c>:([0-9]+)</c>, <c>:([0-9]+)</c> and <c>:([0-9]+)</c>, where those readings are ([0-9]+)%, ([0-9]+)% and ([0-9]+)% of their clearance",
+            true);
+
+        yield return (
+            "the watch fraction as a percent",
+            @"a watch line sits at ([0-9]+)\.([0-9]+)% of whatever",
+            true);
+
+        yield return (
+            "the lead the tightest clearance buys",
+            @"so a sixth of it is ([0-9]+) s of lead",
+            true);
+
+        yield return (
+            "the spread #3174 held constant",
+            @"held the spread constant - ([0-9]+) minutes at ([0-9]+) per minute",
+            true);
+
+        yield return (
+            "the shipped grid's clearances for the measured three",
+            @"the same three hold minutes with ([0-9,]+) s, ([0-9,]+) s and ([0-9,]+) s",
+            true);
+    }
+
+    /// <summary>
+    /// The doc runs state what the code computes. Fail-fast, and it must CONSUME every pin in
+    /// <see cref="Pins"/> — a pattern defined and never asserted against anything looks exactly like a
+    /// pattern doing work.
+    /// </summary>
+    [Fact]
+    public void TheClearanceProse_StatesWhatTheGridComputes()
+    {
+        Verify(ReadTimescaleSupportSource());
+    }
+
+    private static void Verify(string source)
+    {
+        var consumed = new HashSet<string>(StringComparer.Ordinal);
+
+        int[] Read(string name)
+        {
+            consumed.Add(name);
+            return Numbers(DocProseFor(source, DeclarationFor(name)), name);
+        }
+
+        var minutes = TimescaleSupport.CompressionPhaseMinutes;
+        var widest = TimescaleSupport.CompressionMinuteClearanceSeconds(minutes[0]);
+        var narrowest = TimescaleSupport.CompressionMinuteClearanceSeconds(minutes[^1]);
+        var cadenceSeconds = (int)TimescaleSupport.CompressScheduleSpan.TotalSeconds;
+        var knobLine = TimescaleSupport.RefreshSlotPercentOfHourlyCadence * cadenceSeconds / 100;
+
+        var knob = Read("the cadence knob's line against the tightest clearance");
+        Require(knob[0] == knobLine, $"stated knob line {knob[0]} s against {knobLine} s derived");
+        Require(knob[1] == cadenceSeconds, $"stated cadence {knob[1]} s against {cadenceSeconds} s");
+        Require(knob[2] == narrowest, $"stated tightest clearance {knob[2]} s against {narrowest} s");
+        Require(knobLine == 15 * narrowest,
+            $"the knob line is {knobLine} s against {narrowest} s of clearance, which is not the FIFTEEN "
+            + "times the prose states — restate the factor rather than removing this check");
+
+        var share = Read("the quoted reading as a share of cadence");
+        var tenths = (int)Math.Round(1000.0 * share[0] / cadenceSeconds, MidpointRounding.AwayFromZero);
+        Require(share[1] * 10 + share[2] == tenths,
+            $"stated {share[1]}.{share[2]}% against {tenths / 10}.{tenths % 10}% derived from {share[0]} s "
+            + $"over {cadenceSeconds} s");
+
+        var range = Read("the band's clearance range");
+        Require(range[0] == widest, $"stated widest {range[0]} s against {widest} s");
+        Require(range[1] == narrowest, $"stated narrowest {range[1]} s against {narrowest} s");
+
+        RequirePlacement(Read("the largest hypertable's placement"), "query_store_stats");
+        RequirePlacement(Read("the tightest large placement"), "procedure_stats");
+
+        /* The three QUOTED readings. They derive from nothing here, so what is checked is the relationship
+           the same sentence asserts about them: each ran past the clearance the sentence also states. That is
+           the pin available for evidence, and it is not weaker than it looks - the whole paragraph's claim is
+           the comparison, so a digit moved in either list breaks it. */
+        var readings = Read("the previous grid's clearances against the quoted readings");
+        var previousClearances = new[] { 240, 180, 120 };
+        for (var index = 0; index < readings.Length; index++)
+        {
+            Require(readings[index] > previousClearances[index],
+                $"the stated reading {readings[index]} s no longer exceeds the {previousClearances[index]} s "
+                + "of clearance the same sentence states, so the paragraph's claim that every one of them ran "
+                + "past the refresh that followed it does not follow from its own figures");
+        }
+
+        var shipped = Read("the shipped grid's shares");
+        var order = new[] { "query_stats", "query_snapshots", "query_store_stats" };
+        for (var index = 0; index < order.Length; index++)
+        {
+            Require(TimescaleSupport.TryCompressionPhaseMinutesFor(order[index], out var minute),
+                $"{order[index]} is not on the compression grid, so the prose cannot place it");
+            Require(shipped[index] == minute,
+                $"stated minute :{shipped[index]:00} for {order[index]} against :{minute:00} derived");
+
+            var clearance = TimescaleSupport.CompressionMinuteClearanceSeconds(minute);
+            var percent = (int)Math.Round(100.0 * readings[index] / clearance, MidpointRounding.AwayFromZero);
+            Require(shipped[order.Length + index] == percent,
+                $"stated {shipped[order.Length + index]}% for {order[index]} against {percent}% derived from "
+                + $"{readings[index]} s over {clearance} s");
+        }
+
+        var fraction = Read("the watch fraction as a percent");
+        var fractionTenths = (int)Math.Round(
+            1000.0 * TimescaleSupport.WindowWatchLeadNumerator / TimescaleSupport.WindowWatchLeadDenominator,
+            MidpointRounding.ToZero);
+        Require(fraction[0] * 10 + fraction[1] == fractionTenths,
+            $"stated {fraction[0]}.{fraction[1]}% against {fractionTenths / 10}.{fractionTenths % 10}% derived");
+
+        var lead = Read("the lead the tightest clearance buys");
+        var derivedLead = narrowest - TimescaleSupport.CompressionClearanceWatchSeconds(minutes[^1]);
+        Require(lead[0] == derivedLead, $"stated lead {lead[0]} s against {derivedLead} s derived");
+
+        var spread = Read("the spread #3174 held constant");
+        Require(spread[0] == TimescaleSupport.CompressionPhaseBandMinutes,
+            $"stated band width {spread[0]} against {TimescaleSupport.CompressionPhaseBandMinutes}");
+        Require(spread[1] == TimescaleSupport.CompressionPhaseMaxPerMinute,
+            $"stated per-minute spread {spread[1]} against {TimescaleSupport.CompressionPhaseMaxPerMinute}");
+
+        var clearances = Read("the shipped grid's clearances for the measured three");
+        for (var index = 0; index < order.Length; index++)
+        {
+            TimescaleSupport.TryCompressionPhaseMinutesFor(order[index], out var minute);
+            var clearance = TimescaleSupport.CompressionMinuteClearanceSeconds(minute);
+            Require(clearances[index] == clearance,
+                $"stated clearance {clearances[index]} s for {order[index]} against {clearance} s derived");
+        }
+
+        var defined = Pins().Select(pin => pin.Name).ToArray();
+        Require(consumed.Count == defined.Length,
+            $"{consumed.Count} of {defined.Length} pins were asserted against something. A pattern defined "
+            + $"and never read looks exactly like a pattern doing work: {string.Join(", ", defined.Except(consumed))}");
+    }
+
+    private static void RequirePlacement(int[] captured, string hypertable)
+    {
+        Require(TimescaleSupport.TryCompressionPhaseMinutesFor(hypertable, out var minute),
+            $"{hypertable} is not on the compression phase grid, so the prose cannot place it");
+        Require(captured[0] == minute,
+            $"stated minute :{captured[0]:00} for {hypertable} against :{minute:00} derived");
+
+        var clearance = TimescaleSupport.CompressionMinuteClearanceSeconds(minute);
+        Require(captured[1] == clearance,
+            $"stated clearance {captured[1]} s for {hypertable} against {clearance} s derived");
+    }
+
+    /// <summary>
+    /// Every numeric pin catches an injected drift, and does so by CATCHING it rather than by going blind:
+    /// each captured number is bumped one at a time in a mutated copy, the pattern is separately required to
+    /// still match, and the identical verification is required to fail.
+    /// </summary>
+    [Fact]
+    public void EveryClearancePin_ReportsAnInjectedDrift()
+    {
+        var source = ReadTimescaleSupportSource();
+        var blind = new List<string>();
+
+        foreach (var (name, pattern, _) in Pins().Where(pin => pin.DriftSwept))
+        {
+            var prose = DocProseFor(source, DeclarationFor(name));
+            var match = Regex.Match(prose, pattern);
+            Assert.True(match.Success, $"{name}: the pattern does not match the shipped prose at all");
+
+            for (var group = 1; group < match.Groups.Count; group++)
+            {
+                var captured = match.Groups[group].Value;
+                if (!captured.All(character => char.IsDigit(character) || character == ','))
+                {
+                    continue;
+                }
+
+                var bumped = Bump(captured);
+                var mutated = ReplaceCapture(source, DeclarationFor(name), pattern, group, bumped);
+
+                Assert.NotEqual(source, mutated);
+
+                /* The pattern must still see the sentence: a mutation that merely broke the regex would
+                   throw the same exception the caught drift throws, and would pass as one. */
+                var mutatedProse = DocProseFor(mutated, DeclarationFor(name));
+                Assert.True(
+                    Regex.IsMatch(mutatedProse, pattern),
+                    $"{name} group {group}: bumping '{captured}' to '{bumped}' stopped the pattern matching, "
+                    + "so this iteration proves nothing about the pin");
+
+                Exception? failure = null;
+                try
+                {
+                    Verify(mutated);
+                }
+                catch (Exception thrown)
+                {
+                    failure = thrown;
+                }
+
+                if (failure is null)
+                {
+                    blind.Add($"{name} group {group} ('{captured}' -> '{bumped}')");
+                    continue;
+                }
+
+                Assert.DoesNotContain(ParseMiss, failure.Message, StringComparison.Ordinal);
+            }
+        }
+
+        /* EVERY blind group at once rather than the first: a sweep that stops at one leaves the rest
+           unexamined, and the question this test answers is which numerals are load-bearing - a list, not a
+           first offender. */
+        Assert.True(
+            blind.Count == 0,
+            "these captured numerals can be bumped without any verification noticing, so the prose could "
+            + "drift there silently. Either derive them or mark the pin DriftSwept: false with the reason: "
+            + string.Join("; ", blind));
+    }
+
+    /// <summary>Width-preserving where it can be, so a bumped number cannot break a pattern by changing how
+    /// many digits it has: the last digit rolls, and a 9 becomes an 8.</summary>
+    private static string Bump(string captured)
+    {
+        var characters = captured.ToCharArray();
+
+        for (var index = characters.Length - 1; index >= 0; index--)
+        {
+            if (!char.IsDigit(characters[index]))
+            {
+                continue;
+            }
+
+            characters[index] = characters[index] == '9' ? '8' : (char)(characters[index] + 1);
+            return new string(characters);
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(captured), captured, "no digit to bump");
+    }
+
+    /// <summary>
+    /// Splices <paramref name="bumped"/> over the SOURCE characters the captured group came from, located
+    /// through <see cref="DocProseWithMap"/>'s character map rather than by searching for the captured text.
+    ///
+    /// <para><b>Why a map and not a search, stated because the search version SHIPPED here first and was
+    /// wrong.</b> A group holding a single digit — the tenths of a percentage, the per-minute spread — matches
+    /// the first occurrence of that digit anywhere in the doc run, which for these paragraphs is inside
+    /// <c>#3112</c> or <c>3,600</c>. The bump then lands on text no verification reads, the mutated file
+    /// verifies clean, and <see cref="EveryClearancePin_ReportsAnInjectedDrift"/> reports the pin as
+    /// drift-blind when it is the SWEEP that is blind. That is the failure this whole file exists to catch,
+    /// one layer up: a mutation harness that cannot mutate reports every pin as unfalsifiable and reads as a
+    /// finding about the pins.</para>
+    ///
+    /// <para>Contiguity is asserted rather than assumed: a numeral wrapped across two <c>///</c> lines has no
+    /// single source span, and a silent partial splice would be the same defect again. The remedy is to rewrap
+    /// the prose so the numeral is whole on one line.</para>
+    /// </summary>
+    private static string ReplaceCapture(string source, string declaration, string pattern, int group, string bumped)
+    {
+        var (prose, map) = DocProseWithMap(source, declaration);
+        var match = Regex.Match(prose, pattern);
+        Assert.True(match.Success, "the pattern stopped matching before the mutation was applied");
+
+        var captured = match.Groups[group];
+        var from = map[captured.Index];
+        var to = map[captured.Index + captured.Length - 1];
+
+        Assert.True(from >= 0 && to >= from, $"'{captured.Value}' has no source span in '{declaration}'");
+        Assert.Equal(captured.Value, source[from..(to + 1)]);
+
+        return source[..from] + bumped + source[(to + 1)..];
+    }
+
+    private static int[] Numbers(string prose, string name)
+    {
+        var pattern = Pins().First(pin => string.Equals(pin.Name, name, StringComparison.Ordinal)).Pattern;
+        var match = Regex.Match(prose, pattern);
+
+        Require(match.Success, $"{ParseMiss}: '{name}' did not match its own pattern");
+
+        return match.Groups.Cast<Group>().Skip(1)
+            .Where(group => group.Success)
+            .Select(group => int.Parse(group.Value.Replace(",", "", StringComparison.Ordinal), CultureInfo.InvariantCulture))
+            .ToArray();
+    }
+
+    private static string DocProseFor(string source, string declaration) =>
+        DocProseWithMap(source, declaration).Prose;
+
+    /// <summary>
+    /// The doc comment run immediately above <paramref name="declaration"/>, normalised, together with a
+    /// per-character map back into <paramref name="source"/> (<c>-1</c> for the spaces that join two
+    /// <c>///</c> lines, which come from no source character).
+    ///
+    /// <para><b>&lt;b&gt; emphasis and dash style are normalised before any pattern sees them</b>, so bolding
+    /// a figure or switching an em dash for a hyphen cannot break a pin for a reason that has nothing to do
+    /// with what it guards. Neither normalisation introduces a DIGIT, which is what makes the map exact
+    /// everywhere a pin actually reads.</para>
+    /// </summary>
+    private static (string Prose, int[] Map) DocProseWithMap(string source, string declaration)
+    {
+        var declarationIndex = source.IndexOf(declaration, StringComparison.Ordinal);
+        Require(declarationIndex > 0,
+            $"{ParseMiss}: could not find '{declaration}' in TimescaleSupport.cs, so no doc run could be read");
+
+        /* Walk UP from the declaration collecting whole '///' lines, keeping each line's source offset so a
+           character's origin survives the join. */
+        var runs = new List<(int Offset, string Text)>();
+        var cursor = source.LastIndexOf('\n', declarationIndex - 1);
+
+        while (cursor > 0)
+        {
+            var lineStart = source.LastIndexOf('\n', cursor - 1) + 1;
+            var line = source[lineStart..cursor].TrimEnd('\r');
+            var trimmed = line.TrimStart(' ', '\t');
+
+            if (!trimmed.StartsWith("///", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            var bodyOffset = lineStart + (line.Length - trimmed.Length) + 3;
+            var body = source[bodyOffset..cursor].TrimEnd('\r');
+            var leading = body.Length - body.TrimStart(' ').Length;
+
+            runs.Insert(0, (bodyOffset + leading, body.Trim()));
+            cursor = lineStart - 1;
+        }
+
+        Require(runs.Count > 0, $"{ParseMiss}: '{declaration}' carries no doc comment run");
+
+        var builder = new System.Text.StringBuilder();
+        var map = new List<int>();
+
+        for (var index = 0; index < runs.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(' ');
+                map.Add(-1);
+            }
+
+            var (offset, text) = runs[index];
+
+            for (var at = 0; at < text.Length; at++)
+            {
+                if (text.AsSpan(at).StartsWith("<b>", StringComparison.Ordinal))
+                {
+                    at += 2;
+                    continue;
+                }
+
+                if (text.AsSpan(at).StartsWith("</b>", StringComparison.Ordinal))
+                {
+                    at += 3;
+                    continue;
+                }
+
+                var character = text[at];
+                builder.Append(character == '\u2014' || character == '\u2013' ? '-' : character);
+                map.Add(offset + at);
+            }
+        }
+
+        var prose = builder.ToString();
+        Require(prose.StartsWith("<summary>", StringComparison.Ordinal),
+            $"{ParseMiss}: the doc run above '{declaration}' does not begin at its <summary>");
+
+        return (prose, map.ToArray());
+    }
+
+    private static void Require(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+}

--- a/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
+++ b/Darling/Darling.Tests/CompressionClearanceWatchTests.cs
@@ -465,21 +465,29 @@ public sealed class CompressionClearanceWatchTests
     }
 
     /// <summary>
-    /// The enum's declaration ORDER is its severity order, which <c>IsTighter</c> relies on to rank a band
-    /// against a band. Pinned rather than left as a property of how the members happen to be written: a
-    /// reordering would silently invert the summary's choice of which policy to name.
+    /// The property the per-tick summary's single ranking key rests on: both classifier boundaries fall at
+    /// the same SHARE of clearance on every minute in the band, so ranking by share is ranking by band.
+    ///
+    /// <para><b>Integer division is the thing that would break it</b>, which is why this is asserted as
+    /// exactness rather than as an inequality: <see cref="TimescaleSupport.CompressionClearanceWatchSeconds"/>
+    /// truncates, so a clearance that was not a multiple of the watch fraction's denominator would round the
+    /// line down and put that one minute's boundary at a different share from every other minute's. The
+    /// consequence would be silent — a summary naming a reading whose band is milder than one it passed
+    /// over.</para>
     /// </summary>
     [Fact]
-    public void TheClearanceBands_AreDeclaredInSeverityOrder()
+    public void BothClassifierBoundaries_FallAtTheSameShareOfClearanceOnEveryMinute()
     {
-        Assert.True(
-            TimescaleSupport.CompressionClearanceBand.InsideClearance
-                < TimescaleSupport.CompressionClearanceBand.ApproachingRefresh,
-            "InsideClearance no longer sorts below ApproachingRefresh");
-        Assert.True(
-            TimescaleSupport.CompressionClearanceBand.ApproachingRefresh
-                < TimescaleSupport.CompressionClearanceBand.RefreshOverrun,
-            "ApproachingRefresh no longer sorts below RefreshOverrun");
+        var numerator = TimescaleSupport.WindowWatchLeadNumerator;
+        var denominator = TimescaleSupport.WindowWatchLeadDenominator;
+
+        foreach (var minute in TimescaleSupport.CompressionPhaseMinutes)
+        {
+            var clearance = TimescaleSupport.CompressionMinuteClearanceSeconds(minute);
+            var watch = TimescaleSupport.CompressionClearanceWatchSeconds(minute);
+
+            Assert.Equal(clearance * numerator, watch * denominator);
+        }
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -5146,6 +5146,16 @@ WHERE j.proc_name LIKE '%compression%'
     /// summary only fires when nothing is running and no chunk is eligible, which is the routine hour — so
     /// hanging the clearance figure off it would suppress it in exactly the hour the daily chunk close makes
     /// interesting.</para>
+    ///
+    /// <para><b>The off-phase report is one line for the store too, and that branch is where the discipline
+    /// binds hardest rather than least.</b> A policy starting on a minute other than its assigned one is a
+    /// property of the store, not of the hypertable: the phased read either succeeds or it does not, so on a
+    /// job catalog too old to expose <c>fixed_schedule</c>/<c>initial_start</c> every policy is off phase at
+    /// once and stays that way, because that failure does not heal. Per-hypertable it would be one
+    /// Information line per hypertable per hour, indefinitely, on precisely the store where the least can be
+    /// done about it. It is Information rather than Debug because it is the PRECONDITION of every other
+    /// figure in this block — a clearance measured on a store whose grid was never applied describes where a
+    /// policy ran, not where this product placed it.</para>
     /// </summary>
     public static void LogCompressionActivity(
         IReadOnlyList<CompressionActivity> activity, DateTime nowUtc, ILogger? logger)
@@ -5202,6 +5212,9 @@ WHERE j.proc_name LIKE '%compression%'
     private static void LogCompressionClearance(IReadOnlyList<CompressionActivity> activity, ILogger logger)
     {
         CompressionActivity? tightest = null;
+        CompressionActivity? driftExample = null;
+        var offPhase = 0;
+        var onTheGrid = 0;
 
         foreach (var item in activity)
         {
@@ -5240,10 +5253,26 @@ WHERE j.proc_name LIKE '%compression%'
 
             if (item.OffAssignedPhase)
             {
-                logger.LogInformation(
-                    "TimescaleDB: compression of {Hypertable} last started on :{Observed:00}, not the :{Assigned:00} the phase grid assigns it — its clearance is measured from where it actually ran. A policy that drifts by its own runtime each cycle is the finish-to-start scheduling #3035's fixed schedule replaces, which the converge cannot apply on a job catalog too old to expose initial_start.",
-                    item.HypertableName, item.ObservedStartMinute ?? 0, item.AssignedPhaseMinute ?? 0);
+                offPhase++;
+                driftExample ??= item;
             }
+
+            onTheGrid++;
+        }
+
+        /* ONE line for the whole store, not one per hypertable, and this is the branch where that matters
+           most rather than least. The condition is a property of the STORE - a job catalog too old to expose
+           fixed_schedule/initial_start fails the phased read on every start, which
+           ConvergeCompressionScheduleAsync documents - so it is true of every policy at once and it does not
+           heal. Per-hypertable, it would be seventy Information lines an hour forever on exactly the store
+           where the least can be done about it, which is the burial this method's own discipline forbids and
+           which the first version of this branch did. Raised by review. */
+        if (offPhase > 0 && driftExample is not null)
+        {
+            logger.LogInformation(
+                "TimescaleDB: {OffPhase} of {OnGrid} compression policies last started on a minute other than the one the phase grid assigns them (e.g. {Hypertable} on :{Observed:00} rather than :{Assigned:00}) — so every clearance figure in this block is measured from where those policies actually ran, not from where this product placed them. A policy that drifts by its own runtime each cycle is the finish-to-start scheduling #3035's fixed schedule replaces, which the converge cannot apply on a job catalog too old to expose initial_start.",
+                offPhase, onTheGrid, driftExample.HypertableName,
+                driftExample.ObservedStartMinute ?? 0, driftExample.AssignedPhaseMinute ?? 0);
         }
 
         if (tightest is not null)

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -2608,7 +2608,13 @@ WITH NO DATA";
     /// <b>198 s</b> (<c>query_snapshots</c>) and <b>552 s</b> (<c>query_store_stats</c>) — stated in that
     /// order throughout this paragraph, which is the order of the minutes they held. Those are
     /// <c>collect.store_metrics</c>' hourly <c>background_job</c> snapshot — a LAST-RUN reading, so no
-    /// maximum question is answered by them (#3119) — and they are one store's and one night's. Under the
+    /// maximum question is answered by them (#3119) — and they are one store's and one night's. A far broader
+    /// population exists and is recorded on the change that added this member rather than restated here: a
+    /// multi-week <c>timescaledb_information.job_history</c> census of the same hypertables by hour of day,
+    /// which is maximum-capable where these readings are not. It puts <c>query_store_stats</c>' typical
+    /// midnight run INSIDE the clearance below and its upper tail PAST it. The readings quoted here are
+    /// therefore the weaker instrument, and they are kept because they are the ones the shares stated below
+    /// are computed from — a figure this file can be checked against beats a larger one it cannot. Under the
     /// grid in force that night the three started at <c>00:26</c>, <c>00:27</c> and <c>00:28</c> with
     /// <b>240 s</b>, <b>180 s</b> and <b>120 s</b> of clearance, so every one of them ran past the refresh
     /// that followed it. The one whose hypertable that refresh also READ was <c>query_store_stats</c>, and it
@@ -2678,8 +2684,16 @@ WITH NO DATA";
         ApproachingRefresh,
 
         /// <summary>At or past <see cref="CompressionMinuteClearanceSeconds"/>. The run was still holding its
-        /// <c>AccessExclusiveLock</c> when an hourly refresh started, which is the queue
-        /// <see cref="HourlyRefreshPhaseOrder"/>'s stagger exists to keep empty.</summary>
+        /// <c>AccessExclusiveLock</c> when AT LEAST ONE hourly refresh started, which is the queue
+        /// <see cref="HourlyRefreshPhaseOrder"/>'s stagger exists to keep empty.
+        ///
+        /// <para><b>At least one, and the band does not say how many.</b> A grid places a job's START; it
+        /// cannot bound its END, and no arrangement of a sixty-minute hour contains a run longer than an
+        /// hour. A long enough compression run passes several refresh starts in sequence — the light band
+        /// alone holds one per minute — so this band must not be read as "one refresh waited". How far past
+        /// the FIRST start the run went is reported (<see cref="CompressionActivity.ClearOfRefreshSeconds"/>);
+        /// how many starts it passed is not derived, because that needs each refresh's own runtime and not
+        /// just its minute.</para></summary>
         RefreshOverrun,
     }
 

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -5230,21 +5230,48 @@ WHERE j.proc_name LIKE '%compression%'
                 tightest = item;
             }
 
+            /* DERIVED FROM THE MINUTE, not defaulted from a nullable. Both are non-null inside this walk -
+               the loop guard above has already skipped a reading with no minute or no duration - so taking
+               them off the minute removes the `?? 0` rather than hiding one, and a zero clearance below is a
+               REAL zero rather than a defaulted null. */
+            var clearance = CompressionMinuteClearanceSeconds(minute);
+            var clear = clearance - duration.TotalSeconds;
+
+            /* THE SHARE IS PATTERN-MATCHED, NEVER DEFAULTED, and that is the whole of this block's shape.
+               PercentOfClearance is null exactly when the clearance is ZERO - the sink case - and defaulting
+               it to 0d rendered that case as "0.0%", byte-identical to a near-instant run with the whole band
+               to spare. A reading that gets more alarming as it gets worse everywhere else wrapped around to
+               look BEST in the one case with no room at all, and 0.0% could not be told from "finished
+               instantly" by the operator reading it. So the two measurable bands take the share by pattern
+               and the null falls through to its own finding. Raised by review. */
             switch (band)
             {
-                case CompressionClearanceBand.RefreshOverrun:
+                case CompressionClearanceBand.RefreshOverrun when item.PercentOfClearance is not null:
                     logger.LogWarning(
                         "TimescaleDB: compression of {Hypertable} last ran {Seconds:F0}s from :{Minute:00}, at or past the {Clearance}s it had before the next hourly refresh started ({Over:F0}s past it) — so it was still holding AccessExclusiveLock when a refresh wanted the table. This is the daily chunk close: every hypertable's newest {Days}d chunk becomes eligible at the same UTC midnight, so one tick a day carries a full day's rewrite while the other twenty-three find nothing (#3112). The grid's guard is one-sided by decision, so the tail of the compression band has one refresh step of clearance and this is that residual being spent. Widening it costs minutes the heaviest refresh's window is holding (#3174).",
-                        item.HypertableName, duration.TotalSeconds, minute, item.ClearanceSeconds ?? 0,
-                        -(item.ClearOfRefreshSeconds ?? 0d), CompressAfterDays);
+                        item.HypertableName, duration.TotalSeconds, minute, clearance, -clear, CompressAfterDays);
                     break;
 
-                case CompressionClearanceBand.ApproachingRefresh:
+                case CompressionClearanceBand.ApproachingRefresh when item.PercentOfClearance is double percent:
                     logger.LogInformation(
                         "TimescaleDB: compression of {Hypertable} last ran {Seconds:F0}s from :{Minute:00}, {Percent:F1}% of the {Clearance}s it had before the next hourly refresh ({Clear:F0}s clear, watch line {Watch}s).",
-                        item.HypertableName, duration.TotalSeconds, minute, item.PercentOfClearance ?? 0d,
-                        item.ClearanceSeconds ?? 0, item.ClearOfRefreshSeconds ?? 0d,
-                        CompressionClearanceWatchSeconds(minute));
+                        item.HypertableName, duration.TotalSeconds, minute, percent,
+                        clearance, clear, CompressionClearanceWatchSeconds(minute));
+                    break;
+
+                /* THE SINK CASE, and it is a DIFFERENT FINDING rather than the same one with an awkward
+                   number. An ordinary overrun says the day's rewrite outgrew a tight minute, and its remedy
+                   is the band's width. A policy sitting on a refresh's OWN minute says the phase grid was
+                   never applied to it, and its remedy is the converge - so the chunk-close reasoning above
+                   would point an operator at the wrong lever. Reached from either band, so an
+                   ApproachingRefresh with no share - which the arithmetic does not currently allow, since a
+                   zero clearance makes both boundaries zero and every non-negative run an overrun - would
+                   land here rather than on a milder line. That is the direction to be wrong in. */
+                case CompressionClearanceBand.RefreshOverrun:
+                case CompressionClearanceBand.ApproachingRefresh:
+                    logger.LogWarning(
+                        "TimescaleDB: compression of {Hypertable} last ran {Seconds:F0}s from :{Minute:00}, which is a minute an hourly refresh ALSO starts on — so it had NO CLEARANCE whatsoever, not a small amount, and was contending from the moment it began. Its share of clearance is UNDEFINED rather than low. A compression policy on a refresh's own minute means the phase grid was never applied to it, so the remedy is the phase converge and not the band's width (#3035/#3112).",
+                        item.HypertableName, duration.TotalSeconds, minute);
                     break;
 
                 default:
@@ -5275,14 +5302,27 @@ WHERE j.proc_name LIKE '%compression%'
                 driftExample.ObservedStartMinute ?? 0, driftExample.AssignedPhaseMinute ?? 0);
         }
 
-        if (tightest is not null)
+        /* The summary splits the same way and for the same reason: the policy SELECTED because it has no
+           clearance must not be REPORTED as a low share of it. Everything here is derived from the tightest
+           reading's own minute, so no rendered quantity is a defaulted null. */
+        if (tightest is not null && tightest.ClearanceMinute is int tightestMinute)
         {
-            logger.LogDebug(
-                "TimescaleDB: tightest compression clearance this tick is {Hypertable} at {Percent:F1}% of its {Clearance}s from :{Minute:00} ({Band}); the band runs {Widest}s down to {Narrowest}s of clearance.",
-                tightest.HypertableName, tightest.PercentOfClearance ?? 0d, tightest.ClearanceSeconds ?? 0,
-                tightest.ClearanceMinute ?? 0, tightest.ClearanceBand,
-                CompressionMinuteClearanceSeconds(CompressionPhaseMinutes[0]),
-                CompressionMinuteClearanceSeconds(CompressionPhaseMinutes[^1]));
+            var widest = CompressionMinuteClearanceSeconds(CompressionPhaseMinutes[0]);
+            var narrowest = CompressionMinuteClearanceSeconds(CompressionPhaseMinutes[^1]);
+
+            if (tightest.PercentOfClearance is double tightestShare)
+            {
+                logger.LogDebug(
+                    "TimescaleDB: tightest compression clearance this tick is {Hypertable} at {Percent:F1}% of its {Clearance}s from :{Minute:00} ({Band}); the band runs {Widest}s down to {Narrowest}s of clearance.",
+                    tightest.HypertableName, tightestShare, CompressionMinuteClearanceSeconds(tightestMinute),
+                    tightestMinute, tightest.ClearanceBand, widest, narrowest);
+            }
+            else
+            {
+                logger.LogDebug(
+                    "TimescaleDB: tightest compression clearance this tick is {Hypertable} with NO CLEARANCE at all — it ran from :{Minute:00}, a minute an hourly refresh also starts on, so its share of clearance is UNDEFINED rather than low ({Band}); the band runs {Widest}s down to {Narrowest}s of clearance.",
+                    tightest.HypertableName, tightestMinute, tightest.ClearanceBand, widest, narrowest);
+            }
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -5212,8 +5212,7 @@ WHERE j.proc_name LIKE '%compression%'
                 continue;
             }
 
-            if (tightest is null
-                || (item.PercentOfClearance ?? 0d) > (tightest.PercentOfClearance ?? 0d))
+            if (IsTighter(item, tightest))
             {
                 tightest = item;
             }
@@ -5256,6 +5255,47 @@ WHERE j.proc_name LIKE '%compression%'
                 CompressionMinuteClearanceSeconds(CompressionPhaseMinutes[0]),
                 CompressionMinuteClearanceSeconds(CompressionPhaseMinutes[^1]));
         }
+    }
+
+    /// <summary>
+    /// Which of two clearance readings is the one worth naming in the per-tick summary: the more SEVERE band
+    /// first, and within a band the larger share of its own clearance.
+    ///
+    /// <para><b>Band before share, because a share cannot rank a zero clearance.</b>
+    /// <see cref="CompressionActivity.PercentOfClearance"/> is null exactly when the clearance is ZERO, which
+    /// is reachable in production and is the worst geometry there is: a policy the converge could not put on
+    /// a fixed schedule, drifted onto a minute an hourly refresh also starts on.
+    /// <see cref="ClassifyCompressionClearance"/> already bands that
+    /// <see cref="CompressionClearanceBand.RefreshOverrun"/> for any non-negative run. Defaulting the missing
+    /// share to zero would rank the worst case BELOW a routine reading and the summary would name the wrong
+    /// policy — the per-item Warning still fires, so the cost is the aggregate line pointing away from the
+    /// thing it exists to point at. Raised by review.</para>
+    ///
+    /// <para>The share defaults to <see cref="double.PositiveInfinity"/> rather than zero for the same
+    /// reason, as a second line of defence if the band ordering were ever the thing that failed: an
+    /// undefined ratio over a zero denominator with a positive numerator has that limit, not zero.</para>
+    ///
+    /// <para>The enum's declaration ORDER is the severity order this relies on, which is why
+    /// <c>CompressionClearanceWatchTests</c> pins it rather than leaving it as a property of how the members
+    /// happen to be written.</para>
+    /// </summary>
+    private static bool IsTighter(CompressionActivity candidate, CompressionActivity? incumbent)
+    {
+        if (incumbent is null)
+        {
+            return true;
+        }
+
+        var candidateBand = candidate.ClearanceBand ?? CompressionClearanceBand.InsideClearance;
+        var incumbentBand = incumbent.ClearanceBand ?? CompressionClearanceBand.InsideClearance;
+
+        if (candidateBand != incumbentBand)
+        {
+            return candidateBand > incumbentBand;
+        }
+
+        return (candidate.PercentOfClearance ?? double.PositiveInfinity)
+            > (incumbent.PercentOfClearance ?? double.PositiveInfinity);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -5258,45 +5258,38 @@ WHERE j.proc_name LIKE '%compression%'
     }
 
     /// <summary>
-    /// Which of two clearance readings is the one worth naming in the per-tick summary: the more SEVERE band
-    /// first, and within a band the larger share of its own clearance.
+    /// Which of two clearance readings is the one worth naming in the per-tick summary: the larger share of
+    /// its own clearance.
     ///
-    /// <para><b>Band before share, because a share cannot rank a zero clearance.</b>
-    /// <see cref="CompressionActivity.PercentOfClearance"/> is null exactly when the clearance is ZERO, which
-    /// is reachable in production and is the worst geometry there is: a policy the converge could not put on
-    /// a fixed schedule, drifted onto a minute an hourly refresh also starts on.
+    /// <para><b>The share IS the severity, so this needs no second key — and that is a PROPERTY rather than
+    /// a coincidence.</b> <see cref="ClassifyCompressionClearance"/>'s two boundaries are the clearance and
+    /// five sixths of it, and every clearance the grid can produce is a whole number of minutes, so both
+    /// boundaries fall at the same SHARE on every minute in the band — 83.3% and 100%. Ranking by share is
+    /// therefore ranking by band, and a reading the line calls the tightest can never carry a milder band
+    /// than one it passed over. <c>CompressionClearanceWatchTests</c> pins that exactness, because integer
+    /// division is what would break it: a clearance that was not a multiple of six would round the watch
+    /// line down and the two orders would diverge on that minute alone.</para>
+    ///
+    /// <para><b>A missing share means a ZERO clearance, and its limit is infinity rather than zero.</b>
+    /// <see cref="CompressionActivity.PercentOfClearance"/> is null exactly there — inside this walk the
+    /// duration and the minute are both known, so a zero denominator is the only way to lose it — and zero
+    /// clearance is reachable in production and is the worst geometry there is: a policy the converge could
+    /// not put on a fixed schedule, drifted onto a minute an hourly refresh also starts on.
     /// <see cref="ClassifyCompressionClearance"/> already bands that
     /// <see cref="CompressionClearanceBand.RefreshOverrun"/> for any non-negative run. Defaulting the missing
-    /// share to zero would rank the worst case BELOW a routine reading and the summary would name the wrong
-    /// policy — the per-item Warning still fires, so the cost is the aggregate line pointing away from the
-    /// thing it exists to point at. Raised by review.</para>
+    /// share to zero ranked that policy BELOW a routine reading, so the summary named the wrong one — the
+    /// per-item Warning fires either way, so the cost was the aggregate line pointing away from the thing it
+    /// exists to point at. Raised by review.</para>
     ///
-    /// <para>The share defaults to <see cref="double.PositiveInfinity"/> rather than zero for the same
-    /// reason, as a second line of defence if the band ordering were ever the thing that failed: an
-    /// undefined ratio over a zero denominator with a positive numerator has that limit, not zero.</para>
-    ///
-    /// <para>The enum's declaration ORDER is the severity order this relies on, which is why
-    /// <c>CompressionClearanceWatchTests</c> pins it rather than leaving it as a property of how the members
-    /// happen to be written.</para>
+    /// <para><b>One key rather than a band key and a share key.</b> A severity key would be redundant given
+    /// the exactness above, and a redundant arm makes each arm individually unfalsifiable: with both present,
+    /// restoring the zero default changes no outcome and a mutation sweep reports the defect as unreachable.
+    /// So the property is pinned and the comparison is single.</para>
     /// </summary>
-    private static bool IsTighter(CompressionActivity candidate, CompressionActivity? incumbent)
-    {
-        if (incumbent is null)
-        {
-            return true;
-        }
-
-        var candidateBand = candidate.ClearanceBand ?? CompressionClearanceBand.InsideClearance;
-        var incumbentBand = incumbent.ClearanceBand ?? CompressionClearanceBand.InsideClearance;
-
-        if (candidateBand != incumbentBand)
-        {
-            return candidateBand > incumbentBand;
-        }
-
-        return (candidate.PercentOfClearance ?? double.PositiveInfinity)
+    private static bool IsTighter(CompressionActivity candidate, CompressionActivity? incumbent) =>
+        incumbent is null
+        || (candidate.PercentOfClearance ?? double.PositiveInfinity)
             > (incumbent.PercentOfClearance ?? double.PositiveInfinity);
-    }
 
     /// <summary>
     /// Re-arms one stuck background job via the parameterized <see cref="RearmJobSql"/> (job_id BOUND). Returns

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -2144,6 +2144,36 @@ WITH NO DATA";
     public static int RefreshPhaseSlotSeconds => HeaviestRefreshWindowMinutes * 60;
 
     /// <summary>
+    /// The fraction of a window at which a runtime watch on that window speaks, as a numerator over
+    /// <see cref="WindowWatchLeadDenominator"/> — five sixths, so a watch line sits at 83.3% of whatever
+    /// space the thing being watched has.
+    ///
+    /// <para><b>Named because the grid now has TWO watches over it and one lead-time choice, not two.</b>
+    /// <see cref="RefreshSlotWarningSeconds"/> is this fraction of
+    /// <see cref="RefreshPhaseSlotSeconds"/> and <see cref="CompressionClearanceWatchSeconds"/> is the same
+    /// fraction of a compression minute's clearance. Both are re-derived over this pair rather than each
+    /// carrying its own <c>* 5 / 6</c>: a second literal would let the two lead times drift apart silently,
+    /// and this file's own <see cref="CompressScheduleSpan"/> remark states the rule that forbids it —
+    /// cross-check by DERIVING one side from the other, never by pinning each side to its own constant,
+    /// which forces the edit on whichever side the editor is looking at and forces nothing on the other.
+    /// The value of neither line moves by being expressed this way; the derivation is what changes.</para>
+    ///
+    /// <para><b>Why the same fraction is right for both, rather than a coincidence being institutionalised.</b>
+    /// The argument on <see cref="RefreshSlotWarningSeconds"/> is that the remaining sixth has to be usable
+    /// lead time against a runtime that grows with data volume — and the compression side is watched against
+    /// the same kind of quantity, a daily chunk rewrite whose cost scales with the day's ingest. What differs
+    /// between the two is the WIDTH each is a fraction of, and that is exactly what taking a fraction handles.
+    /// A compression minute at the tail of the band has one light-refresh step of clearance, so a sixth of it
+    /// is 10 s of lead — thin, and stated on
+    /// <see cref="CompressionMinuteClearanceMinutes"/> rather than hidden, because the answer to a thin lead
+    /// time there is a wider band and not a different fraction.</para>
+    /// </summary>
+    public const int WindowWatchLeadNumerator = 5;
+
+    /// <summary>The denominator of <see cref="WindowWatchLeadNumerator"/>'s fraction.</summary>
+    public const int WindowWatchLeadDenominator = 6;
+
+    /// <summary>
     /// The line at which the heaviest hourly refresh's LIVE runtime is worth a warning — five sixths of
     /// <see cref="RefreshPhaseSlotSeconds"/>, so 1,050 s against today's 1,260 s window.
     ///
@@ -2193,7 +2223,8 @@ WITH NO DATA";
     /// leaving a reader to notice. That pin has now fired once and been answered by re-deriving the geometry
     /// instead of by renumbering the band, which is the only answer that changes anything.</para>
     /// </summary>
-    public static int RefreshSlotWarningSeconds => RefreshPhaseSlotSeconds * 5 / 6;
+    public static int RefreshSlotWarningSeconds =>
+        RefreshPhaseSlotSeconds * WindowWatchLeadNumerator / WindowWatchLeadDenominator;
 
     /// <summary>
     /// Where one live reading of <see cref="HeaviestHourlyRefreshView"/>'s runtime sits against the slot it
@@ -2416,7 +2447,21 @@ WITH NO DATA";
     /// change would be INTRODUCING, not removing, so the grid keeps the spread and takes only the drift away.
     /// How thin the spread has to be is <see cref="CompressionPhaseMaxPerMinute"/>, and the band's width
     /// follows from it — so the re-derivation moves WHERE compression runs without changing how concentrated
-    /// it is, which is the one property #3112's midnight band is sensitive to.</para>
+    /// it is.</para>
+    ///
+    /// <para><b>Concentration is NOT the only property #3112's midnight band is sensitive to, and the
+    /// correction matters because the other one moved.</b> #3174 held the spread constant — <b>24</b> minutes
+    /// at <b>3</b> per minute before and after — and said so. What it did not hold constant, and did not
+    /// claim to, is each minute's CLEARANCE to the next refresh start
+    /// (<see cref="CompressionMinuteClearanceMinutes"/>): under the previous grid the three hypertables whose
+    /// chunk-close runs were measured sat on minutes with 240 s, 180 s and 120 s of clearance against runs of
+    /// 360 s, 198 s and 552 s, so every one of them ran past the refresh that followed it. On this grid the
+    /// same three hold minutes with <b>1,200 s</b>, <b>1,140 s</b> and <b>1,080 s</b>. A contiguous refresh
+    /// band followed by a contiguous compression band puts most of the compression minutes a long way from
+    /// the next refresh, where three chunks of a uniform grid put every compression minute within a guard
+    /// band of one — so the re-derivation changed the axis the band actually ran through, as a consequence of
+    /// its shape rather than as an aim. It remains true that NOTHING here reduces what midnight
+    /// carries.</para>
     ///
     /// <para>Declared HERE, after <see cref="HourlyRefreshPhaseOrder"/>, because a static field initializer
     /// runs in declaration order and this one reads that list through
@@ -2506,6 +2551,165 @@ WITH NO DATA";
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// How many minutes a compression policy starting on <paramref name="minute"/> has before the next hourly
+    /// refresh starts — the space that minute's run actually has, measured forward round the hour.
+    ///
+    /// <para><b>Why this quantity and not the cadence (#3112).</b> The compression band's WIDTH is derived
+    /// from a COUNT (<see cref="CompressionPhaseBandMinutes"/> over
+    /// <see cref="CompressionPhaseMaxPerMinute"/>), and nothing in the grid compares a compression run's
+    /// DURATION to anything. Both instruments that look as though they would catch it miss it, and one of
+    /// them misses by a factor rather than by a margin. #2136's Store Job Over Cadence judges a job against
+    /// its own <c>schedule_interval</c>, which for a compression policy is
+    /// <see cref="CompressScheduleInterval"/> — so its shipped warning share
+    /// (<see cref="RefreshSlotPercentOfHourlyCadence"/>) puts the line at 900 s of a 3,600 s hour, while the
+    /// wall a compression run actually faces is its own minute's clearance, as little as 60 s. That is
+    /// FIFTEEN times too high on the tightest minute in the band; the 552 s chunk-close run measured below
+    /// reads 15.3% of cadence and never approaches the knob at all. And #1778's
+    /// <see cref="LogCompressionActivity"/> reports a run that is STILL RUNNING and a chunk backlog, never a
+    /// completed run's duration against the space it had. So the compression band is the one band of this
+    /// grid with no runtime instrument over its own geometry, and the daily chunk close is precisely a
+    /// compression-runtime event.</para>
+    ///
+    /// <para><b>Relation-AGNOSTIC, deliberately, and it is a LOWER BOUND on the true clearance.</b> The lock
+    /// adjacency #3012 formed on is per-relation: a compression policy holds
+    /// <c>AccessExclusiveLock</c> on ONE hypertable and only a refresh reading THAT hypertable queues behind
+    /// it. This takes the minimum over EVERY refresh start, which is the same predicate
+    /// <see cref="CompressionPhaseMinutes"/> is built from — a minimum over a superset can only be smaller
+    /// than a minimum over the contending subset, so this figure is never larger than the true clearance and
+    /// the watch over it therefore speaks EARLIER than a relation-aware one, never later. Taken in that
+    /// direction on purpose: recovering each view's contended relation means parsing
+    /// <see cref="HourlyRefreshDefinitions"/>' CREATE text, which is a test-time capability here and not an
+    /// hourly-sweep one, and a watch that fails toward flagging a harmless overrun is worth more than one
+    /// that can miss a harmful one.</para>
+    ///
+    /// <para><b>The band's own range, which is what says where the residual is.</b> Clearance falls one
+    /// minute per minute across the band: 1,440 s on its first minute down to <b>60 s</b> on its last, that
+    /// last figure being exactly one <see cref="LightRefreshStepMinutes"/> step because the bands partition
+    /// the hour and the light band opens the next one. The tail minute is always OCCUPIED — the band is sized
+    /// to hold the whole catalog at <see cref="CompressionPhaseMaxPerMinute"/> per minute, so every minute in
+    /// it carries a policy — so a one-step clearance is a permanent feature of the grid rather than an
+    /// arrangement that happens to be tight today. That is the one-sidedness
+    /// <see cref="HeaviestRefreshStartMinute"/> accepted by DECISION, now carried as a number: which refresh
+    /// band opens the hour was chosen knowing something would still be compressing, and this is how much
+    /// space the something has.</para>
+    ///
+    /// <para><b>What the shipped grid puts where, so the residual is named rather than left to be found.</b>
+    /// <c>query_store_stats</c> — the largest hypertable this store has — sits at <b>:42</b> with
+    /// <b>1,080 s</b>, and <c>procedure_stats</c> sits at <b>:58</b> with <b>120 s</b>, the tightest placement
+    /// any of the large hypertables has. Both figures follow from the catalog's ORDER, so a collector
+    /// registered ahead of either moves them; they are pinned as derived values rather than stated as facts
+    /// about those two tables, and the prose going stale is what reddens the pin.</para>
+    ///
+    /// <para><b>The measurement this exists because of, scoped (#3112).</b> In the <c>2026-09-08 00:00Z</c>
+    /// hour on ONE store, three compression policies were read at <b>360 s</b> (<c>query_stats</c>),
+    /// <b>198 s</b> (<c>query_snapshots</c>) and <b>552 s</b> (<c>query_store_stats</c>) — stated in that
+    /// order throughout this paragraph, which is the order of the minutes they held. Those are
+    /// <c>collect.store_metrics</c>' hourly <c>background_job</c> snapshot — a LAST-RUN reading, so no
+    /// maximum question is answered by them (#3119) — and they are one store's and one night's. Under the
+    /// grid in force that night the three started at <c>00:26</c>, <c>00:27</c> and <c>00:28</c> with
+    /// <b>240 s</b>, <b>180 s</b> and <b>120 s</b> of clearance, so every one of them ran past the refresh
+    /// that followed it. The one whose hypertable that refresh also READ was <c>query_store_stats</c>, and it
+    /// is that refresh — not the other two — whose runtime went to 160.4 s and then 226.8 s against a
+    /// 20–58 s steady state. On the grid this file ships the same three hold <c>:40</c>, <c>:41</c> and
+    /// <c>:42</c>, where those readings are <b>30%</b>, <b>17%</b> and <b>51%</b> of their clearance.
+    /// <b>Nothing here reduces what midnight carries</b>, and the placement that absorbs it was not chosen
+    /// for that: it is a consequence of #3174's re-derivation, which claimed neutrality on CONCENTRATION and
+    /// was neutral on it. Clearance is a different axis and it moved.</para>
+    ///
+    /// <para>Modular in <paramref name="minute"/> rather than range-checked: minute-of-hour arithmetic is
+    /// modular anyway, and this feeds an observability line off a catalog timestamp, so an impossible value
+    /// must cost the line and never the sweep.</para>
+    /// </summary>
+    public static int CompressionMinuteClearanceMinutes(int minute)
+    {
+        var cadence = MinutesInHourlyCadence;
+        var start = ((minute % cadence) + cadence) % cadence;
+        var clearance = cadence;
+
+        foreach (var view in HourlyRefreshPhaseOrder)
+        {
+            var distance = (RefreshPhaseMinutesFor(view) - start + cadence) % cadence;
+
+            if (distance < clearance)
+            {
+                clearance = distance;
+            }
+        }
+
+        return clearance;
+    }
+
+    /// <summary><see cref="CompressionMinuteClearanceMinutes"/> in seconds — the wall a compression run
+    /// starting on that minute has to finish inside, named once so the watch line and the band boundary
+    /// cannot disagree about where it is (the same reason <see cref="RefreshPhaseSlotSeconds"/>
+    /// exists).</summary>
+    public static int CompressionMinuteClearanceSeconds(int minute) =>
+        CompressionMinuteClearanceMinutes(minute) * 60;
+
+    /// <summary>
+    /// The line at which a compression run on <paramref name="minute"/> is worth saying something about:
+    /// <see cref="WindowWatchLeadNumerator"/>/<see cref="WindowWatchLeadDenominator"/> of that minute's
+    /// clearance, the same lead-time fraction #3044 chose for the heaviest refresh's window.
+    ///
+    /// <para>Integer division, so the line is never ABOVE the fraction — a watch that rounded up would speak
+    /// later than its own stated lead time on some widths and not others.</para>
+    /// </summary>
+    public static int CompressionClearanceWatchSeconds(int minute) =>
+        CompressionMinuteClearanceSeconds(minute) * WindowWatchLeadNumerator / WindowWatchLeadDenominator;
+
+    /// <summary>
+    /// Where one observed compression run sits against the clearance the minute it started on had. Produced by
+    /// <see cref="ClassifyCompressionClearance"/>; nothing here reads a clock or a catalog, so it pins
+    /// directly.
+    /// </summary>
+    public enum CompressionClearanceBand
+    {
+        /// <summary>Under <see cref="CompressionClearanceWatchSeconds"/> — the routine band. This is where
+        /// every hour but the daily chunk close sits, by a wide margin: an ordinary tick finds nothing
+        /// eligible and finishes in well under a second.</summary>
+        InsideClearance,
+
+        /// <summary>At or past <see cref="CompressionClearanceWatchSeconds"/> but still inside
+        /// <see cref="CompressionMinuteClearanceSeconds"/>: the run still finished before the next refresh
+        /// started, with less than the watch's lead fraction to spare.</summary>
+        ApproachingRefresh,
+
+        /// <summary>At or past <see cref="CompressionMinuteClearanceSeconds"/>. The run was still holding its
+        /// <c>AccessExclusiveLock</c> when an hourly refresh started, which is the queue
+        /// <see cref="HourlyRefreshPhaseOrder"/>'s stagger exists to keep empty.</summary>
+        RefreshOverrun,
+    }
+
+    /// <summary>
+    /// Classifies one observed compression runtime against the clearance of the minute it started on.
+    ///
+    /// <para><b>Both boundaries are inclusive</b>, for the reason
+    /// <see cref="ClassifyRefreshSlotHeadroom"/>'s are: a run that took exactly its clearance was still
+    /// running when the refresh started, so <see cref="CompressionClearanceBand.RefreshOverrun"/> has to
+    /// begin at <c>&gt;=</c> rather than past it.</para>
+    ///
+    /// <para>Negative and NaN readings classify <see cref="CompressionClearanceBand.InsideClearance"/> rather
+    /// than throwing — same posture as the refresh classifier, and the same reason: a catalog handing back
+    /// something impossible must cost the line, never the sweep that carries it.</para>
+    /// </summary>
+    public static CompressionClearanceBand ClassifyCompressionClearance(double observedSeconds, int startMinute)
+    {
+        if (double.IsNaN(observedSeconds) || observedSeconds < 0d)
+        {
+            return CompressionClearanceBand.InsideClearance;
+        }
+
+        if (observedSeconds >= CompressionMinuteClearanceSeconds(startMinute))
+        {
+            return CompressionClearanceBand.RefreshOverrun;
+        }
+
+        return observedSeconds >= CompressionClearanceWatchSeconds(startMinute)
+            ? CompressionClearanceBand.ApproachingRefresh
+            : CompressionClearanceBand.InsideClearance;
     }
 
     /// <summary>
@@ -4906,6 +5110,28 @@ WHERE j.proc_name LIKE '%compression%'
     /// operator actually needs to see: a compression that is RUNNING right now and how long it has been going
     /// (the field's hours-long runs were invisible while they happened), and a table whose eligible chunks are
     /// piling up. Everything else is one Debug summary line.</para>
+    ///
+    /// <para><b>The #3112 clearance watch rides the same reading, and adds no read, no timer and no per-policy
+    /// routine line.</b> Every term it needs is already in <see cref="CompressionActivity"/>: the hypertable
+    /// names the minute, the minute gives
+    /// <see cref="TimescaleSupport.CompressionMinuteClearanceSeconds"/>, and the last completed run's duration
+    /// is already projected. So the same discipline applies as above — nothing per-policy in the routine band,
+    /// because seventy Debug lines an hour is the burial this method's first paragraph is about. One Debug
+    /// summary carries the TIGHTEST reading in the band, which is the one figure that says how close the grid
+    /// is; a run at or past its watch line gets Information; an overrun gets Warning.</para>
+    ///
+    /// <para><b>Warning rather than Error for an overrun, unlike
+    /// <see cref="LogHeaviestRefreshSlotHeadroom"/>'s exceeded band.</b> There, past the window means a
+    /// documented precondition of the shipped grid is FALSE. Here it does not: the compression guard is
+    /// one-sided BY DECISION (<see cref="HeaviestRefreshStartMinute"/>), so a policy on the tail of the band
+    /// running past the hour is the accepted residual being consumed rather than an invariant breaking. It
+    /// still wants saying, because that residual is what #3112's midnight band ran through, and nothing said
+    /// it.</para>
+    ///
+    /// <para><b>Emitted unconditionally rather than folded into the existing all-clear summary.</b> That
+    /// summary only fires when nothing is running and no chunk is eligible, which is the routine hour — so
+    /// hanging the clearance figure off it would suppress it in exactly the hour the daily chunk close makes
+    /// interesting.</para>
     /// </summary>
     public static void LogCompressionActivity(
         IReadOnlyList<CompressionActivity> activity, DateTime nowUtc, ILogger? logger)
@@ -4948,6 +5174,73 @@ WHERE j.proc_name LIKE '%compression%'
             logger.LogDebug(
                 "TimescaleDB: {Count} compression policies on a {Interval} tick, nothing running, no eligible chunk uncompressed.",
                 activity.Count, CompressScheduleInterval);
+        }
+
+        LogCompressionClearance(activity, logger);
+    }
+
+    /// <summary>
+    /// The #3112 half of <see cref="LogCompressionActivity"/>: every completed compression run against the
+    /// clearance the minute it started on had. Split out as its own method rather than threaded through the
+    /// loop above so the two concerns can be read, and tested, apart — #1778 asks "is compression keeping
+    /// up", this asks "did a run reach the next refresh".
+    /// </summary>
+    private static void LogCompressionClearance(IReadOnlyList<CompressionActivity> activity, ILogger logger)
+    {
+        CompressionActivity? tightest = null;
+
+        foreach (var item in activity)
+        {
+            if (item.ClearanceBand is not CompressionClearanceBand band
+                || item.ClearanceMinute is not int minute
+                || item.LastRunDuration is not TimeSpan duration)
+            {
+                continue;
+            }
+
+            if (tightest is null
+                || (item.PercentOfClearance ?? 0d) > (tightest.PercentOfClearance ?? 0d))
+            {
+                tightest = item;
+            }
+
+            switch (band)
+            {
+                case CompressionClearanceBand.RefreshOverrun:
+                    logger.LogWarning(
+                        "TimescaleDB: compression of {Hypertable} last ran {Seconds:F0}s from :{Minute:00}, at or past the {Clearance}s it had before the next hourly refresh started ({Over:F0}s past it) — so it was still holding AccessExclusiveLock when a refresh wanted the table. This is the daily chunk close: every hypertable's newest {Days}d chunk becomes eligible at the same UTC midnight, so one tick a day carries a full day's rewrite while the other twenty-three find nothing (#3112). The grid's guard is one-sided by decision, so the tail of the compression band has one refresh step of clearance and this is that residual being spent. Widening it costs minutes the heaviest refresh's window is holding (#3174).",
+                        item.HypertableName, duration.TotalSeconds, minute, item.ClearanceSeconds ?? 0,
+                        -(item.ClearOfRefreshSeconds ?? 0d), CompressAfterDays);
+                    break;
+
+                case CompressionClearanceBand.ApproachingRefresh:
+                    logger.LogInformation(
+                        "TimescaleDB: compression of {Hypertable} last ran {Seconds:F0}s from :{Minute:00}, {Percent:F1}% of the {Clearance}s it had before the next hourly refresh ({Clear:F0}s clear, watch line {Watch}s).",
+                        item.HypertableName, duration.TotalSeconds, minute, item.PercentOfClearance ?? 0d,
+                        item.ClearanceSeconds ?? 0, item.ClearOfRefreshSeconds ?? 0d,
+                        CompressionClearanceWatchSeconds(minute));
+                    break;
+
+                default:
+                    break;
+            }
+
+            if (item.OffAssignedPhase)
+            {
+                logger.LogInformation(
+                    "TimescaleDB: compression of {Hypertable} last started on :{Observed:00}, not the :{Assigned:00} the phase grid assigns it — its clearance is measured from where it actually ran. A policy that drifts by its own runtime each cycle is the finish-to-start scheduling #3035's fixed schedule replaces, which the converge cannot apply on a job catalog too old to expose initial_start.",
+                    item.HypertableName, item.ObservedStartMinute ?? 0, item.AssignedPhaseMinute ?? 0);
+            }
+        }
+
+        if (tightest is not null)
+        {
+            logger.LogDebug(
+                "TimescaleDB: tightest compression clearance this tick is {Hypertable} at {Percent:F1}% of its {Clearance}s from :{Minute:00} ({Band}); the band runs {Widest}s down to {Narrowest}s of clearance.",
+                tightest.HypertableName, tightest.PercentOfClearance ?? 0d, tightest.ClearanceSeconds ?? 0,
+                tightest.ClearanceMinute ?? 0, tightest.ClearanceBand,
+                CompressionMinuteClearanceSeconds(CompressionPhaseMinutes[0]),
+                CompressionMinuteClearanceSeconds(CompressionPhaseMinutes[^1]));
         }
     }
 
@@ -5096,6 +5389,77 @@ public sealed record CompressionActivity(
         var elapsed = nowUtc - startedUtc;
         return elapsed > TimeSpan.Zero ? elapsed : TimeSpan.Zero;
     }
+
+    /// <summary>
+    /// The minute of the hour this hypertable's compression policy is ASSIGNED by
+    /// <see cref="TimescaleSupport.CompressionPhaseMinutes"/>, or null when this product does not own the
+    /// hypertable — a bring-your-own store's own table, or a fixture table. Null is what keeps every
+    /// clearance figure below silent for a FOREIGN hypertable: this code chose no minute for it, so it has no
+    /// standing to say whether its run overran anything.
+    /// </summary>
+    public int? AssignedPhaseMinute =>
+        HypertableName is not null
+        && TimescaleSupport.TryCompressionPhaseMinutesFor(HypertableName, out var assigned)
+            ? assigned
+            : null;
+
+    /// <summary>
+    /// The minute of the hour the last run actually STARTED on, or null when the store recorded no start (or
+    /// recorded the never-ran sentinel, which <see cref="RunningFor"/> documents).
+    /// </summary>
+    public int? ObservedStartMinute =>
+        LastRunStartedAtUtc is DateTime startedUtc && startedUtc != DateTime.MinValue
+            ? startedUtc.Minute
+            : null;
+
+    /// <summary>
+    /// The minute the clearance is measured from: the OBSERVED start when there is one, otherwise the
+    /// assigned minute.
+    ///
+    /// <para><b>Observed first, and that ordering is the point (#3112).</b> The assigned minute is what this
+    /// product INTENDS; the observed minute is what happened. Those differ on exactly the store state
+    /// <see cref="TimescaleSupport.ConvergeCompressionScheduleAsync"/> documents as its degraded path — a job
+    /// catalog too old to expose <c>fixed_schedule</c>/<c>initial_start</c> keeps TimescaleDB's
+    /// finish-to-start scheduling and drifts through the hour by its own runtime — and on that store the
+    /// intended clearance is a fiction while the observed one is the fact. Reading the intent would report the
+    /// grid working on a store where it had not been applied.</para>
+    /// </summary>
+    public int? ClearanceMinute =>
+        AssignedPhaseMinute is null ? null : ObservedStartMinute ?? AssignedPhaseMinute;
+
+    /// <summary>True when the last run started on a minute other than the one the grid assigns — the drift
+    /// condition above, worth reporting because it makes every other figure here a statement about a policy
+    /// this product has not actually placed.</summary>
+    public bool OffAssignedPhase =>
+        AssignedPhaseMinute is int assigned && ObservedStartMinute is int observed && assigned != observed;
+
+    /// <summary>How long the run had before the next hourly refresh started, from
+    /// <see cref="TimescaleSupport.CompressionMinuteClearanceSeconds"/>. Null for a foreign hypertable.</summary>
+    public int? ClearanceSeconds =>
+        ClearanceMinute is int minute ? TimescaleSupport.CompressionMinuteClearanceSeconds(minute) : null;
+
+    /// <summary>Where the last completed run sits against that clearance. Null when there is no completed run
+    /// to judge or the hypertable is foreign — never a synthesized <c>InsideClearance</c>, which would read as
+    /// "measured and fine" for something not measured at all.</summary>
+    public TimescaleSupport.CompressionClearanceBand? ClearanceBand =>
+        ClearanceMinute is int minute && LastRunDuration is TimeSpan duration
+            ? TimescaleSupport.ClassifyCompressionClearance(duration.TotalSeconds, minute)
+            : null;
+
+    /// <summary>Seconds of the clearance left unused. Goes NEGATIVE past it rather than clamping, for the
+    /// reason <see cref="HeaviestRefreshSlotReading.ClearOfSlotSeconds"/> does: how far THROUGH the next
+    /// refresh's start a run went is the number that sizes the repair, and clamping reports every overrun as
+    /// a dead heat.</summary>
+    public double? ClearOfRefreshSeconds =>
+        ClearanceSeconds is int clearance && LastRunDuration is TimeSpan duration
+            ? clearance - duration.TotalSeconds
+            : null;
+
+    /// <summary>The last completed run as a percentage of its minute's clearance.</summary>
+    public double? PercentOfClearance =>
+        ClearanceSeconds is int clearance and > 0 && LastRunDuration is TimeSpan duration
+            ? 100.0 * duration.TotalSeconds / clearance
+            : null;
 }
 
 /// <summary>


### PR DESCRIPTION
Works #3112. **The decision is option 3 — accept the midnight burst with a watch — and the watch is a real gap rather than a placeholder.** Nothing here reduces what midnight carries, and nothing here moves a `compress_after`.

## Options 1 and 2 are the SAME lever, and that settles the ordering

The daily chunk close is not a job. It is an **eligibility event**: a chunk is compressible when `range_end < now() - compress_after`. TimescaleDB aligns 1-day chunks to the epoch, so `range_end` is a UTC midnight for every hypertable, and the eligibility instant is `range_end + compress_after` — identical everywhere while `compress_after` is a whole number of days. `schedule_interval` and `initial_start` move only which minute *discovers* that eligibility, which is what #3035/#3174's grid already does.

So the only lever on *when* the day's work becomes available is `compress_after`:

- **Option 1** (a pre-midnight window) is `compress_after` **below** a day, uniformly. The whole burst relocates to a different hour; the hour it lands on carries exactly what midnight carried. It also compresses younger data, which cuts into `CompressAfterDays`' own stated safety margin ("a day-old chunk never takes another write"). **Relocating a burst without reducing it is the outcome this issue set out not to produce**, so option 1 is dominated by option 2 — same lever, worse sign.
- **Option 2** (a sub-day stagger per hypertable family) is the same lever with per-family positive offsets, and it does reduce per-hour concentration. `compress_after` takes an INTERVAL, so `INTERVAL '1 day 2 hours'` is expressible.

## Why option 2 does not ship today

**It reaches no deployed store, and the code says so about itself.** `AddCompressionPolicySql` passes `if_not_exists => true`, which `ConvergeCompressionScheduleAsync`'s own doc records as measured: *"a documented no-op against a policy the store already has (measured: returns -1, NOTICE, parameters untouched) — it keys on the policy EXISTING, not on its parameters matching. So the create path reaches fresh installs only."* And the converge alters `schedule_interval`, `fixed_schedule` and `initial_start` only — its doc states *"this cannot arm a paused job or alter what a policy considers eligible."* A `CompressAfterDays` edit therefore lands on fresh installs and nowhere else. Shipping it needs a **new mutation surface** — an `alter_job(config => …)` sweep rewriting what every policy considers eligible on every store, including bring-your-own stores whose hypertables this product does not own — which is the one property the existing converge deliberately refuses to touch.

**~~The figures to size it against are last-snapshot samples, not maxima.~~ EXPIRED — corrected rather than left standing.** When this was written the only figures available were the 552 / 360 / 198 s runs from `collect.store_metrics`' hourly `background_job` snapshot, read once in the midnight hour on one store, to which #3119's caveat applies. **The census above has since supplied a maximum-capable population, whose recurring midnight maximum is 2,303.0 s.** So this reason no longer holds and the decision does not rest on it; the two above are independently sufficient. What remains true is narrower and is about the *product*, not about what an investigation can reach: there is still no compression-side measured ceiling **constant**, where the refresh side has two (`HeaviestHourlyRefreshObservedCeilingSeconds`, `OtherHourlyRefreshObservedCeilingSeconds`); the compression band's width comes from a **count**. This PR does not add one, because a constant I cannot re-derive from a read I ran is a pin over hearsay.

**A first version of this paragraph rested on a 2,678.8 s ceiling, and that figure has since been withdrawn as a planning number** — it is a `max_concurrent_sweeps=8` incident on 2026-09-05, and non-midnight long runs occur on **3 of the 22 days** (the store's first two plus that one) while the other 19 show nothing. So there are two phenomena, and the sporadic one is **explained** rather than mysterious; only the midnight regime is this issue's, and it is present on **21 of 22 days**. The recurring midnight population is `max` **2,303.0 s**, `p95` **2,000.8 s**, `median` **781.7 s**.

**On the right numbers the containment point is sharper, not weaker.** The whole compression band is 24 minutes — **1,440 s** — so a p95 of 2,000.8 s (33.3 min) and a max of 2,303.0 s (38.4 min) **exceed the entire band**, not just one minute's clearance: **no placement inside it contains either.** From the band's FIRST minute `:36`, p95 finishes at **01:09Z** and max at **01:14Z**, crossing 10 and 12 refresh starts; from `query_store_stats`' own `:42`, p95 finishes **01:15Z** and crosses all 13. The median, 781.7 s, fits the band at any minute and crosses nothing from `:36` or `:42`.

**A grid places a job's START and cannot bound its END**, so neither #3174's grid nor this watch is a containment guarantee. `CompressionClearanceBand.RefreshOverrun` therefore says "at least one refresh start", never "one"; the magnitude past the FIRST start is reported and the count of starts passed is not derived, because that needs each refresh's own runtime and not just its minute.

**And the work is not spread the way a uniform stagger assumes.** On the store measured, 47 of its 70 hypertables hold under 50 MB across *every chunk they have*, while the top five hold **82%** of the 89.7 GB those hypertables total (not of the store, which is larger — the payload dimension tables are plain). A stagger that matters is a stagger over about five families — and "which five" is a property of a store's data, not of the catalog, so a hand-picked heavy list is a frozen enumeration that goes stale on the next heavy collector.

## The result that actually decides it: #3174 already moved the axis the band ran through

Reconstructed from the shipped constants at both commits, not from a live read. Under the previous grid the compression minute for each hypertable was `CompressionPhaseMinutes[index % 24]` over minutes `{22–29, 37–44, 52–59}` with refresh starts `{0, 15, 30, 45}`. That places the five policies #3112's recurrence report named at **:26, :27, :28, :52, :58** — identical, in order, to the five observed start times `00:26 / 00:27 / 00:28 / 00:52 / 00:58`. Five for five, which is what says the reconstruction is the same grid and not a plausible-looking one.

| hypertable | measured chunk-close run | previous minute | previous clearance | shipped minute | shipped clearance |
|---|---|---|---|---|---|
| `query_stats` | 360 s | `:26` | 240 s | `:40` | **1,200 s** |
| `query_snapshots` | 198 s | `:27` | 180 s | `:41` | **1,140 s** |
| `query_store_stats` | 552 s | `:28` | 120 s | `:42` | **1,080 s** |
| `plan_correction` | — | `:52` | 480 s | `:52` | 480 s |
| `procedure_stats` | — | `:58` | 120 s | `:58` | **120 s** |

All three measured runs exceeded their previous clearance. All three are 17–51% of their shipped one. **#3174's PR body claimed neutrality on CONCENTRATION and was neutral on it — 24 minutes at 3 per minute before and after — but clearance is a different axis and it moved by 5–9x for the three heaviest.** That claim's last sentence ("it neither helps nor hurts that band") is corrected in `CompressionPhaseMinutes`' own doc here rather than left standing.

Recovering each hourly view's contended relation from its own shipped CREATE text puts the same conclusion at relation level: of the five, exactly one had a same-hypertable refresh adjacent to it — `query_store_stats` compression at `:28` against `query_store_stats_hourly` at `:30`, **two minutes** — and that is the refresh whose runtime went 160.4 s then 226.8 s against a 20–58 s steady state, which is the instance the mechanism predicted.

A second scheduling change now would put two changes in the same midnight and make neither attributable.

## Tonight is that grid's first midnight, and the observation needs one caveat built in

The fleet was upgraded 18:02–18:06Z to a nightly built from `dev` at `517ac165ffe7` — the #3178 commit — schema V113 on all three stores. **This PR is not in that build.** So tonight produces the first reading of `query_store_stats` compression on a `:42` minute rather than a `:28` one.

**"The binaries carry #3178" and "the 70 live policies moved to the new minutes" are different claims** — `AddCompressionPolicySql`'s `if_not_exists => true` is a documented no-op against an existing policy, while `ConvergeCompressionScheduleAsync` does alter `initial_start`, so only a catalog read settles it. **That read has since been taken**: compression on `{36–59}` contiguous, refreshes on `{0–11, 15}`, `fixed_schedule` true on all 70 policies, schema V113. So the grid is applied, by measurement rather than by inference, and the two remaining outcomes are these:

- **`query_store_stats` overruns at `:42`.** Placement is not the lever — which is this PR's own conclusion, not a surprise — and option 2 is promoted with a sized population behind it rather than a snapshot.
- **It does not overrun.** The clearance account holds for a typical night, which the census already says: a 781.7 s median against 1,080 s. One clean night is weak evidence either way, because the census puts the tail past the clearance on some nights; the informative statistic is the **rate over several nights**.

**And hour 0 alone cannot score it.** The band now starts at `:36`, so a p95-length run from `:36` finishes at 01:09Z and one from `:42` at 01:15Z — in the FOLLOWING hour's light refresh band, where the previous grid's `:26`–`:28` overruns landed in the same hour's `:30` refresh. A clean hour 0 is not a non-recurrence verdict; the window has to run to ~01:15Z.

**One correction to "the census says it should overrun tonight".** It does not say that. At roughly 20 runs per (policy, hour-of-day) cell, hour-0 p95 is the second-largest of about twenty draws, so 2,000.8 s predicts an overrun on **some** nights — between 2 and 11 of 20 — while the 781.7 s median predicts the typical night lands inside. A single night is close to a coin flip, which is the whole reason the prediction is stated as a rate.

For completeness, the tail clears the relation-aware bound too: the nearest refresh reading `query_store_stats` after `:42` is `query_store_stats_hourly` at `:02`, 1,200 s away, and 2,000.8 s exceeds that as well. The agnostic 1,080 s is the lower bound, as designed.

**Anyone reproducing tonight's numbers must exclude 18:02–18:06Z on all three stores** — the service stop for the upgrade leaves a collection gap there, and an upgrade artefact in the population is the same class of contaminant as an unparenthesised filter.

## The census overtook the first version of this prediction, and the restatement is a RATE, not a binary

A 22-day `timescaledb_information.job_history` census (33,005 compression rows, `succeeded`/`finish_time` filter reported inert) was run against the read filed for this lane after the body above was first written. It was **not** run by me and its row counts are not re-derivable here; it is quoted as supplied. It also **corrected a bug I introduced in that read**: `WHERE A OR B AND succeeded AND finish IS NOT NULL` parses as `A OR (B AND …)`, so the `%compression%` branch escaped both filters while the statement still looked filtered. That is silent population selection arriving through **operator precedence** rather than through a predicate, and it was parenthesized before running. No shipped statement carries the shape — of the four compression `proc_name` reads in `TimescaleSupport.cs`, two parenthesize the OR and two have it as the last predicate with nothing after it.

Its hour-0 figures, put through the **shipped** classifier at each hypertable's **shipped** minute:

| hypertable | minute | clearance | median | p95 | max | median band | p95 band | max band |
|---|---|---|---|---|---|---|---|---|
| `query_stats` | `:40` | 1,200 s | 52.3 s (4%) | 274.4 s (23%) | 359.9 s (30%) | Inside | Inside | Inside |
| `query_snapshots` | `:41` | 1,140 s | 27.6 s (2%) | 232.7 s (20%) | 233.3 s (20%) | Inside | Inside | Inside |
| `query_store_stats` | `:42` | 1,080 s | 781.7 s (**72%**) | 2,000.8 s (**185%**) | 2,303.0 s (**213%**) | Inside | **Overrun** | **Overrun** |
| `plan_correction` | `:52` | 480 s | 91.7 s (19%) | 288.3 s (60%) | 340.1 s (71%) | Inside | Inside | Inside |
| `procedure_stats` | `:58` | **120 s** | 27.6 s (23%) | 92.9 s (77%) | 168.4 s (**140%**) | Inside | Inside | **Overrun** |

**Read against the previous grid's clearances the same way, the census makes the clearance account stronger rather than weaker:**

| overruns of 5, at | previous grid | shipped grid |
|---|---|---|
| the hour-0 **median** | **1** | **0** |
| the hour-0 **p95** | **3** | **1** |
| the hour-0 **max** | **4** | **2** |

`query_store_stats`' median midnight run of 781.7 s is **6.5x** the 120 s it had at `:28` — so the overrun was happening on *every* night under the previous grid, which is exactly why the band recurred on both nights measured. At `:42` the same median is 72% of clearance and lands **inside the watch line**.

**So the restated prediction is a rate.** The overrun rate on `query_store_stats` at midnight should fall from effectively every night to the fraction of the hour-0 distribution above 1,080 s — which is between 2 and 11 of about 20 runs and which this body does not guess, because the census can state it and I have asked for that count. Recurrence on the tail is **expected, not a surprise**; what the watch is for there is quantifying the overrun, and `ClearOfRefreshSeconds` is what reports it. `procedure_stats` at `:58` overruns only at max, and it is the placement this body already named as the residual.

**One caveat on the p95, and it is the expiry `RefreshCeilingProvenancePinTests` already documents one constant over.** At roughly 20 runs per (policy, hour-of-day) cell, a nearest-rank 95th percentile is the second-largest draw. "Exceeds at p95" therefore means "at least two of about twenty midnights exceeded it", not "95% of midnights". The maximum is the mix-insensitive figure; the median is the one that describes a typical night; the p95 in between is nearly the maximum and should not be read as a rate.

## What ships: the band's missing runtime instrument

Every band of this grid has a runtime watch except the compression band.

- The heaviest refresh's window: `RefreshPhaseSlotSeconds` / `RefreshSlotWarningSeconds` / `ClassifyRefreshSlotHeadroom`, read live and logged (#3044).
- The light refreshes' guard: `CompressionPhaseGuardMinutes`, derived from a measured ceiling.
- The compression band: a **count**. Nothing compares a run's duration to the space its minute has.

Both instruments that look as though they would catch an overrun miss it, and one misses by a factor. **#2136's cadence knob** judges a compression job against its `schedule_interval`, so its shipped warning share puts the line at 900 s of a 3,600 s hour while the wall the run faces is its own minute's clearance — as little as **60 s**. That is fifteen times too high on the tightest minute in the band; the 552 s run reads 15.3% of cadence and never approaches the knob. **#1778's `LogCompressionActivity`** reports a run still RUNNING and a chunk backlog, never a completed run's duration against anything.

`CompressionMinuteClearanceMinutes(minute)` derives the distance forward round the hour to the next refresh start. `ClassifyCompressionClearance` bands an observed run against it, and the existing hourly observability sweep logs it — **no new read, no new timer**: every term is already in `CompressionActivity`.

**Relation-agnostic, and it is a provable lower bound.** The lock adjacency is per-relation, but this takes the minimum over *every* refresh start — the same predicate `CompressionPhaseMinutes` is built from. A minimum over a superset cannot exceed a minimum over the contending subset, so the figure is never larger than the true clearance and the watch speaks **earlier** than a relation-aware one, never later. Recovering the contended relation means parsing CREATE text, which is a test-time capability here and not an hourly-sweep one.

**Measured from where the run actually STARTED, not from where the grid puts the policy.** Those differ on exactly the store state the converge documents as its degraded path — a job catalog too old to expose `fixed_schedule`/`initial_start` keeps finish-to-start scheduling and drifts — and on that store the assigned minute is a fiction. A drifted policy also gets its own line naming both minutes.

**Levels, and why this does not become a muted exception.** The census answers the obvious objection — a watch that fires every night gets muted, and then the instrument is dead. Put through the shipped classifier, **the hour-0 MEDIAN of all five hypertables bands `InsideClearance`**, so on a typical midnight this logs nothing above Debug; `query_store_stats`' median sits at 72% of clearance, below its 900 s watch line. It speaks on the tail, which is what it is for. Overrun is **Warning**, not the Error the refresh watch's exceeded band gets: past the window there means a documented precondition is FALSE, while here it is the one-sided guard's accepted residual being consumed, which is a decision `HeaviestRefreshStartMinute` already took. The routine band costs **one Debug line for the whole store**, carrying the tightest reading — the discipline `LogCompressionActivity`'s own summary states, which 70 hourly lines would break. Emitted unconditionally rather than hung off the existing all-clear summary, which fires only when nothing is running and no chunk is eligible — i.e. suppressed in exactly the hour the chunk close makes interesting.

**One lead-time fraction, not two.** `WindowWatchLeadNumerator`/`Denominator` names the five sixths #3044 chose, and `RefreshSlotWarningSeconds` is **re-derived over it with its value unchanged at 1,050 s**. This file's own `CompressScheduleSpan` remark states the rule that forbids the alternative: cross-check by deriving one side from the other, never by pinning each side to its own literal.

## The compression grid did not need re-deriving

It is untouched. The rule, the band, the per-minute spread and every minute in it are exactly as #3174 left them; what is added is a derived *reading* over that grid. The residual is now a number instead of a sentence: the band's tail minute has one light-refresh step of clearance — **60 s** — and is always occupied, because the band is sized to hold the whole catalog at `CompressionPhaseMaxPerMinute`. The tightest large placement is `procedure_stats` at `:58` with 120 s, and it did not move at #3174.

## Verification

`Darling.Tests` targets `net10.0-windows` and cannot run on macOS, so the **actual shipped test files** — the new `CompressionClearanceWatchTests.cs` plus #3174's own four, unmodified (`TimescaleSupportTests`, `TimescaleContinuousAggregateTests`, `RefreshCeilingProvenancePinTests`, `DarlingSelfAlertTests`) and their real helpers — were compiled into a `net10.0` xunit.v3 suite named `Darling.Tests` (so `InternalsVisibleTo` still applies) and run — plus `CommentFilterAdoptionTests` and `DocCommentHygieneTests`, whose scans walk the real tree, with the harness output placed inside the worktree so their walk-up finds the real solution file: **306 total, 0 failed, 0 errors, 17 skipped (every one live-Postgres gated), 0 not run.** #3174's own pins are green against the re-derived `RefreshSlotWarningSeconds`.

**CI, which is where the two tree-wide enumerations were actually caught.** `Darling PostgreSQL tests` reports **8,221 total, 0 failed, 0 errors, 6 skipped, 0 not run** in 86.6 s of test execution, on a job whose step list shows it really ran the suite (`Initialize and start throwaway PostgreSQL` 8 s → `Run Darling PG tests` 89 s). The first push was **red there and green on `build` and `Darling Linux build`**, which is the reason to judge this repo's CI by the PG job: adding this test file shifted `CommentFilterAdoptionTests`' ordered list of every line-prefix comment filter, and then its class summary's count of that list by kind. Both are frozen enumerations doing their job; the entry states the two bounds the new file's doc-run walk and source map rest on, and the count moved with it. `RefreshCeilingProvenancePinTests` and the new prose pins read the real `TimescaleSupport.cs` through `[CallerFilePath]`. Live-Postgres and Windows-only paths are CI's to arbitrate.

Red-proofed by mutation. Each applied to the committed tree, **confirmed applied by a `git diff --numstat` plus a content check** (mutation present, original absent), rebuilt (a build failure hard-aborts the case), run, and restored — every case restored clean.

| mutation | tests red |
|---|---|
| clearance measured from the ASSIGNED minute, not the observed one | 3 |
| clearance is the distance to the FURTHEST refresh start | 5, incl. the nothing-starts-inside clause and the prose pins |
| a zero distance is skipped instead of being zero clearance | 1 |
| the overrun boundary is exclusive | 2 |
| no completed run synthesizes a passing verdict | 1 |
| clearance left over is clamped at zero | 1 |
| the watch fraction is re-inlined as a literal | 1 |
| a FOREIGN hypertable gets a clearance verdict | 2 |
| the routine band logs one line per policy | 1 |
| the tightest / widest stated clearance, and #3174's spread, restated wrong in the doc | 1 each |
| the drift sweep's own source map is off by one | **1 — the sweep itself** |
| the per-tick summary's missing share defaults to zero (the review finding, restored) | 1 |
| the watch line rounds so the two classifier boundaries stop sharing a share | 4 |
| the off-phase report goes back to one line per hypertable | 1 |
| the off-phase report fires when nothing is off phase | 1 |
| the summary reverts to one template with the zero default (the reported defect) | 1 |
| the sink arm renders a percentage instead of the distinct token | 1 |

**Two guards were themselves too weak, and both were caught by their own sweep rather than by review.**

The shared-fraction check first scanned the raw file and counted **2** copies of `* 5 / 6` — both DOC PROSE, one quoting the arithmetic behind 1,077 s and one stating the rule the check enforces. It uses `CSharpSourceWalker.StripCommentsAndStrings` now, over whitespace-collapsed code so `*5/6` cannot slip past a spacing variant, and it asserts the stripper kept code before searching — a stripper returning nothing would make the search vacuously clean.

And **the drift sweep could not mutate.** It located a captured group by searching the source for the captured text, so a group holding a single digit — the tenths of a percentage, the per-minute spread — matched the first such digit anywhere in the doc run, which for these paragraphs is inside `#3112` or `3,600`. The bump landed on text no verification reads, the mutated file verified clean, and the sweep reported **five** pins as drift-blind when it was the sweep that was blind. It maps prose characters back to source offsets now and asserts the source span equals the captured text; five of those six then caught their bump. The one that survives is the three quoted readings, marked `DriftSwept: false` with the reason — a ±1 changes neither the "ran past its clearance" verdict nor the rounded share, so material drift is caught and a single digit is not, which is better said than implied.

The sweep also reports **every** blind group rather than the first, because the question it answers is which numerals are load-bearing — a list, not a first offender.

## The review finding, and a third guard that could not fail

Review found a real ordering defect in the per-tick summary. `PercentOfClearance` is null exactly when the clearance is **zero** — reachable in production, and the worst geometry the grid can produce: a policy the converge could not put on a fixed schedule, drifted onto a minute an hourly refresh also starts on. `ClassifyCompressionClearance` bands that `RefreshOverrun` correctly, but the summary ranked by `PercentOfClearance ?? 0d`, so that policy lost to any routine reading with a positive share and the one line documented as naming the tightest reading named a milder one. The per-item Warning fired either way, so the cost was the aggregate line pointing away from the thing it exists to point at. Confirmed reachable and fixed.

**The first fix was two mechanisms, and the mutation sweep showed neither was falsifiable.** It ranked by band first and by share second, with the missing share defaulting to positive infinity. Restoring `?? 0d` changed no outcome, because the band arm already decided it; disabling the band arm changed no outcome, because the infinity default already decided it. **Two mutations, both green, on a test written specifically for this defect** — a redundant arm makes each arm individually unreachable, and a sweep then reports a real defect as unreachable code.

So the comparison is **single** now, and the property that makes one key sufficient is pinned rather than assumed: `ClassifyCompressionClearance`'s two boundaries are the clearance and five sixths of it, and every clearance the grid produces is a whole number of minutes, so both boundaries fall at the same **share** — 83.3% and 100% — on every minute in the band. Ranking by share is therefore ranking by band. Integer division is what would break that, and the pin asserts exactness (`clearance * numerator == watch * denominator`) for every minute rather than an inequality: a clearance that was not a multiple of the denominator would round the watch line down and put one minute's boundary at a different share, and the consequence would be silent. With one key, restoring `?? 0d` reddens exactly the new ranking test, and rounding the watch line reddens the exactness pin plus three others.

The ranking test uses the zero-clearance case deliberately and asserts its own premise first — that the share really is unavailable there and the companion's really is positive — because a large-but-finite overrun ranks correctly under either rule and so cannot tell them apart. It runs both arrival orders, since a comparator can be right in one and wrong in the other.

**A third round found the sharpest one: the selection was right and the REPORTING inverted it.** `IsTighter` treats a missing share as maximally tight, so a policy whose minute lands exactly on a refresh start — `ClearanceSeconds == 0`, which makes `PercentOfClearance` null through its own `and > 0` guard — was correctly picked as the tightest reading. It was then printed with `?? 0d`. Rendered side by side, the defect is plain:

```
sink      (5 s, zero clearance):  tightest ... query_store_stats at 0.0% of its 0s from :00 (RefreshOverrun)
comparison (0.1 s, 1,080 s spare): tightest ... query_store_stats at 0.0% of its 1080s from :42 (InsideClearance)
```

**The share token is byte-identical.** Every other reading in this watch gets more alarming as it gets worse; this one wrapped around to render the most reassuring number the format can emit, in the one case with no room at all — and `0.0%` cannot be told from "finished instantly" by whoever is scanning it. **It failed toward the better label.**

**No rendered quantity is a defaulted null now.** The clearance and the slack come off the minute, which is non-null inside the walk, so the `?? 0` is removed rather than hidden and a zero clearance reads as a real zero. The share is pattern-matched, so the null falls through to its own arm.

**That arm is a different FINDING, not the same one with an awkward number.** An ordinary overrun says the day's rewrite outgrew a tight minute and its remedy is the band's width; a policy sitting on a refresh's own minute says the phase grid was never applied to it and its remedy is the converge — so the chunk-close reasoning would have pointed an operator at the wrong lever. It is reached from **either** band, so a share-less `ApproachingRefresh` (which the arithmetic does not currently allow, since a zero clearance makes both boundaries zero) lands on the louder line rather than a milder one.

**The pin is on the rendered line, because a pin on the selection passes with the defect present.** It renders both cases for the same hypertable, extracts the percentages each states, and requires: the near-instant run states one (so the comparison is not vacuous), the sink case states none below 100%, the distinct `NO CLEARANCE` token is present (so the previous clause is not vacuous either), the two share-sets **differ**, the sink line carries the phase-converge remedy and not the chunk-close one, and an ordinary overrun still carries the chunk-close one. Reverting the summary to the single `?? 0d` template reddens it; so does making the sink arm print a percentage.

**A second round had already found another real defect, in the branch that broke this method's own discipline.** The off-phase report logged **per hypertable** at Information — two paragraphs below the doc stating that per-policy hourly lines are how a signal gets buried. Worse where it matters most: a policy off its assigned minute is a property of the **store**, not the hypertable, because the phased read either succeeds or it does not, so on a job catalog too old to expose `fixed_schedule`/`initial_start` every policy is off phase at once and **the failure does not heal** — one line per hypertable per hour, indefinitely, on precisely the store where the least can be done about it. It is one line for the store now, carrying the count out of the on-grid total plus one worked example's two minutes, and it stays Information because it is the **precondition of every other figure in the block**: a clearance measured on a store whose grid was never applied describes where a policy ran, not where this product placed it. Its test uses the case the condition actually produces — every policy off phase at once — and separately asserts silence when none is.

## What this does NOT do

- **It does not reduce what midnight carries**, and it does not claim the band is fixed. It makes the overrun visible, which nothing did.
- **It does not touch `compress_after`, the grid, or any schedule.** No store behaviour changes; one Debug line is added per hour and two conditional lines that cannot fire in the routine band.
- It does not settle whether #3174's placement holds under the growth trend. That needs a midnight the shipped grid has not yet run.
- It does not make the compression side's ceiling *measured*. The watch is what will produce that population, from `job_stats` — maintained unconditionally, unlike `job_history` — on every store rather than the one whose GUC #3175/#3177 healed.
- **It does not help the coverage consequence** and does not worsen it: a bloat figure on a churning PDT population can be a full pass stale and short-lived indexes may never be measured. Nothing here changes when anything is collected.

## CHANGELOG

Not edited here — entry text for the coordinator to batch:

```
- Watch a TimescaleDB compression run against the clearance its own minute of the hour has before the next
  continuous-aggregate refresh starts, so a daily chunk-close run that overruns into a refresh is reported
  instead of reading as 15% of its hourly cadence; both the refresh window's watch line and the new
  compression one are derived over a single named lead-time fraction (#3112).
```
