### PR TITLE
Report a recorded refresh ceiling that a live run has falsified, separately from the slot it still fits inside

### DIFF
--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -684,6 +684,44 @@ public sealed class RefreshCeilingProvenancePinTests
     }
 
     /// <summary>
+    /// Each ceiling constant's summary NAMES ITS OWN STATISTIC and names its own population, and neither
+    /// treats a single closed day and the constant's population as the same population (#3182).
+    ///
+    /// <para><b>Why this is a test.</b> The defect #3182 records is a summary that said "the census
+    /// maximum" while quoting one day's figure, with a sentence asserting that the two "describe the same
+    /// population". Nothing could fail on that: a statistic and a population stated in prose cannot be
+    /// derived from anything, so a constant whose summary does not name its own statistic can drift into
+    /// being a different one with nothing going red. Which is what happened — and the rest of this file,
+    /// which checks every FIGURE the prose draws, passed the whole time, because each figure was correct
+    /// arithmetic over a population the sentence above it mislabelled.</para>
+    ///
+    /// <para>Checked as a SHAPE rather than as a wording: the summary must declare a statistic and must
+    /// name a population, and the specific false identity claim must stay gone. A reworded but honest
+    /// summary passes; one that drops either half does not. Lives HERE rather than beside the staleness
+    /// finding's own cases because <see cref="DocProseFor"/> is the doc-run walker this file already
+    /// carries a stated bound for, and a second hand-rolled one is the shape
+    /// <c>CommentFilterAdoptionTests</c> exists to stop.</para>
+    /// </summary>
+    [Fact]
+    public void EachCeilingSummary_NamesItsStatisticAndItsPopulation()
+    {
+        var source = ReadTimescaleSupportSource();
+
+        foreach (var declaration in new[] { CeilingDeclaration, LightCeilingDeclaration })
+        {
+            var prose = DocProseFor(source, declaration);
+
+            Assert.Contains("This is a MAXIMUM.", prose, StringComparison.Ordinal);
+            Assert.Contains("Its population is", prose, StringComparison.Ordinal);
+        }
+
+        /* THE CLAIM THAT HAD TO GO, checked file-wide rather than in the paragraph that carried it: the
+           substitution of a day for a population has as many wordings as it has sites, and the one wording
+           that is known to have been made is the one worth being unable to restore. */
+        Assert.DoesNotContain("describe the same population", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Each shape the guard forbids, injected ONE AT A TIME into a copy of the source with the guard
     /// required to fail on it — a bundled mutation reports that something fired, not which clause did.
     ///

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -719,6 +719,27 @@ public sealed class RefreshCeilingProvenancePinTests
            substitution of a day for a population has as many wordings as it has sites, and the one wording
            that is known to have been made is the one worth being unable to restore. */
         Assert.DoesNotContain("describe the same population", source, StringComparison.Ordinal);
+
+        /* AND EACH ONE DISCLAIMS THE OTHER'S POPULATION, which is the half naming your own statistic does
+           not cover. These two constants sit next to each other, are derived by the same named read with
+           the same positional exclusion rule, and answer to DIFFERENT spans - one to the whole
+           post-boundary record, one to a closed day inside it. A reader who takes the pair as matched and
+           compares a maximum from one against a maximum from the other, or against a sweep over a store's
+           whole job history, concludes that a constant is understated by a FACTOR when what they have is a
+           population mismatch. That conclusion has been reached and published, so the disclaimer is not
+           hypothetical tidiness: each summary has to name the other constant and say the populations are
+           not the same, or the pair goes on inviting the comparison. */
+        foreach (var (declaration, sibling) in new[]
+        {
+            (CeilingDeclaration, nameof(TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds)),
+            (LightCeilingDeclaration, nameof(TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds)),
+        })
+        {
+            var prose = DocProseFor(source, declaration);
+
+            Assert.Contains(sibling, prose, StringComparison.Ordinal);
+            Assert.Contains("NOT THE SAME POPULATION AS ITS SIBLING'S", prose, StringComparison.Ordinal);
+        }
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/RefreshCeilingStalenessTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingStalenessTests.cs
@@ -208,15 +208,21 @@ public sealed class RefreshCeilingStalenessTests
             new RefreshCeilingStalenessWatch(), log);
         Assert.Equal("(no log lines captured)", log.Joined);
 
-        /* And NaN is not silently recorded as a mark either, which would let a real falsification afterwards
-           be compared against a NaN and swallowed — every comparison against NaN is false, so a mark of NaN
-           would report EVERY later reading rather than none, and the rate limit would be gone in the one
-           case a catalog handed back nonsense. */
+        /* AND THE LOAD-BEARING HALF, which is the limiter rather than the classifier. Every comparison
+           against NaN is false, so a NaN allowed to become the high-water mark answers "report" for every
+           later reading too — one impossible catalog reading would disable the rate limit for the life of
+           the process. Asserted against ShouldReport DIRECTLY, because that is the surface where the value
+           can arrive: the classifier's own comparison already answers CeilingHolds for a non-finite reading,
+           so a guard there would be unreachable and a test on it would pass with the guard deleted. */
         var watch = new RefreshCeilingStalenessWatch();
-        TimescaleSupport.LogRefreshCeilingStaleness(
-            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, double.NaN, watch,
-            new CapturingTestLogger());
+        Assert.False(watch.ShouldReport(HeaviestConstant, double.NaN));
+        Assert.False(watch.ShouldReport(HeaviestConstant, double.PositiveInfinity));
         Assert.Null(watch.ReportedHighWaterMark(HeaviestConstant));
+
+        /* And a real falsification afterwards behaves as though the nonsense never arrived. */
+        Assert.True(watch.ShouldReport(HeaviestConstant, Ceiling + 1));
+        Assert.Equal(Ceiling + 1, watch.ReportedHighWaterMark(HeaviestConstant));
+        Assert.False(watch.ShouldReport(HeaviestConstant, Ceiling + 1));
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/RefreshCeilingStalenessTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingStalenessTests.cs
@@ -438,44 +438,6 @@ public sealed class RefreshCeilingStalenessTests
     }
 
     /// <summary>
-    /// Each ceiling constant's summary NAMES ITS OWN STATISTIC and its own population, and the heaviest
-    /// one no longer claims a single day and its population are the same population.
-    ///
-    /// <para><b>Why this is a test and not a review note.</b> The defect #3182 records is a summary that
-    /// said "the census maximum" while quoting one day's figure, with a sentence asserting the two
-    /// "describe the same population". Nothing could fail on that: the statistic and the population are
-    /// prose, and prose cannot call into the product. A constant whose summary does not name its own
-    /// statistic can drift into being a different one with nothing going red — which is what happened.</para>
-    ///
-    /// <para>Checked as a SHAPE and not as a wording: the summary has to declare a statistic and has to
-    /// name a population, and the specific false identity claim has to stay gone. A reworded but still
-    /// honest summary passes; a summary that drops either half does not.</para>
-    /// </summary>
-    [Fact]
-    public void EachCeilingSummary_NamesItsStatisticAndItsPopulation()
-    {
-        var source = ReadTimescaleSupportSource();
-
-        foreach (var declaration in new[]
-        {
-            "public const int HeaviestHourlyRefreshObservedCeilingSeconds",
-            "public const double OtherHourlyRefreshObservedCeilingSeconds",
-        })
-        {
-            var prose = DocProseFor(source, declaration);
-
-            Assert.Contains("This is a MAXIMUM.", prose, StringComparison.Ordinal);
-            Assert.Contains("Its population is", prose, StringComparison.Ordinal);
-        }
-
-        /* THE CLAIM THAT HAD TO GO. The live-envelope paragraph said a single closed day and the constant's
-           population "describe the same population", which is what let one day's maximum carry a census's
-           authority. They coincide because the population's largest run fell inside that day, which is a
-           fact about where one run landed. */
-        Assert.DoesNotContain("describe the same population", source, StringComparison.Ordinal);
-    }
-
-    /// <summary>
     /// A MEASURED reading, quoted as evidence rather than derived: the clean 17:00Z run of 2026-09-08, whose
     /// existence is the concrete demonstration that the recorded ceiling was overtaken from inside the
     /// routine band (#3182).
@@ -627,36 +589,6 @@ public sealed class RefreshCeilingStalenessTests
         logger.Joined == "(no log lines captured)"
             ? 0
             : logger.Joined.Split(" | ", StringSplitOptions.None).Length;
-
-    /// <summary>
-    /// One member's doc-comment run, joined to a single line — the same shape
-    /// <c>RefreshCeilingProvenancePinTests</c> parses, so a claim that wraps across <c>///</c> lines is one
-    /// string rather than a match a line-oriented search misses.
-    /// </summary>
-    private static string DocProseFor(string source, string declaration)
-    {
-        var lines = source.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
-        var index = Array.FindIndex(lines, l => l.Contains(declaration, StringComparison.Ordinal));
-        Assert.True(index >= 0, $"'{declaration}' was not found in TimescaleSupport.cs");
-
-        var run = new List<string>();
-        for (var i = index - 1; i >= 0; i--)
-        {
-            var line = lines[i].Trim();
-            if (!line.StartsWith("///", StringComparison.Ordinal))
-            {
-                break;
-            }
-
-            run.Insert(0, line[3..].Trim());
-        }
-
-        Assert.NotEmpty(run);
-        return string.Join(" ", run);
-    }
-
-    private static string ReadTimescaleSupportSource([CallerFilePath] string thisFile = "") =>
-        ReadSibling(thisFile, "PerformanceMonitor.Darling.Storage", "TimescaleSupport.cs");
 
     private static string ReadDarlingWorkerSource([CallerFilePath] string thisFile = "") =>
         ReadSibling(thisFile, "PerformanceMonitor.Darling.Service", "DarlingWorker.cs");

