### PR TITLE
Separate the light refreshes whose runs are long enough to overlap, inside the band the hour already had

### DIFF
--- a/Darling/Darling.Tests/RefreshCeilingStalenessTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingStalenessTests.cs
@@ -585,6 +585,165 @@ public sealed class RefreshCeilingStalenessTests
             + "minute and the grid is giving up guard width nobody decided to give up");
     }
 
+    /// <summary>
+    /// THE LIVE HALF OF #3185's MEMBERSHIP RULE: a light refresh that outran the gap its cost class was
+    /// given is reported, whichever class the rule put it in.
+    ///
+    /// <para><b>The defect this exists for is one no build-time test can reach.</b>
+    /// <see cref="TimescaleSupport.IsUnboundedCardinalityRefresh"/> decides how much of the light band a
+    /// view gets by reading its GROUP BY, and a view can be slow for a reason its group key does not show.
+    /// A hand-kept list of heavy views goes stale LOUDLY — on the next registration, where a reviewer sees
+    /// it. A rule that has stopped predicting goes stale QUIETLY, forever, which is strictly worse and is
+    /// why the rule needs a live falsifier rather than only a build-time one.</para>
+    ///
+    /// <para><b>And it is not covered by the ceiling finding above.</b> A deployment-bounded member at
+    /// 100 s outran its 60 s step while sitting a long way under
+    /// <see cref="TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds"/>, so
+    /// <see cref="TimescaleSupport.LogRefreshCeilingStaleness"/> is silent on precisely the reading this is
+    /// for. Both probes here are derived from
+    /// <see cref="TimescaleSupport.LightRefreshSpacingMinutesFor"/> so they follow the shipped gap at any
+    /// width it takes.</para>
+    /// </summary>
+    [Fact]
+    public void ALightRefreshPastItsClassGap_IsReported_AndOneAtTheGapIsNot()
+    {
+        var bounded = TimescaleSupport.MemoryBaselineView;
+        var unbounded = TimescaleSupport.QueryStoreStatsHourlyView;
+
+        Assert.False(TimescaleSupport.IsUnboundedCardinalityRefresh(bounded));
+        Assert.True(TimescaleSupport.IsUnboundedCardinalityRefresh(unbounded));
+
+        var boundedGap = TimescaleSupport.LightRefreshSpacingMinutesFor(bounded) * 60;
+        var unboundedGap = TimescaleSupport.LightRefreshSpacingMinutesFor(unbounded) * 60;
+
+        /* The two classes get DIFFERENT gaps, or the finding cannot tell the two remedies apart and the
+           layout it reports against is not the layout that shipped. */
+        Assert.True(
+            unboundedGap > boundedGap,
+            "the two cost classes are given the same gap, so separating the unbounded members bought "
+            + "nothing and every assertion below reduces to one case (#3185)");
+
+        /* AT the gap says nothing: a run that took exactly its gap finished as the next one began. */
+        Assert.False(TimescaleSupport.LightRefreshRunExceedsItsSpacing(bounded, boundedGap));
+        var quiet = new CapturingTestLogger();
+        TimescaleSupport.LogLightRefreshSpacingBreach(
+            bounded, boundedGap, new RefreshCeilingStalenessWatch(), quiet);
+        Assert.Equal("(no log lines captured)", quiet.Joined);
+
+        /* One second past it reports, at Warning, naming the constant whose repair is the CLASSIFICATION. */
+        Assert.True(TimescaleSupport.LightRefreshRunExceedsItsSpacing(bounded, boundedGap + 1));
+        var boundedLog = new CapturingTestLogger();
+        TimescaleSupport.LogLightRefreshSpacingBreach(
+            bounded, boundedGap + 1, new RefreshCeilingStalenessWatch(), boundedLog);
+        Assert.StartsWith("Warning:", boundedLog.Joined, StringComparison.Ordinal);
+        Assert.Contains(bounded, boundedLog.Joined, StringComparison.Ordinal);
+        Assert.Contains(
+            nameof(TimescaleSupport.LightRefreshStepMinutes), boundedLog.Joined, StringComparison.Ordinal);
+
+        /* AND THE READING THE CEILING FINDING CANNOT SEE, which is the whole reason this is a second
+           finding: the same run is a long way under the recorded light ceiling, so that watch says nothing
+           about it. */
+        Assert.True(boundedGap + 1 < TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds);
+        var ceilingSilent = new CapturingTestLogger();
+        TimescaleSupport.LogRefreshCeilingStaleness(
+            TimescaleSupport.OtherRefreshCeilingConstantName,
+            TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds,
+            bounded, boundedGap + 1, new RefreshCeilingStalenessWatch(), ceilingSilent);
+        Assert.Equal("(no log lines captured)", ceilingSilent.Joined);
+
+        /* An unbounded member's own gap is wider, so the bounded probe is silent for it — the classes are
+           judged against their own room and not against a single line. */
+        Assert.False(TimescaleSupport.LightRefreshRunExceedsItsSpacing(unbounded, boundedGap + 1));
+
+        /* Past ITS gap it reports, naming the constant whose repair is the SEPARATION. */
+        var unboundedLog = new CapturingTestLogger();
+        TimescaleSupport.LogLightRefreshSpacingBreach(
+            unbounded, unboundedGap + 1, new RefreshCeilingStalenessWatch(), unboundedLog);
+        Assert.StartsWith("Warning:", unboundedLog.Joined, StringComparison.Ordinal);
+        Assert.Contains(
+            nameof(TimescaleSupport.UnboundedLightRefreshSeparationMinutes),
+            unboundedLog.Joined,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The two cost classes are rate-limited under DIFFERENT keys, so the larger breach cannot suppress the
+    /// smaller one.
+    ///
+    /// <para><b>This is the one thing a shared high-water mark must not do when the findings are not the
+    /// same finding.</b> An unbounded member's breach is reported in hundreds of seconds and a bounded
+    /// member's in tens, so one key would mean the first unbounded breach permanently silences every
+    /// bounded one — and the bounded one is the finding that says the CLASSIFICATION is wrong, which is the
+    /// half no build-time rule covers. Asserted in that order deliberately: the large reading first, so a
+    /// single shared mark would already be above the small one when it arrives.</para>
+    /// </summary>
+    [Fact]
+    public void TheTwoCostClasses_DoNotSuppressEachOther_UnderOneWatch()
+    {
+        var bounded = TimescaleSupport.MemoryBaselineView;
+        var unbounded = TimescaleSupport.QueryStoreStatsHourlyView;
+
+        Assert.NotEqual(
+            TimescaleSupport.LightRefreshSpacingConstantNameFor(bounded),
+            TimescaleSupport.LightRefreshSpacingConstantNameFor(unbounded));
+
+        var watch = new RefreshCeilingStalenessWatch();
+        var log = new CapturingTestLogger();
+
+        var large = (TimescaleSupport.LightRefreshSpacingMinutesFor(unbounded) * 60) + 100;
+        var small = (TimescaleSupport.LightRefreshSpacingMinutesFor(bounded) * 60) + 1;
+
+        Assert.True(large > small, "the large probe is not larger, so a shared mark would not suppress");
+
+        TimescaleSupport.LogLightRefreshSpacingBreach(unbounded, large, watch, log);
+        TimescaleSupport.LogLightRefreshSpacingBreach(bounded, small, watch, log);
+
+        Assert.Equal(2, CountLines(log));
+
+        /* And WITHIN one class the mark still holds, so the split did not cost the rate limit. */
+        var repeat = new CapturingTestLogger();
+        var again = new RefreshCeilingStalenessWatch();
+        TimescaleSupport.LogLightRefreshSpacingBreach(bounded, small + 10, again, repeat);
+        TimescaleSupport.LogLightRefreshSpacingBreach(bounded, small, again, repeat);
+        Assert.Equal(1, CountLines(repeat));
+    }
+
+    /// <summary>
+    /// The service sweep CALLS the spacing finding on the same per-view feed it calls the ceiling finding
+    /// on, and passes the same watch instance.
+    ///
+    /// <para>Parsed out of the real <c>DarlingWorker.cs</c> for the reason the sibling guards in this file
+    /// are: a finding that exists and is never reached is the defect it was written to remove. Asserted
+    /// inside the light-refresh loop rather than merely present in the file, because the finding is
+    /// per-view and a call outside that loop would report one reading an hour.</para>
+    /// </summary>
+    [Fact]
+    public void TheSpacingFinding_IsCalledPerLightRefresh_OnTheSameWatch()
+    {
+        var worker = ReadDarlingWorkerSource();
+
+        var loop = worker.IndexOf(
+            nameof(TimescaleSupport.ReadOtherHourlyRefreshRuntimesAsync), StringComparison.Ordinal);
+        Assert.True(loop > 0, "the light-refresh runtime loop is gone from DarlingWorker");
+
+        var call = worker.IndexOf(
+            nameof(TimescaleSupport.LogLightRefreshSpacingBreach), StringComparison.Ordinal);
+        Assert.True(
+            call > loop,
+            "TimescaleSupport.LogLightRefreshSpacingBreach is not called after the per-view light-refresh "
+            + "read, so the spacing finding either does not run or runs on something other than a per-view "
+            + "reading (#3185)");
+
+        /* The tail of that loop, so "inside it" is a claim about the loop and not about the file. */
+        var body = worker[loop..];
+        var close = body.IndexOf("\r\n            }", StringComparison.Ordinal);
+        Assert.True(close > 0, "could not find the end of the light-refresh loop");
+        Assert.Contains(
+            nameof(TimescaleSupport.LogLightRefreshSpacingBreach),
+            body[..close],
+            StringComparison.Ordinal);
+    }
+
     private static int CountLines(CapturingTestLogger logger) =>
         logger.Joined == "(no log lines captured)"
             ? 0

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -616,6 +616,30 @@ public sealed class TimescaleContinuousAggregateTests
         /* Distinct starts survive the degradation, which is the guarantee #3012 needed and the one the
            separation is built on top of rather than in place of. */
         Assert.Equal(degraded.Length, degraded.Distinct().Count());
+
+        /* AND THE GAP THE LIVE FINDING JUDGES AGAINST IS THE GAP THE MAP PRODUCED, per class. Raised by
+           review: LightRefreshSpacingMinutesFor reads two constants, so on its own it states a PROMISE, and
+           a promise nothing measures is what a doc comment says while the code does something else. This
+           measures the smallest distance between two of a class's minutes on the shipped map and holds the
+           member to it, so a layout change that stopped delivering the gap that member names is red here
+           rather than reported against a figure the band never honoured. */
+        foreach (var isUnbounded in new[] { true, false })
+        {
+            var minutes = lightViews
+                .Where(view => TimescaleSupport.IsUnboundedCardinalityRefresh(view) == isUnbounded)
+                .Select(TimescaleSupport.RefreshPhaseMinutesFor)
+                .OrderBy(minute => minute)
+                .ToArray();
+
+            Assert.True(minutes.Length > 1, $"the {(isUnbounded ? "unbounded" : "bounded")} class has "
+                + "fewer than two members on the band, so it has no gap to measure and this claim is vacuous");
+
+            var achieved = minutes.Zip(minutes.Skip(1), (earlier, later) => later - earlier).Min();
+            var member = lightViews.First(view =>
+                TimescaleSupport.IsUnboundedCardinalityRefresh(view) == isUnbounded);
+
+            Assert.Equal(TimescaleSupport.LightRefreshSpacingMinutesFor(member), achieved);
+        }
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -472,6 +472,304 @@ public sealed class TimescaleContinuousAggregateTests
     }
 
     /// <summary>
+    /// TREATMENT THREE of #3012's family, and the #3185 defect: the light band separates the members whose
+    /// runs are long enough for CPU and I/O contention to matter, and it does that WITHOUT widening.
+    ///
+    /// <para><b>The defect this is written against.</b> Distinct starts is a LOCK guarantee — two refreshes
+    /// hold mutually compatible <c>AccessShareLock</c>s, so light refreshes cannot convoy on each other and
+    /// the band was sized by member COUNT alone. Sized that way, a one-minute step put
+    /// <see cref="TimescaleSupport.QueryStoreStatsHourlyView"/> and
+    /// <see cref="TimescaleSupport.QueryStoreStatsCorrectedHourlyView"/> two minutes apart where the previous
+    /// grid had them fifteen, and two ~265 s aggregations overlapped for essentially their whole runs at
+    /// 5.4x the per-output-group cost, cardinality flat to 1.4%.</para>
+    ///
+    /// <para><b>Every probe is derived from
+    /// <see cref="TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds"/> here, not from
+    /// <see cref="TimescaleSupport.UnboundedLightRefreshSeparationMinutes"/>.</b> That member IS the guard,
+    /// and asserting a separation against the member that produced it is a tautology that passes at any
+    /// value including one minute. The requirement is that the gap covers the recorded light-refresh
+    /// CEILING, so the ceiling is what the gap is measured against.</para>
+    ///
+    /// <para><b>And the band's width is asserted as a SET IDENTITY rather than as a bound.</b> The whole
+    /// argument for this shape over a wider step is that the separation is free: a bound like "no light
+    /// minute past the span" would pass for a band that had grown and then been re-measured, while the set
+    /// identity says the band occupies exactly the positions it always did and the guard, the heaviest
+    /// refresh's window and the compression band are therefore untouched.</para>
+    /// </summary>
+    [Fact]
+    public void TheLightBand_SeparatesEveryUnboundedCardinalityRefresh_WithoutWidening()
+    {
+        var lightViews = TimescaleSupport.HourlyRefreshPhaseOrder
+            .Where(view => !string.Equals(
+                view, TimescaleSupport.HeaviestHourlyRefreshView, StringComparison.Ordinal))
+            .ToArray();
+
+        /* THE BAND DID NOT WIDEN: the light minutes are exactly the band's own positions, so nothing was
+           taken from the guard or from the heaviest refresh's window to pay for the separation. */
+        Assert.Equal(
+            Enumerable
+                .Range(0, TimescaleSupport.LightHourlyRefreshCount)
+                .Select(index => index * TimescaleSupport.LightRefreshStepMinutes)
+                .ToArray(),
+            lightViews.Select(TimescaleSupport.RefreshPhaseMinutesFor).OrderBy(minute => minute).ToArray());
+
+        var unbounded = lightViews
+            .Where(TimescaleSupport.IsUnboundedCardinalityRefresh)
+            .Select(view => (View: view, Minute: TimescaleSupport.RefreshPhaseMinutesFor(view)))
+            .OrderBy(placed => placed.Minute)
+            .ToArray();
+
+        /* POSITIVE CONTROL, and it is also the one thing that catches a mis-declared static initializer:
+           UnboundedCardinalityRefreshViews is a field built from HourlyRefreshDefinitions, and a version of
+           it that ran empty would classify every view deployment-bounded and pass every gap assertion below
+           for having no gaps to check. */
+        Assert.True(
+            unbounded.Length > 1,
+            "fewer than two light refreshes classify unbounded-cardinality, so the separation this case "
+            + "exists for has nothing to separate and every assertion below is vacuous — either the "
+            + "registry changed or TimescaleSupport.IsUnboundedCardinalityRefresh has stopped recovering "
+            + "GROUP BY terms from the shipped CREATE text (#3185)");
+
+        /* THE REQUIREMENT: consecutive unbounded members cannot overlap at the recorded ceiling. */
+        for (var index = 1; index < unbounded.Length; index++)
+        {
+            var gapSeconds = (unbounded[index].Minute - unbounded[index - 1].Minute) * 60;
+
+            Assert.True(
+                gapSeconds >= TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds,
+                $"{unbounded[index - 1].View} starts at :{unbounded[index - 1].Minute.ToString("00", CultureInfo.InvariantCulture)} "
+                + $"and {unbounded[index].View} at :{unbounded[index].Minute.ToString("00", CultureInfo.InvariantCulture)}, "
+                + $"a gap of {gapSeconds.ToString(CultureInfo.InvariantCulture)}s against a recorded light-refresh ceiling of "
+                + $"{TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds.ToString(CultureInfo.InvariantCulture)}s — so the two can overlap for "
+                + "the difference, which is the #3185 regression");
+        }
+
+        /* And the LAST of them clears the heaviest refresh's window, which is the same inequality as the
+           band holding them all: the window opens at LightBandSpanMinutes + the guard, and the guard is the
+           separation. Asserted in seconds against the ceiling so it is not that identity restated. */
+        Assert.True(
+            (unbounded[^1].Minute * 60) + TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds
+                <= TimescaleSupport.HeaviestRefreshStartMinute * 60,
+            $"{unbounded[^1].View} starts at :{unbounded[^1].Minute.ToString("00", CultureInfo.InvariantCulture)} and can run "
+            + $"{TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds.ToString(CultureInfo.InvariantCulture)}s, which reaches into the heaviest "
+            + $"refresh's window at :{TimescaleSupport.HeaviestRefreshStartMinute.ToString("00", CultureInfo.InvariantCulture)} — the one overlap the "
+            + "grid exists to prevent (#3012)");
+
+        /* THE MEASURED CASE, named because it is the pair #3185's readings were taken from. Kept beside the
+           general sweep for the reason the query_store_stats family is kept above: the sweep says the
+           property holds, this says the property covers the thing that was measured. */
+        Assert.True(
+            Math.Abs(
+                TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.QueryStoreStatsHourlyView)
+                - TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.QueryStoreStatsCorrectedHourlyView))
+                * 60
+            >= TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds,
+            "the two views #3185 measured at 5.4x per-group cost are back inside one light-refresh ceiling "
+            + "of each other");
+
+        /* THE FEASIBILITY BOUND IS NOT VACUOUS: it admits the shipped count and refuses some larger one, so
+           a registry that grew past what the band can separate goes red instead of overlapping quietly. */
+        Assert.True(TimescaleSupport.LightBandHoldsUnboundedRefreshCount(unbounded.Length));
+        Assert.Contains(
+            Enumerable.Range(unbounded.Length + 1, TimescaleSupport.LightHourlyRefreshCount),
+            count => !TimescaleSupport.LightBandHoldsUnboundedRefreshCount(count));
+
+        /* And the map REFUSES rather than placing what it cannot separate. Reached through the order-taking
+           seam at the registry's unbounded members ALONE: duplicating the whole registry cannot reach it,
+           because one light member in four is unbounded today and that is exactly the density the
+           separation admits — a doubled list doubles the positions as fast as the members. A band that is
+           all unbounded is the shape that does not fit, and it is the shape a run of heavy registrations
+           walks toward. */
+        var allUnbounded = TimescaleSupport.HourlyRefreshPhaseOrder
+            .Where(view => !string.Equals(
+                view, TimescaleSupport.HeaviestHourlyRefreshView, StringComparison.Ordinal))
+            .Where(TimescaleSupport.IsUnboundedCardinalityRefresh)
+            .ToArray();
+
+        /* The refusal's own condition, evaluated over THAT order's band rather than over the shipped one —
+           LightBandHoldsUnboundedRefreshCount reads the shipped registry and answers true for three
+           members, because the shipped band has twelve positions for them. A band of three has three. */
+        Assert.True(
+            TimescaleSupport.LightBandIndexForUnboundedRefresh(allUnbounded.Length - 1)
+                > allUnbounded.Length - 1,
+            "a band of nothing but today's unbounded members would still hold them all, so the refusal "
+            + "below cannot be reached and this half of the case proves nothing");
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TimescaleSupport.RefreshPhaseMinutesFor(
+                allUnbounded, TimescaleSupport.QueryStoreStatsHourlyView));
+    }
+
+    /// <summary>
+    /// MEMBERSHIP IS DERIVED FROM THE SHIPPED CREATE TEXT, and every grouping term in every registered
+    /// hourly aggregate has to be classified deliberately.
+    ///
+    /// <para><b>Why the rule is a list of COLUMNS and this is the guard that keeps it honest.</b> A list of
+    /// heavy VIEWS is a frozen enumeration — right until the next aggregate is registered, then silently
+    /// wrong, which is the positional coupling #3174 removed one level over. A view's one-bucket output
+    /// cardinality is decided by its own GROUP BY, so
+    /// <see cref="TimescaleSupport.IsUnboundedCardinalityRefresh"/> reads that. What can still go stale is
+    /// the COLUMN list: an aggregate registered tomorrow could group by a per-statement column nobody has
+    /// classified, and the quiet answer — "not on the per-statement list, therefore bounded" — is the answer
+    /// that gives it the least room. So every term is required to appear on one of the two lists, and the
+    /// bounded half lives HERE: it has no product consumer, and a new grouping column has to be classified
+    /// in a file that is red until someone does it.</para>
+    ///
+    /// <para><b>The parse is controlled per view before its result is used.</b> A recovery that matched
+    /// nothing would return no terms for every view, and no terms contains no per-statement column — so a
+    /// broken parse reports every aggregate deployment-bounded and a clean sweep for having checked nothing.
+    /// Two named views' exact term lists are asserted, one from each class, which is what discriminates a
+    /// working parse from one that merely returned something.</para>
+    /// </summary>
+    [Fact]
+    public void EveryGroupingTerm_IsClassified_AndTheParseIsControlledPerView()
+    {
+        /* Bounded by the DEPLOYMENT: servers, databases, schema objects, small enumerations, and the
+           collection instants a cadence produces. None of these grows with the monitored workload's
+           distinct statement population, which is what makes the cost of grouping by them predictable. */
+        var deploymentBounded = new[]
+        {
+            "server_id",
+            "server_name",
+            "database_name",
+            "module_name",
+            "schema_name",
+            "object_name",
+            "execution_type_desc",
+            "replica_role",
+            "bucket",
+            "collection_time",
+        };
+
+        foreach (var (createSql, view) in TimescaleSupport.HourlyRefreshDefinitions)
+        {
+            var terms = TimescaleSupport.RefreshGroupingTermsFor(createSql);
+
+            Assert.True(
+                terms.Count > 0,
+                $"no GROUP BY terms could be recovered from {view}'s CREATE, so its refresh cost class is "
+                + "being decided by an empty list — TimescaleSupport.RefreshGroupingTermsFor has stopped "
+                + "matching the shipped text (#3185)");
+
+            foreach (var term in terms)
+            {
+                Assert.True(
+                    TimescaleSupport.PerStatementGroupingColumns.Contains(term, StringComparer.Ordinal)
+                    || deploymentBounded.Contains(term, StringComparer.Ordinal)
+                    || term.StartsWith("time_bucket(", StringComparison.Ordinal),
+                    $"{view} groups by `{term}`, which is on neither TimescaleSupport."
+                    + "PerStatementGroupingColumns nor this case's deployment-bounded list. Decide which it "
+                    + "is: a column whose distinct count grows with the monitored workload's statement "
+                    + "population belongs on the first list and its view gets "
+                    + "UnboundedLightRefreshSeparationMinutes of the band; one bounded by the size of the "
+                    + "deployment belongs on the second and its view keeps LightRefreshStepMinutes. "
+                    + "Unclassified defaults to bounded, which is the answer that gives it the least room "
+                    + "(#3185)");
+            }
+        }
+
+        /* PARSE CONTROL, one view from each class, spelled out. Depth-zero splitting is what makes the
+           hierarchical view's time_bucket() come back as ONE term: a plain comma split yields a term of
+           `time_bucket('1 hour'` and one of `bucket)`, and the second of those is a real column name. */
+        Assert.Equal(
+            new[] { "server_id", "server_name", "database_name", "bucket" },
+            TimescaleSupport.RefreshGroupingTermsFor(TimescaleSupport.CreateQueryStatsDbHourlySql));
+
+        Assert.Equal(
+            new[] { "server_id", "server_name", "database_name", "module_name", "query_hash", "time_bucket('1 hour', bucket)" },
+            TimescaleSupport.RefreshGroupingTermsFor(TimescaleSupport.CreateQueryStoreStatsCorrectedHourlySql));
+
+        /* And the two classes both have members, so neither branch of the rule is dead. */
+        var byClass = TimescaleSupport.HourlyRefreshPhaseOrder
+            .GroupBy(TimescaleSupport.IsUnboundedCardinalityRefresh)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        Assert.True(byClass.TryGetValue(true, out var unboundedCount) && unboundedCount > 0);
+        Assert.True(byClass.TryGetValue(false, out var boundedCount) && boundedCount > 0);
+
+        /* A view the registry does not hold has no CREATE to classify, and the answer is loud rather than
+           the quiet "bounded" a defaulted lookup would give it. */
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TimescaleSupport.IsUnboundedCardinalityRefresh(TimescaleSupport.QueryStatsDailyView));
+
+        /* THE FAIL-SAFE ARM, exercised at the only surface that can reach it. Nothing in the registry is
+           unparseable, so this branch is unreachable through the shipped definitions — and an unreachable
+           guard reads as protection while certifying nothing. A CREATE with no GROUP BY at all classifies
+           UNBOUNDED, which gives that aggregate the wider gap and makes the band's feasibility bound the
+           thing that reports the problem, rather than handing it a one-minute step in silence. */
+        Assert.True(TimescaleSupport.GroupKeyIsUnboundedCardinality(
+            "CREATE MATERIALIZED VIEW collect.nothing AS SELECT 1 WITH NO DATA"));
+
+        /* And the arm is not a blanket true: a parseable, deployment-bounded key still answers false
+           through the same function, so the fail-safe cannot be what every view is riding on. */
+        Assert.False(TimescaleSupport.GroupKeyIsUnboundedCardinality(
+            TimescaleSupport.CreateQueryStatsDbHourlySql));
+        Assert.True(TimescaleSupport.GroupKeyIsUnboundedCardinality(
+            TimescaleSupport.CreateQueryStoreStatsHourlySql));
+    }
+
+    /// <summary>
+    /// THE STEP CANNOT BE WIDENED, which is #3185's first candidate repair answered in the build rather
+    /// than in a discussion.
+    ///
+    /// <para>"Give the light band a step sized by member duration" is the obvious reading of a band that
+    /// overlaps its own members, and it reads like a trade someone could choose to make against
+    /// <see cref="TimescaleSupport.HeaviestRefreshWindowMinutes"/>. It is not a trade:
+    /// <see cref="TimescaleSupport.WidestFeasibleLightRefreshStepMinutes"/> returns the SHIPPED step, so the
+    /// band is already as wide as the hour carries and every wider step is red. The binding constraint is
+    /// not the hour's sixty minutes — it is the heaviest refresh's watch line, which is why the infeasible
+    /// answer arrives two minutes in rather than at the fifty-five a duration-derived step would ask
+    /// for.</para>
+    ///
+    /// <para>Asserted at step + 1 as well, so the bound is TIGHT rather than merely true: a member that
+    /// returned the shipped step by reading it would pass the first assertion and fail this one.</para>
+    /// </summary>
+    [Fact]
+    public void TheWidestFeasibleLightRefreshStep_IsTheShippedOne_SoADurationDerivedStepIsRed()
+    {
+        Assert.Equal(
+            TimescaleSupport.LightRefreshStepMinutes,
+            TimescaleSupport.WidestFeasibleLightRefreshStepMinutes);
+
+        /* The opened-up chain agrees with the shipped one where they overlap, so it cannot drift into being
+           a second and kinder model of the grid — the requirement #3182 put on its guard twin. */
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotWarningSeconds,
+            TimescaleSupport.RefreshSlotWarningSecondsForLightBandAndGuard(
+                TimescaleSupport.LightBandSpanMinutes, TimescaleSupport.CompressionPhaseGuardMinutes));
+
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotWarningSecondsForGuardMinutes(
+                TimescaleSupport.CompressionPhaseGuardMinutes),
+            TimescaleSupport.RefreshSlotWarningSecondsForLightBandAndGuard(
+                TimescaleSupport.LightBandSpanMinutes, TimescaleSupport.CompressionPhaseGuardMinutes));
+
+        /* TIGHTNESS: one minute wider and the grid's own precondition is already false. */
+        var oneWider = (TimescaleSupport.LightHourlyRefreshCount - 1)
+            * (TimescaleSupport.LightRefreshStepMinutes + 1);
+
+        Assert.False(
+            TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds
+                < TimescaleSupport.RefreshSlotWarningSecondsForLightBandAndGuard(
+                    oneWider, TimescaleSupport.CompressionPhaseGuardMinutes),
+            $"a {(TimescaleSupport.LightRefreshStepMinutes + 1).ToString(CultureInfo.InvariantCulture)}-minute light step still leaves a watch line above "
+            + "the heaviest refresh's recorded ceiling, so WidestFeasibleLightRefreshStepMinutes is "
+            + "understating what the hour carries and the argument for separating inside the band instead of "
+            + "widening it no longer holds (#3185)");
+
+        /* And the step a duration derivation would ask for — the light ceiling rounded up, which is the
+           same rounding CompressionPhaseGuardMinutes uses — is infeasible, which is the whole finding. */
+        var durationDerivedStep =
+            (int)Math.Ceiling(TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds / 60.0);
+
+        Assert.True(
+            durationDerivedStep > TimescaleSupport.WidestFeasibleLightRefreshStepMinutes,
+            "a light step derived from the light-refresh ceiling now fits inside what the hour carries, so "
+            + "the uniform shape #3185 rejected has become available and the interleaved layout is no "
+            + "longer the only one that fits");
+    }
+
+    /// <summary>
     /// The phase grid is keyed on the VIEW, and nothing shipped carries a job id.
     ///
     /// <para>#3012's evidence names job ids in the 1050s. Those exist only on the store it was measured

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -574,30 +574,48 @@ public sealed class TimescaleContinuousAggregateTests
             Enumerable.Range(unbounded.Length + 1, TimescaleSupport.LightHourlyRefreshCount),
             count => !TimescaleSupport.LightBandHoldsUnboundedRefreshCount(count));
 
