### PR TITLE
State what the refresh-slot routine-band case establishes, in the present tense

### DIFF
--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2742,12 +2742,13 @@ LIMIT 1", connection))
 
         /* THE ROUTINE-BAND CASE IS FED THE GRID'S OWN SIZING FIGURE, which is what makes asserting Debug
            here worth anything. The recorded ceiling is 896 s, 71.1% of the 1,260 s slot and 154 s below the
-           1,050 s watch line, so ClassifyRefreshSlotHeadroom bands it InsideSlot and the line comes out at
-           Debug. A lower literal would cover the level table just as well while dropping the claim this case
-           exists to hold: that the figure the grid is SIZED AROUND is a routine reading, not a warning.
-           Because both sides are read from TimescaleSupport rather than written as literals here, the two
-           can only meet by a real change — a census that raises the ceiling, or a re-derivation that narrows
-           the slot — and when they do, this case goes red instead of the product quietly calling its own
+           1,050 s watch line — ceiling, slot and watch line are all #3178's — so
+           ClassifyRefreshSlotHeadroom bands it InsideSlot and the line comes out at Debug. A lower literal
+           would cover the level table just as well while dropping the claim this case exists to hold: that
+           the figure the grid is SIZED AROUND is a routine reading, not a warning. Because both sides are
+           read from TimescaleSupport rather than written as literals here, the two can only meet by a real
+           change — a census raising the ceiling (#3166) or a re-derivation narrowing the slot (#3174,
+           #3178) — and when they do, this case goes red instead of the product quietly calling its own
            sizing figure a warning. */
         var inside = new CapturingTestLogger();
         TimescaleSupport.LogHeaviestRefreshSlotHeadroom(

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2740,13 +2740,15 @@ LIMIT 1", connection))
         TimescaleSupport.LogHeaviestRefreshSlotHeadroom(null, quiet);
         Assert.Equal("(no log lines captured)", quiet.Joined);
 
-        /* THE ROUTINE-BAND CASE IS FED THE RECORDED CEILING, and after #3166's census re-derivation that
-           reading logs Warning rather than Debug — so this assertion FAILS and is left exactly as written.
-           It is the same inversion as the band pins: a sizing figure the product's own watch line calls a
-           warning cannot also be the example of a routine reading. Re-pointing this case at a lower literal
-           would keep the level table covered while quietly dropping the claim that the grid's own figure is
-           routine, which is the claim worth losing loudly. The remedy is the slot or the fraction (#3035,
-           #3044, #3107). */
+        /* THE ROUTINE-BAND CASE IS FED THE GRID'S OWN SIZING FIGURE, which is what makes asserting Debug
+           here worth anything. The recorded ceiling is 896 s, 71.1% of the 1,260 s slot and 154 s below the
+           1,050 s watch line, so ClassifyRefreshSlotHeadroom bands it InsideSlot and the line comes out at
+           Debug. A lower literal would cover the level table just as well while dropping the claim this case
+           exists to hold: that the figure the grid is SIZED AROUND is a routine reading, not a warning.
+           Because both sides are read from TimescaleSupport rather than written as literals here, the two
+           can only meet by a real change — a census that raises the ceiling, or a re-derivation that narrows
+           the slot — and when they do, this case goes red instead of the product quietly calling its own
+           sizing figure a warning. */
         var inside = new CapturingTestLogger();
         TimescaleSupport.LogHeaviestRefreshSlotHeadroom(
             new HeaviestRefreshSlotReading(


### PR DESCRIPTION
Comment-only change in `TimescaleSupportTests.cs`. **The assertion and the value it is fed are untouched** — `git diff` is nine lines added, seven removed, all inside one block comment.

## What was wrong

The comment above the routine-band case in `TheRefreshSlotLogLine_IsLeveledByBand_AndSaysNothingWithoutAReading` narrated a failure:

> THE ROUTINE-BAND CASE IS FED THE RECORDED CEILING, and after #3166's census re-derivation that reading logs Warning rather than Debug — so this assertion FAILS and is left exactly as written. … The remedy is the slot or the fraction (#3035, #3044, #3107).

Both factual claims are false on the current grid, and the assertion below it passes. That also makes the comment a history-of-a-change note rather than a statement of what the code does, which is what the repo's comment convention rules out.

## What is true, measured rather than reasoned

Evaluated by compiling `PerformanceMonitor.Darling.Storage` (plain `net10.0`) and reading the real derivation chain through reflection, rather than hand-computing it:

| | value |
|---|---|
| `HeaviestHourlyRefreshObservedCeilingSeconds` | **896** |
| `HeaviestRefreshWindowMinutes` | 21 |
| `RefreshPhaseSlotSeconds` | **1,260** |
| `RefreshSlotWarningSeconds` | **1,050** |
| `ClassifyRefreshSlotHeadroom(896)` | **`InsideSlot`** |
| `ClassifyRefreshSlotHeadroom(1050)` | `ApproachingSlot` |
| `ClassifyRefreshSlotHeadroom(1260)` | `SlotExceeded` |

`InsideSlot` falls to `LogHeaviestRefreshSlotHeadroom`'s `default:` arm, which is `LogDebug`. So the case establishes that the grid's own sizing figure is a routine reading — 71.1% of the slot, 154 s below the watch line.

#3178 is what changed it: the slot went to 1,260 s and the watch line to 1,050 s, and #3178's own red-tests table already records the outcome ("the line at the ceiling is `Debug:`").

## What the replacement keeps

The stale comment's *reasoning* was right and is preserved: re-pointing the case at an arbitrary lower literal would keep the level table covered while dropping the claim worth holding — that the figure the grid is sized around is routine, not a warning. The replacement states that in the present tense and adds why it stays true without maintenance: both sides are read from `TimescaleSupport` rather than written as literals here, so the ceiling and the watch line can only meet through a real change (a census that raises the ceiling, a re-derivation that narrows the slot), and when they do this case goes red rather than the product quietly calling its own sizing figure a warning.

## Verification

`Darling.Tests` targets `net10.0-windows` and cannot run on macOS, so the **shipped** `TimescaleSupportTests.cs` was compiled unmodified — with its real helpers `CapturingTestLogger`, `LiveStoreCleanup`, `LiveCleanupBatch`, `IlCallSiteScanner` — into a `net10.0` xunit.v3 harness named `Darling.Tests` so `InternalsVisibleTo` still applies.

**48 total, 0 failed, 0 errors, 15 skipped, 0 not run.** Every skip is live-Postgres gated (`DARLING_TEST_PG`). The target case is absent from all 15 `[SKIP]` lines, so it ran rather than being counted as covered.

**Red-proofed.** With the fed value mutated from `HeaviestHourlyRefreshObservedCeilingSeconds` to `RefreshSlotWarningSeconds`, the case fails with `Assert.StartsWith() Failure: String start does not match / String: "Warning: TimescaleDB: query_store_stats_interval_h"···` — so the Debug assertion discriminates and does not pass vacuously. Mutation confirmed present in the tree by `git diff --numstat` plus a content check before running, and confirmed restored by content afterwards, with CRLF endings intact (3,819 CRLF, 0 bare LF, no BOM).

`dotnet build Darling/Darling.Tests/Darling.Tests.csproj -p:EnableWindowsTargeting=true` succeeds, 0 errors.

## CHANGELOG entry text (not committed)

Under `[Unreleased]` → `Fixed`:

- The refresh-slot log-level test's routine-band comment stated that the case failed because the recorded ceiling logged Warning; on the #3178 grid the ceiling bands `InsideSlot` and logs Debug, and the comment now states what the case establishes instead of narrating a repaired failure.