--- a/Darling/Darling.Tests/RefreshCeilingStalenessTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingStalenessTests.cs
@@ -1,0 +1,673 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The #3182 finding: a live reading that has overtaken a ceiling CONSTANT, reported separately from where
+/// that reading sits against its slot.
+///
+/// <para><b>The defect these cases are written against.</b>
+/// <see cref="TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds"/> is recorded as the maximum of
+/// a closed population. Runs above it happened, and every one of them classified
+/// <see cref="TimescaleSupport.RefreshSlotHeadroom.InsideSlot"/> and logged at Debug, because a run can be
+/// past the recorded ceiling and still a long way inside the window the grid gives it. So the product had a
+/// signal for "the slot is exceeded" and no signal at all for "the number the grid was DERIVED from is
+/// wrong" — and the second is what a stale sizing constant produces. The two are different facts with
+/// different remedies and both can be true of one reading.</para>
+///
+/// <para><b>Every probe is DERIVED from the constants, never a literal.</b> The falsifying reading is the
+/// recorded ceiling plus one second, which is the tightest falsifier that exists at any value the constant
+/// can take; the band probes are the watch line and the slot width. One case quotes a measured reading, and
+/// it says so and carries its own admissibility guard.</para>
+///
+/// <para><b>What is NOT claimed here.</b> Nothing in this file asserts that either constant IS or is NOT
+/// currently stale — that is a measurement, it moves hourly, and a test that encoded tonight's answer would
+/// be the same frozen-figure defect one level up. What is asserted is that a falsification is REPORTED when
+/// it occurs, from any band, at a level that is not the level the defect hid at, and no more than once per
+/// constant until a larger run arrives.</para>
+/// </summary>
+public sealed class RefreshCeilingStalenessTests
+{
+    private static int Ceiling => TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds;
+
+    private static int WatchLine => TimescaleSupport.RefreshSlotWarningSeconds;
+
+    private static int Slot => TimescaleSupport.RefreshPhaseSlotSeconds;
+
+    private static string HeaviestConstant => TimescaleSupport.HeaviestRefreshCeilingConstantName;
+
+    private static string LightConstant => TimescaleSupport.OtherRefreshCeilingConstantName;
+
+    /// <summary>
+    /// THE HEADLINE CASE, and the one the whole finding exists for: a reading above the recorded ceiling but
+    /// below the watch line. The slot watch calls it routine and logs Debug — correctly, it IS routine
+    /// against the slot — and the staleness finding still speaks.
+    ///
+    /// <para><b>The vacuity guard is the first assertion and it is not decoration.</b> This case only tests
+    /// anything while a falsifying reading can EXIST inside the routine band, which needs
+    /// <c>Ceiling + 1 &lt; RefreshSlotWarningSeconds</c>. If a re-derivation ever put the ceiling at or past
+    /// the watch line, every falsifying reading would be a warning or a breach anyway, the finding's whole
+    /// premise would have changed, and this case would go red rather than quietly stop covering the band it
+    /// names.</para>
+    /// </summary>
+    [Fact]
+    public void TheFinding_SpeaksFromInsideTheRoutineBand_WhereTheSlotWatchIsSilent()
+    {
+        Assert.True(
+            Ceiling + 1 < WatchLine,
+            $"the {Ceiling} s ceiling plus one second is at or past the {WatchLine} s watch line, so no "
+            + "falsifying reading can land in the routine band and this case covers nothing. That is a real "
+            + "change in the finding's premise — the constant would then be inside the band the slot watch "
+            + "already speaks in — so re-read #3182 rather than adjusting this probe");
+
+        var falsifying = Ceiling + 1;
+
+        /* The slot watch's verdict on the same reading, from the shipped classifier: routine, and Debug. */
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotHeadroom.InsideSlot,
+            TimescaleSupport.ClassifyRefreshSlotHeadroom(falsifying));
+
+        var slotWatch = new CapturingTestLogger();
+        TimescaleSupport.LogHeaviestRefreshSlotHeadroom(
+            new HeaviestRefreshSlotReading(TimescaleSupport.HeaviestHourlyRefreshView, falsifying), slotWatch);
+        Assert.StartsWith("Debug:", slotWatch.Joined, StringComparison.Ordinal);
+
+        /* And the finding, on the same reading: a Warning that names the CONSTANT. */
+        Assert.Equal(
+            TimescaleSupport.RefreshCeilingFreshness.CeilingFalsified,
+            TimescaleSupport.ClassifyRefreshCeilingFreshness(falsifying, Ceiling));
+
+        var finding = new CapturingTestLogger();
+        TimescaleSupport.LogRefreshCeilingStaleness(
+            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, falsifying,
+            new RefreshCeilingStalenessWatch(), finding);
+
+        Assert.StartsWith("Warning:", finding.Joined, StringComparison.Ordinal);
+        Assert.Contains(HeaviestConstant, finding.Joined, StringComparison.Ordinal);
+        Assert.Contains(TimescaleSupport.HeaviestHourlyRefreshView, finding.Joined, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The finding is reachable from EVERY slot band, enumerated over the shipped enum rather than over a
+    /// list written here — so a band added later has to be given a probe deliberately instead of silently
+    /// falling outside the coverage this case claims.
+    ///
+    /// <para>Each probe is asserted to actually LAND in the band it is offered for, before the finding is
+    /// asked anything. A probe that had drifted into a neighbouring band would otherwise report coverage of
+    /// a band nothing tested.</para>
+    /// </summary>
+    [Fact]
+    public void TheFinding_IsReachableFromEverySlotBand()
+    {
+        var probes = new Dictionary<TimescaleSupport.RefreshSlotHeadroom, double>
+        {
+            [TimescaleSupport.RefreshSlotHeadroom.InsideSlot] = Ceiling + 1,
+            [TimescaleSupport.RefreshSlotHeadroom.ApproachingSlot] = WatchLine,
+            [TimescaleSupport.RefreshSlotHeadroom.SlotExceeded] = Slot,
+        };
+
+        var bands = Enum.GetValues<TimescaleSupport.RefreshSlotHeadroom>();
+        Assert.NotEmpty(bands);
+        Assert.All(bands, band => Assert.True(
+            probes.ContainsKey(band),
+            $"the slot classifier has a {band} band with no probe here, so this case's claim to cover every "
+            + "band is false. Add a falsifying reading that lands in it (#3182)"));
+
+        foreach (var (band, reading) in probes)
+        {
+            Assert.Equal(band, TimescaleSupport.ClassifyRefreshSlotHeadroom(reading));
+
+            Assert.True(
+                reading > Ceiling,
+                $"the {band} probe of {reading} s is not above the {Ceiling} s ceiling, so it cannot "
+                + "falsify anything and this band's coverage is vacuous");
+
+            var log = new CapturingTestLogger();
+            TimescaleSupport.LogRefreshCeilingStaleness(
+                HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, reading,
+                new RefreshCeilingStalenessWatch(), log);
+
+            Assert.StartsWith("Warning:", log.Joined, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The ceiling boundary EXCLUDES equality where the slot bands include it, and that opposition is the
+    /// point rather than an inconsistency.
+    ///
+    /// <para>A run that took exactly its window was already colliding with its neighbour, so the slot wall is
+    /// inclusive. A reading equal to a recorded maximum is the reading that maximum was taken from and
+    /// CONFIRMS the constant. Inclusive here would report the grid's own sizing figure as a falsification of
+    /// itself on the hour it was measured — which is the one reading guaranteed to arrive.</para>
+    /// </summary>
+    [Fact]
+    public void TheCeilingBoundaryExcludesEquality_WhereTheSlotWallIncludesIt()
+    {
+        Assert.Equal(
+            TimescaleSupport.RefreshCeilingFreshness.CeilingHolds,
+            TimescaleSupport.ClassifyRefreshCeilingFreshness(Ceiling, Ceiling));
+
+        Assert.Equal(
+            TimescaleSupport.RefreshCeilingFreshness.CeilingFalsified,
+            TimescaleSupport.ClassifyRefreshCeilingFreshness(Ceiling + 1, Ceiling));
+
+        /* The contrast, from the shipped sibling: AT the slot width is already a breach. */
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotHeadroom.SlotExceeded,
+            TimescaleSupport.ClassifyRefreshSlotHeadroom(Slot));
+
+        /* And the constant's own recorded value logs NOTHING, which is the consequence that matters: the
+           sizing figure arrives once an hour on a store sitting at its recorded ceiling, and a finding that
+           fired on it would be noise from the first tick. */
+        var log = new CapturingTestLogger();
+        TimescaleSupport.LogRefreshCeilingStaleness(
+            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, Ceiling,
+            new RefreshCeilingStalenessWatch(), log);
+        Assert.Equal("(no log lines captured)", log.Joined);
+    }
+
+    /// <summary>
+    /// An impossible reading costs the LINE, never the sweep — the posture
+    /// <see cref="TimescaleSupport.ClassifyRefreshSlotHeadroom"/> and
+    /// <see cref="TimescaleSupport.ClassifyCompressionClearance"/> both take.
+    ///
+    /// <para>NaN is asserted explicitly even though <c>NaN &gt; x</c> is false anyway: the answer has to be a
+    /// DECISION in the code, not a property of IEEE comparison that a later refactor could invert without
+    /// anything noticing.</para>
+    /// </summary>
+    [Fact]
+    public void AnImpossibleReading_HoldsTheCeiling_AndSaysNothing()
+    {
+        Assert.Equal(
+            TimescaleSupport.RefreshCeilingFreshness.CeilingHolds,
+            TimescaleSupport.ClassifyRefreshCeilingFreshness(double.NaN, Ceiling));
+        Assert.Equal(
+            TimescaleSupport.RefreshCeilingFreshness.CeilingHolds,
+            TimescaleSupport.ClassifyRefreshCeilingFreshness(-1d, Ceiling));
+
+        var log = new CapturingTestLogger();
+        TimescaleSupport.LogRefreshCeilingStaleness(
+            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, double.NaN,
+            new RefreshCeilingStalenessWatch(), log);
+        TimescaleSupport.LogRefreshCeilingStaleness(
+            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, -1d,
+            new RefreshCeilingStalenessWatch(), log);
+        Assert.Equal("(no log lines captured)", log.Joined);
+
+        /* And NaN is not silently recorded as a mark either, which would let a real falsification afterwards
+           be compared against a NaN and swallowed — every comparison against NaN is false, so a mark of NaN
+           would report EVERY later reading rather than none, and the rate limit would be gone in the one
+           case a catalog handed back nonsense. */
+        var watch = new RefreshCeilingStalenessWatch();
+        TimescaleSupport.LogRefreshCeilingStaleness(
+            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, double.NaN, watch,
+            new CapturingTestLogger());
+        Assert.Null(watch.ReportedHighWaterMark(HeaviestConstant));
+    }
+
+    /// <summary>
+    /// The rate limit: the first falsifying reading reports, and after that only one LARGER than the largest
+    /// already reported.
+    ///
+    /// <para><b>Why a high-water mark rather than a latch or a time window.</b> What this finding asks for is
+    /// a constant re-derived to at least the largest run on record, so a new record changes the answer and a
+    /// repeat does not. A once-per-process latch would hide the reading that actually sizes the
+    /// re-derivation behind whichever one happened to arrive first, and a time window would re-report a value
+    /// already reported on a timer — which is how an hourly Warning becomes furniture.</para>
+    ///
+    /// <para>The mark is read directly rather than inferred from the log, because a test that could only
+    /// count lines would be testing the message.</para>
+    /// </summary>
+    [Fact]
+    public void TheRateLimit_ReportsTheFirstFalsification_ThenOnlyALargerRun()
+    {
+        var watch = new RefreshCeilingStalenessWatch();
+
+        Assert.Null(watch.ReportedHighWaterMark(HeaviestConstant));
+
+        Assert.True(watch.ShouldReport(HeaviestConstant, Ceiling + 1));
+        Assert.Equal(Ceiling + 1, watch.ReportedHighWaterMark(HeaviestConstant));
+
+        /* The same reading again says nothing. */
+        Assert.False(watch.ShouldReport(HeaviestConstant, Ceiling + 1));
+
+        /* A LARGER run does, because it changes what the constant has to be re-derived to. */
+        Assert.True(watch.ShouldReport(HeaviestConstant, Ceiling + 5));
+        Assert.Equal(Ceiling + 5, watch.ReportedHighWaterMark(HeaviestConstant));
+
+        /* A smaller one afterwards does not, and the mark does NOT fall back to it. The mark is a record of
+           the largest value already said out loud, not a measure of current load, so load falling cannot
+           make the finding start repeating itself. */
+        Assert.False(watch.ShouldReport(HeaviestConstant, Ceiling + 3));
+        Assert.Equal(Ceiling + 5, watch.ReportedHighWaterMark(HeaviestConstant));
+
+        Assert.True(watch.ShouldReport(HeaviestConstant, Ceiling + 9));
+        Assert.Equal(Ceiling + 9, watch.ReportedHighWaterMark(HeaviestConstant));
+    }
+
+    /// <summary>
+    /// The whole sequence again through the SHIPPED log path rather than through
+    /// <see cref="RefreshCeilingStalenessWatch.ShouldReport"/> directly — because a limiter that works and a
+    /// caller that never consults it produce identical unit results, and the wiring between them is where
+    /// this kind of thing breaks.
+    /// </summary>
+    [Fact]
+    public void TheLogPath_ConsultsTheRateLimit_RatherThanReportingEveryTick()
+    {
+        var watch = new RefreshCeilingStalenessWatch();
+        var log = new CapturingTestLogger();
+
+        void Report(double seconds) => TimescaleSupport.LogRefreshCeilingStaleness(
+            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, seconds, watch, log);
+
+        Report(Ceiling + 1);
+        Report(Ceiling + 1);
+        Report(Ceiling + 1);
+
+        Assert.Equal(1, CountLines(log));
+
+        Report(Ceiling + 7);
+        Assert.Equal(2, CountLines(log));
+
+        Report(Ceiling + 2);
+        Assert.Equal(2, CountLines(log));
+    }
+
+    /// <summary>
+    /// The rate limit is keyed on the CONSTANT, not on the view — which matters only for the light ceiling
+    /// and matters a lot there: one constant
+    /// (<see cref="TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds"/>) covers the twelve other
+    /// hourly views, so keying on the view would let each of them report the same constant's staleness
+    /// independently and the limit would be twelve times looser than it reads.
+    ///
+    /// <para>The two constants are independent of each other, which is the other half: a falsification of
+    /// one must not silence the other.</para>
+    /// </summary>
+    [Fact]
+    public void TheRateLimit_IsKeyedOnTheConstant_NotOnTheView()
+    {
+        var lightCeiling = TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds;
+        var lightViews = TimescaleSupport.HourlyRefreshPhaseOrder
+            .Where(v => !string.Equals(v, TimescaleSupport.HeaviestHourlyRefreshView, StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.True(
+            lightViews.Length > 1,
+            "there is at most one light hourly view, so a view-keyed limit would be indistinguishable from a "
+            + "constant-keyed one and this case covers nothing");
+
+        var watch = new RefreshCeilingStalenessWatch();
+        var log = new CapturingTestLogger();
+
+        foreach (var view in lightViews)
+        {
+            TimescaleSupport.LogRefreshCeilingStaleness(
+                LightConstant, lightCeiling, view, lightCeiling + 1d, watch, log);
+        }
+
+        Assert.Equal(1, CountLines(log));
+
+        /* And the heaviest constant is untouched by all of that. */
+        Assert.Null(watch.ReportedHighWaterMark(HeaviestConstant));
+        TimescaleSupport.LogRefreshCeilingStaleness(
+            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, Ceiling + 1, watch, log);
+        Assert.Equal(2, CountLines(log));
+    }
+
+    /// <summary>
+    /// The two findings cannot be read as each other. The staleness line asks for the CONSTANT to be
+    /// re-derived and cites #3182; the slot breach line asks for the GRID to be re-derived and cites #3035.
+    /// Neither remedy appears in the other's line.
+    ///
+    /// <para>This is the pin that stops the finding being "collapsed" back into the band watch by a later
+    /// simplification — two log lines whose text is interchangeable are one signal with two spellings, and
+    /// the whole of #3182 is that these are two facts.</para>
+    /// </summary>
+    [Fact]
+    public void TheTwoFindings_NameDifferentRemedies()
+    {
+        var staleness = new CapturingTestLogger();
+        TimescaleSupport.LogRefreshCeilingStaleness(
+            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView, Ceiling + 1,
+            new RefreshCeilingStalenessWatch(), staleness);
+
+        Assert.Contains("#3182", staleness.Joined, StringComparison.Ordinal);
+        Assert.Contains(HeaviestConstant, staleness.Joined, StringComparison.Ordinal);
+
+        var breach = new CapturingTestLogger();
+        TimescaleSupport.LogHeaviestRefreshSlotHeadroom(
+            new HeaviestRefreshSlotReading(TimescaleSupport.HeaviestHourlyRefreshView, Slot), breach);
+
+        Assert.StartsWith("Error:", breach.Joined, StringComparison.Ordinal);
+        Assert.Contains("#3035", breach.Joined, StringComparison.Ordinal);
+
+        /* Each line names its own subject and NOT the other's, so an operator reading one is not sent to the
+           other's repair. */
+        Assert.DoesNotContain(HeaviestConstant, breach.Joined, StringComparison.Ordinal);
+
+        /* And the levels differ, which is the load-bearing half: levelling the staleness finding Error too
+           would make a stale constant indistinguishable from a violated precondition on every log surface
+           there is. */
+        Assert.DoesNotContain("Error:", staleness.Joined, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The light ceiling now HAS a live feed keyed on the view, and it is the same statement as the heaviest
+    /// one with its view filter inverted.
+    ///
+    /// <para><b>Why the filter-inversion equality is the pin.</b> The measured OR-join is shared between the
+    /// two statements, so asserting that both carry both of its arms would be an assertion about a shared
+    /// constant and could not fail. What CAN fail is the two statements diverging — one of them re-spelled,
+    /// re-joined, or given a different projection — and the inversion equality is red the moment they differ
+    /// anywhere other than that one operator.</para>
+    /// </summary>
+    [Fact]
+    public void TheLightRefreshRead_IsTheHeaviestReadWithItsViewFilterInverted()
+    {
+        var heaviest = TimescaleSupport.HeaviestRefreshRuntimeSql;
+        var light = TimescaleSupport.OtherHourlyRefreshRuntimesSql;
+
+        var include = $"ca.view_name = '{TimescaleSupport.HeaviestHourlyRefreshView}'";
+        var exclude = $"ca.view_name <> '{TimescaleSupport.HeaviestHourlyRefreshView}'";
+
+        Assert.Contains(include, heaviest, StringComparison.Ordinal);
+        Assert.Contains(exclude, light, StringComparison.Ordinal);
+
+        Assert.Equal(light, heaviest.Replace(include, exclude, StringComparison.Ordinal));
+
+        /* Both keep the status filter, for the reason every sibling read has it. */
+        Assert.Contains("js.last_run_status = 'Success'", light, StringComparison.Ordinal);
+
+        /* And the projection is the VIEW name, which is the identity the grid is keyed on — a job id would
+           name a different job on any other deployment. */
+        Assert.Contains("ca.view_name,", light, StringComparison.Ordinal);
+        Assert.DoesNotContain("job_id =", light, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The finding is WIRED, checked against the real service source. A classifier, a limiter and a log
+    /// method that nothing calls are individually perfect and jointly inert — the failure shape this repo
+    /// already parses <c>DarlingStoreUpgrade.cs</c> and the Kestrel hosts for.
+    ///
+    /// <para>Both constants have to be wired, and the light one needs its READ wired too, since it had no
+    /// live reading anywhere in the product before #3182.</para>
+    /// </summary>
+    [Fact]
+    public void BothCeilingsAreWiredIntoTheHourlySweep()
+    {
+        var worker = ReadDarlingWorkerSource();
+
+        Assert.Contains(
+            nameof(TimescaleSupport.LogRefreshCeilingStaleness), worker, StringComparison.Ordinal);
+        Assert.Contains(
+            nameof(TimescaleSupport.HeaviestRefreshCeilingConstantName), worker, StringComparison.Ordinal);
+        Assert.Contains(
+            nameof(TimescaleSupport.OtherRefreshCeilingConstantName), worker, StringComparison.Ordinal);
+        Assert.Contains(
+            nameof(TimescaleSupport.ReadOtherHourlyRefreshRuntimesAsync), worker, StringComparison.Ordinal);
+
+        /* The limiter has to be a FIELD, not a local: one constructed inside the sweep is recreated every
+           tick and limits nothing, which is the one wiring mistake here that leaves every unit case green
+           while the log fills up hourly. A field declaration is the shape that cannot coexist with a
+           per-sweep local, so its presence is the check. */
+        Assert.Contains(
+            $"private readonly {nameof(RefreshCeilingStalenessWatch)} ", worker, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            $"new {nameof(RefreshCeilingStalenessWatch)}()", ServiceSweepBody(worker),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Each ceiling constant's summary NAMES ITS OWN STATISTIC and its own population, and the heaviest
+    /// one no longer claims a single day and its population are the same population.
+    ///
+    /// <para><b>Why this is a test and not a review note.</b> The defect #3182 records is a summary that
+    /// said "the census maximum" while quoting one day's figure, with a sentence asserting the two
+    /// "describe the same population". Nothing could fail on that: the statistic and the population are
+    /// prose, and prose cannot call into the product. A constant whose summary does not name its own
+    /// statistic can drift into being a different one with nothing going red — which is what happened.</para>
+    ///
+    /// <para>Checked as a SHAPE and not as a wording: the summary has to declare a statistic and has to
+    /// name a population, and the specific false identity claim has to stay gone. A reworded but still
+    /// honest summary passes; a summary that drops either half does not.</para>
+    /// </summary>
+    [Fact]
+    public void EachCeilingSummary_NamesItsStatisticAndItsPopulation()
+    {
+        var source = ReadTimescaleSupportSource();
+
+        foreach (var declaration in new[]
+        {
+            "public const int HeaviestHourlyRefreshObservedCeilingSeconds",
+            "public const double OtherHourlyRefreshObservedCeilingSeconds",
+        })
+        {
+            var prose = DocProseFor(source, declaration);
+
+            Assert.Contains("This is a MAXIMUM.", prose, StringComparison.Ordinal);
+            Assert.Contains("Its population is", prose, StringComparison.Ordinal);
+        }
+
+        /* THE CLAIM THAT HAD TO GO. The live-envelope paragraph said a single closed day and the constant's
+           population "describe the same population", which is what let one day's maximum carry a census's
+           authority. They coincide because the population's largest run fell inside that day, which is a
+           fact about where one run landed. */
+        Assert.DoesNotContain("describe the same population", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A MEASURED reading, quoted as evidence rather than derived: the clean 17:00Z run of 2026-09-08, whose
+    /// existence is the concrete demonstration that the recorded ceiling was overtaken from inside the
+    /// routine band (#3182).
+    ///
+    /// <para><b>This case is written to EXPIRE, and the expiry is the useful part.</b> Its guards require the
+    /// quoted run to still be ABOVE the recorded ceiling and BELOW the watch line. A re-derivation that
+    /// raised the ceiling past this run turns it red — correctly, because the reading would then no longer
+    /// demonstrate anything and the evidence has to be re-read rather than the case silently continuing to
+    /// pass on a premise that has gone. Nothing else in this file depends on the value.</para>
+    /// </summary>
+    [Fact]
+    public void TheMeasuredRunThatDemonstratedTheDefect_StillFalsifiesTheRecordedCeiling()
+    {
+        const double MeasuredCleanRunSeconds = 952d;
+
+        Assert.True(
+            MeasuredCleanRunSeconds > Ceiling,
+            $"the quoted {MeasuredCleanRunSeconds} s run is no longer above the {Ceiling} s recorded "
+            + "ceiling, so it no longer demonstrates the defect this file guards. Either the constant was "
+            + "re-derived over a population that contains this run — in which case quote a run that is "
+            + "still outside it, or drop this case and keep the derived ones — or the reading is being "
+            + "cited against a constant it was not measured against (#3182)");
+
+        Assert.True(
+            MeasuredCleanRunSeconds < WatchLine,
+            $"the quoted {MeasuredCleanRunSeconds} s run is at or past the {WatchLine} s watch line, so it "
+            + "no longer demonstrates a falsification from INSIDE the routine band, which is the specific "
+            + "invisibility #3182 is about");
+
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotHeadroom.InsideSlot,
+            TimescaleSupport.ClassifyRefreshSlotHeadroom(MeasuredCleanRunSeconds));
+
+        Assert.Equal(
+            TimescaleSupport.RefreshCeilingFreshness.CeilingFalsified,
+            TimescaleSupport.ClassifyRefreshCeilingFreshness(MeasuredCleanRunSeconds, Ceiling));
+
+        var log = new CapturingTestLogger();
+        TimescaleSupport.LogRefreshCeilingStaleness(
+            HeaviestConstant, Ceiling, TimescaleSupport.HeaviestHourlyRefreshView,
+            MeasuredCleanRunSeconds, new RefreshCeilingStalenessWatch(), log);
+        Assert.StartsWith("Warning:", log.Joined, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The body of the hourly compression-job-health sweep — the method the finding is called from — so
+    /// "the limiter is not constructed per sweep" can be asserted against the code that would construct it
+    /// rather than against the whole file, where the field's own initializer is a false positive.
+    /// </summary>
+    private static string ServiceSweepBody(string worker)
+    {
+        const string Signature = "private async Task EvaluateCompressionJobHealthAsync(";
+        var start = worker.IndexOf(Signature, StringComparison.Ordinal);
+        Assert.True(start >= 0,
+            $"'{Signature}' was not found in DarlingWorker.cs, so this guard is reading a sweep that no "
+            + "longer exists under that name — find where the #3182 finding is called from and point it "
+            + "there rather than dropping the assertion");
+
+        var end = worker.IndexOf("\r\n    private ", start + Signature.Length, StringComparison.Ordinal);
+        return end > start ? worker[start..end] : worker[start..];
+    }
+
+    /// <summary>
+    /// The feasibility model AGREES WITH THE SHIPPED GRID at the live guard, which is the only thing that
+    /// makes it worth consulting. A second, kinder model of the same arithmetic would answer "feasible"
+    /// where the build answers "red", and a bound that disagrees with the thing it bounds is worse than no
+    /// bound at all.
+    /// </summary>
+    [Fact]
+    public void TheFeasibilityModel_ReproducesTheShippedGridAtTheLiveGuard()
+    {
+        Assert.Equal(
+            TimescaleSupport.HeaviestRefreshWindowMinutes,
+            TimescaleSupport.GuardAndWindowSharedMinutes - TimescaleSupport.CompressionPhaseGuardMinutes);
+
+        Assert.Equal(
+            WatchLine,
+            TimescaleSupport.RefreshSlotWarningSecondsForGuardMinutes(
+                TimescaleSupport.CompressionPhaseGuardMinutes));
+    }
+
+    /// <summary>
+    /// The shipped guard is inside the bound the hour can carry — the check that turns "48 minutes of guard
+    /// does not fit in 60" from a paragraph into a build failure (#3182).
+    ///
+    /// <para><b>What this goes red on, said plainly, because that is the whole reason it exists.</b> The
+    /// guard is <see cref="TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds"/> rounded up to a whole
+    /// minute; that ceiling is a maximum over a long-tailed series, so the derivation has no upper bound of
+    /// its own while the hour does. Re-derive that constant above
+    /// <see cref="TimescaleSupport.WidestFeasibleOtherRefreshCeilingSeconds"/> and this is red — which is
+    /// the correct outcome and not an obstacle: at that point the guard the measurement asks for and the
+    /// window the heaviest refresh needs cannot both be had, and that is a scheduling decision rather than a
+    /// renumbering.</para>
+    /// </summary>
+    [Fact]
+    public void TheShippedGuard_FitsInsideTheHourItSharesWithTheHeaviestWindow()
+    {
+        Assert.True(
+            TimescaleSupport.WidestFeasibleCompressionPhaseGuardMinutes >= 0,
+            $"no guard width at all leaves a window wide enough for the {Ceiling} s recorded ceiling, so the "
+            + "hour cannot contain this grid at ANY guard. That is not a guard to narrow: the repair is a "
+            + "cheaper refresh or a longer cadence for that one aggregate, and neither is a constant to "
+            + "re-derive (#3035, #3182)");
+
+        Assert.True(
+            TimescaleSupport.CompressionPhaseGuardMinutes
+                <= TimescaleSupport.WidestFeasibleCompressionPhaseGuardMinutes,
+            $"the guard is {TimescaleSupport.CompressionPhaseGuardMinutes} minutes against a feasible "
+            + $"maximum of {TimescaleSupport.WidestFeasibleCompressionPhaseGuardMinutes}, so the light "
+            + "refreshes' guard and the heaviest refresh's window are both claiming minutes the hour does "
+            + "not have. Do not widen the hour — there is none to take (#3182)");
+
+        Assert.True(
+            TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds
+                <= TimescaleSupport.WidestFeasibleOtherRefreshCeilingSeconds,
+            $"the light-refresh ceiling is {TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds} s "
+            + $"against the {TimescaleSupport.WidestFeasibleOtherRefreshCeilingSeconds} s the grid can "
+            + "absorb. A census maximum above that line is a statement that the two bands cannot both be "
+            + "satisfied, not a constant to update (#3182)");
+    }
+
+    /// <summary>
+    /// The bound is TIGHT, which is what stops it being a wider allowance than it reads: the widest feasible
+    /// guard is feasible and one minute more is not.
+    ///
+    /// <para>An off-by-one in the search would leave the bound either one minute pessimistic — costing a
+    /// minute of guard nobody chose to give up — or one minute optimistic, which is the direction that
+    /// matters: a bound that admits an infeasible guard is a check that certifies the defect.</para>
+    /// </summary>
+    [Fact]
+    public void TheFeasibleGuardBound_IsTight()
+    {
+        var widest = TimescaleSupport.WidestFeasibleCompressionPhaseGuardMinutes;
+        Assert.True(widest >= 0);
+
+        Assert.True(
+            Ceiling < TimescaleSupport.RefreshSlotWarningSecondsForGuardMinutes(widest),
+            $"the guard reported as widest-feasible ({widest} minutes) leaves a watch line of "
+            + $"{TimescaleSupport.RefreshSlotWarningSecondsForGuardMinutes(widest)} s, which the {Ceiling} s "
+            + "ceiling is already at or past — so the bound admits an infeasible guard");
+
+        Assert.False(
+            Ceiling < TimescaleSupport.RefreshSlotWarningSecondsForGuardMinutes(widest + 1),
+            $"a guard of {widest + 1} minutes is also feasible, so the bound is pessimistic by at least a "
+            + "minute and the grid is giving up guard width nobody decided to give up");
+    }
+
+    private static int CountLines(CapturingTestLogger logger) =>
+        logger.Joined == "(no log lines captured)"
+            ? 0
+            : logger.Joined.Split(" | ", StringSplitOptions.None).Length;
+
+    /// <summary>
+    /// One member's doc-comment run, joined to a single line — the same shape
+    /// <c>RefreshCeilingProvenancePinTests</c> parses, so a claim that wraps across <c>///</c> lines is one
+    /// string rather than a match a line-oriented search misses.
+    /// </summary>
+    private static string DocProseFor(string source, string declaration)
+    {
+        var lines = source.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var index = Array.FindIndex(lines, l => l.Contains(declaration, StringComparison.Ordinal));
+        Assert.True(index >= 0, $"'{declaration}' was not found in TimescaleSupport.cs");
+
+        var run = new List<string>();
+        for (var i = index - 1; i >= 0; i--)
+        {
+            var line = lines[i].Trim();
+            if (!line.StartsWith("///", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            run.Insert(0, line[3..].Trim());
+        }
+
+        Assert.NotEmpty(run);
+        return string.Join(" ", run);
+    }
+
+    private static string ReadTimescaleSupportSource([CallerFilePath] string thisFile = "") =>
+        ReadSibling(thisFile, "PerformanceMonitor.Darling.Storage", "TimescaleSupport.cs");
+
+    private static string ReadDarlingWorkerSource([CallerFilePath] string thisFile = "") =>
+        ReadSibling(thisFile, "PerformanceMonitor.Darling.Service", "DarlingWorker.cs");
+
+    /// <summary>
+    /// A sibling project's REAL source, resolved from <c>[CallerFilePath]</c> — no fixture copy to go stale,
+    /// which is the whole point of parsing source in the first place.
+    /// </summary>
+    private static string ReadSibling(string thisFile, string project, string file)
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(thisFile)!, "..", project, file));
+
+        Assert.True(File.Exists(path),
+            $"{file} was not found at '{path}'. This guard parses the REAL file (resolved from "
+            + "[CallerFilePath], so there is no copy to go stale); restore the path rather than pointing it "
+            + "at a fixture.");
+        return File.ReadAllText(path);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -551,6 +551,13 @@ public sealed class DarlingWorker : BackgroundService
     /// self-alert evaluator are constructed with.</summary>
     private readonly AlertReadFailureCounter _readFailures = AlertReadFailureCounter.Shared;
 
+    /// <summary>#3182: the process-lifetime high-water mark behind the refresh-ceiling staleness finding.
+    /// Held HERE rather than inside TimescaleSupport because the lifetime the rate limit needs is this
+    /// process — a store whose recorded ceiling has drifted overtakes it on a large share of hourly sweeps,
+    /// so a limiter recreated per sweep would limit nothing — and static state would buy that lifetime at
+    /// the price of tests that cannot arrange a sequence of readings without leaking it to each other.</summary>
+    private readonly RefreshCeilingStalenessWatch _refreshCeilingStaleness = new();
+
     /* #2953: the collector's own startup verdict, published to the web host so /api/ping can report whether
        collection is actually running WITHOUT reading the store. The other three seams carry control-plane
        values the store is the authority for; this one carries the one fact the store cannot be asked about,
@@ -4412,9 +4419,49 @@ LIMIT 1";
                in collect.store_metrics. A log line rather than a band or an alert: see
                TimescaleSupport.LogHeaviestRefreshSlotHeadroom for why, including why #2136's knob happening to
                equal one slot today is not a substitute. */
-            TimescaleSupport.LogHeaviestRefreshSlotHeadroom(
-                await TimescaleSupport.ReadHeaviestRefreshRuntimeAsync(connection, _logger, cancellationToken),
-                _logger);
+            var heaviestRefresh = await TimescaleSupport.ReadHeaviestRefreshRuntimeAsync(
+                connection, _logger, cancellationToken);
+            TimescaleSupport.LogHeaviestRefreshSlotHeadroom(heaviestRefresh, _logger);
+            readClock.Restart();
+
+            /* #3182: whether either ceiling CONSTANT has been overtaken, which is a different finding from
+               the band above and is levelled and rate-limited separately. The band answers "does this run
+               fit in the window the grid gives it"; this answers "is the number the grid was DERIVED from
+               still a maximum". The defect it exists for is that the answer to the second can be NO while
+               the first says InsideSlot and logs at Debug — a recorded ceiling was overtaken on roughly half
+               the runs of its own job and nothing anywhere said so. Called BESIDE the band watch rather than
+               inside its switch precisely so it is reachable from every band. */
+            if (heaviestRefresh is not null)
+            {
+                TimescaleSupport.LogRefreshCeilingStaleness(
+                    TimescaleSupport.HeaviestRefreshCeilingConstantName,
+                    TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds,
+                    heaviestRefresh.View,
+                    heaviestRefresh.LastRunSeconds,
+                    _refreshCeilingStaleness,
+                    _logger);
+            }
+
+            readClock.Restart();
+
+            /* And the same question for the OTHER twelve hourly refreshes, which had no live reading keyed
+               to a view anywhere in the product before #3182. Their ceiling is not merely asserted against:
+               CompressionPhaseGuardMinutes IS that constant rounded up to a whole minute, so a light refresh
+               running past it leaves a compression policy able to start while the refresh still holds
+               AccessShareLock — #3012's convoy. One constant covers all twelve, so the rate limit is keyed
+               on the constant and the loop cannot make it twelve times looser than it reads. */
+            foreach (var lightRefresh in await TimescaleSupport.ReadOtherHourlyRefreshRuntimesAsync(
+                connection, _logger, cancellationToken))
+            {
+                TimescaleSupport.LogRefreshCeilingStaleness(
+                    TimescaleSupport.OtherRefreshCeilingConstantName,
+                    TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds,
+                    lightRefresh.View,
+                    lightRefresh.LastRunSeconds,
+                    _refreshCeilingStaleness,
+                    _logger);
+            }
+
             readClock.Restart();
 
             var stuckJobs = await TimescaleSupport.ReadStuckCompressionJobsAsync(

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -4422,7 +4422,6 @@ LIMIT 1";
             var heaviestRefresh = await TimescaleSupport.ReadHeaviestRefreshRuntimeAsync(
                 connection, _logger, cancellationToken);
             TimescaleSupport.LogHeaviestRefreshSlotHeadroom(heaviestRefresh, _logger);
-            readClock.Restart();
 
             /* #3182: whether either ceiling CONSTANT has been overtaken, which is a different finding from
                the band above and is levelled and rate-limited separately. The band answers "does this run
@@ -4442,6 +4441,9 @@ LIMIT 1";
                     _logger);
             }
 
+            /* One restart per I/O boundary, not per statement: the two log calls above are synchronous, so a
+               restart between them would hand the catch below a ~0 ms elapsed for the READ that actually
+               faulted. Raised by review. */
             readClock.Restart();
 
             /* And the same question for the OTHER twelve hourly refreshes, which had no live reading keyed

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1923,6 +1923,26 @@ WITH NO DATA";
     /// The runtime the compression grid is sized against for <see cref="HeaviestHourlyRefreshView"/>: the
     /// LARGEST run in the clean narrowed-window population, on the one store that carries this workload.
     ///
+    /// <para><b>WHICH STATISTIC, OVER WHICH POPULATION — stated at the top because that is the sentence a
+    /// later reader cites, and its absence is what let a narrower slice pass as the whole (#3182).</b> This
+    /// is a MAXIMUM. Its population is the runs of this job's refresh policy that started AFTER the
+    /// narrowing boundary named below, on one store, up to the instant named below. It is not a maximum over
+    /// this job's whole recorded history, not a fleet figure, and not a percentile — the estimator paragraph
+    /// re-takes that choice rather than assuming it. Every figure this comment draws is drawn against THAT
+    /// statistic over THAT population, and a figure taken from a narrower slice of it — one day, one hour —
+    /// is a DIFFERENT statistic even on the occasions when the two agree to the second.</para>
+    ///
+    /// <para><b>A maximum over a closed population is a LOWER BOUND on what the job does, and since #3182
+    /// the product REPORTS when a live run falsifies it.</b> That is not a restatement of the slot watch and
+    /// the two are not interchangeable: <see cref="ClassifyRefreshSlotHeadroom"/> asks whether a run fits
+    /// the window the grid gives it and its remedy is re-deriving the grid, while
+    /// <see cref="ClassifyRefreshCeilingFreshness"/> asks whether THIS NUMBER is still a maximum and its
+    /// remedy is re-deriving this number. A run can be above this constant and comfortably inside the slot,
+    /// which is exactly the state that carried the defect: the recorded ceiling was overtaken from inside
+    /// the routine band, where the slot watch logs at Debug, so nothing anywhere said the constant had gone
+    /// stale. <see cref="LogRefreshCeilingStaleness"/> is called beside that watch rather than inside its
+    /// band switch, so the finding is reachable from the routine band too.</para>
+    ///
     /// <para><b>THE DERIVATION, recorded as a method and not only as a value, because a value cannot be
     /// re-derived by the next reader and a method can (#3101).</b> POPULATION: runs of this job's refresh
     /// policy under the narrowed <see cref="HourlyRefreshStartOffset"/> window, each read from that store's
@@ -2103,8 +2123,14 @@ WITH NO DATA";
     /// <b>896.1 s</b>. That leaves <b>363.9 s</b> of the slot, <b>28.8%</b> of it, and sits <b>153.9 s</b>
     /// BELOW <see cref="RefreshSlotWarningSeconds"/>, which <see cref="ClassifyRefreshSlotHeadroom"/> bands
     /// <see cref="RefreshSlotHeadroom.InsideSlot"/>. #3119 had to state these figures apart from the
-    /// clearance because the constant was the maximum of a SAMPLE and the census exceeded it; now that the
-    /// constant IS the census maximum, the two describe the same population and agree to the second. What
+    /// clearance because the constant was the maximum of a SAMPLE and the census exceeded it. They agree to
+    /// the second — and that agreement is a COINCIDENCE ABOUT WHERE ONE RUN LANDED rather than an identity
+    /// of populations (#3182). This day's runs are a SUBSET of the population above, not the whole of it:
+    /// the two figures coincide because the population's largest run falls inside this day, which is a fact
+    /// about that run's position and no evidence that a day is a census. <b>A day is not a population for
+    /// this constant and no sentence here may treat it as one</b>, because that is precisely the substitution
+    /// that lets one day's figure carry a census's authority. What one day is worth is what any single
+    /// reading is worth: it is a lower bound, and the classifier can be run against it. What
     /// remains is the reading itself: short of the window width, so the grid's stated precondition holds —
     /// but the residual is D wide and D is that maximum, so nothing here can be described as completing well
     /// inside its slot. RefreshCeilingProvenancePinTests derives every figure stated against that maximum
@@ -2275,9 +2301,170 @@ WITH NO DATA";
     }
 
     /// <summary>
+    /// Whether a live reading has FALSIFIED a recorded ceiling — the #3182 finding, and a different fact
+    /// from <see cref="RefreshSlotHeadroom"/> with a different remedy.
+    ///
+    /// <para><b>Why this is not a fourth slot band.</b> The slot bands answer "does this run fit in the
+    /// window the grid gives it", and their remedy is re-deriving the grid. This answers "is the number the
+    /// grid was DERIVED FROM still the maximum it claims to be", and its remedy is re-deriving that number.
+    /// Both can be true of one reading and neither implies the other: a run past the slot may be under a
+    /// ceiling that was measured on a worse day, and a run that falsifies the ceiling may sit comfortably
+    /// inside the slot. The second case is the one that had no signal at all, which is what #3182 is
+    /// about — a recorded maximum can be overtaken from inside the routine band, where the slot watch logs
+    /// at Debug and says nothing is happening.</para>
+    /// </summary>
+    public enum RefreshCeilingFreshness
+    {
+        /// <summary>The reading is at or under the recorded ceiling, so the constant is still a bound on
+        /// what has been seen.</summary>
+        CeilingHolds,
+
+        /// <summary>The reading is ABOVE the recorded ceiling. The constant is not the maximum of the job's
+        /// behaviour any more — whatever population it was derived from has been overtaken, and the value
+        /// has to be re-derived rather than the grid re-dimensioned.</summary>
+        CeilingFalsified,
+    }
+
+    /// <summary>
+    /// Classifies one observed runtime against a constant that claims to be a MAXIMUM.
+    ///
+    /// <para><b>STRICTLY greater, and that is the opposite inclusivity from
+    /// <see cref="ClassifyRefreshSlotHeadroom"/> — deliberately.</b> The slot bands open at <c>&gt;=</c>
+    /// because a run that took exactly its window was already colliding with its neighbour, so the wall is
+    /// inclusive. A recorded maximum is a different kind of claim: a reading EQUAL to it is the reading it
+    /// was derived from and confirms the constant rather than contradicting it. Only a value above it is
+    /// evidence the constant is wrong, so this boundary has to exclude equality where the other one
+    /// includes it. Getting that backwards would report the grid's own sizing figure as a falsification of
+    /// itself on the hour it was measured.</para>
+    ///
+    /// <para>Negative and NaN readings answer <see cref="RefreshCeilingFreshness.CeilingHolds"/> rather
+    /// than throwing, the posture <see cref="ClassifyRefreshSlotHeadroom"/> and
+    /// <see cref="ClassifyCompressionClearance"/> both take: a catalog handing back something impossible
+    /// must cost the line, never the sweep that carries it. NaN needs the explicit test because
+    /// <c>NaN &gt; x</c> is false anyway — the guard is here so the answer is a DECISION rather than a
+    /// property of IEEE comparison that a later refactor could invert without noticing.</para>
+    /// </summary>
+    public static RefreshCeilingFreshness ClassifyRefreshCeilingFreshness(
+        double observedSeconds, double recordedCeilingSeconds)
+    {
+        if (double.IsNaN(observedSeconds) || observedSeconds < 0d)
+        {
+            return RefreshCeilingFreshness.CeilingHolds;
+        }
+
+        return observedSeconds > recordedCeilingSeconds
+            ? RefreshCeilingFreshness.CeilingFalsified
+            : RefreshCeilingFreshness.CeilingHolds;
+    }
+
+    /// <summary>
+    /// The name <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> is reported under by
+    /// <see cref="LogRefreshCeilingStaleness"/>, taken from the member rather than typed — an operator
+    /// reading the line has to be able to grep the constant it names.
+    /// </summary>
+    public const string HeaviestRefreshCeilingConstantName =
+        nameof(HeaviestHourlyRefreshObservedCeilingSeconds);
+
+    /// <summary>
+    /// The name <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> is reported under, for the reason
+    /// <see cref="HeaviestRefreshCeilingConstantName"/> exists.
+    /// </summary>
+    public const string OtherRefreshCeilingConstantName =
+        nameof(OtherHourlyRefreshObservedCeilingSeconds);
+
+    /// <summary>
+    /// Reports that a live reading has overtaken a ceiling constant — the #3182 finding, kept SEPARATE from
+    /// <see cref="LogHeaviestRefreshSlotHeadroom"/> so it is reachable from every slot band.
+    ///
+    /// <para><b>Why a separate call and not a fourth case in that switch.</b> The defect #3182 records is
+    /// that a constant claiming to be a census maximum was overtaken while the runs that overtook it
+    /// classified <see cref="RefreshSlotHeadroom.InsideSlot"/> and logged at Debug. A branch inside the
+    /// band switch can only speak in the band it is written in; this is called beside it, so a falsified
+    /// ceiling is reported in the routine band, the warning band and the breach band alike. The two
+    /// findings are also worded so they cannot be mistaken for each other: this one names the CONSTANT and
+    /// asks for it to be re-derived, the slot line names the GRID and asks for that to be.</para>
+    ///
+    /// <para><b>WARNING, and the level is a decision rather than a default.</b> Debug is where the defect
+    /// lived, so it is not available. Error is reserved by
+    /// <see cref="LogHeaviestRefreshSlotHeadroom"/> for a stated precondition of the shipped grid being
+    /// FALSE, which a falsified ceiling does NOT make: the precondition is that a run fits inside its slot,
+    /// and a reading can be past the ceiling and still well inside the window. Levelling this Error too
+    /// would collapse the distinction the finding exists to draw. Warning is the level that says "still
+    /// true, still time to act deliberately", which is exactly the state a stale sizing constant is in.</para>
+    ///
+    /// <para><b>RATE-LIMITED BY A HIGH-WATER MARK, because a constant that has drifted trips this often.</b>
+    /// A ceiling overtaken by ordinary load is overtaken on a large share of runs, and an hourly Warning
+    /// that repeats the same fact is how a signal becomes furniture — the discipline
+    /// <see cref="LogCompressionActivity"/> states for Information. So
+    /// <see cref="RefreshCeilingStalenessWatch"/> reports the first falsifying reading for a constant and
+    /// thereafter only one that exceeds the largest already reported. That shape is chosen over a
+    /// once-per-process latch and over a time window for one reason: what this finding asks for is a
+    /// constant re-derived to at least the largest run on record, so a NEW record changes the answer and a
+    /// repeat does not. A time window would re-report the same value on a timer, and a plain latch would
+    /// hide the reading that actually sizes the re-derivation behind the first one that happened to
+    /// arrive.</para>
+    /// </summary>
+    public static void LogRefreshCeilingStaleness(
+        string constantName,
+        double recordedCeilingSeconds,
+        string view,
+        double observedSeconds,
+        RefreshCeilingStalenessWatch watch,
+        ILogger? logger)
+    {
+        if (watch is null)
+        {
+            throw new ArgumentNullException(nameof(watch));
+        }
+
+        if (logger is null)
+        {
+            return;
+        }
+
+        if (ClassifyRefreshCeilingFreshness(observedSeconds, recordedCeilingSeconds)
+            != RefreshCeilingFreshness.CeilingFalsified)
+        {
+            return;
+        }
+
+        if (!watch.ShouldReport(constantName, observedSeconds))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "TimescaleDB: {View}'s refresh policy last ran {Seconds:F1}s, which is {Over:F1}s ABOVE {Constant} = {Ceiling:F1}s — a constant recorded as the MAXIMUM of a closed population. So that population has been overtaken and the constant is stale: it has to be RE-DERIVED over a population that includes this run (#3182), which is a different repair from re-deriving the compression phase grid (#3035) and is needed whatever band the slot watch puts this reading in. Its per-run history is timescaledb_information.job_history, one row per run, but only where timescaledb.enable_job_execution_logging is on — it is off by default and a store provisioned before that GUC gained its own conf marker reports nothing there until it heals, so an empty result is that gap and not a quiet hour (#3175/#3177). Reported once per constant and then only for a larger run, because what the re-derivation needs is the LARGEST reading and a repeat of one already reported adds nothing.",
+            view, observedSeconds, observedSeconds - recordedCeilingSeconds, constantName,
+            recordedCeilingSeconds);
+    }
+
+    /// <summary>
     /// The longest run recorded for any hourly refresh OTHER than <see cref="HeaviestHourlyRefreshView"/> —
     /// and, since #3174, the number <see cref="CompressionPhaseGuardMinutes"/> is DERIVED from rather than
     /// merely characterised against.
+    ///
+    /// <para><b>WHICH STATISTIC, OVER WHICH POPULATION — stated at the top for the reason
+    /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> states it there (#3182).</b> This is a
+    /// MAXIMUM. Its population is the runs of the twelve other hourly views' refresh policies that started
+    /// AFTER the narrowing boundary named below, on one store, up to the instant named below. Not a
+    /// percentile, not a per-view figure, and not a fleet reading: one number covers twelve policies, so a
+    /// live run of ANY of them above it falsifies it. "Recorded" in the line above means recorded in that
+    /// read, and nowhere else — the word carries no claim about runs the read did not see.</para>
+    ///
+    /// <para><b>And since #3182 the product reports when a live run of one of those twelve falsifies it,
+    /// which it previously could not because nothing read them.</b> The heaviest refresh had
+    /// <see cref="HeaviestRefreshRuntimeSql"/>; these twelve had no live reading attributable to a view
+    /// anywhere in the product, because #2136's <see cref="JobCadenceReadSql"/> keys on
+    /// <c>proc_name || hypertable_name</c> and a refresh policy's <c>hypertable_name</c> is the
+    /// MATERIALIZATION hypertable rather than the view. So a check that looks like it covers these jobs
+    /// cannot attribute what it reads to the constant that bounds them.
+    /// <see cref="OtherHourlyRefreshRuntimesSql"/> is the read that can, and
+    /// <see cref="LogRefreshCeilingStaleness"/> is what it feeds. <b>The direction of the harm is why this
+    /// one matters more than a stale assertion:</b> this constant is arithmetic input, so a light refresh
+    /// past it means <see cref="CompressionPhaseGuardMinutes"/> no longer covers the refresh it exists to
+    /// cover, and a compression policy can start while that refresh still holds
+    /// <c>AccessShareLock</c> — #3012's convoy, by construction rather than by chance.</para>
     ///
     /// <para><b>THE DERIVATION, recorded as a method rather than only as a value (#3174).</b> The old figure
     /// came from the first full staggered cycle — 26 s / 2 s / 864 s / 140 s — a cycle that STRADDLES the
@@ -2372,6 +2559,106 @@ WITH NO DATA";
     /// </summary>
     public static int CompressionPhaseGuardMinutes =>
         (int)Math.Ceiling(OtherHourlyRefreshObservedCeilingSeconds / 60.0);
+
+    /// <summary>
+    /// The minutes <see cref="CompressionPhaseGuardMinutes"/> and
+    /// <see cref="HeaviestRefreshWindowMinutes"/> SHARE — what the hour has left once the light band and the
+    /// compression band are at the widths their own measurements ask for.
+    ///
+    /// <para>Named because it is the budget the two of them compete for, and because it is the term that
+    /// makes that competition arithmetic rather than prose: every minute the guard takes is a minute the
+    /// heaviest refresh's window loses, and this is the total there is to divide. Derived from the same
+    /// expressions <see cref="HeaviestRefreshStartMinute"/> and
+    /// <see cref="HeaviestRefreshWindowMinutes"/> are built from, so a re-derived grid moves it rather than
+    /// leaving it behind as a second opinion.</para>
+    /// </summary>
+    public static int GuardAndWindowSharedMinutes =>
+        MinutesInHourlyCadence
+        - ((LightHourlyRefreshCount - 1) * LightRefreshStepMinutes)
+        - CompressionPhaseBandMinutes;
+
+    /// <summary>
+    /// The watch line a guard of <paramref name="guardMinutes"/> would leave — the same chain
+    /// <see cref="RefreshSlotWarningSeconds"/> is, evaluated at a hypothetical guard instead of the shipped
+    /// one.
+    ///
+    /// <para><b>It exists so the feasibility question can be ASKED, which the shipped chain cannot do.</b>
+    /// <see cref="HeaviestRefreshWindowMinutes"/> reads <see cref="CompressionPhaseGuardMinutes"/>, so the
+    /// live chain answers for exactly one guard and there is no way to find out what a WIDER guard would
+    /// cost without re-spelling the arithmetic. This is that arithmetic in one place, and
+    /// TimescaleSupportTests requires it to agree with the shipped chain at the live guard — so it cannot
+    /// drift into being a second, kinder model of the grid.</para>
+    ///
+    /// <para>Integer division throughout, matching <see cref="RefreshSlotWarningSeconds"/>: a line computed
+    /// with rounding would sit above the shipped one on some widths and the two would disagree about
+    /// feasibility at exactly the boundary the question is about.</para>
+    /// </summary>
+    public static int RefreshSlotWarningSecondsForGuardMinutes(int guardMinutes) =>
+        (GuardAndWindowSharedMinutes - guardMinutes) * 60
+        * WindowWatchLeadNumerator / WindowWatchLeadDenominator;
+
+    /// <summary>
+    /// The WIDEST <see cref="CompressionPhaseGuardMinutes"/> the hour can carry while the grid's own stated
+    /// precondition still holds at <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> — negative when
+    /// no guard at all leaves a wide enough window.
+    ///
+    /// <para><b>Why this is stated rather than discovered (#3182).</b> The guard is
+    /// <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> rounded up to a whole minute, and that ceiling
+    /// is a MAXIMUM over a series with a long tail — so the derivation has no upper bound of its own, while
+    /// the hour does. Nothing in the derivation notices when the two conflict: the conflict surfaces as a
+    /// grid that has already been widened past what the hour contains, and then as an argument about which
+    /// number to bend. This term is the bound the derivation is missing, and
+    /// <see cref="WidestFeasibleOtherRefreshCeilingSeconds"/> converts it back into the units the constant is
+    /// measured in, so a re-derivation that does not fit is red AT THE CONSTANT rather than after the grid
+    /// has been re-dimensioned around it.</para>
+    ///
+    /// <para><b>Searched downward rather than solved, so it is the SHIPPED comparison that decides.</b> The
+    /// precondition is <c>HeaviestHourlyRefreshObservedCeilingSeconds &lt; RefreshSlotWarningSeconds</c>, and
+    /// that line is an integer-divided fraction of an integer window. A closed form would have to reproduce
+    /// two truncations, and a closed form that reproduced them slightly differently would answer feasible
+    /// where the build answers infeasible — the one disagreement this term must not be capable of. The walk
+    /// evaluates the same expression the grid does, at most
+    /// <see cref="GuardAndWindowSharedMinutes"/> times, once.</para>
+    ///
+    /// <para><b>Negative is a real answer, not an error code.</b> A heaviest ceiling large enough that even a
+    /// zero-minute guard leaves too narrow a window is a grid the hour cannot contain at ANY guard, which is
+    /// a different fact from "the guard is too wide" and calls for a different repair — a cheaper refresh or
+    /// a longer cadence for that one aggregate, neither of which is a constant to re-derive. Returning a
+    /// negative says so; throwing would make the caller decide what it meant.</para>
+    /// </summary>
+    public static int WidestFeasibleCompressionPhaseGuardMinutes
+    {
+        get
+        {
+            for (var guard = GuardAndWindowSharedMinutes; guard >= 0; guard--)
+            {
+                if (HeaviestHourlyRefreshObservedCeilingSeconds
+                    < RefreshSlotWarningSecondsForGuardMinutes(guard))
+                {
+                    return guard;
+                }
+            }
+
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// The largest value <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> may take before the grid
+    /// stops fitting in the hour — <see cref="WidestFeasibleCompressionPhaseGuardMinutes"/> back in seconds,
+    /// so the bound is stated in the unit the constant is measured in.
+    ///
+    /// <para>This is the number a re-derivation of that constant has to be read against. A light-refresh
+    /// census whose maximum lands above it is not a constant to update: it is a statement that the guard the
+    /// measurement asks for and the window the heaviest refresh needs cannot both be had, and that is a
+    /// SCHEDULING decision rather than a renumbering — the same distinction
+    /// <see cref="RefreshSlotHeadroom.SlotExceeded"/> draws for the other constant.</para>
+    ///
+    /// <para>Zero when no guard is feasible at all, because a negative ceiling is not a value the constant
+    /// can take and a bound expressed as one would read as a wider allowance than it is.</para>
+    /// </summary>
+    public static int WidestFeasibleOtherRefreshCeilingSeconds =>
+        Math.Max(0, WidestFeasibleCompressionPhaseGuardMinutes) * 60;
 
     /// <summary>
     /// The most compression policies the grid will put on one minute — the input the compression band's WIDTH
@@ -4796,8 +5083,24 @@ WHERE js.last_run_status = 'Success'";
     /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> and read there for the live envelope
     /// (#3119). This read supplies the BOUND, which is what was missing, not the history.</para>
     /// </summary>
-    public static string HeaviestRefreshRuntimeSql =>
-        $@"
+    /// <summary>
+    /// Everything <see cref="HeaviestRefreshRuntimeSql"/> and <see cref="OtherHourlyRefreshRuntimesSql"/>
+    /// have in common: the projection, the MEASURED OR-join, and the two filters that make the rows refresh
+    /// policies on this store's own aggregates. The two statements differ only in which views they keep.
+    ///
+    /// <para><b>Shared rather than copied, and the copy it replaces is the reason (#3182).</b> This join was
+    /// already carried in two places — here and
+    /// <see cref="ContinuousAggregateRefreshStateSql"/> — because the materialization-hypertable arm ALONE
+    /// was measured to find nothing, so both arms have to be present and a re-guessed join reads back empty
+    /// rather than wrong. A third copy would be a third chance to lose an arm, and it would be the copy with
+    /// the fewest readers. One text, two filters.</para>
+    ///
+    /// <para>Not a full statement on its own: it opens with the <c>FROM</c> and ends inside the
+    /// <c>WHERE</c>, so a caller appends its own <c>AND</c> clauses. That shape is what lets the composed
+    /// text be byte-identical to what each statement used to spell out, which is what keeps the pins on them
+    /// reading the statements rather than this fragment.</para>
+    /// </summary>
+    private const string RefreshPolicyRuntimeProjectionSql = @"
 SELECT
     ca.view_name,
     EXTRACT(EPOCH FROM js.last_run_duration)::double precision AS last_run_seconds
@@ -4807,8 +5110,43 @@ JOIN timescaledb_information.continuous_aggregates AS ca
   OR  (ca.materialization_hypertable_schema = j.hypertable_schema AND ca.materialization_hypertable_name = j.hypertable_name)
 JOIN timescaledb_information.job_stats AS js USING (job_id)
 WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
-AND   ca.view_schema = 'collect'
+AND   ca.view_schema = 'collect'";
+
+    public static string HeaviestRefreshRuntimeSql =>
+        $@"{RefreshPolicyRuntimeProjectionSql}
 AND   ca.view_name = '{HeaviestHourlyRefreshView}'
+AND   js.last_run_status = 'Success'";
+
+    /// <summary>
+    /// The same read pointed at every OTHER continuous aggregate refresh policy — the live feed
+    /// <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> did not have (#3182).
+    ///
+    /// <para><b>Why this exists at all.</b> That constant is not merely asserted against; it is ARITHMETIC
+    /// INPUT — <see cref="CompressionPhaseGuardMinutes"/> is it rounded up to a whole minute, so a light
+    /// refresh running longer than the constant records leaves a compression policy able to start while that
+    /// refresh still holds <c>AccessShareLock</c>, which is #3012's convoy. Until #3182 nothing read a light
+    /// refresh's runtime back at all: the heaviest one had <see cref="HeaviestRefreshRuntimeSql"/> and the
+    /// other twelve had no live reading keyed to a view anywhere in the product. #2136's
+    /// <see cref="JobCadenceReadSql"/> does read their durations, but it keys on
+    /// <c>proc_name || hypertable_name</c> and a refresh policy's <c>hypertable_name</c> is the
+    /// MATERIALIZATION hypertable, so those readings cannot be attributed to a view without this join —
+    /// which is why the gap survived a check that looks like it covers them.</para>
+    ///
+    /// <para><b>Filtered to "not the heaviest" in SQL and to "hourly" in C#, which is a split rather than an
+    /// inconsistency.</b> Excluding one named view is a compile-time constant and belongs in the statement.
+    /// Deciding which views are HOURLY is <see cref="HourlyRefreshPhaseOrder"/>'s job — it is the registry
+    /// this whole grid is keyed on, a view missing from it is already a stated defect
+    /// (<see cref="RefreshPhaseMinutesFor(string)"/> throws for one), and interpolating a runtime list into a
+    /// statement would put a second copy of that registry in SQL text where nothing checks it against the
+    /// first. So the daily tier's policies come back from the read and are dropped by
+    /// <see cref="ReadOtherHourlyRefreshRuntimesAsync"/> against the registry.</para>
+    ///
+    /// <para><c>last_run_status = 'Success'</c> for the reason every sibling read has it: a failed run's
+    /// duration is not a runtime reading, and job failures are their own condition.</para>
+    /// </summary>
+    public static string OtherHourlyRefreshRuntimesSql =>
+        $@"{RefreshPolicyRuntimeProjectionSql}
+AND   ca.view_name <> '{HeaviestHourlyRefreshView}'
 AND   js.last_run_status = 'Success'";
 
     /// <summary>
@@ -4844,6 +5182,63 @@ AND   js.last_run_status = 'Success'";
             logger?.LogDebug("Heaviest-refresh slot headroom: could not read job stats: {Message}", ex.Message);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Reads <see cref="OtherHourlyRefreshRuntimesSql"/> and keeps the rows whose view is on
+    /// <see cref="HourlyRefreshPhaseOrder"/> — one reading per OTHER hourly refresh policy that has
+    /// completed a successful run (#3182).
+    ///
+    /// <para>Failure-isolated to an EMPTY LIST, the posture <see cref="ReadCompressionActivityAsync"/> and
+    /// <see cref="ReadJobCadenceReadingsAsync"/> take, rather than to a null the way the single-row heaviest
+    /// read is: a list read that found nothing and a list read that failed are the same absence of readings
+    /// to the caller, and the honest-empty rule is that neither is allowed to become a synthesized zero.</para>
+    ///
+    /// <para><b>A DAILY policy's row is dropped rather than logged.</b> The statement cannot tell the tiers
+    /// apart — both use <see cref="RefreshPolicyProcName"/> — and a daily aggregate's runtime is not
+    /// something <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> bounds, so measuring it against that
+    /// constant would manufacture a finding out of a tier mismatch. Dropped silently because it is the
+    /// EXPECTED shape of the result rather than an anomaly: the daily tier is supposed to be there.</para>
+    /// </summary>
+    public static async Task<IReadOnlyList<HourlyRefreshRuntimeReading>> ReadOtherHourlyRefreshRuntimesAsync(
+        NpgsqlConnection connection, ILogger? logger, CancellationToken cancellationToken = default)
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        var readings = new List<HourlyRefreshRuntimeReading>();
+        var hourly = new HashSet<string>(HourlyRefreshPhaseOrder, StringComparer.Ordinal);
+
+        try
+        {
+            using var command = new NpgsqlCommand(OtherHourlyRefreshRuntimesSql, connection) { CommandTimeout = JobCatalogReadTimeoutSeconds };
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                if (reader.IsDBNull(0) || reader.IsDBNull(1))
+                {
+                    continue;
+                }
+
+                var view = reader.GetString(0);
+                if (!hourly.Contains(view))
+                {
+                    continue;
+                }
+
+                readings.Add(new HourlyRefreshRuntimeReading(
+                    view, Convert.ToDouble(reader.GetValue(1), CultureInfo.InvariantCulture)));
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger?.LogDebug(
+                "Light-refresh ceiling freshness: could not read job stats: {Message}", ex.Message);
+        }
+
+        return readings;
     }
 
     /// <summary>
@@ -5433,6 +5828,100 @@ public sealed record HeaviestRefreshSlotReading(string View, double LastRunSecon
     /// hour can spare (<see cref="TimescaleSupport.HeaviestRefreshWindowMinutes"/>), which is the margin the
     /// #3044 watch is stated against.</summary>
     public double PercentOfSlot => 100.0 * LastRunSeconds / TimescaleSupport.RefreshPhaseSlotSeconds;
+}
+
+/// <summary>
+/// One live reading of an hourly refresh policy's runtime, keyed on the CAGG's user-view name (#3182) —
+/// what <see cref="TimescaleSupport.ReadOtherHourlyRefreshRuntimesAsync"/> returns for the twelve hourly
+/// views that are not <see cref="TimescaleSupport.HeaviestHourlyRefreshView"/>.
+///
+/// <para>Deliberately carries NO derived verdict, which is the difference from
+/// <see cref="HeaviestRefreshSlotReading"/>. The heaviest refresh has a slot of its own, so a reading of it
+/// has a band; a light refresh has only the guard band after its start, which is not a per-view quantity —
+/// so the only question asked of these readings is whether one has overtaken
+/// <see cref="TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds"/>, and that is asked by the
+/// classifier rather than answered here. Inventing a per-view band would be a verdict the grid does not
+/// have.</para>
+/// </summary>
+public sealed record HourlyRefreshRuntimeReading(string View, double LastRunSeconds);
+
+/// <summary>
+/// The rate limiter for <see cref="TimescaleSupport.LogRefreshCeilingStaleness"/> (#3182): a HIGH-WATER
+/// MARK per ceiling constant, held for the lifetime of the instance the caller keeps.
+///
+/// <para><b>Why an object the caller owns rather than static state.</b> The lifetime this limiter needs is
+/// the PROCESS — a store whose ceiling has drifted trips the finding on a large share of hourly sweeps, and
+/// a limiter reset per sweep would limit nothing. Static state would give that lifetime for free and take
+/// testability with it: two test cases sharing a static latch are order-dependent, and the interesting
+/// property here is a SEQUENCE of readings, which cannot be tested at all if the sequence leaks between
+/// cases. So the service holds one instance and the tests hold their own.</para>
+///
+/// <para><b>What it reports, stated as the rule rather than left to the implementation.</b> The first
+/// falsifying reading for a constant reports. After that, only a reading strictly greater than the largest
+/// already reported for that constant reports. Nothing ever lowers the mark, so the finding cannot start
+/// repeating because load fell — and that asymmetry is deliberate rather than an oversight: the mark is not
+/// a measure of current load, it is a record of the largest value already SAID OUT LOUD, and a value
+/// already said out loud stays said. A run below it changes nothing about what the constant has to be
+/// re-derived to.</para>
+///
+/// <para><b>Keyed on the constant's NAME, and the two names are
+/// <see cref="TimescaleSupport.HeaviestRefreshCeilingConstantName"/> and
+/// <see cref="TimescaleSupport.OtherRefreshCeilingConstantName"/>.</b> Not on the view: the light ceiling is
+/// ONE constant covering twelve views, so keying on the view would let each of them report the same
+/// constant's staleness independently and the rate limit would be twelve times looser than it reads. What
+/// is being reported is a constant being wrong, so the constant is the key.</para>
+///
+/// <para>Locked, because the sweep that calls it is one of several the worker runs and nothing in the type
+/// system says it stays single-threaded. A missed report is a lost finding and a double report is noise;
+/// neither costs anything worth an interlocked-compare loop at one call an hour.</para>
+/// </summary>
+public sealed class RefreshCeilingStalenessWatch
+{
+    private readonly Dictionary<string, double> _reportedHighWaterMark = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Whether <paramref name="observedSeconds"/> should be REPORTED for
+    /// <paramref name="constantName"/> — true for the first falsifying reading and thereafter only for one
+    /// larger than the largest already reported. Records the mark when it answers true, so a caller that
+    /// asks twice about the same reading is told once.
+    /// </summary>
+    public bool ShouldReport(string constantName, double observedSeconds)
+    {
+        if (constantName is null)
+        {
+            throw new ArgumentNullException(nameof(constantName));
+        }
+
+        lock (_reportedHighWaterMark)
+        {
+            if (_reportedHighWaterMark.TryGetValue(constantName, out var mark)
+                && observedSeconds <= mark)
+            {
+                return false;
+            }
+
+            _reportedHighWaterMark[constantName] = observedSeconds;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// The largest reading already reported for <paramref name="constantName"/>, or null when none has
+    /// been. Exists so the sequence property can be asserted directly instead of inferred from log lines —
+    /// a test that could only read the log would be testing the message, not the limiter.
+    /// </summary>
+    public double? ReportedHighWaterMark(string constantName)
+    {
+        if (constantName is null)
+        {
+            throw new ArgumentNullException(nameof(constantName));
+        }
+
+        lock (_reportedHighWaterMark)
+        {
+            return _reportedHighWaterMark.TryGetValue(constantName, out var mark) ? mark : null;
+        }
+    }
 }
 
 /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -2337,25 +2337,23 @@ WITH NO DATA";
     /// includes it. Getting that backwards would report the grid's own sizing figure as a falsification of
     /// itself on the hour it was measured.</para>
     ///
-    /// <para>Negative and NaN readings answer <see cref="RefreshCeilingFreshness.CeilingHolds"/> rather
-    /// than throwing, the posture <see cref="ClassifyRefreshSlotHeadroom"/> and
-    /// <see cref="ClassifyCompressionClearance"/> both take: a catalog handing back something impossible
-    /// must cost the line, never the sweep that carries it. NaN needs the explicit test because
-    /// <c>NaN &gt; x</c> is false anyway — the guard is here so the answer is a DECISION rather than a
-    /// property of IEEE comparison that a later refactor could invert without noticing.</para>
+    /// <para><b>NO SPECIAL CASE for an impossible reading, and its ABSENCE is deliberate.</b> The siblings
+    /// need one because they compare against a WIDTH: a negative reading is under every band boundary and a
+    /// NaN is under none of them, so both have to be steered somewhere. This compares against a ceiling that
+    /// is positive by construction — both constants that feed it are — so a negative reading is not greater
+    /// than it and <c>NaN &gt; x</c> is false, and each of them answers
+    /// <see cref="RefreshCeilingFreshness.CeilingHolds"/> from the one comparison. A guard added here would
+    /// be unreachable by any value the product can produce, and an unreachable guard is not caution: it is a
+    /// line no test can distinguish from its own absence, so it reads as protection and certifies nothing.
+    /// Where a non-finite reading does real damage is the rate limiter's mark —
+    /// <see cref="RefreshCeilingStalenessWatch.ShouldReport"/> holds that, and holds it where a mutation can
+    /// reach it.</para>
     /// </summary>
     public static RefreshCeilingFreshness ClassifyRefreshCeilingFreshness(
-        double observedSeconds, double recordedCeilingSeconds)
-    {
-        if (double.IsNaN(observedSeconds) || observedSeconds < 0d)
-        {
-            return RefreshCeilingFreshness.CeilingHolds;
-        }
-
-        return observedSeconds > recordedCeilingSeconds
+        double observedSeconds, double recordedCeilingSeconds) =>
+        observedSeconds > recordedCeilingSeconds
             ? RefreshCeilingFreshness.CeilingFalsified
             : RefreshCeilingFreshness.CeilingHolds;
-    }
 
     /// <summary>
     /// The name <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> is reported under by
@@ -5884,12 +5882,25 @@ public sealed class RefreshCeilingStalenessWatch
     /// <paramref name="constantName"/> — true for the first falsifying reading and thereafter only for one
     /// larger than the largest already reported. Records the mark when it answers true, so a caller that
     /// asks twice about the same reading is told once.
+    ///
+    /// <para><b>A NON-FINITE reading is refused and NOT recorded, and this is the one place that guard does
+    /// work.</b> The comparison below is <c>observedSeconds &lt;= mark</c>, and every comparison against NaN
+    /// is false — so a NaN allowed through would answer true, become the mark, and then answer true for
+    /// EVERY later reading, because none of them is <c>&lt;= NaN</c> either. One impossible catalog reading
+    /// would disable the rate limit for the life of the process, silently and permanently. That is why the
+    /// guard is here rather than in <see cref="TimescaleSupport.ClassifyRefreshCeilingFreshness"/>, where the
+    /// comparison already answers correctly for a non-finite value and a guard would be unreachable.</para>
     /// </summary>
     public bool ShouldReport(string constantName, double observedSeconds)
     {
         if (constantName is null)
         {
             throw new ArgumentNullException(nameof(constantName));
+        }
+
+        if (!double.IsFinite(observedSeconds))
+        {
+            return false;
         }
 
         lock (_reportedHighWaterMark)

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -5051,6 +5051,35 @@ WHERE js.last_run_status = 'Success'";
     }
 
     /// <summary>
+    /// Everything <see cref="HeaviestRefreshRuntimeSql"/> and <see cref="OtherHourlyRefreshRuntimesSql"/>
+    /// have in common: the projection, the MEASURED OR-join, and the two filters that make the rows refresh
+    /// policies on this store's own aggregates. The two statements differ only in which views they keep.
+    ///
+    /// <para><b>Shared rather than copied, and the copy it replaces is the reason (#3182).</b> This join was
+    /// already carried in two places — here and
+    /// <see cref="ContinuousAggregateRefreshStateSql"/> — because the materialization-hypertable arm ALONE
+    /// was measured to find nothing, so both arms have to be present and a re-guessed join reads back empty
+    /// rather than wrong. A third copy would be a third chance to lose an arm, and it would be the copy with
+    /// the fewest readers. One text, two filters.</para>
+    ///
+    /// <para>Not a full statement on its own: it opens with the <c>FROM</c> and ends inside the
+    /// <c>WHERE</c>, so a caller appends its own <c>AND</c> clauses. That shape is what lets the composed
+    /// text be byte-identical to what each statement used to spell out, which is what keeps the pins on them
+    /// reading the statements rather than this fragment.</para>
+    /// </summary>
+    private const string RefreshPolicyRuntimeProjectionSql = @"
+SELECT
+    ca.view_name,
+    EXTRACT(EPOCH FROM js.last_run_duration)::double precision AS last_run_seconds
+FROM timescaledb_information.jobs AS j
+JOIN timescaledb_information.continuous_aggregates AS ca
+  ON  (ca.view_schema = j.hypertable_schema AND ca.view_name = j.hypertable_name)
+  OR  (ca.materialization_hypertable_schema = j.hypertable_schema AND ca.materialization_hypertable_name = j.hypertable_name)
+JOIN timescaledb_information.job_stats AS js USING (job_id)
+WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
+AND   ca.view_schema = 'collect'";
+
+    /// <summary>
     /// The last SUCCESSFUL run of <see cref="HeaviestHourlyRefreshView"/>'s refresh policy, in seconds — the
     /// live figure <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>'s envelope is about (#3044).
     ///
@@ -5081,35 +5110,6 @@ WHERE js.last_run_status = 'Success'";
     /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> and read there for the live envelope
     /// (#3119). This read supplies the BOUND, which is what was missing, not the history.</para>
     /// </summary>
-    /// <summary>
-    /// Everything <see cref="HeaviestRefreshRuntimeSql"/> and <see cref="OtherHourlyRefreshRuntimesSql"/>
-    /// have in common: the projection, the MEASURED OR-join, and the two filters that make the rows refresh
-    /// policies on this store's own aggregates. The two statements differ only in which views they keep.
-    ///
-    /// <para><b>Shared rather than copied, and the copy it replaces is the reason (#3182).</b> This join was
-    /// already carried in two places — here and
-    /// <see cref="ContinuousAggregateRefreshStateSql"/> — because the materialization-hypertable arm ALONE
-    /// was measured to find nothing, so both arms have to be present and a re-guessed join reads back empty
-    /// rather than wrong. A third copy would be a third chance to lose an arm, and it would be the copy with
-    /// the fewest readers. One text, two filters.</para>
-    ///
-    /// <para>Not a full statement on its own: it opens with the <c>FROM</c> and ends inside the
-    /// <c>WHERE</c>, so a caller appends its own <c>AND</c> clauses. That shape is what lets the composed
-    /// text be byte-identical to what each statement used to spell out, which is what keeps the pins on them
-    /// reading the statements rather than this fragment.</para>
-    /// </summary>
-    private const string RefreshPolicyRuntimeProjectionSql = @"
-SELECT
-    ca.view_name,
-    EXTRACT(EPOCH FROM js.last_run_duration)::double precision AS last_run_seconds
-FROM timescaledb_information.jobs AS j
-JOIN timescaledb_information.continuous_aggregates AS ca
-  ON  (ca.view_schema = j.hypertable_schema AND ca.view_name = j.hypertable_name)
-  OR  (ca.materialization_hypertable_schema = j.hypertable_schema AND ca.materialization_hypertable_name = j.hypertable_name)
-JOIN timescaledb_information.job_stats AS js USING (job_id)
-WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
-AND   ca.view_schema = 'collect'";
-
     public static string HeaviestRefreshRuntimeSql =>
         $@"{RefreshPolicyRuntimeProjectionSql}
 AND   ca.view_name = '{HeaviestHourlyRefreshView}'

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1932,6 +1932,20 @@ WITH NO DATA";
     /// statistic over THAT population, and a figure taken from a narrower slice of it — one day, one hour —
     /// is a DIFFERENT statistic even on the occasions when the two agree to the second.</para>
     ///
+    /// <para><b>AND IT IS NOT THE SAME POPULATION AS ITS SIBLING'S, which has to be said here because the
+    /// two constants read as a matched pair and are not one (#3182).</b>
+    /// <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> is scoped to the runs after the narrowing
+    /// boundary and grows with every hour its policies run; the LIVE ENVELOPE paragraph below is scoped to
+    /// ONE CLOSED DAY inside that span. So a maximum quoted from one of these constants is not comparable
+    /// with a maximum quoted from the other, and a figure swept over a wider span than either — the whole
+    /// of a store's job history, say — is comparable with neither, because the boundary exists precisely
+    /// because runs before it did structurally more work on an unnarrowed
+    /// <see cref="HourlyRefreshStartOffset"/>. <b>That comparison has been made and published as a defect
+    /// that was not one</b>, which is what this paragraph exists to stop: an all-span maximum measured
+    /// against a boundary-scoped constant reads as a constant understated by a factor when it is a
+    /// population mismatch. Whichever of the two spans a later reader wants, they have to take it from the
+    /// constant they are reading and not from its neighbour.</para>
+    ///
     /// <para><b>A maximum over a closed population is a LOWER BOUND on what the job does, and since #3182
     /// the product REPORTS when a live run falsifies it.</b> That is not a restatement of the slot watch and
     /// the two are not interchangeable: <see cref="ClassifyRefreshSlotHeadroom"/> asks whether a run fits
@@ -2449,6 +2463,16 @@ WITH NO DATA";
     /// percentile, not a per-view figure, and not a fleet reading: one number covers twelve policies, so a
     /// live run of ANY of them above it falsifies it. "Recorded" in the line above means recorded in that
     /// read, and nowhere else — the word carries no claim about runs the read did not see.</para>
+    ///
+    /// <para><b>AND IT IS NOT THE SAME POPULATION AS ITS SIBLING'S (#3182).</b> This one spans the whole of
+    /// the post-boundary record and grows; the live-envelope figures on
+    /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> are scoped to one closed day inside that
+    /// span. The two constants sit next to each other, are derived by the same named read with the same
+    /// positional exclusion rule, and still answer to different spans — so a maximum from one is not
+    /// comparable with a maximum from the other, and neither is comparable with a sweep over a store's
+    /// whole job history, because the boundary is there because runs before it worked an unnarrowed
+    /// <see cref="HourlyRefreshStartOffset"/>. The direction that mismatch fails in is stated on the
+    /// sibling: it makes a boundary-scoped constant read as understated by a factor.</para>
     ///
     /// <para><b>And since #3182 the product reports when a live run of one of those twelve falsifies it,
     /// which it previously could not because nothing read them.</b> The heaviest refresh had


### PR DESCRIPTION
There is a signal for "the slot is exceeded" and there was none for "the constant the grid was derived from is wrong". Those are two facts with two remedies, and the second can be true while the first is false — which is the state that carried #3182, because a recorded ceiling can be overtaken from inside the routine band, where the slot watch logs at Debug and reports that nothing is happening.

## What ships

`ClassifyRefreshCeilingFreshness(observed, recordedCeiling)` answers whether a live reading has falsified a constant that claims to be a maximum. `LogRefreshCeilingStaleness` reports it, and `DarlingWorker` calls it **beside** `LogHeaviestRefreshSlotHeadroom` rather than inside its band switch, so a falsified ceiling is reported from `InsideSlot`, `ApproachingSlot` and `SlotExceeded` alike. `TheFinding_IsReachableFromEverySlotBand` enumerates over the shipped enum, so a band added later has to be given a probe deliberately.

**The boundary excludes equality where the slot wall includes it.** A run that took exactly its window was already colliding with its neighbour, so `SlotExceeded` opens at `>=`. A reading *equal* to a recorded maximum is the reading that maximum was taken from and confirms the constant, so this opens at `>`. Inclusive here would report the grid's own sizing figure as a falsification of itself on the one hour guaranteed to arrive.

**Warning, and the level is a decision.** Debug is where the defect lived, so it is unavailable. Error is reserved for a stated precondition of the grid being false, which a falsified ceiling does not make — a run can be past the constant and a long way inside the window. Levelling this Error too would collapse the distinction the finding exists to draw, and `TheTwoFindings_NameDifferentRemedies` pins that the two lines name different remedies and do not name each other's.

**Rate-limited by a high-water mark per constant.** A ceiling that has drifted is overtaken on a large share of runs, so an unlimited hourly Warning becomes furniture. The first falsifying reading reports; after that only one larger than the largest already reported. That shape rather than a latch or a time window, because what the finding asks for is a constant re-derived to at least the largest run on record: a new record changes the answer and a repeat does not. The mark never falls, so load falling cannot make the finding start repeating.

## The light ceiling gets a live feed, because it had none

`OtherHourlyRefreshObservedCeilingSeconds` is the load-bearing one. It is not merely asserted against — `CompressionPhaseGuardMinutes` **is** it rounded up to a whole minute, so a light refresh running past it leaves a compression policy able to start while that refresh still holds `AccessShareLock`, which is #3012's convoy by construction.

Nothing read those twelve views' runtimes back. #2136's `JobCadenceReadSql` does read their durations, but it keys on `proc_name || hypertable_name` and a refresh policy's `hypertable_name` is the *materialization* hypertable — so a check that looks like it covers these jobs cannot attribute what it reads to the constant that bounds them. `OtherHourlyRefreshRuntimesSql` is `HeaviestRefreshRuntimeSql` with its view filter inverted, sharing one copy of the measured OR-join; `TheLightRefreshRead_IsTheHeaviestReadWithItsViewFilterInverted` asserts the two statements are byte-identical apart from that one operator, which is what a shared-fragment pin could not do.

Hourly-versus-daily is filtered in C# against `HourlyRefreshPhaseOrder` rather than interpolated into SQL, so the registry stays the one place that decides which views are hourly.

## The guard's derivation gets the upper bound it was missing

`CompressionPhaseGuardMinutes = ceil(OtherHourlyRefreshObservedCeilingSeconds / 60)` over a long-tailed maximum has **no upper bound of its own, and the hour has one**. Nothing in the derivation noticed the conflict; it surfaced as a grid already re-dimensioned past what the hour contains.

`GuardAndWindowSharedMinutes` (25) names the budget the guard and the heaviest refresh's window divide. `WidestFeasibleCompressionPhaseGuardMinutes` (7) is the widest guard that still leaves the grid's own precondition true at the recorded ceiling, searched downward through the shipped comparison rather than solved in closed form so it cannot answer "feasible" where the build answers red. `WidestFeasibleOtherRefreshCeilingSeconds` (420 s) puts that bound back in the constant's own unit.

So a re-derivation above 420 s is **red at the constant**, with a message saying the two bands cannot both be satisfied, instead of the conflict being discovered after the grid has been rebuilt around it.

**And it answers the question rather than only tripping on it.** The honest post-boundary maximum for the light views is **265.5 s** (`query_store_stats_corrected_hourly`), which rounds to a guard of **5** and leaves a 19-minute heaviest window — comfortably inside the 420 s / 7-minute bound. The alarming figure was 2,886 s, which would have needed a guard of 49 against a 25-minute budget. The bound is what tells those two apart without anyone having to argue about it.

## The two summaries now name their own statistic and their own population

Both already stated `ESTIMATOR: the maximum` deep in their derivation paragraphs. What they lacked was that sentence at the top, where a reader cites it — and the heaviest one carried a sentence asserting that one closed day and the constant's population "describe the same population". That is the substitution that let a one-day figure carry a census's authority. They coincide because the population's largest run falls inside that day, which is a fact about where one run landed.

**And each now disclaims the OTHER's population, which naming your own statistic does not cover.** The two constants sit next to each other, are derived by the same named read with the same positional exclusion rule, and answer to different spans: one to the whole post-boundary record, one to a closed day inside it. Nothing said so. A reader who takes them as a matched pair — or measures either against a sweep over a store's whole job history — concludes a constant is understated by a *factor* when what they have is a population mismatch, because the boundary exists precisely because runs before it worked an unnarrowed `HourlyRefreshStartOffset`. That conclusion has been reached and published on this issue, twice, so the disclaimer is not tidiness.

`EachCeilingSummary_NamesItsStatisticAndItsPopulation` pins all of it — a declared statistic, a named population, each summary naming the other constant and stating the populations are not the same, and the false identity claim staying gone. A reworded honest summary passes; one that drops any half does not.

## What is NOT here, and the arithmetic for the decision

**Neither constant's value is re-derived, and neither dimension moves.** Not caution: the measurements offered cannot yet support a re-derivation, for reasons checkable against the repo's own recorded figures rather than against anyone's judgement.

**And the constant is 6% stale, not broken.** The 09-08 17:00Z run of 952 s exceeds the recorded 896 by 56 s. On the three recent post-narrowing days the daily peaks are 778 / 896 / 952 s, so the constant sits at the top of that range and was overtaken by one run at the top of the next day's. The slot at 1,260 s has real headroom on a normal day. This is the wrong statistic being maintained badly, not a grid on fire — and that is exactly why a signal was the right first ship: nothing was going to page anyone about a 6% overtake, and nothing did for the whole record.

**1. The populations offered are ~80% a regime the product no longer runs in.** *(Since confirmed by a scoped re-measurement — see the corrected figures below.)* `HeaviestHourlyRefreshObservedCeilingSeconds`'s own summary states the split verbatim: **304 runs** at or before the narrowing boundary, median **1081.7 s**, maximum **13300.7 s**; **57 runs** after it, median **418.3 s**, maximum **896.1 s**. The 379-run population is 304 pre-boundary + 57 + the ~18 runs after that census read.

So:

| figure quoted against the constant | what it actually is |
|---|---|
| max **13,300.7 s** | the **pre-boundary** maximum, stated in the constant's own doc |
| median **894.5 s** | a **mixed** median — post-boundary is 418.3 over 57 runs, pre-boundary is 1081.7 over 304 |
| the constant, **896** | the **post-boundary maximum**, to 0.1 s |

The finding "the constant is the population's median" is a coincidence between a post-narrowing **maximum** and a mostly-pre-narrowing **median**. On its own stated population the constant is not a mislabeled statistic — it is the maximum, correctly. What it is, is **stale**: the 09-08 17:00Z run of 952 s and the 18:15Z run of 1,495 s both overtook it, both post-boundary. That is the defect, and it is what ships a signal here.

The same applies to the light constant. 226.8 s is the maximum over **874 post-boundary runs of 12 views**, read 2026-09-08 14:57Z; `query_store_stats_hourly`'s 2,886.0 s is over 502 runs across 22 days. If 2,886 s were a post-boundary run before that read, the light census's maximum would be 2,886 and not 226.8 — so it is pre-boundary, unless it occurred in the 4.3 hours between 14:57Z and 19:15Z, which the census's two largest post-boundary runs (226.8 s and 160.4 s, both at 00:30) make unlikely. Not 12.7x understated: measured across regimes.

**2. The population under tonight's geometry is one run old.** #3180 (`6faf666cd`) re-phased the heaviest refresh to `:15` tonight. The 18:15Z run of 1,495 s is the *first* run on that minute and it followed an interrupted 18:00 run. Exclude it as confounded and the current-regime population has ~1 admissible member; include it and the honest ceiling is 1,495 s. Either way, re-deriving tonight is the original defect — one quiet day — at n≈1.

**3. Two arithmetic corrections to the numbers in the issue.** `ceil(2886 / 60)` is **49**, not 48: 48 × 60 = 2,880 < 2,886. The guard is 49 and the window is 25 − 49 = **−24**. And at the p95-derived guard of 9 the window is 16 minutes: the slot is 960 s, which does clear a 894.5 s ceiling by 65.5 s, **but the grid's stated precondition is against the watch line, not the slot** — 16 × 60 × 5/6 = **800 s**, and 894.5 > 800. So a p95-derived guard **does not close**; `WidestFeasibleCompressionPhaseGuardMinutes` is 7 and 9 is red.

**4. Every lever named for the heaviest refresh is out of scope tonight or is not a constant.** Its summary lists three repairs:

- *fewer compression minutes* — the compression band, held for #3180's dogfood;
- *a cheaper refresh* — a change to the aggregate's definition, not a constant to re-derive;
- *a longer cadence for this one aggregate* — `AddHourlyRefreshPolicySql` passes `HourlyRefreshScheduleInterval` as **both** `schedule_interval` **and** `end_offset` (verified from the emitted statement), so a longer cadence changes how close to `now` the aggregate materializes, which is a data-freshness change to a product surface. Split them and the grid's cadence itself moves — `MinutesInHourlyCadence` derives from `HourlyRefreshScheduleSpan` — which moves every phase minute.

### The scoped re-measurement

Measured over the honest post-boundary population (`start_time > 2026-09-05 13:44:23`, hourly policies, succeeded, non-null finish):

| view | runs | max | median |
|---|---|---|---|
| `query_store_stats_interval_hourly` | 76 | 1,495.2 s | 462.3 s |
| `query_store_stats_corrected_hourly` | 79 | 265.5 s | 36.9 s |
| `query_store_stats_hourly` | 78 | 263.9 s | 34.5 s |
| every other hourly view | 78–79 | 0.6–23.3 s | 0.1–7.8 s |

- **`OtherHourlyRefreshObservedCeilingSeconds = 226.8` against a true post-boundary maximum of 265.5 s** — understated by **16%**, guard 5 rather than 4, window 19 minutes. Not 49. **Nothing forces a re-dimensioning**, and the feasibility bound shipped here confirms it rather than merely permitting it.
- **`HeaviestHourlyRefreshObservedCeilingSeconds = 896`**: exactly three post-boundary runs exceed it — 1,495.2 s (09-08 18:15, the upgrade catch-up, confounded three ways), **952.0 s (09-08 17:00, clean)**, and 896.1 s (09-07 23:00), which *is* the run the constant was taken from. **One clean run, 6% over, and nothing anywhere reported it.** That is the defect at its true size, and it is precisely what this PR makes visible.

### Why the value does not move — and a correction to what I said earlier

The full population is now in hand: **77 rows** for the heaviest view's policy with `start_time > 2026-09-05 13:44:23`, of which **0** did not succeed and **1** has a null finish (the run the 18:06Z install interrupted), leaving **n=76** — max **1,495.2** / p95 **840.1** / median **462.3** / total **39,286.7**.

**I earlier wrote that the constant "can move to 952 under its own stated method". That was wrong, and it was wrong by exactly the mechanism the method warns about.** The exclusion rule is positional and emphatic — *"membership is decided by position against the boundary, never by whether a reading looks like it belongs"* — and the estimator is the maximum. So under the constant's own stated method the honest value is **1,495.2 s**, not 952. Reaching 952 requires dropping the 18:15 catch-up for being confounded, which is precisely the "looks like it belongs" judgement the rule exists to forbid. I had the estimator right and applied a discretionary exclusion on top of it without noticing.

And **1,495.2 s exceeds `RefreshPhaseSlotSeconds` (1,260)**, so an honest re-derivation under the stated rule reddens **six assertions across two files** rather than settling anything:

- `TimescaleSupportTests` x3 — `Ceiling < RefreshPhaseSlotSeconds` (twice) and `Ceiling < RefreshSlotWarningSeconds`
- `RefreshCeilingProvenancePinTests` x3 — `Ceiling < WatchLine`, plus the two `Assert.All` clauses over the published population, which would then contain a member past both lines

That is not a reason to hand-pick a smaller number. It is the grid decision, arriving through the front door.

### The population is defined by ONE boundary and contains THREE regimes

This is the strongest argument for leaving the value alone, and it is measured rather than argued. The start times in the post-boundary population drift for the first twenty runs and then snap to the hour:

| segment | runs | schedule | when |
|---|---|---|---|
| 09-05 14:44 → 09-06 11:26 | 20 | drifting (finish-to-start) | pre-convergence |
| 09-06 13:00 → 09-08 17:00 | 53 | fixed, on the hour | pre-install |
| 09-08 18:15 → 20:15 | 3 | fixed, at `:15` | post-install |

**The drift is finish-to-start scheduling, and the constant's own published population proves it — nine times out of nine.** Under finish-to-start, `start[n+1] = start[n] + duration[n] + 1 hour`. Feeding the nine boundary-day durations the doc already publishes (`194, 222, 225, 335, 594, 465, 359, 293, 355` seconds) through that recurrence from 14:44 reproduces every subsequent observed start time to **under one minute**:

| predicted | observed | using |
|---|---|---|
| 15:47 | 15:47 | 194 s |
| 16:51 | 16:51 | 222 s |
| 17:55 | 17:55 | 225 s |
| 19:00 | 19:00 | 335 s |
| 20:10 | 20:10 | 594 s |
| 21:18 | 21:18 | 465 s |
| 22:24 | 22:24 | 359 s |
| 23:29 | 23:29 | 293 s |
| 00:35 | 00:35 | 355 s |

No store access is needed to check that: the durations are in the doc comment and the start times are in this PR. **The drift is not a rate.** It equals each run's own duration, measured at 3 to 10 minutes across these nine — so describing it as "4–6 minutes per hour" both understates the range and loses the mechanism, which is what makes it identifiable as finish-to-start rather than as clock skew.

**So the population this constant is derived from is defined by one boundary and in fact spans three scheduling regimes.** That is the same defect this issue is about, one level up: the positional rule correctly excludes the pre-narrowing regime and is silent about the two transitions inside what it admits. A maximum over that population is a maximum over a mixture, which is where this started.

**And the post-install runs are FASTER**, so the number a re-derivation would target is still moving: 18:15 → 1,495.2 s (the catch-up), then **689.7** and **699.5**, against pre-install evening runs of 760.2 and 952.0. Consistent with per-group cost falling from ~1.37 to ~0.99 ms once the heaviest refresh got an isolated minute at `:15`.

**One attribution I could not verify.** Neither `#3041` nor `#3178` appears anywhere in `TimescaleSupport.cs`, so the segment boundaries above are described by what changed rather than by the issue that changed it. `#3178` is cited in `TimescaleSupportTests` for the ceiling/slot/watch-line triple, and `origin/dev`'s tip is `#3180`.

### And the light constant should wait on #3185

`OtherHourlyRefreshObservedCeilingSeconds` passing 226.8 for the first time tonight is not the light refreshes getting slower. #3185 records the cause: the light band steps by member **count**, so `query_store_stats_hourly` and `query_store_stats_corrected_hourly` now sit at `:02` and `:04` — **2 minutes apart**, confirmed from `RefreshPhaseMinutesFor` against the shipped registry — where they were 15. Both now run ~265 s, and per-group cost rose **5.4x** with cardinality flat. Re-deriving a ceiling from a population produced by a spacing defect would bake that defect into the grid's dimensions.

**So: neither value moves here, and the reason is no longer "I lack the data".** The data says the stated method yields a figure that reddens the build, over a population that mixes three regimes, on a grid that has an open defect against it. The constant should be re-derived once the grid is stable, and it is not.

## The within-day climb has an explanation now, and #3099 should be closed on it

The heaviest refresh materializes essentially one bucket per run, at a near-constant cost per output group. Duration tracks **output cardinality**, not the 24-hour `start_offset` window — that window holds ~11.4M groups constant to within 3% all day, so a window-cost model predicts flat duration and is refuted by the observed 2.5x swing.

| bucket (2026-09-08) | groups | refresh duration | ms/group |
|---|---|---|---|
| 09:00 | 273,677 | 381.3 s | 1.393 |
| 12:00 | 429,962 | 560.0 s | 1.302 |
| 14:00 | 626,022 | 740.6 s | 1.183 |
| 16:00 | 697,050 | 952.0 s | 1.366 |

Cardinality varies **2.55x**, duration **2.50x**, and cost-per-group holds within **1.18x** across these four.

**An independent cross-check nobody arranged.** Each duration above is labelled by the BUCKET it materialized, and each matches the run one hour LATER in the issue body's 09-08 series exactly — 381 at 10:00, 560 at 13:00, 741 at 15:00, 952 at 17:00, four for four — while matching the same-hour run zero for four. That one-hour offset is `end_offset`, which `AddHourlyRefreshPolicySql` sets from `HourlyRefreshScheduleInterval` (confirmed against the emitted statement). Two unrelated readings agreeing on the offset is what makes the model more than a fit.

So the climb is the diurnal Query Store load curve driving bucket cardinality. Not contention. **#3099 records this climb as having no surviving explanation and carries two open measurement asks premised on that mystery — they should be closed on this.**

Two same-source pairs settle direction with volume held constant: `query_store_stats_interval_hourly` and `query_store_stats_hourly` read the identical 904,912 rows for a given hour at reduction ratios of 1.30:1 and 2.62:1, with refresh medians of 894.5 s and 105.5 s; `query_stats_hourly` (29:1, 11.2 s) against `query_stats_db_hourly` (1,481:1, 1.8 s) over an identical ~311,000 rows.

### Why the constant is still not re-derived from that model here

A cardinality model is the right direction and it is a real improvement — two terms that fail differently, one of them (cost per group) a property of the code rather than of the load, and it predicts growth instead of going quietly stale. Three things stop it being this PR.

**It does not remove the property it is credited with removing.** `peak cardinality x k` needs a PEAK, and a peak over observed hours is a maximum over a sampled variable — the same estimator, moved from duration to cardinality. A sampled peak cardinality is correct about the days it was sampled over in exactly the way a sampled duration is.

**It straddles the assertion boundary, so it does not settle the question either.** At the observed peak of 697,050 groups:

| k (ms/group) | modelled ceiling | vs the 1,050 s watch line |
|---|---|---|
| 1.12 | 780.7 s | holds |
| 1.183 | 824.6 s | holds |
| 1.30 | 906.2 s | holds |
| 1.393 | 971.0 s | holds |
| 1.61 | 1,122.3 s | **fails** |

The four measured points span 1.183–1.393 and all hold; the top of the wider 1.12–1.61 band does not. So the choice of `k` decides whether `HeaviestHourlyRefreshObservedCeilingSeconds < RefreshSlotWarningSeconds` survives, and four points do not pin `k` tightly enough to make that call.

**And it would weaken the pin it replaces.** `RefreshCeilingProvenancePinTests` requires the constant to equal the maximum of a population the comment publishes — 57 runs today. Shipping a model means publishing two term populations and pinning a product; with four cardinality points that is a 4-point population replacing a 57-run one. Re-deriving on a thinner population is the defect this issue is about, one variable over.

**The designed follow-up, which is the strongest idea in the model.** Compare a live run against `cardinality x k` and report whether the DURATION or the COST PER GROUP moved. Those are different faults with different remedies — more Query Store volume versus the refresh itself getting slower per group — and the staleness finding shipped here is the same two-facts-two-remedies shape one level shallower. It needs a per-bucket cardinality reading the product does not collect, so it is a collector-scale change and not a constant to renumber.

### The p95 of 4,278.9 s should not be used as a planning figure

At 1.3 ms/group it implies **3.29M groups** in one bucket against an observed peak of 698k — **4.7x**. And the same pre/post split above places it: 304 of the 379 runs are pre-boundary with a median of 1,081.7 s and a maximum of 13,300.7 s, so the 95th percentile of the mixed record sits deep in the pre-narrowing tail. Two independent routes, one from the cardinality model and one from the constant's own published split, agree it is contaminated.

## Verification

125 tests in a `net10.0` xunit.v3 harness compiling the real Windows-only `.cs` files (`Darling.Tests` assembly name, so `InternalsVisibleTo` applies): 0 failed, 15 skipped, all skips the live-store `_AgainstDevPostgres` gate. `TimescaleSupportTests`, `TimescaleContinuousAggregateTests`, `CompressionClearanceWatchTests` and `RefreshCeilingProvenancePinTests` all pass unchanged — including the file-wide open-population guard and the live-envelope pins over the paragraph edited here.

Nineteen mutations, each applied singly, confirmed present by `git diff --numstat` plus a content check, rebuilt, run, restored, and restoration confirmed by content. All nineteen red; the baseline green at 125/0/15 before and after each. The table is in the lane report.

Two whole-tree hygiene suites went red on the first CI run and both were mine: the shared read fragment was declared between `HeaviestRefreshRuntimeSql`'s summary and its member, leaving that summary stacked on the fragment and the statement undocumented, and the new file hand-rolled a second `///`-run walker where `RefreshCeilingProvenancePinTests` already carries a stated bound for one. The fragment moved above the summary it was displacing and the summary-shape pin moved into the file that is already a registered prefix-filter site, which costs nothing — registering a new site would have added a frozen count to `CommentFilterAdoptionTests`' own summary for a walker that did not need to exist.

One mutation was **green** on the first pass and the design changed rather than the test: the `double.IsNaN` guard in the classifier was unreachable, because `NaN > x` is already false for a ceiling that is positive by construction. Deleting it left every case green — a line that reads as protection and certifies nothing. It moved to `RefreshCeilingStalenessWatch.ShouldReport`, where a non-finite value does real damage (every comparison against NaN is false, so a NaN mark reports every later reading and disables the rate limit for the life of the process) and where deleting it is a caught mutation.

## CHANGELOG entry text

Under `[Unreleased]` → `Added`:

- A refresh-ceiling staleness finding, reported separately from where the reading sits against its slot: a live run above a constant recorded as a maximum means the constant is wrong, which is a different fact with a different remedy from the slot being exceeded, and it is reported from every band including the routine one. Rate-limited by a high-water mark per constant. `OtherHourlyRefreshObservedCeilingSeconds` gets a live per-view feed for the first time, and the guard's derivation gets the upper bound the hour imposes on it, so a re-derivation that does not fit is red at the constant.