-        /* And the map REFUSES rather than placing what it cannot separate. Reached through the order-taking
-           seam at the registry's unbounded members ALONE: duplicating the whole registry cannot reach it,
-           because one light member in four is unbounded today and that is exactly the density the
-           separation admits — a doubled list doubles the positions as fast as the members. A band that is
-           all unbounded is the shape that does not fit, and it is the shape a run of heavy registrations
-           walks toward. */
+        /* AND THE DEGRADED CASE, which is what the map does instead of refusing. Reached through the
+           order-taking seam at the registry's unbounded members ALONE: duplicating the whole registry
+           cannot reach it, because one light member in four is unbounded today and that is exactly the
+           density the separation admits — a doubled list doubles the positions as fast as the members. A
+           band that is all unbounded is the shape that does not fit, and it is the shape a run of heavy
+           registrations walks toward.
+
+           It degrades rather than throwing because CompressionPhaseMinutes is a static field whose
+           initializer reaches this map, and a static initializer that throws costs the whole type for the
+           life of the process. Measured, not assumed: mutating the GROUP BY recovery to return nothing
+           makes every view classify unbounded, and with a throwing map that took 72 tests red across four
+           unrelated files. */
         var allUnbounded = TimescaleSupport.HourlyRefreshPhaseOrder
             .Where(view => !string.Equals(
                 view, TimescaleSupport.HeaviestHourlyRefreshView, StringComparison.Ordinal))
             .Where(TimescaleSupport.IsUnboundedCardinalityRefresh)
             .ToArray();
 
-        /* The refusal's own condition, evaluated over THAT order's band rather than over the shipped one —
-           LightBandHoldsUnboundedRefreshCount reads the shipped registry and answers true for three
-           members, because the shipped band has twelve positions for them. A band of three has three. */
+        /* The condition, evaluated over THAT order's band rather than over the shipped one —
+           LightBandHoldsUnboundedRefreshCount's public overload reads the shipped registry and answers
+           true for three members, because the shipped band has twelve positions for them. A band of three
+           has three. */
         Assert.True(
             TimescaleSupport.LightBandIndexForUnboundedRefresh(allUnbounded.Length - 1)
                 > allUnbounded.Length - 1,
-            "a band of nothing but today's unbounded members would still hold them all, so the refusal "
-            + "below cannot be reached and this half of the case proves nothing");
+            "a band of nothing but today's unbounded members would still hold them all, so the degraded "
+            + "case below cannot be reached and this half of the case proves nothing");
 
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => TimescaleSupport.RefreshPhaseMinutesFor(
-                allUnbounded, TimescaleSupport.QueryStoreStatsHourlyView));
+        var degraded = allUnbounded
+            .Select(view => TimescaleSupport.RefreshPhaseMinutesFor(allUnbounded, view))
+            .ToArray();
+
+        Assert.Equal(
+            Enumerable
+                .Range(0, allUnbounded.Length)
+                .Select(index => index * TimescaleSupport.LightRefreshStepMinutes)
+                .ToArray(),
+            degraded);
+
+        /* Distinct starts survive the degradation, which is the guarantee #3012 needed and the one the
+           separation is built on top of rather than in place of. */
+        Assert.Equal(degraded.Length, degraded.Distinct().Count());
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -3296,10 +3296,12 @@ LIMIT 1", connection))
     /// inside 896 s of refresh while every other pin in the tree stayed green. Both halves are asserted:
     /// the full assignment, and the heaviest view's own minute.</para>
     ///
-    /// <para><b>The table is the whole map, not a sample, and #3174 moved every row of it.</b> The heaviest
-    /// refresh is answered by identity and every other view takes the next minute of the light band, so
-    /// this table is also the readable statement of what "thirteen distinct minutes" resolves to on today's
-    /// list — the one place a reader can see the grid without re-deriving it.</para>
+    /// <para><b>The table is the whole map, not a sample, and #3185 moved the light band's half of it.</b>
+    /// The heaviest refresh is answered by identity; the three unbounded-cardinality light views take every
+    /// fourth position from the first, and the nine deployment-bounded ones fill the positions those leave
+    /// in registry order. So this table is also the readable statement of what "thirteen distinct minutes"
+    /// resolves to on today's list — the one place a reader can see the grid without re-deriving it, and
+    /// the one place the interleaving is visible as minutes rather than as a rule.</para>
     /// </summary>
     [Fact]
     public void TheRefreshGridIsUnchanged_AndTheCompressionGridsOneInputFromItIsPinned()
@@ -3308,14 +3310,14 @@ LIMIT 1", connection))
         {
             (TimescaleSupport.QueryStatsHourlyView, 0),
             (TimescaleSupport.ProcedureStatsHourlyView, 1),
-            (TimescaleSupport.QueryStoreStatsHourlyView, 2),
-            (TimescaleSupport.QueryStatsDbHourlyView, 3),
+            (TimescaleSupport.QueryStoreStatsHourlyView, 4),
+            (TimescaleSupport.QueryStatsDbHourlyView, 2),
             (TimescaleSupport.QueryStoreStatsIntervalHourlyView, 15),
-            (TimescaleSupport.QueryStoreStatsCorrectedHourlyView, 4),
-            (TimescaleSupport.PerfmonBaselineView, 5),
-            (TimescaleSupport.WaitStatsBaselineView, 6),
-            (TimescaleSupport.SessionStatsBaselineView, 7),
-            (TimescaleSupport.QueryStatsBaselineView, 8),
+            (TimescaleSupport.QueryStoreStatsCorrectedHourlyView, 8),
+            (TimescaleSupport.PerfmonBaselineView, 3),
+            (TimescaleSupport.WaitStatsBaselineView, 5),
+            (TimescaleSupport.SessionStatsBaselineView, 6),
+            (TimescaleSupport.QueryStatsBaselineView, 7),
             (TimescaleSupport.BlockedProcessBaselineView, 9),
             (TimescaleSupport.DeadlockBaselineView, 10),
             (TimescaleSupport.MemoryBaselineView, 11),

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -4462,6 +4462,21 @@ LIMIT 1";
                     lightRefresh.LastRunSeconds,
                     _refreshCeilingStaleness,
                     _logger);
+
+                /* #3185: and whether the run outran the gap the band gave its own COST CLASS, which is a
+                   third fact with a third remedy. The band separates the members whose runs are long enough
+                   for CPU and I/O contention to matter and leaves the rest one minute apart, and which
+                   members those are is derived from each view's GROUP BY rather than listed — so the one
+                   thing that can go silently wrong is a view being slow for a reason its group key does not
+                   show. That is not visible to any build-time rule, and it is not visible to the ceiling
+                   watch above either: a bounded member at 100 s outran its 60 s step while sitting a long
+                   way under the 226.8 s ceiling. Same read, same reading, same rate limiter — keyed on the
+                   constant the reading falsified, so the class questions do not suppress each other. */
+                TimescaleSupport.LogLightRefreshSpacingBreach(
+                    lightRefresh.View,
+                    lightRefresh.LastRunSeconds,
+                    _refreshCeilingStaleness,
+                    _logger);
             }
 
             readClock.Restart();

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -2026,16 +2026,6 @@ WITH NO DATA";
     }
 
     /// <summary>
-    /// How many of the LIGHT band's members are unbounded-cardinality — counted through
-    /// <see cref="IsUnboundedCardinalityRefresh"/> over the shipped registry rather than written down, so
-    /// registering an aggregate moves the layout instead of leaving a stale count beside it.
-    /// </summary>
-    public static int UnboundedLightRefreshCount =>
-        HourlyRefreshPhaseOrder.Count(view =>
-            !string.Equals(view, HeaviestHourlyRefreshView, StringComparison.Ordinal)
-            && UnboundedCardinalityRefreshViews.Contains(view));
-
-    /// <summary>
     /// The minutes the grid keeps between two consecutive unbounded-cardinality light refreshes — the same
     /// expression <see cref="CompressionPhaseGuardMinutes"/> is, because it is the same question.
     ///

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -2094,9 +2094,16 @@ WITH NO DATA";
     /// <see cref="WidestFeasibleLightRefreshStepMinutes"/> says the band is already as wide as the hour
     /// carries. It is a scheduling decision: a cheaper aggregate, a longer cadence for one of them, or
     /// fewer compression minutes. What the MAP does meanwhile is fall back to consecutive positions, which
-    /// is #3174's grid — distinct starts, no separation — and the two things that report it are this
-    /// predicate, asserted by TimescaleContinuousAggregateTests, and
-    /// <see cref="LogLightRefreshSpacingBreach"/> on the live readings.</para>
+    /// is #3174's grid — distinct starts, no separation.</para>
+    ///
+    /// <para><b>THIS PREDICATE is what reports that, and it is the only reporter the condition needs.</b>
+    /// TimescaleContinuousAggregateTests asserts it over the shipped registry, and the classification it
+    /// counts is recovered from compile-time CREATE constants — so a degraded layout cannot differ between
+    /// CI and a running store, and a build in which the band degrades is red before it ships.
+    /// <see cref="LogLightRefreshSpacingBreach"/> is NOT a second reporter for this: it judges a live run
+    /// against the gap its class is given, and a state that cannot ship is a state no live run arrives in.
+    /// What that finding covers is the failure this predicate cannot see — a view slow for a reason its
+    /// group key does not show — which is reachable on every shipped build.</para>
     ///
     /// <para><b>Why a throw would be worse than a degraded grid, which is measured rather than assumed.</b>
     /// <see cref="CompressionPhaseMinutes"/> is a static field whose initializer reaches
@@ -2200,8 +2207,8 @@ WITH NO DATA";
     /// <para><b>A band that cannot separate its unbounded members degrades to consecutive positions rather
     /// than refusing</b> (<see cref="LightBandHoldsUnboundedRefreshCount(int)"/>), because this condition
     /// is reachable from a static field initializer and a throw there costs the whole type rather than one
-    /// aggregate. The condition is reported by a build assertion and by
-    /// <see cref="LogLightRefreshSpacingBreach"/>, not by an exception.</para>
+    /// aggregate. It is reported by that predicate at build time rather than by an exception at run time,
+    /// and a build it is false on does not ship.</para>
     ///
     /// <para><c>internal</c> rather than public: the product must always reach the map through the overload
     /// that supplies its own list, or a caller could phase a policy against an order the converge does not
@@ -2845,7 +2852,17 @@ WITH NO DATA";
     /// <para>Read off the same two terms
     /// <see cref="RefreshPhaseMinutesFor(IReadOnlyList{string}, string)"/> lays the band out with, so what
     /// this reports a run against is the room the grid actually gave it rather than a second opinion about
-    /// what it should have had.</para>
+    /// what it should have had. TimescaleContinuousAggregateTests holds that to the MEASURED gap — the
+    /// smallest distance between two of that class's minutes on the shipped map — so a layout change that
+    /// stopped delivering the gap this names is red rather than reported against a promise nothing
+    /// keeps.</para>
+    ///
+    /// <para><b>It does not consult <see cref="LightBandHoldsUnboundedRefreshCount(int)"/>, and the reason
+    /// is that a branch for the degraded band would be unreachable.</b> That predicate is asserted over the
+    /// shipped registry at build time and its input is recovered from compile-time constants, so a build in
+    /// which the band degrades does not ship — there is no live reading to judge against a consecutive gap
+    /// an unbounded member was given. A branch for it would read as care and certify nothing, which is what
+    /// <see cref="ClassifyRefreshCeilingFreshness"/>'s summary says about the guard it does not have.</para>
     /// </summary>
     public static int LightRefreshSpacingMinutesFor(string view) =>
         IsUnboundedCardinalityRefresh(view)

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -2089,15 +2089,38 @@ WITH NO DATA";
     /// "the last one fits in the band" and "the last one clears the heaviest refresh's window" cancel to the
     /// same statement. One condition covers both, which is why there is not a second one.</para>
     ///
-    /// <para><b>False is the answer that matters.</b> A registry that grew past what the band can separate
-    /// is not a wider band — <see cref="WidestFeasibleLightRefreshStepMinutes"/> says the band is already as
-    /// wide as the hour carries. It is a scheduling decision: a cheaper aggregate, a longer cadence for one
-    /// of them, or fewer compression minutes. <see cref="RefreshPhaseMinutesFor(string)"/> throws rather
-    /// than placing a member it cannot separate, so the answer arrives per aggregate and named.</para>
+    /// <para><b>False is the answer that matters, and it is not answered by throwing.</b> A registry that
+    /// grew past what the band can separate is not a wider band —
+    /// <see cref="WidestFeasibleLightRefreshStepMinutes"/> says the band is already as wide as the hour
+    /// carries. It is a scheduling decision: a cheaper aggregate, a longer cadence for one of them, or
+    /// fewer compression minutes. What the MAP does meanwhile is fall back to consecutive positions, which
+    /// is #3174's grid — distinct starts, no separation — and the two things that report it are this
+    /// predicate, asserted by TimescaleContinuousAggregateTests, and
+    /// <see cref="LogLightRefreshSpacingBreach"/> on the live readings.</para>
+    ///
+    /// <para><b>Why a throw would be worse than a degraded grid, which is measured rather than assumed.</b>
+    /// <see cref="CompressionPhaseMinutes"/> is a static field whose initializer reaches
+    /// <see cref="RefreshPhaseMinutesFor(string)"/>, and a static initializer that throws takes the whole
+    /// TYPE down with a <c>TypeInitializationException</c> for the life of the process — every
+    /// retention horizon, every compression statement, every refresh policy, not just the aggregate that
+    /// could not be placed. Mutating the GROUP BY recovery to return nothing reaches exactly that: every
+    /// view classifies unbounded, the band cannot separate twelve, and a throwing map took 72 tests red
+    /// across four unrelated files. The existing throw for an unregistered view cannot fire from there
+    /// because that initializer only ever iterates registered views; this condition can, because it depends
+    /// on a parse. So the map degrades and the report is separate.</para>
     /// </summary>
     public static bool LightBandHoldsUnboundedRefreshCount(int count) =>
+        LightBandHoldsUnboundedRefreshCount(count, LightHourlyRefreshCount);
+
+    /// <summary>
+    /// <see cref="LightBandHoldsUnboundedRefreshCount(int)"/> asked of an EXPLICIT band size — the seam
+    /// <see cref="RefreshPhaseMinutesFor(IReadOnlyList{string}, string)"/> needs, because that overload
+    /// answers for the order it was handed and the shipped
+    /// <see cref="LightHourlyRefreshCount"/> is not that order's band.
+    /// </summary>
+    internal static bool LightBandHoldsUnboundedRefreshCount(int count, int lightBandPositions) =>
         count <= 0
-        || LightBandIndexForUnboundedRefresh(count - 1) <= LightHourlyRefreshCount - 1;
+        || LightBandIndexForUnboundedRefresh(count - 1) <= lightBandPositions - 1;
 
     /// <summary>
     /// Which minute of the hour <paramref name="view"/>'s hourly refresh policy starts on.
@@ -2171,7 +2194,14 @@ WITH NO DATA";
     /// pool of positions and the bounded members are handed the positions the unbounded members did not
     /// take, so no position can be issued twice by construction rather than by arithmetic. It survives any
     /// permutation of the order for the same reason the consecutive form did: which member gets which
-    /// position moves, how many positions exist does not.</para>
+    /// position moves, how many positions exist does not. It also holds in the DEGRADED case below, where
+    /// every member takes a consecutive position and the pool is the same pool.</para>
+    ///
+    /// <para><b>A band that cannot separate its unbounded members degrades to consecutive positions rather
+    /// than refusing</b> (<see cref="LightBandHoldsUnboundedRefreshCount(int)"/>), because this condition
+    /// is reachable from a static field initializer and a throw there costs the whole type rather than one
+    /// aggregate. The condition is reported by a build assertion and by
+    /// <see cref="LogLightRefreshSpacingBreach"/>, not by an exception.</para>
     ///
     /// <para><c>internal</c> rather than public: the product must always reach the map through the overload
     /// that supplies its own list, or a caller could phase a policy against an order the converge does not
@@ -2187,20 +2217,22 @@ WITH NO DATA";
         var lightCount = order.Count(candidate =>
             !string.Equals(candidate, HeaviestHourlyRefreshView, StringComparison.Ordinal));
 
-        var unboundedIndexes = order
-            .Where(candidate =>
-                !string.Equals(candidate, HeaviestHourlyRefreshView, StringComparison.Ordinal)
-                && UnboundedCardinalityRefreshViews.Contains(candidate))
-            .Select((_, ordinal) => LightBandIndexForUnboundedRefresh(ordinal))
-            .ToArray();
+        var unboundedCount = order.Count(candidate =>
+            !string.Equals(candidate, HeaviestHourlyRefreshView, StringComparison.Ordinal)
+            && UnboundedCardinalityRefreshViews.Contains(candidate));
 
-        if (unboundedIndexes.Length > 0 && unboundedIndexes[^1] > lightCount - 1)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(view),
-                view,
-                $"the light band holds {lightCount} positions and cannot separate {unboundedIndexes.Length} unbounded-cardinality refreshes by {UnboundedLightRefreshSeparationMinutes} minutes each — see TimescaleSupport.LightBandHoldsUnboundedRefreshCount; the repair is a cheaper aggregate, a longer cadence for one of them, or fewer compression minutes, not a wider light band (#3185)");
-        }
+        /* When the band cannot hold them separated, every light member takes a consecutive position —
+           #3174's grid, which still gives distinct starts. Degrading rather than throwing because this
+           condition is reachable from CompressionPhaseMinutes' static initializer; see
+           LightBandHoldsUnboundedRefreshCount for what a throw there costs. */
+        var separates = LightBandHoldsUnboundedRefreshCount(unboundedCount, lightCount);
+
+        var unboundedIndexes = separates
+            ? Enumerable
+                .Range(0, unboundedCount)
+                .Select(LightBandIndexForUnboundedRefresh)
+                .ToArray()
+            : Array.Empty<int>();
 
         var taken = new HashSet<int>(unboundedIndexes);
         var boundedIndexes = Enumerable
@@ -2214,7 +2246,9 @@ WITH NO DATA";
         foreach (var candidate in order)
         {
             var heaviest = string.Equals(candidate, HeaviestHourlyRefreshView, StringComparison.Ordinal);
-            var unbounded = !heaviest && UnboundedCardinalityRefreshViews.Contains(candidate);
+            var unbounded = separates
+                && !heaviest
+                && UnboundedCardinalityRefreshViews.Contains(candidate);
 
             if (string.Equals(candidate, view, StringComparison.Ordinal))
             {

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1696,6 +1696,27 @@ WITH NO DATA";
     /// compression policy's queued <c>AccessExclusiveLock</c> arriving while a refresh held
     /// <c>AccessShareLock</c>, and two refreshes hold mutually compatible locks — and it is strictly stronger
     /// than the old grid delivered, where four policies including the heaviest all started on :00.</para>
+    ///
+    /// <para><b>This step is sized by member COUNT and cannot be sized by member DURATION, which is why the
+    /// duration question is answered by a different term (#3185).</b> One minute delivers distinct starts at
+    /// any length the band can hold and guarantees nothing at all about overlap: a member running past
+    /// <c>LightRefreshStepMinutes * 60</c> overlaps its successor for the remainder of its run, and two
+    /// members past it overlap each other for essentially their whole runs. Widening this step is not the
+    /// repair, and that is DERIVED rather than argued —
+    /// <see cref="WidestFeasibleLightRefreshStepMinutes"/> searches the shipped comparison and returns this
+    /// same value, so the band is already as wide as the hour can carry. The binding constraint is not the
+    /// hour's sixty minutes but <see cref="HeaviestRefreshWindowMinutes"/>: eleven gaps at two minutes take
+    /// eleven minutes from <see cref="GuardAndWindowSharedMinutes"/>, which drops the watch line under
+    /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> at every guard, so no step above one is
+    /// reachable at any guard rather than merely at today's.</para>
+    ///
+    /// <para><b>So the members that can consume a wider gap are separated INSIDE this band, and the band's
+    /// width does not move.</b> The gap goes between the members that need it and the ones that do not fill
+    /// it in — see <see cref="UnboundedLightRefreshSeparationMinutes"/> for the width,
+    /// <see cref="IsUnboundedCardinalityRefresh"/> for which members those are, and
+    /// <see cref="RefreshPhaseMinutesFor(IReadOnlyList{string}, string)"/> for the layout. A per-member step —
+    /// the obvious generalization of this constant — is what does NOT fit: giving each member a gap sized to
+    /// its own class widens the band to nineteen minutes, and the band cannot grow at all.</para>
     /// </summary>
     public const int LightRefreshStepMinutes = 1;
 
@@ -1705,6 +1726,20 @@ WITH NO DATA";
     /// registering an aggregate moves the grid instead of leaving a stale count beside it.
     /// </summary>
     public static int LightHourlyRefreshCount => HourlyRefreshPhaseOrder.Count - 1;
+
+    /// <summary>
+    /// How many minutes of the hour the light band SPANS — the distance from the first light refresh's
+    /// minute to the last one's, which is one fewer gap than there are members.
+    ///
+    /// <para>Named because three separate expressions were spelling it out —
+    /// <see cref="HeaviestRefreshStartMinute"/>, <see cref="GuardAndWindowSharedMinutes"/> and the watch
+    /// line's feasibility walk — and a band whose width is written three times can be widened in two of
+    /// them. It is a SPAN and not a count of minutes occupied: the band holds
+    /// <see cref="LightHourlyRefreshCount"/> starts and this is the last one's offset, so it is what the
+    /// guard sits after and what the rest of the hour is measured from.</para>
+    /// </summary>
+    public static int LightBandSpanMinutes =>
+        (LightHourlyRefreshCount - 1) * LightRefreshStepMinutes;
 
     /// <summary>
     /// The minute <see cref="HeaviestHourlyRefreshView"/>'s refresh starts on: past the last light refresh,
@@ -1721,7 +1756,7 @@ WITH NO DATA";
     /// compression.</para>
     /// </summary>
     public static int HeaviestRefreshStartMinute =>
-        ((LightHourlyRefreshCount - 1) * LightRefreshStepMinutes) + CompressionPhaseGuardMinutes;
+        LightBandSpanMinutes + CompressionPhaseGuardMinutes;
 
     /// <summary>
     /// The heaviest hourly refresh's window: what the hour has LEFT once the light band, its guard and the
@@ -1820,15 +1855,270 @@ WITH NO DATA";
         HourlyAggregates.Concat(BaselineAggregates).ToArray();
 
     /// <summary>
+    /// The grouping columns that identify an individual STATEMENT or PLAN, as opposed to a server, a
+    /// database, a schema object or a time bucket — the columns whose distinct count is a property of the
+    /// monitored workload rather than of the deployment.
+    ///
+    /// <para><b>This is the list the light band's spacing is decided by, and it is a list of COLUMNS rather
+    /// than of views for a reason (#3185).</b> A list of heavy views is a frozen enumeration: it is correct
+    /// until the next aggregate is registered and then silently wrong, which is exactly the failure the
+    /// phase grid's positional coupling was. A view's cost is decided by how many output groups one bucket
+    /// produces, and that is decided by its own GROUP BY — so the membership question is answered by reading
+    /// the shipped CREATE text through <see cref="HourlyRefreshDefinitions"/>, and a new aggregate is
+    /// classified the moment it is registered.</para>
+    ///
+    /// <para><b>The mechanism is measured, with source volume held constant, which is what makes this the
+    /// group key rather than a proxy for something else.</b> Two same-source pairs isolate it.
+    /// <see cref="QueryStoreStatsIntervalHourlyView"/> and <see cref="QueryStoreStatsHourlyView"/> read the
+    /// IDENTICAL rows for a given hour and reduce them 1.30:1 and 2.62:1, for refresh medians of 894.5 s and
+    /// 105.5 s. <see cref="QueryStatsHourlyView"/> and <see cref="QueryStatsDbHourlyView"/> read an identical
+    /// ~311,000 rows and reduce them 29:1 and 1,481:1, for 11.2 s and 1.8 s. In both pairs the only thing
+    /// that differs is how far the group key resolves, and the cost follows it.</para>
+    ///
+    /// <para><b>And the partition it produces matches the measured one.</b> #3183's scoped post-boundary
+    /// re-measurement recorded three light views above 3 s — <see cref="QueryStatsHourlyView"/> at 23.3 s,
+    /// <see cref="QueryStoreStatsHourlyView"/> at 263.9 s and
+    /// <see cref="QueryStoreStatsCorrectedHourlyView"/> at 265.5 s — and the other nine at 0.6 s to under
+    /// 3 s. Those three are exactly the light views whose group key reaches a column named here. The rule is
+    /// not fitted to that result: it is fitted to the pairs above, and the split is what it predicts.</para>
+    ///
+    /// <para><b>What is NOT here is the safeguard.</b> A view can be slow for a reason its group key does
+    /// not show, and no build-time rule can see that. <see cref="LogLightRefreshSpacingBreach"/> is the live
+    /// half — a light refresh that runs past the minutes its class was given is reported, whichever class
+    /// the rule put it in, so a rule that has stopped predicting says so rather than going quiet.</para>
+    /// </summary>
+    public static readonly IReadOnlyList<string> PerStatementGroupingColumns = new[]
+    {
+        "query_hash",
+        "sql_handle",
+        "query_id",
+        "plan_id",
+        "runtime_stats_interval_id",
+        "first_execution_time",
+    };
+
+    /// <summary>
+    /// The GROUP BY terms of one aggregate's CREATE, recovered from the shipped text — the seam
+    /// <see cref="IsUnboundedCardinalityRefresh"/> reads and the seam a test can check the parse against.
+    ///
+    /// <para>Split at PARENTHESIS DEPTH ZERO, so <c>time_bucket('1 hour', bucket)</c> comes back as one term
+    /// rather than as two halves of one — a comma split would produce a term of <c>time_bucket('1 hour'</c>
+    /// and one of <c>bucket)</c>, and the second of those matches a real column name.</para>
+    ///
+    /// <para><b>Case-insensitive on the keywords, deliberately.</b> A parse that found no GROUP BY would
+    /// return nothing, and nothing contains no per-statement column — so a missed clause classifies a view
+    /// as deployment-bounded, which is the label that gives it LESS room. The failure has to be loud in the
+    /// safe direction from both ends: matching regardless of case is one end, and a test asserting that
+    /// every shipped definition yields at least one term is the other.</para>
+    /// </summary>
+    internal static IReadOnlyList<string> RefreshGroupingTermsFor(string createSql)
+    {
+        if (createSql is null)
+        {
+            throw new ArgumentNullException(nameof(createSql));
+        }
+
+        var start = createSql.LastIndexOf("GROUP BY", StringComparison.OrdinalIgnoreCase);
+        if (start < 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        start += "GROUP BY".Length;
+        var end = createSql.IndexOf("WITH NO DATA", start, StringComparison.OrdinalIgnoreCase);
+        var clause = end < 0 ? createSql[start..] : createSql[start..end];
+
+        var terms = new List<string>();
+        var depth = 0;
+        var termStart = 0;
+
+        for (var index = 0; index <= clause.Length; index++)
+        {
+            if (index == clause.Length || (clause[index] == ',' && depth == 0))
+            {
+                var term = string.Join(
+                    " ",
+                    clause[termStart..index].Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+                if (term.Length > 0)
+                {
+                    terms.Add(term);
+                }
+
+                termStart = index + 1;
+                continue;
+            }
+
+            if (clause[index] == '(')
+            {
+                depth++;
+            }
+            else if (clause[index] == ')')
+            {
+                depth--;
+            }
+        }
+
+        return terms;
+    }
+
+    /// <summary>
+    /// The hourly views whose one-bucket output cardinality is UNBOUNDED by the deployment — the ones whose
+    /// GROUP BY reaches a <see cref="PerStatementGroupingColumns"/> column.
+    ///
+    /// <para><b>MUST stay declared after <see cref="HourlyRefreshDefinitions"/> and before
+    /// <see cref="CompressionPhaseMinutes"/>.</b> Static field initializers run in declaration order, and
+    /// this one reads the definitions while the compression grid's initializer reaches
+    /// <see cref="RefreshPhaseMinutesFor(string)"/>, which reads this. Declared out of order it is an empty
+    /// set at the moment the compression grid is built, and every hourly view is placed as
+    /// deployment-bounded once, permanently, with nothing red.</para>
+    ///
+    /// </summary>
+    private static readonly IReadOnlySet<string> UnboundedCardinalityRefreshViews =
+        HourlyRefreshDefinitions
+            .Where(definition => GroupKeyIsUnboundedCardinality(definition.CreateSql))
+            .Select(definition => definition.View)
+            .ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// THE RULE, over one CREATE — whether its group key reaches a
+    /// <see cref="PerStatementGroupingColumns"/> column.
+    ///
+    /// <para><b>A CREATE whose GROUP BY cannot be recovered answers TRUE</b>, which is the label that asks
+    /// for more of the band. Read the other way an unparseable definition would quietly take a one-minute
+    /// step — the state #3185 recorded — and nothing would say so; this way it takes band positions and
+    /// <see cref="LightBandHoldsUnboundedRefreshCount"/> is what reports that the hour no longer holds.</para>
+    ///
+    /// <para><b>Declared as its own function so that branch is REACHABLE.</b> No shipped definition is
+    /// unparseable, so folded into the field initializer above the empty-terms arm would be a line no value
+    /// the registry can produce reaches: protection that certifies nothing and that no mutation can
+    /// distinguish from its own absence. Here a test hands it a CREATE with no GROUP BY and gets an
+    /// answer.</para>
+    /// </summary>
+    internal static bool GroupKeyIsUnboundedCardinality(string createSql)
+    {
+        var terms = RefreshGroupingTermsFor(createSql);
+
+        return terms.Count == 0
+            || terms.Any(term => PerStatementGroupingColumns.Contains(term, StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// Whether <paramref name="view"/>'s refresh cost grows with the monitored workload's distinct statement
+    /// population rather than with the size of the deployment.
+    ///
+    /// <para>Throws for a view that is not a registered hourly aggregate, for
+    /// <see cref="RefreshPhaseMinutesFor(string)"/>'s reason: a defaulted answer here decides how much of
+    /// the hour that view is given, and the quiet answer is the one that gives it the least.</para>
+    /// </summary>
+    public static bool IsUnboundedCardinalityRefresh(string view)
+    {
+        if (!HourlyRefreshDefinitions.Any(definition =>
+                string.Equals(definition.View, view, StringComparison.Ordinal)))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(view),
+                view,
+                "not a registered hourly continuous aggregate — its refresh cost class cannot be recovered from a CREATE that TimescaleSupport.HourlyRefreshDefinitions does not hold");
+        }
+
+        return UnboundedCardinalityRefreshViews.Contains(view);
+    }
+
+    /// <summary>
+    /// How many of the LIGHT band's members are unbounded-cardinality — counted through
+    /// <see cref="IsUnboundedCardinalityRefresh"/> over the shipped registry rather than written down, so
+    /// registering an aggregate moves the layout instead of leaving a stale count beside it.
+    /// </summary>
+    public static int UnboundedLightRefreshCount =>
+        HourlyRefreshPhaseOrder.Count(view =>
+            !string.Equals(view, HeaviestHourlyRefreshView, StringComparison.Ordinal)
+            && UnboundedCardinalityRefreshViews.Contains(view));
+
+    /// <summary>
+    /// The minutes the grid keeps between two consecutive unbounded-cardinality light refreshes — the same
+    /// expression <see cref="CompressionPhaseGuardMinutes"/> is, because it is the same question.
+    ///
+    /// <para><b>One number, two jobs, and they cannot disagree because they are one expression.</b> The
+    /// guard asks how long after a light refresh starts something else may safely start; so does this. The
+    /// guard's answer clears the band's last member from
+    /// <see cref="HeaviestRefreshStartMinute"/> and this one clears one heavy light member from the next.
+    /// Deriving them separately from the same constant would leave two places to update and one of them
+    /// behind.</para>
+    ///
+    /// <para><b>It is a bound against the RECORDED ceiling, which is the honest scope of the guarantee.</b>
+    /// <c>UnboundedLightRefreshSeparationMinutes * 60</c> exceeds
+    /// <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> by the guard's own rounding margin, so two
+    /// unbounded light refreshes provably cannot overlap AS LONG AS that constant is still a maximum. The
+    /// one way it can be insufficient is the constant being stale, and that is a reported finding with a
+    /// named remedy rather than a silent condition — <see cref="LogRefreshCeilingStaleness"/> (#3182).</para>
+    ///
+    /// <para><b>Why the constant is not re-derived to tonight's readings first.</b> The 263.9 s and 265.5 s
+    /// runs #3185 measured are runs of two aggregations that overlapped for essentially their whole
+    /// duration; the same two ran ~47 s each when the previous grid held them fifteen minutes apart. A
+    /// ceiling taken from the overlapping population would size the separation from the defect the
+    /// separation exists to remove, which is why #3182 holds both ceiling values until the grid is
+    /// stable.</para>
+    /// </summary>
+    public static int UnboundedLightRefreshSeparationMinutes => CompressionPhaseGuardMinutes;
+
+    /// <summary>
+    /// <see cref="UnboundedLightRefreshSeparationMinutes"/> expressed in band POSITIONS, which is the unit
+    /// the layout places members in — rounded UP, so a separation that does not divide the step still
+    /// clears it.
+    /// </summary>
+    public static int UnboundedLightRefreshSeparationIndexes =>
+        (int)Math.Ceiling(UnboundedLightRefreshSeparationMinutes / (double)LightRefreshStepMinutes);
+
+    /// <summary>
+    /// Which position in the light band the <paramref name="ordinal"/>-th unbounded-cardinality light
+    /// refresh takes, counting unbounded members only and from zero — exactly the shape a bounded member's
+    /// own position has, with the separation in place of the step.
+    /// </summary>
+    public static int LightBandIndexForUnboundedRefresh(int ordinal) =>
+        ordinal * UnboundedLightRefreshSeparationIndexes;
+
+    /// <summary>
+    /// Whether the light band still holds <paramref name="count"/> unbounded-cardinality members once each
+    /// is <see cref="UnboundedLightRefreshSeparationMinutes"/> clear of the last.
+    ///
+    /// <para><b>This is the feasibility bound the spacing needs, and it reads two ways at once.</b> The last
+    /// unbounded member's position landing inside the band is the same inequality as that member finishing
+    /// before <see cref="HeaviestRefreshStartMinute"/> opens: the start minute is
+    /// <see cref="LightBandSpanMinutes"/> plus the guard, the guard IS the separation, so
+    /// "the last one fits in the band" and "the last one clears the heaviest refresh's window" cancel to the
+    /// same statement. One condition covers both, which is why there is not a second one.</para>
+    ///
+    /// <para><b>False is the answer that matters.</b> A registry that grew past what the band can separate
+    /// is not a wider band — <see cref="WidestFeasibleLightRefreshStepMinutes"/> says the band is already as
+    /// wide as the hour carries. It is a scheduling decision: a cheaper aggregate, a longer cadence for one
+    /// of them, or fewer compression minutes. <see cref="RefreshPhaseMinutesFor(string)"/> throws rather
+    /// than placing a member it cannot separate, so the answer arrives per aggregate and named.</para>
+    /// </summary>
+    public static bool LightBandHoldsUnboundedRefreshCount(int count) =>
+        count <= 0
+        || LightBandIndexForUnboundedRefresh(count - 1) <= LightHourlyRefreshCount - 1;
+
+    /// <summary>
     /// Which minute of the hour <paramref name="view"/>'s hourly refresh policy starts on.
     ///
     /// <para><b>INJECTIVE, and that is the whole of the contention guarantee.</b>
     /// <see cref="HeaviestHourlyRefreshView"/> is answered by IDENTITY, not by position, and gets
-    /// <see cref="HeaviestRefreshStartMinute"/> alone. Every other view gets its own consecutive minute in
-    /// the light band, counted over the light views only. There is no modulus anywhere, so two policies
-    /// cannot share a residue — the map has no collisions to have, at any list length the band can hold, in
-    /// any order, with anything inserted anywhere. That is what makes contention structurally impossible
-    /// instead of a property of where a view happens to sit in a list, which is the state #3174 replaced.</para>
+    /// <see cref="HeaviestRefreshStartMinute"/> alone. Every other view gets its own minute in the light
+    /// band. There is no modulus anywhere, so two policies cannot share a residue — the map has no
+    /// collisions to have, at any list length the band can hold, in any order, with anything inserted
+    /// anywhere. That is what makes contention structurally impossible instead of a property of where a view
+    /// happens to sit in a list, which is the state #3174 replaced.</para>
+    ///
+    /// <para><b>Distinct minutes are a LOCK guarantee and were read as a cost guarantee, which is the defect
+    /// #3185 recorded.</b> Two refreshes hold mutually compatible <c>AccessShareLock</c>s, so overlapping
+    /// light refreshes cannot convoy and the band was sized on that alone. They still contend for CPU and
+    /// I/O: measured across the install, two ~265 s aggregations placed two minutes apart ran at
+    /// <b>5.4x</b> the per-output-group cost the same view had at fifteen minutes apart, with cardinality
+    /// flat to 1.4%. So the band separates the members whose runs are long enough for that to matter —
+    /// <see cref="IsUnboundedCardinalityRefresh"/> — and leaves the rest at
+    /// <see cref="LightRefreshStepMinutes"/>, where distinct starts is the whole of what is needed and the
+    /// measured runs are 0.6 s to under 3 s against a 60 s step.</para>
     ///
     /// <para>Throws for a view that is not on <see cref="HourlyRefreshPhaseOrder"/> — including every DAILY
     /// view, which must not be dragged onto the grid. That is deliberately loud rather than defaulted: a new
@@ -1853,10 +2143,35 @@ WITH NO DATA";
     /// its own list.</para>
     ///
     /// <para><b>Only the ORDER is a parameter, deliberately.</b> The GEOMETRY —
-    /// <see cref="HeaviestRefreshStartMinute"/> and <see cref="LightRefreshStepMinutes"/> — still comes from
-    /// the shipped registry, so this cannot be used to fabricate a different grid: handing it a permutation
-    /// asks "does the map still collide-free at this order", which is the question, and handing it a
-    /// different POPULATION would be asking something the caller has no business asking.</para>
+    /// <see cref="HeaviestRefreshStartMinute"/>, <see cref="LightRefreshStepMinutes"/> and
+    /// <see cref="UnboundedLightRefreshSeparationIndexes"/> — still comes from the shipped registry, so this
+    /// cannot be used to fabricate a different grid: handing it a permutation asks "does the map still
+    /// collide-free at this order", which is the question, and handing it a different POPULATION would be
+    /// asking something the caller has no business asking.</para>
+    ///
+    /// <para><b>THE LIGHT BAND'S LAYOUT, which is what #3185 changed.</b> The band is a fixed set of
+    /// positions — <see cref="LightHourlyRefreshCount"/> of them, <see cref="LightRefreshStepMinutes"/>
+    /// apart, spanning <see cref="LightBandSpanMinutes"/>. The unbounded-cardinality members take every
+    /// <see cref="UnboundedLightRefreshSeparationIndexes"/>-th position from the first
+    /// (<see cref="LightBandIndexForUnboundedRefresh"/>); the deployment-bounded members take the positions
+    /// those leave, in registry order. So the gap the long runs need is filled by the short ones instead of
+    /// being added to the band, and <see cref="LightBandSpanMinutes"/> does not move — the guard, the
+    /// heaviest refresh's window and the compression band are all exactly what they were.</para>
+    ///
+    /// <para><b>The alternative shape, priced and rejected.</b> Walking the registry in order and jumping
+    /// forward whenever a member has to clear the last unbounded one widens the band to thirteen minutes at
+    /// today's two-per-hour spacing and to fifteen at three, which drops the watch line to 850 s against an
+    /// 896 s <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>. That shape is red at today's
+    /// registry and red again the moment
+    /// <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> is re-derived upward. Interleaving is what
+    /// makes the separation free rather than a trade, and free is why it does not have to be argued
+    /// against <see cref="HeaviestRefreshWindowMinutes"/>.</para>
+    ///
+    /// <para><b>Still injective, and for a stronger reason than before.</b> The two classes draw from one
+    /// pool of positions and the bounded members are handed the positions the unbounded members did not
+    /// take, so no position can be issued twice by construction rather than by arithmetic. It survives any
+    /// permutation of the order for the same reason the consecutive form did: which member gets which
+    /// position moves, how many positions exist does not.</para>
     ///
     /// <para><c>internal</c> rather than public: the product must always reach the map through the overload
     /// that supplies its own list, or a caller could phase a policy against an order the converge does not
@@ -1869,22 +2184,59 @@ WITH NO DATA";
             throw new ArgumentNullException(nameof(order));
         }
 
-        var lightIndex = 0;
+        var lightCount = order.Count(candidate =>
+            !string.Equals(candidate, HeaviestHourlyRefreshView, StringComparison.Ordinal));
+
+        var unboundedIndexes = order
+            .Where(candidate =>
+                !string.Equals(candidate, HeaviestHourlyRefreshView, StringComparison.Ordinal)
+                && UnboundedCardinalityRefreshViews.Contains(candidate))
+            .Select((_, ordinal) => LightBandIndexForUnboundedRefresh(ordinal))
+            .ToArray();
+
+        if (unboundedIndexes.Length > 0 && unboundedIndexes[^1] > lightCount - 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(view),
+                view,
+                $"the light band holds {lightCount} positions and cannot separate {unboundedIndexes.Length} unbounded-cardinality refreshes by {UnboundedLightRefreshSeparationMinutes} minutes each — see TimescaleSupport.LightBandHoldsUnboundedRefreshCount; the repair is a cheaper aggregate, a longer cadence for one of them, or fewer compression minutes, not a wider light band (#3185)");
+        }
+
+        var taken = new HashSet<int>(unboundedIndexes);
+        var boundedIndexes = Enumerable
+            .Range(0, lightCount)
+            .Where(index => !taken.Contains(index))
+            .ToArray();
+
+        var unboundedOrdinal = 0;
+        var boundedOrdinal = 0;
 
         foreach (var candidate in order)
         {
             var heaviest = string.Equals(candidate, HeaviestHourlyRefreshView, StringComparison.Ordinal);
+            var unbounded = !heaviest && UnboundedCardinalityRefreshViews.Contains(candidate);
 
             if (string.Equals(candidate, view, StringComparison.Ordinal))
             {
-                return heaviest
-                    ? HeaviestRefreshStartMinute
-                    : lightIndex * LightRefreshStepMinutes;
+                if (heaviest)
+                {
+                    return HeaviestRefreshStartMinute;
+                }
+
+                var index = unbounded
+                    ? unboundedIndexes[unboundedOrdinal]
+                    : boundedIndexes[boundedOrdinal];
+
+                return index * LightRefreshStepMinutes;
             }
 
-            if (!heaviest)
+            if (unbounded)
             {
-                lightIndex++;
+                unboundedOrdinal++;
+            }
+            else if (!heaviest)
+            {
+                boundedOrdinal++;
             }
         }
 
@@ -2452,6 +2804,121 @@ WITH NO DATA";
     }
 
     /// <summary>
+    /// The minutes the light band guarantees between <paramref name="view"/>'s start and the next start of a
+    /// view in its own class — <see cref="UnboundedLightRefreshSeparationMinutes"/> for an
+    /// unbounded-cardinality member and <see cref="LightRefreshStepMinutes"/> for a deployment-bounded one.
+    ///
+    /// <para>Read off the same two terms
+    /// <see cref="RefreshPhaseMinutesFor(IReadOnlyList{string}, string)"/> lays the band out with, so what
+    /// this reports a run against is the room the grid actually gave it rather than a second opinion about
+    /// what it should have had.</para>
+    /// </summary>
+    public static int LightRefreshSpacingMinutesFor(string view) =>
+        IsUnboundedCardinalityRefresh(view)
+            ? UnboundedLightRefreshSeparationMinutes
+            : LightRefreshStepMinutes;
+
+    /// <summary>
+    /// The name <see cref="LogLightRefreshSpacingBreach"/> reports <paramref name="view"/>'s breach under,
+    /// which is the constant the reading falsified — <see cref="LightRefreshStepMinutes"/> for a
+    /// deployment-bounded member and <see cref="UnboundedLightRefreshSeparationMinutes"/> for an unbounded
+    /// one.
+    ///
+    /// <para><b>Two names rather than one, because the two breaches ask for different repairs.</b> A bounded
+    /// member past its step means the CLASSIFICATION is wrong for that view —
+    /// <see cref="IsUnboundedCardinalityRefresh"/> read its group key and predicted a short run. An unbounded
+    /// member past its separation means the SEPARATION is too narrow, which is
+    /// <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> being stale. Sharing one name would let the
+    /// larger of the two suppress the other through the rate limiter's high-water mark, which is the one
+    /// thing a shared key must not do when the findings are not the same finding.</para>
+    /// </summary>
+    public static string LightRefreshSpacingConstantNameFor(string view) =>
+        IsUnboundedCardinalityRefresh(view)
+            ? nameof(UnboundedLightRefreshSeparationMinutes)
+            : nameof(LightRefreshStepMinutes);
+
+    /// <summary>
+    /// Whether one observed light-refresh runtime is longer than the minutes its class was given on the
+    /// band — the comparison <see cref="LogLightRefreshSpacingBreach"/> reports, separated out so it can be
+    /// asked without a logger.
+    ///
+    /// <para><b>STRICTLY greater, matching <see cref="ClassifyRefreshCeilingFreshness"/>.</b> The spacing is
+    /// a claim that the next start is this many minutes away; a run that took exactly that long finished as
+    /// the next one began and did not overlap it. Only a longer run did.</para>
+    /// </summary>
+    public static bool LightRefreshRunExceedsItsSpacing(string view, double observedSeconds) =>
+        observedSeconds > LightRefreshSpacingMinutesFor(view) * 60;
+
+    /// <summary>
+    /// Reports that a light refresh ran past the minutes its class was given on the band, so it overlapped
+    /// the next start in its class — the #3185 finding, and the LIVE half of a membership rule that is
+    /// otherwise a build-time prediction.
+    ///
+    /// <para><b>Why the classifier needs a live half at all.</b>
+    /// <see cref="IsUnboundedCardinalityRefresh"/> decides how much of the band a view gets by reading its
+    /// GROUP BY, and a view can be slow for a reason its group key does not show — an expensive aggregate
+    /// expression, a source hypertable that grew, a store under pressure. No build-time rule sees that, and
+    /// a membership rule that has stopped predicting is exactly the failure the rule was written to avoid: a
+    /// hand-kept list of heavy views goes stale loudly, on the next registration, while a rule that has
+    /// stopped matching reality goes stale quietly, forever. This is what makes it loud.</para>
+    ///
+    /// <para><b>A different finding from <see cref="LogRefreshCeilingStaleness"/>, and the difference is the
+    /// remedy.</b> That one says a constant recorded as a maximum has been overtaken and asks for the
+    /// constant to be re-derived. This one says the run overlapped a sibling, and asks either for the view
+    /// to be separated — a CLASS question — or for the separation to be widened. They are also not nested:
+    /// a bounded member at 100 s breaches its 60 s step while sitting far under
+    /// <see cref="OtherHourlyRefreshObservedCeilingSeconds"/>, so the ceiling watch is silent on precisely
+    /// the case this exists for.</para>
+    ///
+    /// <para><b>WARNING, on <see cref="LogRefreshCeilingStaleness"/>'s argument.</b> Debug is where a
+    /// silently-inapplicable mechanism lives, so it is unavailable. Error is reserved for a stated
+    /// precondition of the grid being false, and an overlap between two light refreshes does not make one
+    /// false — the band's guarantee for the bounded class is distinct STARTS, which holds, and the cost of
+    /// two short runs overlapping is seconds. What is true is that the layout's reason for giving this view
+    /// one minute no longer holds, which is a deliberate-action finding.</para>
+    ///
+    /// <para><b>Rate-limited through <see cref="RefreshCeilingStalenessWatch"/> on the constant the reading
+    /// falsified</b> (<see cref="LightRefreshSpacingConstantNameFor"/>), so the same instance the ceiling
+    /// findings use carries this one: a high-water mark per constant is the shape this needs for the same
+    /// reason — what the repair wants is the LARGEST overrun, and a repeat of one already reported adds
+    /// nothing. One key per class rather than per view, because the repair is a change to the class's
+    /// spacing rule and not to one view's minute.</para>
+    /// </summary>
+    public static void LogLightRefreshSpacingBreach(
+        string view,
+        double observedSeconds,
+        RefreshCeilingStalenessWatch watch,
+        ILogger? logger)
+    {
+        if (watch is null)
+        {
+            throw new ArgumentNullException(nameof(watch));
+        }
+
+        if (logger is null)
+        {
+            return;
+        }
+
+        if (!LightRefreshRunExceedsItsSpacing(view, observedSeconds))
+        {
+            return;
+        }
+
+        var spacingMinutes = LightRefreshSpacingMinutesFor(view);
+        var constantName = LightRefreshSpacingConstantNameFor(view);
+
+        if (!watch.ShouldReport(constantName, observedSeconds))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "TimescaleDB: {View}'s refresh policy last ran {Seconds:F1}s against the {Minutes}-minute gap the phase grid gives its cost class ({Constant}), so it overlapped the next refresh in that class for {Over:F1}s. Two refreshes hold mutually compatible AccessShareLocks and cannot convoy, so this is not #3012 — it is CPU and I/O contention, measured at 5.4x the per-output-group cost when two ~265s aggregations were placed two minutes apart (#3185). The repair depends on which constant is named: LightRefreshStepMinutes means TimescaleSupport.IsUnboundedCardinalityRefresh read this view's GROUP BY and predicted a short run, so the CLASSIFICATION is wrong for it; UnboundedLightRefreshSeparationMinutes means the separation itself is too narrow, which is OtherHourlyRefreshObservedCeilingSeconds being stale (#3182). Reported once per class and then only for a larger run, because what the repair needs is the largest overrun.",
+            view, observedSeconds, spacingMinutes, constantName, observedSeconds - (spacingMinutes * 60));
+    }
+
+    /// <summary>
     /// The longest run recorded for any hourly refresh OTHER than <see cref="HeaviestHourlyRefreshView"/> —
     /// and, since #3174, the number <see cref="CompressionPhaseGuardMinutes"/> is DERIVED from rather than
     /// merely characterised against.
@@ -2578,6 +3045,15 @@ WITH NO DATA";
     /// expressed over it: widening the guard moves the heaviest refresh later and narrows its window rather
     /// than overrunning a neighbour. TimescaleContinuousAggregateTests holds the three bands to tiling the
     /// hour exactly, so a guard wide enough to leave no window at all is red rather than silent.</para>
+    ///
+    /// <para><b>It answers a SECOND question, and the same number answers both (#3185).</b>
+    /// <see cref="UnboundedLightRefreshSeparationMinutes"/> IS this member: "how long after a light refresh
+    /// starts is it safe to start something else" is the question the guard asks about a compression policy
+    /// and the light band asks about the next long-running refresh. Two derivations from one constant would
+    /// be two places to update; one expression cannot disagree with itself. So re-deriving
+    /// <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> moves the light band's internal spacing as
+    /// well as this band's width, which is the coupling that makes the constant worth getting right rather
+    /// than a number two grids each keep a copy of.</para>
     /// </summary>
     public static int CompressionPhaseGuardMinutes =>
         (int)Math.Ceiling(OtherHourlyRefreshObservedCeilingSeconds / 60.0);
@@ -2596,7 +3072,7 @@ WITH NO DATA";
     /// </summary>
     public static int GuardAndWindowSharedMinutes =>
         MinutesInHourlyCadence
-        - ((LightHourlyRefreshCount - 1) * LightRefreshStepMinutes)
+        - LightBandSpanMinutes
         - CompressionPhaseBandMinutes;
 
     /// <summary>
@@ -2614,9 +3090,34 @@ WITH NO DATA";
     /// <para>Integer division throughout, matching <see cref="RefreshSlotWarningSeconds"/>: a line computed
     /// with rounding would sit above the shipped one on some widths and the two would disagree about
     /// feasibility at exactly the boundary the question is about.</para>
+    ///
+    /// <para>Delegates to <see cref="RefreshSlotWarningSecondsForLightBandAndGuard"/> at the shipped band
+    /// span rather than carrying its own copy of the arithmetic, so the two feasibility questions the hour
+    /// admits — a wider guard and a wider light band — are asked of ONE expression.</para>
     /// </summary>
     public static int RefreshSlotWarningSecondsForGuardMinutes(int guardMinutes) =>
-        (GuardAndWindowSharedMinutes - guardMinutes) * 60
+        RefreshSlotWarningSecondsForLightBandAndGuard(LightBandSpanMinutes, guardMinutes);
+
+    /// <summary>
+    /// The watch line a light band spanning <paramref name="lightBandSpanMinutes"/> and a guard of
+    /// <paramref name="guardMinutes"/> would leave — the shipped chain with BOTH of the terms that compete
+    /// for the hour opened up (#3185).
+    ///
+    /// <para><b>Why the band span had to become a parameter too.</b> #3182 opened the guard because the
+    /// guard's derivation had no upper bound and the hour does. The light band's width has exactly the same
+    /// shape: it is <see cref="LightHourlyRefreshCount"/> minus one times
+    /// <see cref="LightRefreshStepMinutes"/>, neither of which consults what the hour has left, and the
+    /// obvious repair for #3185 was to widen the step. Nothing could ask what that would cost without
+    /// re-spelling the arithmetic, and re-spelled arithmetic is how a second and kinder model of the grid
+    /// gets built. <see cref="WidestFeasibleLightRefreshStepMinutes"/> asks it here instead.</para>
+    ///
+    /// <para>The hour is <see cref="MinutesInHourlyCadence"/> and
+    /// <see cref="CompressionPhaseBandMinutes"/> comes from the catalog, so those two stay closed: what is
+    /// open is the two terms a re-derivation can actually move.</para>
+    /// </summary>
+    public static int RefreshSlotWarningSecondsForLightBandAndGuard(
+        int lightBandSpanMinutes, int guardMinutes) =>
+        (MinutesInHourlyCadence - lightBandSpanMinutes - CompressionPhaseBandMinutes - guardMinutes) * 60
         * WindowWatchLeadNumerator / WindowWatchLeadDenominator;
 
     /// <summary>
@@ -2681,6 +3182,45 @@ WITH NO DATA";
     /// </summary>
     public static int WidestFeasibleOtherRefreshCeilingSeconds =>
         Math.Max(0, WidestFeasibleCompressionPhaseGuardMinutes) * 60;
+
+    /// <summary>
+    /// The WIDEST <see cref="LightRefreshStepMinutes"/> the hour can carry while the grid's own stated
+    /// precondition still holds at <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> — zero when
+    /// even a one-minute step leaves too narrow a window.
+    ///
+    /// <para><b>This exists to answer #3185's first candidate repair in the build rather than in a
+    /// discussion.</b> "Give the light band a step that respects member duration" is the obvious reading of
+    /// a band that overlaps its own members, and it sounds like a trade against
+    /// <see cref="HeaviestRefreshWindowMinutes"/> that someone could choose to make. It is not a trade: this
+    /// returns <see cref="LightRefreshStepMinutes"/> itself, so the shipped step is already the widest the
+    /// hour carries and every duration-derived step is red. A member's duration is answered by
+    /// <see cref="UnboundedLightRefreshSeparationMinutes"/> INSIDE the band because outside it there is
+    /// nothing to spend.</para>
+    ///
+    /// <para><b>Searched downward through the shipped comparison</b>, for
+    /// <see cref="WidestFeasibleCompressionPhaseGuardMinutes"/>'s reason: the line is an integer-divided
+    /// fraction of an integer window, and a closed form that reproduced the two truncations slightly
+    /// differently would answer feasible where the build answers red. Evaluated at the SHIPPED guard, since
+    /// widening the step and widening the guard are alternatives rather than a pair — each is measured
+    /// against the hour with the other where it is.</para>
+    /// </summary>
+    public static int WidestFeasibleLightRefreshStepMinutes
+    {
+        get
+        {
+            for (var step = MinutesInHourlyCadence; step >= 1; step--)
+            {
+                if (HeaviestHourlyRefreshObservedCeilingSeconds
+                    < RefreshSlotWarningSecondsForLightBandAndGuard(
+                        (LightHourlyRefreshCount - 1) * step, CompressionPhaseGuardMinutes))
+                {
+                    return step;
+                }
+            }
+
+            return 0;
+        }
+    }
 
     /// <summary>
     /// The most compression policies the grid will put on one minute — the input the compression band's WIDTH

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1905,6 +1905,15 @@ WITH NO DATA";
     /// rather than as two halves of one — a comma split would produce a term of <c>time_bucket('1 hour'</c>
     /// and one of <c>bucket)</c>, and the second of those matches a real column name.</para>
     ///
+    /// <para><b>It takes the LAST <c>GROUP BY</c> in the text, which is an assumption rather than a
+    /// parse.</b> Every registered aggregate has exactly one, so the two readings agree today. A future
+    /// CREATE that grouped inside a subquery would break one of them and which one depends on where that
+    /// subquery sat — so this is not a choice that generalizes, it is a statement about the shipped set. A
+    /// definition whose inner terms did not all resolve to classified columns is caught by
+    /// <c>EveryGroupingTerm_IsClassified_AndTheParseIsControlledPerView</c>; one whose inner terms happened
+    /// to resolve would be misclassified silently, and the repair then is a real parse rather than a
+    /// different index. Raised by review.</para>
+    ///
     /// <para><b>Case-insensitive on the keywords, deliberately.</b> A parse that found no GROUP BY would
     /// return nothing, and nothing contains no per-statement column — so a missed clause classifies a view
     /// as deployment-bounded, which is the label that gives it LESS room. The failure has to be loud in the
@@ -2056,6 +2065,20 @@ WITH NO DATA";
     /// <see cref="UnboundedLightRefreshSeparationMinutes"/> expressed in band POSITIONS, which is the unit
     /// the layout places members in — rounded UP, so a separation that does not divide the step still
     /// clears it.
+    ///
+    /// <para><b>AT LEAST ONE, which is what the injectivity claim rests on, and it is worth writing down
+    /// because the implication is three members long.</b> A value of zero would give every
+    /// unbounded member band position zero — every one of them on the same minute, which is #3012's
+    /// adjacency exactly — and
+    /// <see cref="LightBandHoldsUnboundedRefreshCount(int, int)"/> would still answer true, because zero
+    /// fits in any band. It cannot be zero: <see cref="CompressionPhaseGuardMinutes"/> is asserted STRICTLY
+    /// POSITIVE by TimescaleContinuousAggregateTests' tiling case, this is that value over a positive step,
+    /// and the ceiling of a positive quotient is at least one. Raised by review. No assertion is added here
+    /// for it — the positivity is already asserted at the constant, and the collapse is caught twice over on
+    /// the map's own output, by that file's whole-set distinctness claim and by
+    /// <c>TheLightBand_SeparatesEveryUnboundedCardinalityRefresh_WithoutWidening</c>'s set identity. Both
+    /// are red under a mutation that zeroes the separation, which is how that is known rather than
+    /// argued.</para>
     /// </summary>
     public static int UnboundedLightRefreshSeparationIndexes =>
         (int)Math.Ceiling(UnboundedLightRefreshSeparationMinutes / (double)LightRefreshStepMinutes);


### PR DESCRIPTION
The light band stepped every member by `LightRefreshStepMinutes = 1`, which is sized by member COUNT and guarantees nothing about member DURATION. Two ~265 s aggregations landed two minutes apart where the previous grid held them fifteen, and per-output-group cost rose 5.4x with cardinality flat to 1.4%. The band now separates the members whose runs are long enough for that to matter, inside the eleven minutes it already spanned.

**The two parts that matter most are not the layout arithmetic.** Membership in the separated class is read from each view's own `GROUP BY` rather than listed, and a build assertion requires every grouping term in every registered hourly definition to appear on one of the two classified lists — so an aggregate registered tomorrow that groups by an unclassified column is red until someone decides which class it is in, instead of quietly taking a one-minute step. And `LogLightRefreshSpacingBreach` is the runtime backstop for the case a build-time rule structurally cannot see: a view that is slow for a reason its group key does not show. The layout is the part that had to fit; those two are the part that keeps fitting.

## The step cannot be widened, and that is now searched rather than argued

`WidestFeasibleLightRefreshStepMinutes` walks the shipped comparison downward and returns `LightRefreshStepMinutes` itself, so the band is already as wide as the hour carries and every duration-derived step is red at the constant. `RefreshSlotWarningSecondsForLightBandAndGuard` is #3182's guard-parameterised watch line with the band span opened up too — `RefreshSlotWarningSecondsForGuardMinutes` delegates to it at the shipped span, so there is still one copy of the arithmetic.

**The binding constraint is not the hour's sixty minutes.** A duration-derived step of five would span 55 minutes, which is the number the issue reasons about, but the answer arrives two minutes in: eleven gaps at two minutes leave `GuardAndWindowSharedMinutes` at 14 and a watch line of **500 s** against an 896 s `HeaviestHourlyRefreshObservedCeilingSeconds`. Red at every guard, not only at today's.

| shape | band span | shared | watch line at guard 4 | at guard 5 |
|---|---|---|---|---|
| shipped, step 1 | 11 | 25 | 1,050 s — holds | 1,000 s — holds |
| uniform step 2 | 22 | 14 | 500 s — **red** | 450 s — **red** |
| uniform step 5 (the light ceiling rounded up) | 55 | −19 | negative — **red** | negative — **red** |

## The shape that was priced and rejected

Walking the registry in order and jumping forward whenever a member has to clear the last unbounded one — the natural reading of "space only the heavy members" — widens the band, and the widening is what kills it:

| ordered-walk variant | band span | window | watch line | vs 896 s |
|---|---|---|---|---|
| 2 unbounded, 4-minute separation | 13 | 19 | 950 s | holds |
| 2 unbounded, 5-minute separation (post-#3182) | 14 | 17 | 850 s | **red** |
| 3 unbounded, 4-minute separation (today's registry) | 15 | 17 | 850 s | **red** |
| 3 unbounded, 5-minute separation | 17 | 14 | 700 s | **red** |

So that shape is red at today's registry, and would have been red again the moment `OtherHourlyRefreshObservedCeilingSeconds` is re-derived upward. Interleaving is what makes the separation free: the gap the long runs need is filled by the short ones instead of being added to the band.

## What ships

The unbounded-cardinality light members take every `UnboundedLightRefreshSeparationIndexes`-th position of the band from the first; the deployment-bounded members take the positions those leave, in registry order. `LightBandSpanMinutes` names the span once — three expressions were spelling it out — and does not move, so the guard, the heaviest refresh's window and the compression band are byte-for-byte what they were. `GuardAndWindowSharedMinutes` is still 25, `WidestFeasibleCompressionPhaseGuardMinutes` still 7, `WidestFeasibleOtherRefreshCeilingSeconds` still 420, `CompressionPhaseMinutes` still 36–59.

| view | was | now | class |
|---|---|---|---|
| `query_stats_hourly` | `:00` | `:00` | unbounded |
| `procedure_stats_hourly` | `:01` | `:01` | bounded |
| `query_stats_db_hourly` | `:03` | `:02` | bounded |
| `perfmon_baseline` | `:05` | `:03` | bounded |
| **`query_store_stats_hourly`** | **`:02`** | **`:04`** | **unbounded** |
| `wait_stats_baseline` | `:06` | `:05` | bounded |
| `session_stats_baseline` | `:07` | `:06` | bounded |
| `query_stats_baseline` | `:08` | `:07` | bounded |
| **`query_store_stats_corrected_hourly`** | **`:04`** | **`:08`** | **unbounded** |
| `blocked_process_baseline` | `:09` | `:09` | bounded |
| `deadlock_baseline` | `:10` | `:10` | bounded |
| `memory_baseline` | `:11` | `:11` | bounded |
| `query_store_stats_interval_hourly` | `:15` | `:15` | heaviest |

The two views the issue measured are four minutes apart instead of two — 240 s against a 226.8 s recorded ceiling — and the last unbounded member at `:08` reaches 12 against a heaviest-refresh window that opens at 15.

`LightRefreshSpacingMinutesFor` names the gap each class is given, and the band pin holds it to the **measured** gap — the smallest distance between two of that class's minutes on the shipped map — so a layout change that stopped delivering the gap that member names is red rather than reported against a figure the band never honoured. Two of the twenty-six mutations are caught by nothing else.

**`UnboundedLightRefreshSeparationMinutes` IS `CompressionPhaseGuardMinutes`**, one expression rather than two derivations from one constant. "How long after a light refresh starts is it safe to start something else" is the question the guard asks about a compression policy and the band asks about the next long-running refresh, and the identity is what makes "the last unbounded member fits in the band" and "the last unbounded member clears the heaviest refresh's window" the same inequality. One condition, two readings, which is why there is not a second one.

## Membership is derived from each view's own GROUP BY

A list of heavy VIEWS is a frozen enumeration — right until the next aggregate is registered, then silently wrong, which is the positional coupling #3174 removed one level over. A view's one-bucket output cardinality is decided by its group key, so `IsUnboundedCardinalityRefresh` recovers the GROUP BY terms from the shipped CREATE through `HourlyRefreshDefinitions` and asks whether any of them identifies an individual statement or plan.

**The mechanism is measured with source volume held constant**, which is what makes this the group key rather than a proxy for something else. `query_store_stats_interval_hourly` and `query_store_stats_hourly` read the identical rows for a given hour and reduce them 1.30:1 and 2.62:1, for refresh medians of 894.5 s and 105.5 s. `query_stats_hourly` and `query_stats_db_hourly` read an identical ~311,000 rows and reduce them 29:1 and 1,481:1, for 11.2 s and 1.8 s. In both pairs the only thing that differs is how far the group key resolves.

**And the partition it produces matches the measured one.** #3183's scoped post-boundary re-measurement recorded three light views above 3 s — 23.3 s, 263.9 s, 265.5 s — and the other nine at 0.6 s to under 3 s. Those three are exactly the light views whose key reaches a per-statement column. The rule is fitted to the pairs above, not to that result; the split is what it predicts. Note it separates a third member the issue does not name, `query_stats_hourly` at 23.3 s, and that costs the band nothing.

**What can still go stale is the COLUMN list, so every grouping term has to be classified.** `EveryGroupingTerm_IsClassified_AndTheParseIsControlledPerView` requires each term in each registered hourly definition to appear either on `PerStatementGroupingColumns` or on the test's deployment-bounded list — so an aggregate registered tomorrow that groups by an unclassified column is red until someone decides which it is. The bounded half lives in the test because it has no product consumer and its whole job is to be red. The parse is controlled per view before its result is used: a recovery that matched nothing returns no terms for every view, and no terms contains no per-statement column, so a broken parse would report every aggregate bounded and a clean sweep for having checked nothing. Two named views' exact term lists are asserted, one from each class.

## The live half, because no build-time rule can see a view that is slow for another reason

`LogLightRefreshSpacingBreach` reports a light refresh that ran past the minutes its class was given, on the per-view feed #3183 already added and through the same rate limiter. **A hand-kept list goes stale loudly, on the next registration, where a reviewer sees it; a rule that has stopped predicting goes stale quietly, forever.** This is what makes it loud.

It is a third finding rather than a case of the ceiling one, and they are not nested: a bounded member at 100 s outran its 60 s step while sitting a long way under `OtherHourlyRefreshObservedCeilingSeconds`, so that watch is silent on precisely the reading this exists for. Keyed on the constant the reading falsified — `LightRefreshStepMinutes` means the CLASSIFICATION is wrong for that view, `UnboundedLightRefreshSeparationMinutes` means the separation is too narrow — because one key would let the first unbounded breach, reported in hundreds of seconds, permanently silence every bounded one, reported in tens. Warning on #3183's argument: Debug is where a silently-inapplicable mechanism lives, and Error is reserved for a stated precondition of the grid being false, which two light refreshes overlapping does not make.

## The feasibility conclusion depends on the SHIPPED heaviest ceiling, and that dependency is inherited

Every shape priced above is measured against `HeaviestHourlyRefreshObservedCeilingSeconds = 896`. **#3182 established that 896 is stale under that constant's own positional rule — the honest post-boundary maximum is 1,495.2 s — and #3183 froze the value rather than re-deriving it.** So whoever resolves that ceiling inherits a light band sized against the number their resolution replaces, and should not have to reconstruct that from two PRs in flight at once.

The dependency is not introduced here. Every grid constant is byte-identical between `dev` and this head: `CompressionPhaseBandMinutes` 24, `CompressionPhaseGuardMinutes` 4, `LightBandSpanMinutes` 11, `HeaviestRefreshStartMinute` 15, `HeaviestRefreshWindowMinutes` 21, `RefreshPhaseSlotSeconds` 1,260, `RefreshSlotWarningSeconds` 1,050, `GuardAndWindowSharedMinutes` 25, `WidestFeasibleCompressionPhaseGuardMinutes` 7, `WidestFeasibleOtherRefreshCeilingSeconds` 420, `CompressionPhaseMinutes` 36-59. The band span does not move, so the grid's relationship to 896 is exactly what already ships.

**And the dependency is encoded rather than latent, which is the part worth knowing.** Re-derive the constant to 1,495.2 and both searched terms change their answers, evaluated through the shipped comparison:

| term | at the shipped 896 | at the honest 1,495.2 |
|---|---|---|
| `WidestFeasibleCompressionPhaseGuardMinutes` | 7 | **−1** |
| `WidestFeasibleOtherRefreshCeilingSeconds` | 420 s | **0 s** |
| `WidestFeasibleLightRefreshStepMinutes` | 1 | **0** |

`RefreshSlotWarningSecondsForGuardMinutes(0)` is 1,250 s, so **even a zero-minute guard does not clear 1,495.2** — the downward walk finds nothing and returns the negative. That is the case `WidestFeasibleCompressionPhaseGuardMinutes`' own summary pre-registers as "a real answer, not an error code": a grid the hour cannot contain at ANY guard, whose named repairs are a cheaper refresh or a longer cadence for that one aggregate. Neither is a light-band question, and neither is reachable by re-dimensioning any band. So the two searched terms report "no feasible guard" and "no feasible step" the moment the constant moves, rather than a grid quietly re-sizing itself around an infeasible ceiling — which is also why re-deriving 896 reddens the build, and why #3183 froze it.

**Read the other way: my search concluding "the shipped step is the widest the hour carries" is a statement about 896, not about the hour.** It is the right statement to build against — designing against a value the product deliberately froze would be the error — but it is conditional, and the condition is named here.

## Neither ceiling constant's value moves, and the sequencing is the reason

The 263.9 s and 265.5 s runs are runs of two aggregations that overlapped for essentially their whole duration; the same two ran ~47 s each when the previous grid held them fifteen minutes apart. A ceiling taken from the overlapping population would size the separation from the defect the separation exists to remove. So the separation is a bound against the RECORDED ceiling — `4 * 60 = 240 s` against 226.8 s, the guard's own rounding margin — and the one way it can be insufficient is that constant being stale, which is a reported finding with a named remedy since #3183. #3182 re-derives both values once the grid is stable, which is what this unblocks.

**One thing the shipped guard of 4 does not cover today.** 226.8 s is a midnight figure — its own doc attributes it to #3112's chunk-close burst — and tonight's 265.5 s is past `4 * 60`. That is #3182's to fix, and this change does not depend on it: the separation and the guard are one expression, so re-deriving the constant to 265.5 moves both to 5 and the layout still fits (last unbounded position 11 against a band of 11, `GuardAndWindowSharedMinutes` still 25, watch line 1,000 s). The rejected ordered-walk shape does not.

## A band that cannot separate degrades rather than refusing

`CompressionPhaseMinutes` is a static field whose initializer reaches `RefreshPhaseMinutesFor`, and a static initializer that throws costs the whole TYPE for the life of the process — every retention horizon, every compression statement, every refresh policy, not just the aggregate that could not be placed. **Measured rather than assumed:** the mutation that makes the GROUP BY recovery return nothing classifies every view unbounded, the band cannot separate twelve, and a throwing map took **72 tests red across four unrelated files**. So the map falls back to consecutive positions — #3174's grid, still distinct starts, still injective — and `LightBandHoldsUnboundedRefreshCount` reports it at build time. The existing throw for an unregistered view cannot fire from that initializer because it only ever iterates registered views; this condition can, because it depends on a parse.

**That predicate is the only reporter the condition needs, and the live finding is not a second one.** Raised by review: the doc originally claimed both reported it. The predicate's input is recovered from compile-time CREATE constants, so a degraded layout cannot differ between CI and a running store and a build it is false on does not ship — there is no live reading to judge against a consecutive gap an unbounded member was given. A branch in the finding for that state would read as care and certify nothing, which is what `ClassifyRefreshCeilingFreshness` says about the guard it deliberately does not have. What the finding covers is the failure the predicate cannot see, which is reachable on every shipped build.

Relatedly, `GroupKeyIsUnboundedCardinality` is its own function so its fail-safe arm is REACHABLE. No shipped definition is unparseable, so folded into the field initializer that arm would be a line no value the registry can produce reaches — protection that certifies nothing and that no mutation can distinguish from its own absence. A test hands it a CREATE with no GROUP BY and gets an answer, and hands it a bounded one and gets the other answer.

## Verification

**353 tests, 0 failed, 17 skipped** in a `net10.0` xunit.v3 harness compiling the real Windows-only `.cs` files (`Darling.Tests` assembly name, so `InternalsVisibleTo` applies), every skip the live-store `_AgainstDevPostgres` gate. The mutation runs below read 356 and 357 because the same harness also compiled three then four scratch probes of my own; the figure with those excluded is 353, measured by dropping them and rebuilding rather than by subtracting. `TimescaleSupportTests`, `TimescaleContinuousAggregateTests`, `CompressionClearanceWatchTests`, `RefreshCeilingStalenessTests`, `RefreshCeilingProvenancePinTests`, `DarlingSelfAlertTests`, `DocCommentHygieneTests`, `CommentFilterAdoptionTests` and `CSharpSourceWalkerTests` all run; the only pre-existing case that needed editing is the pinned grid table, whose light-band half moved.

Twenty-seven mutations, each applied singly, confirmed present by `git diff --numstat` plus a content check, rebuilt, run, restored, and restoration confirmed byte-exact against the pre-mutation file. **All twenty-seven red; the baseline printed green before the first and after the last** (356/0/17 with three probes for M01-M25, 357/0/17 with four for M26), against a working tree `git status --porcelain` reported clean. The table is in the lane report. One mutation changed the design rather than the test — the 72-test cascade above — and the throw became a degradation.

**`Darling whole-tree guards` reports green having skipped its own steps, and that is correct rather than a hollow pass.** Its gate reads the `build` job's `Run Darling tests` outcome and skips when the suite has already run on the commit; `build`'s step 14 is `success` at 488 s, so the guards ran there. The job exists to make "green having run nothing" distinguishable, and it says which log holds the answer. Worth stating because a 16-second green on a whole-tree suite is exactly the shape that should be checked rather than trusted.

### Two review observations, both real, both answered by measurement

**The separation index must be at least one, or the injectivity claim is false.** A zero would put every unbounded member on band position zero — #3012's adjacency — and `LightBandHoldsUnboundedRefreshCount` would still answer true, because zero fits in any band. It cannot be zero: `CompressionPhaseGuardMinutes` is asserted strictly positive by the tiling case, the separation is that value over a positive step, and the ceiling of a positive quotient is at least one. **No assertion is added for it** — the positivity is already asserted at the constant, and an assertion downstream of it would be unreachable. The claim that the collapse is caught anyway is verified rather than argued: the mutation that zeroes the separation is red at **9 tests**, including the whole-set distinctness claim and the per-relation contention sweep. The implication is now written down where it is relied on, because it is three members long.

**The GROUP BY recovery takes the last such clause in the text, which is an assumption rather than a parse.** Every registered aggregate has exactly one, so the two readings agree today; a future CREATE that grouped inside a subquery would break one of them and which one depends on where the subquery sat, so this does not generalize. A definition whose inner terms did not all resolve to classified columns is caught by the completeness sweep; one whose inner terms happened to resolve would be misclassified silently, and the repair then is a real parse rather than a different index. Stated at the member.

## Not in scope

The compression band's width, `CompressAfterDays`, the compression policies' phase minutes, and either ceiling constant's VALUE (#3182, which this unblocks).

## CHANGELOG entry text

Under `[Unreleased]` → `Fixed`:

- **The hourly refresh band separates the aggregates whose runs are long enough to collide, inside the minutes it already had** ([#3185]) - the light band stepped every member by one minute, which is sized by member COUNT and says nothing about member DURATION: a one-minute step guarantees distinct starts at any length the band can hold and guarantees nothing at all about overlap. `query_store_stats_hourly` and `query_store_stats_corrected_hourly` landed at `:02` and `:04` where the previous grid held them fifteen minutes apart, and two ~265 s aggregations overlapped for essentially their whole runs at **5.4x** the per-output-group cost with cardinality flat to 1.4%. Widening the step is not available and that is now searched rather than argued - `WidestFeasibleLightRefreshStepMinutes` returns the shipped step, because eleven gaps at two minutes drop the heaviest refresh's watch line to 500 s against an 896 s recorded ceiling. So the members that can consume a wider gap take every fourth position of the band and the ones that cannot fill the rest: the band spans the same eleven minutes and the guard, the heaviest refresh's window and the compression band do not move. Membership is read from each view's own GROUP BY rather than listed - a per-statement group key means cost grows with the monitored workload's distinct statement population, which two same-source measurements isolate with volume held constant - so an aggregate registered tomorrow is classified when it is registered, and every grouping term in every registered definition has to appear on one of the two classified lists or the build is red. `LogLightRefreshSpacingBreach` reports a run that outran the gap its class was given, keyed on the constant it falsified, for the case no build-time rule can see: a view that is slow for a reason its group key does not show.
