### PR TITLE
Record and classify Entra MFA broker failures instead of showing one line and logging nothing (#3196)

### DIFF
--- a/Lite.Tests/EntraBrokerFailureTests.cs
+++ b/Lite.Tests/EntraBrokerFailureTests.cs
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Darling.Tests;
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite.Helpers;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #3196: an externally reported Microsoft Entra MFA connection failure that produced no log entry
+/// anywhere, so the only record of it was a screenshot of a dialog.
+///
+/// <para>These pin the two halves that are verifiable without an Entra tenant: that a broker failure
+/// is classified by which stage of the handshake it died at, and that the connection test writes the
+/// exception somewhere. Whether the reporter's tenant then authenticates is a real-tenant step and
+/// no test here claims it.</para>
+/// </summary>
+public class EntraBrokerFailureTests
+{
+    /* The driver's rendering of an interactive-Entra failure, reconstructed from the format strings in
+       Microsoft.Data.SqlClient's ActiveDirectoryAuthenticationProvider and MSAL's WamAdapters rather
+       than from a reporter's paste: SqlClient interpolates the MSAL error code into its own message as
+       "Error code 0x<code>", and MSAL's broker adapter renders the native error object underneath it.
+       0x80070520 is ERROR_NO_SUCH_LOGON_SESSION, which is the reported case. */
+    private const string ReportedBrokerRefusal =
+        "Failed to authenticate the user in Active Directory (Authentication=ActiveDirectoryInteractive). "
+        + "Error code 0xunknown_broker_error\n"
+        + "Failed to acquire access token for ActiveDirectoryInteractive: Unknown Status: Unexpected\n"
+        + "Error: 0xffffffff80070520\n"
+        + "Context: (pii)\n"
+        + "Tag: 0x21420087";
+
+    [Theory]
+    [InlineData(ReportedBrokerRefusal, EntraBrokerFailureKind.BrokerRejected)]
+    [InlineData("Error code 0xWAM_provider_error_3399614467", EntraBrokerFailureKind.BrokerRejected)]
+    [InlineData("Error code 0xwindow_handle_required", EntraBrokerFailureKind.WindowHandleMissing)]
+    [InlineData("Error code 0xwam_runtime_init_failed", EntraBrokerFailureKind.BrokerUnavailable)]
+    public void Classify_NamesTheStageTheBrokerHandshakeDiedAt(string message, EntraBrokerFailureKind expected)
+    {
+        Assert.Equal(expected, EntraBrokerFailure.Classify(new InvalidOperationException(message)));
+    }
+
+    [Fact]
+    public void Classify_ReadsTheWholeInnerExceptionChain()
+    {
+        /* The shape the driver actually produces: SqlClient's own exception on the outside, its
+           internal AuthenticationException in the middle, MSAL's broker exception at the bottom. A
+           classifier that reads only the outermost Message finds nothing here, which is the whole
+           reason this is asserted on a nested chain rather than a flat one. */
+        var chain = new InvalidOperationException(
+            "A connection was successfully established with the server, but then an error occurred.",
+            new InvalidOperationException(
+                "Failed to authenticate the user in Active Directory.",
+                new InvalidOperationException("unknown_broker_error")));
+
+        Assert.Equal(EntraBrokerFailureKind.BrokerRejected, EntraBrokerFailure.Classify(chain));
+    }
+
+    [Fact]
+    public void Classify_PrefersTheMoreSpecificStageWhenOneMessageCarriesTwoMarkers()
+    {
+        /* WindowHandleMissing is a fault in this application; BrokerRejected is a condition on the
+           user's machine. Reporting the second when the first is also present sends a reporter to
+           their IT department over our bug, so the specific arm wins. This fails if the refusal check
+           is moved ahead of the handle check. */
+        var both = new InvalidOperationException("unknown_broker_error and window_handle_required");
+
+        Assert.Equal(EntraBrokerFailureKind.WindowHandleMissing, EntraBrokerFailure.Classify(both));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Login failed for user 'someone'.")]
+    [InlineData("A network-related or instance-specific error occurred while establishing a connection.")]
+    [InlineData("Execution Timeout Expired.")]
+    [InlineData("User canceled authentication.")]
+    /* SQL Server's own Service Broker shares the word and nothing else. A substring match on
+       "broker" classifies this as a WAM failure and tells a user their Windows account is broken
+       when a queue is disabled. */
+    [InlineData("The service broker queue 'dbo.ExampleQueue' is currently disabled.")]
+    [InlineData("Service Broker needs to be enabled in this database.")]
+    public void Classify_DoesNotClaimABrokerFailureForAnythingElse(string? message)
+    {
+        var ex = message is null ? null : new InvalidOperationException(message);
+
+        Assert.Equal(EntraBrokerFailureKind.None, EntraBrokerFailure.Classify(ex));
+    }
+
+    [Fact]
+    public void Explain_CoversEveryStageTheClassifierCanReturn()
+    {
+        /* Enumerated rather than listed, so a stage added to the enum without prose fails here
+           instead of silently explaining nothing to the user who hit it. */
+        foreach (var kind in Enum.GetValues<EntraBrokerFailureKind>())
+        {
+            var explanation = EntraBrokerFailure.Explain(kind);
+
+            if (kind == EntraBrokerFailureKind.None)
+            {
+                Assert.Null(explanation);
+                continue;
+            }
+
+            Assert.False(
+                string.IsNullOrWhiteSpace(explanation),
+                $"{kind} is a stage the classifier can return and has no explanation");
+        }
+    }
+
+    [Fact]
+    public void Compose_KeepsTheDriversErrorCodesAlongsideTheExplanation()
+    {
+        /* The explanation says which side failed; only the driver's text carries the error codes a
+           report needs. Replacing one with the other loses the actionable half. */
+        var body = ConnectionFailureMessage.Compose(
+            ReportedBrokerRefusal,
+            EntraBrokerFailureKind.BrokerRejected,
+            @"C:\Users\someone\AppData\Local\PerformanceMonitorLite-Data\logs");
+
+        Assert.Contains("unknown_broker_error", body, StringComparison.Ordinal);
+        Assert.Contains("Web Account Manager", body, StringComparison.Ordinal);
+        Assert.Contains(@"PerformanceMonitorLite-Data\logs", body, StringComparison.Ordinal);
+
+        /* Order matters: the driver's error first, then what it means, then where the rest of it is. */
+        Assert.True(
+            body.IndexOf("unknown_broker_error", StringComparison.Ordinal)
+                < body.IndexOf("Web Account Manager", StringComparison.Ordinal),
+            "the driver's own error must come before the explanation of it");
+        Assert.True(
+            body.IndexOf("Web Account Manager", StringComparison.Ordinal)
+                < body.IndexOf(@"PerformanceMonitorLite-Data\logs", StringComparison.Ordinal),
+            "the log location must come last");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Compose_OmitsTheLogPointerRatherThanPointingNowhere(string? logDirectory)
+    {
+        /* A pointer with no path after it reads as "the logs are missing", which is the confusion
+           this text exists to end. */
+        var body = ConnectionFailureMessage.Compose("Login failed.", EntraBrokerFailureKind.None, logDirectory);
+
+        Assert.DoesNotContain("is in the log at", body, StringComparison.Ordinal);
+        Assert.Contains("Login failed.", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Compose_AddsNothingWhenThereIsNothingToAdd()
+    {
+        Assert.Equal(string.Empty, ConnectionFailureMessage.Compose(null, EntraBrokerFailureKind.None, null));
+    }
+
+    [Fact]
+    public void ConnectionTest_WritesTheExceptionToTheLog()
+    {
+        /* The reported defect: the dialog showed an error and the process recorded nothing, so the
+           only artefact was a screenshot. Behavioural coverage cannot reach this - the catch lives in
+           a WPF Window that needs a dispatcher and a live form - so the call site is asserted in
+           source, per the DetachedCollectorGateTests idiom.
+
+           Comments and string literals are stripped first, deliberately. The catch block carries a
+           comment naming AppLogger.Error and explaining why it is there; a raw substring search over
+           the file is satisfied by that comment alone, so it would pass with the call deleted. */
+        var source = CSharpSourceWalker.StripCommentsAndStrings(
+            ReadRepoFile("Lite/Windows/AddServerDialog.xaml.cs"));
+
+        var signature = source.IndexOf("RunConnectionTestAsync()", StringComparison.Ordinal);
+        Assert.True(signature >= 0, "RunConnectionTestAsync is the connection-test entry point and must exist");
+
+        var open = source.IndexOf('{', signature);
+        Assert.True(open > signature, "RunConnectionTestAsync must have a body");
+
+        var body = CSharpSourceWalker.BraceBalanced(source, open);
+
+        Assert.Contains("catch", body, StringComparison.Ordinal);
+        Assert.Contains("AppLogger.Error", body, StringComparison.Ordinal);
+        Assert.Contains("EntraBrokerFailure.Classify", body, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepoFile(string relativePath, [CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        var parts = relativePath.Split('/');
+        while (dir is not null && !File.Exists(Path.Combine(new[] { dir }.Concat(parts).ToArray())))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return File.ReadAllText(Path.Combine(new[] { dir! }.Concat(parts).ToArray()));
+    }
+}

--- a/Lite/Helpers/ConnectionFailureMessage.cs
+++ b/Lite/Helpers/ConnectionFailureMessage.cs
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitorLite.Helpers;
+
+/// <summary>
+/// Composes the body of the "Connection Failed" dialog: the driver's own error, what stage of a
+/// Microsoft Entra MFA broker handshake failed when that is what happened, and where the log with
+/// the full exception chain lives.
+///
+/// <para><b>Why the log location is in the dialog.</b> The reporter of #3196 hit a connection
+/// failure whose dialog text was the only record of it, went looking for a log, and reported back
+/// that neither the data directory nor a logs directory under it existed. A dialog that shows an
+/// error and does not say where the rest of it went leaves a reporter guessing at a path, and the
+/// path is not guessable — it is a resolved absolute directory, not a name. Naming it costs one
+/// line and is the difference between a follow-up that carries the exception chain and one that
+/// carries a screenshot.</para>
+///
+/// <para>Pure, and takes the log directory rather than reading <c>App.DataDirectory</c>, so the
+/// composition is testable without a WPF application object.</para>
+/// </summary>
+public static class ConnectionFailureMessage
+{
+    /// <summary>
+    /// Builds the detail block that follows "Could not connect to {server}." — including its leading
+    /// blank line — or an empty string when there is nothing to say.
+    /// </summary>
+    /// <param name="driverError">The exception message from the connection attempt, or null.</param>
+    /// <param name="brokerFailure">
+    /// The broker stage from <see cref="EntraBrokerFailure.Classify"/>.
+    /// <see cref="EntraBrokerFailureKind.None"/> adds nothing.
+    /// </param>
+    /// <param name="logDirectory">
+    /// The resolved directory holding the log files, or null/blank to omit the pointer. Omitted
+    /// rather than guessed: a wrong path sends a reporter somewhere empty and reads as "there are no
+    /// logs", which is the confusion this is here to end.
+    /// </param>
+    public static string Compose(
+        string? driverError,
+        EntraBrokerFailureKind brokerFailure,
+        string? logDirectory)
+    {
+        var body = new StringBuilder();
+
+        if (!string.IsNullOrWhiteSpace(driverError))
+        {
+            body.Append("\n\nError: ").Append(driverError);
+        }
+
+        /* The explanation goes AFTER the driver's text, not instead of it. The driver's message
+           carries the error codes a report needs to be actionable; this only says which side of the
+           handshake they came from. */
+        var explanation = EntraBrokerFailure.Explain(brokerFailure);
+        if (explanation is not null)
+        {
+            body.Append("\n\n").Append(explanation);
+        }
+
+        if (!string.IsNullOrWhiteSpace(logDirectory))
+        {
+            body.Append("\n\nThe full error, including any inner exceptions, is in the log at:\n")
+                .Append(logDirectory);
+        }
+
+        return body.ToString();
+    }
+}

--- a/Lite/Services/ServerManager.cs
+++ b/Lite/Services/ServerManager.cs
@@ -511,7 +511,11 @@ public class ServerManager
             }
             else
             {
-                _logger?.LogWarning("Connectivity check failed for server '{DisplayName}': {Message}", server.DisplayName, ex.Message);
+                /* The exception object, not just its Message. A federated-auth failure arrives as a
+                   SqlException wrapping MSAL's exception wrapping the Windows broker's, and Message
+                   is the outermost layer only; the sibling generic-catch arm below already passes the
+                   whole chain, and a SqlException is the shape an Entra MFA failure actually takes. */
+                _logger?.LogWarning(ex, "Connectivity check failed for server '{DisplayName}'", server.DisplayName);
             }
         }
         catch (Exception ex)

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -332,7 +332,7 @@ public partial class AddServerDialog : Window
         return builder;
     }
 
-    private async System.Threading.Tasks.Task<(bool Connected, string? ErrorMessage, bool MfaCancelled, string? ServerVersion)> RunConnectionTestAsync()
+    private async System.Threading.Tasks.Task<(bool Connected, string? ErrorMessage, bool MfaCancelled, string? ServerVersion, EntraBrokerFailureKind BrokerFailure)> RunConnectionTestAsync()
     {
         TestButton.IsEnabled = false;
         SaveButton.IsEnabled = false;
@@ -345,6 +345,7 @@ public partial class AddServerDialog : Window
         string? errorMessage = null;
         bool mfaCancelled = false;
         string? serverVersion = null;
+        var brokerFailure = EntraBrokerFailureKind.None;
 
         try
         {
@@ -360,6 +361,24 @@ public partial class AddServerDialog : Window
             errorMessage = ex.Message;
             if (EntraMfaAuthRadio.IsChecked == true && MfaAuthenticationHelper.IsMfaCancelledException(ex))
                 mfaCancelled = true;
+            else
+                brokerFailure = EntraBrokerFailure.Classify(ex);
+
+            /* Logged here, where the exception object still exists. ex.Message alone is what the
+               dialog can show, and for a federated-auth failure the message is the shallowest layer
+               of a chain several deep - the driver wraps MSAL's exception, which wraps the broker's.
+               AppLogger.Error walks that chain; nothing else on this path does, so a failure that is
+               not logged here is a failure whose detail the process never recorded anywhere. Not
+               gated on mfaCancelled: a cancellation is a decision the user made and its own dialog
+               already reports it, so logging it as an error would file user intent as a fault. */
+            if (!mfaCancelled)
+            {
+                AppLogger.Error(
+                    "AddServer",
+                    $"Connection test failed for '{ServerNameBox.Text.Trim()}' "
+                        + $"(authentication: {DescribeSelectedAuthentication()}, broker stage: {brokerFailure})",
+                    ex);
+            }
         }
         finally
         {
@@ -368,8 +387,35 @@ public partial class AddServerDialog : Window
             StatusText.Text = string.Empty;
         }
 
-        return (connected, errorMessage, mfaCancelled, serverVersion);
+        return (connected, errorMessage, mfaCancelled, serverVersion, brokerFailure);
     }
+
+    /// <summary>
+    /// The selected authentication mode, for the log line only.
+    ///
+    /// <para>Named from the radio buttons rather than read back off the connection string, because
+    /// the connection string holds a password and a log line must not. The mode is the part of the
+    /// form that changes which code path failed, and it is the first thing a report needs.</para>
+    /// </summary>
+    private string DescribeSelectedAuthentication()
+    {
+        if (WindowsAuthRadio.IsChecked == true) return "Windows";
+        if (SqlAuthRadio.IsChecked == true) return "SQL Server";
+        if (EntraMfaAuthRadio.IsChecked == true) return "Microsoft Entra MFA";
+        if (ServicePrincipalAuthRadio.IsChecked == true) return "Service principal";
+        if (ManagedIdentityAuthRadio.IsChecked == true) return "Managed identity";
+        return "unknown";
+    }
+
+    /// <summary>
+    /// The detail block for a "Connection Failed" dialog, carrying the log location so a report can
+    /// include the exception chain rather than a screenshot of its first line.
+    /// </summary>
+    private static string ComposeFailureDetail(string? errorMessage, EntraBrokerFailureKind brokerFailure) =>
+        ConnectionFailureMessage.Compose(
+            errorMessage,
+            brokerFailure,
+            string.IsNullOrEmpty(App.DataDirectory) ? null : System.IO.Path.Combine(App.DataDirectory, "logs"));
 
     private async void TestButton_Click(object sender, RoutedEventArgs e)
     {
@@ -379,7 +425,7 @@ public partial class AddServerDialog : Window
             return;
         }
 
-        var (connected, errorMessage, mfaCancelled, serverVersion) = await RunConnectionTestAsync();
+        var (connected, errorMessage, mfaCancelled, serverVersion, brokerFailure) = await RunConnectionTestAsync();
 
         if (connected)
         {
@@ -410,7 +456,7 @@ public partial class AddServerDialog : Window
         }
         else
         {
-            var detail = errorMessage != null ? $"\n\nError: {errorMessage}" : string.Empty;
+            var detail = ComposeFailureDetail(errorMessage, brokerFailure);
             MessageBox.Show(
                 $"Could not connect to {ServerNameBox.Text.Trim()}.{detail}",
                 "Connection Failed",
@@ -504,7 +550,7 @@ public partial class AddServerDialog : Window
         // Test connection when data collection is enabled
         if (EnabledCheckBox.IsChecked == true)
         {
-            var (connected, errorMessage, mfaCancelled, _) = await RunConnectionTestAsync();
+            var (connected, errorMessage, mfaCancelled, _, brokerFailure) = await RunConnectionTestAsync();
 
             if (!connected)
             {
@@ -524,7 +570,7 @@ public partial class AddServerDialog : Window
                 }
                 else
                 {
-                    var detail = errorMessage != null ? $"\n\nError: {errorMessage}" : string.Empty;
+                    var detail = ComposeFailureDetail(errorMessage, brokerFailure);
                     MessageBox.Show(
                         $"Could not connect to {ServerNameBox.Text.Trim()}.{detail}\n\nTo save this server without a working connection, uncheck \"Enable data collection for this server\".",
                         "Connection Failed",

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -368,9 +368,9 @@ public partial class AddServerDialog : Window
                dialog can show, and for a federated-auth failure the message is the shallowest layer
                of a chain several deep - the driver wraps MSAL's exception, which wraps the broker's.
                AppLogger.Error walks that chain; nothing else on this path does, so a failure that is
-               not logged here is a failure whose detail the process never recorded anywhere. Not
-               gated on mfaCancelled: a cancellation is a decision the user made and its own dialog
-               already reports it, so logging it as an error would file user intent as a fault. */
+               not logged here is a failure whose detail the process never recorded anywhere.
+               Cancellations are excluded: one is a decision the user made, its own dialog already
+               reports it, and filing user intent as an error would bury real faults among them. */
             if (!mfaCancelled)
             {
                 AppLogger.Error(

--- a/PerformanceMonitor.Common/Helpers/EntraBrokerFailure.cs
+++ b/PerformanceMonitor.Common/Helpers/EntraBrokerFailure.cs
@@ -152,8 +152,8 @@ public static class EntraBrokerFailure
             + "sign-in and refused it. The server name, the database name and the account password "
             + "are not what failed. Windows does not report the reason to applications, and the SQL "
             + "client offers no way to sign in through a browser instead, so retrying as-is will "
-            + "fail the same way. Signing the Windows work-or-school account out and back in, or "
-            + "clearing the broker's cached state, is what usually clears it.",
+            + "fail the same way. The documented remedies are Windows-side: signing the "
+            + "work-or-school account out and back in, or clearing the broker's cached state.",
 
         _ => null,
     };

--- a/PerformanceMonitor.Common/Helpers/EntraBrokerFailure.cs
+++ b/PerformanceMonitor.Common/Helpers/EntraBrokerFailure.cs
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Common;
+
+/// <summary>
+/// The kind of Windows Web Account Manager (WAM) broker failure behind a failed
+/// <c>Authentication=ActiveDirectoryInteractive</c> connection, or <see cref="None"/> when the
+/// failure is not a broker failure at all.
+///
+/// <para>The three broker arms are kept apart because they point at different things and are fixed
+/// by different people. Collapsing them into one "Entra auth failed" bucket is what makes a report
+/// unactionable: the reporter of #3196 sent an error whose text alone settles which arm it is, and
+/// the answer changed what there was to do about it.</para>
+/// </summary>
+public enum EntraBrokerFailureKind
+{
+    /// <summary>Not a broker failure. Ordinary login/network/timeout failures land here.</summary>
+    None,
+
+    /// <summary>
+    /// MSAL was handed no parent window handle (<c>window_handle_required</c>). The application's
+    /// own wiring is at fault: <see cref="System.IntPtr.Zero"/> reached
+    /// <c>WithParentActivityOrWindow</c>, and MSAL rejects the request before the broker is asked
+    /// anything.
+    /// </summary>
+    WindowHandleMissing,
+
+    /// <summary>
+    /// The broker runtime itself could not be loaded (<c>wam_runtime_init_failed</c>). Nothing about
+    /// the account or the tenant is implicated; the native <c>msalruntime</c> library did not start.
+    /// </summary>
+    BrokerUnavailable,
+
+    /// <summary>
+    /// The broker loaded, was given a window, ran, and refused the sign-in
+    /// (<c>unknown_broker_error</c>, <c>WAM_provider_error_*</c>). The failure is on the Windows
+    /// account side, past everything the application controls.
+    /// </summary>
+    BrokerRejected,
+}
+
+/// <summary>
+/// Classifies a failed interactive-Entra connection by which stage of the WAM broker handshake it
+/// died at, and states in plain language what that stage means.
+///
+/// <para><b>Why a classifier rather than a fix.</b> <c>Microsoft.Data.SqlClient</c> routes
+/// <c>Authentication=ActiveDirectoryInteractive</c> through the Windows WAM broker and offers no way
+/// out of it for an application that uses the driver's own Entra application id.
+/// <c>ActiveDirectoryAuthenticationProviderOptions.UseWamBroker</c> looks like an opt-out and is not
+/// one: the provider computes <c>useWamBroker = (applicationClientId == driverOwnId) ||
+/// options.UseWamBroker</c>, so leaving the id unset pins the broker on and the flag is inert. MSAL
+/// falls back to a browser only when the broker is <i>unavailable</i> — an invoked broker that
+/// returns an error is propagated, not retried another way. So a broker refusal has no in-process
+/// remedy, and naming the stage is the whole of what this code can honestly do.</para>
+///
+/// <para><b>Why the stage is worth naming.</b> The broker's own explanation of <i>why</i> it refused
+/// is unreachable from here. MSAL only un-redacts it when its logger has PII enabled, and SqlClient
+/// never configures an MSAL logger, so the reason arrives as the literal text <c>Context: (pii)</c>.
+/// What is left is the stage, and the stage alone separates "the application forgot the window
+/// handle" from "Windows refused" — which is the difference between a bug here and a condition on
+/// the user's machine.</para>
+///
+/// <para><b>Verification status.</b> The classification above is read off the driver and MSAL
+/// sources and off the error text a reporter sent. None of it is verified against a live Entra-MFA
+/// tenant, because reproducing an interactive Entra failure needs a real tenant and a Windows host.
+/// The string matching and the stage boundaries are pinned by tests; that the strings are the ones a
+/// live tenant produces rests on the reported error and on the driver source, not on a run.</para>
+/// </summary>
+public static class EntraBrokerFailure
+{
+    /* Matched against the whole exception chain's message text rather than against a typed
+       MsalException, deliberately. SqlClient wraps the MsalException in its own internal
+       AuthenticationException and then in a SqlException, and reading the error code off the middle
+       layer would mean referencing Microsoft.Identity.Client directly and pinning Lite to whichever
+       MSAL version the driver happens to carry. The codes travel in the text: SqlClient renders the
+       MSAL error code into its message as "Error code 0x<code>", which is how the #3196 report
+       arrived legible. */
+
+    private const string WindowHandleMarker = "window_handle_required";
+
+    private const string RuntimeInitMarker = "wam_runtime_init_failed";
+
+    /* Two markers for the refusal arm because MSAL splits it: a status it has a mapping for becomes
+       WAM_provider_error_<code>, and one it does not becomes unknown_broker_error. Both mean the
+       broker ran and said no. */
+    private const string UnknownBrokerMarker = "unknown_broker_error";
+
+    private const string ProviderErrorMarker = "wam_provider_error";
+
+    /// <summary>
+    /// Classifies <paramref name="ex"/> and every exception nested inside it.
+    /// </summary>
+    /// <param name="ex">The failure from the connection attempt. Null classifies as
+    /// <see cref="EntraBrokerFailureKind.None"/>.</param>
+    /// <returns>The stage the broker handshake died at, or
+    /// <see cref="EntraBrokerFailureKind.None"/> when this is not a broker failure.</returns>
+    public static EntraBrokerFailureKind Classify(Exception? ex)
+    {
+        /* Ordered by specificity, not by likelihood. The handle and runtime-init arms name a
+           definite cause; the refusal arm is the residue, so it is tested last. Testing it first
+           would swallow the two arms that say something more precise. */
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            var message = current.Message;
+            if (string.IsNullOrEmpty(message))
+                continue;
+
+            if (Contains(message, WindowHandleMarker))
+                return EntraBrokerFailureKind.WindowHandleMissing;
+
+            if (Contains(message, RuntimeInitMarker))
+                return EntraBrokerFailureKind.BrokerUnavailable;
+
+            if (Contains(message, UnknownBrokerMarker) || Contains(message, ProviderErrorMarker))
+                return EntraBrokerFailureKind.BrokerRejected;
+        }
+
+        return EntraBrokerFailureKind.None;
+    }
+
+    /// <summary>
+    /// The user-facing explanation for a broker failure stage, or null for
+    /// <see cref="EntraBrokerFailureKind.None"/>.
+    ///
+    /// <para>Each arm says which side the failure is on and stops there. None of them offers a retry
+    /// that would work, because for a broker refusal there is not one: the driver has no browser
+    /// fallback to reach for.</para>
+    /// </summary>
+    /// <param name="kind">The stage from <see cref="Classify"/>.</param>
+    /// <returns>Text to show beneath the driver's own error, or null when there is nothing to add.</returns>
+    public static string? Explain(EntraBrokerFailureKind kind) => kind switch
+    {
+        EntraBrokerFailureKind.WindowHandleMissing =>
+            "Microsoft Entra MFA sign-in was rejected before Windows was asked: the sign-in prompt "
+            + "was given no parent window to open in. This is a fault in Performance Monitor itself "
+            + "rather than anything about the server or the account, and it should be reported.",
+
+        EntraBrokerFailureKind.BrokerUnavailable =>
+            "Microsoft Entra MFA sign-in could not start because the Windows account broker did not "
+            + "load on this machine. The server name, database and account are not implicated.",
+
+        EntraBrokerFailureKind.BrokerRejected =>
+            "The Windows account broker (Web Account Manager) handled this Microsoft Entra MFA "
+            + "sign-in and refused it. The server name, the database name and the account password "
+            + "are not what failed. Windows does not report the reason to applications, and the SQL "
+            + "client offers no way to sign in through a browser instead, so retrying as-is will "
+            + "fail the same way. Signing the Windows work-or-school account out and back in, or "
+            + "clearing the broker's cached state, is what usually clears it.",
+
+        _ => null,
+    };
+
+    private static bool Contains(string haystack, string needle) =>
+        haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+}


### PR DESCRIPTION
Adding an Azure SQL Database server with **Microsoft Entra MFA** can fail with a Windows account-broker error that the process records nowhere. `AddServerDialog.RunConnectionTestAsync` catches the exception, keeps `ex.Message`, and never calls `AppLogger` — there is no `AppLogger` reference in that file at all — so the dialog text is the only artefact the failure leaves behind. The reporter of #3196 hit exactly that, went looking for a log, and found neither the data directory nor a logs directory under it.

This does not fix the authentication failure. It cannot: see the mechanism below, and see the note about verification.

## What the driver actually does, and why there is no fallback to reach for

Read off `Microsoft.Data.SqlClient` 7.0.2, `Microsoft.Identity.Client` 4.84.2, `Microsoft.Identity.Client.Broker` 4.84.2 and `msalruntime` 0.20.6 — all four are what the lockfile resolves for Lite.

`ActiveDirectoryAuthenticationProviderOptions.UseWamBroker` looks like an opt-out and is not one. The provider computes:

```csharp
_useWamBroker = _applicationClientId == "2fd908ad-0664-4344-b9be-cd3e8b574c38" || options.UseWamBroker;
```

That GUID is the driver's own first-party Entra application id and it is the field's initializer, so an application that does not supply an `ApplicationClientId` — which is every caller of the parameterless `new ActiveDirectoryAuthenticationProvider()`, including `EntraInteractiveAuth` — pins the broker **on** and makes the flag inert. The driver's own doc comment agrees: *"When null, the SqlClient first-party application id is used and WAM broker mode is forced on (regardless of `UseWamBroker`)."*

MSAL falls back to a browser only when the broker is **unavailable** — `IsBrokerInstalledAndInvokable` returns false for an unsupported OS, a non-AAD authority, or a failed `msalruntime` init. An invoked broker that *returns an error* is propagated, not retried another way. So a broker refusal has no in-process remedy.

The broker's own explanation of why it refused is also unreachable. `msalruntime` redacts it to the literal string `Context: (pii)` unless PII is enabled, MSAL only enables it via `s_lazyCore.Value.EnablePii(_logger.PiiLoggingEnabled)`, and SqlClient's `CreateClientAppInstance` never calls `WithLogging`. There is no seam to turn it on from here.

What is left is the **stage** the handshake died at, which the error text does settle — and the stage is the difference between a bug in this application and a condition on the user's machine:

| Stage | Marker | Whose problem |
|---|---|---|
| `WindowHandleMissing` | `window_handle_required` | ours — `IntPtr.Zero` reached `WithParentActivityOrWindow` |
| `BrokerUnavailable` | `wam_runtime_init_failed` | the machine — `msalruntime` did not load |
| `BrokerRejected` | `unknown_broker_error`, `WAM_provider_error_*` | the Windows account side, past anything we control |

That table is also why **#2184 is not the defect here**. `RuntimeBroker.AcquireTokenInteractiveAsync` throws `window_handle_required` when `_parentHandle == IntPtr.Zero`, and the reported error is `unknown_broker_error` — so the handle was non-zero and #2184's plumbing is working. Two further checks agree: `v3.6.0` (the reported version) contains `EntraInteractiveAuth.cs`, and MSAL's `WithParentActivityOrWindowFunc` **invokes** the callback per `AcquireTokenInteractive` rather than capturing it at `Build()`, so a cached `IPublicClientApplication` cannot hand the broker a stale HWND.

## The change

`EntraBrokerFailure` (shared) classifies a failure by stage, walking the whole inner-exception chain — the driver wraps MSAL's exception, which wraps the broker's, and `Message` is the outermost layer only. Matching is on the rendered text rather than on a typed `MsalException`, so Lite is not pinned to whichever MSAL version the driver happens to carry; the codes travel in the text because SqlClient interpolates them as `Error code 0x<code>`.

`ConnectionFailureMessage` composes the dialog body: the driver's error first (it carries the codes a report needs), then what stage it came from, then the resolved log directory. The log location is in the dialog because a path like `%LOCALAPPDATA%\PerformanceMonitorLite-Data\logs` is not guessable from a dialog that does not name it.

`AddServerDialog` logs the exception through `AppLogger.Error`, which already walks the inner chain recursively — the call was simply missing. Cancellation is excluded: it is a decision the user made and has its own dialog, so logging it as an error would file user intent as a fault. The log line names the selected authentication mode, taken from the radio buttons rather than read back off the connection string, because the connection string holds a password.

`ServerManager.CheckServerConnectivity`'s `SqlException` arm now passes the exception rather than `ex.Message`, matching the generic arm beside it. That is the path a saved Entra MFA server hits on every collection cycle, and a `SqlException` is the shape this failure takes.

## Verification

**Not verified against a live Entra-MFA tenant.** It cannot be from here — reproducing an interactive Entra failure needs a real tenant and a Windows host, which is the same limit #2184 had (its fix was confirmed by that issue's reporter, not by CI). The classifier's doc comment says so in the file. What is verified is the mechanism, read off the four packages above, and the classification boundaries, pinned by 21 tests.

Every pin was red-proved by mutation, restored, and re-confirmed against a `Total: 21, Failed: 0, Not Run: 0` baseline:

| Mutation | Result |
|---|---|
| chain walk reduced to the outermost `Message` | Failed: 1 |
| refusal arm tested ahead of the handle arm | Failed: 1 |
| refusal marker loosened to the bare word `broker` | Failed: 2 (both Service Broker cases) |
| `Explain` returns null for `BrokerUnavailable` | Failed: 1 |
| `Compose` never appends the driver error | Failed: 4 |
| blank log directory renders a pointer to nowhere | Failed: 1 |
| the `AppLogger.Error` call deleted, its comment kept | Failed: 1 |

The last one needed its **instrument** mutated too. `ConnectionTest_WritesTheExceptionToTheLog` asserts a call site in source, because the `catch` lives in a WPF `Window` that behavioural coverage cannot reach — and the block carries a comment naming `AppLogger.Error`. With the call deleted and `CSharpSourceWalker.StripCommentsAndStrings` removed from the pin, the pin **passes**: Failed: 0. The strip is what makes it a check on code rather than on my own comment.

`Service Broker` is in the negative cases deliberately: SQL Server's own feature shares the word and nothing else, and a substring match on `broker` tells a user their Windows account is broken when a queue is disabled.

## SKU parity

Darling needs no equivalent. Its Viewer rejects Entra MFA outright at the credential step (`ServerStoreCredential.UnsupportedAuthMessage`, `AddServerDialog.xaml.cs:340` — *"no Darling service connect path"*), so there is no interactive-auth seam there to keep in parity. `EntraBrokerFailure` still lands in `PerformanceMonitor.Common` beside `MfaAuthenticationHelper`, which is where the existing Entra helper lives.

## Not done here

Two routes would actually unblock this user class, and both are product decisions rather than bug fixes:

- **Ship an own Entra application id.** Supplying any `ApplicationClientId` other than the driver's flips `UseWamBroker` to defaulting `false`, which moves the redirect URI to `http://localhost` and the flow to the system browser. It needs a registered multi-tenant Entra application, and a third-party client id may need the user's tenant admin to consent.
- **Offer a WAM-free Entra mode.** Lite's vocabulary is Windows / SQL Server / Entra MFA / service principal / managed identity, and the only interactive one is the broker path. `ActiveDirectoryDefault` returns from `AcquireTokenAsync` before any MSAL public-client application is built, so it never touches WAM at all — it runs `DefaultAzureCredential`, which picks up an `az login`. `ActiveDirectoryDeviceCodeFlow` also avoids the broker (MSAL's `DeviceCodeRequest` references it nowhere) and works with the driver's own client id, needing only a callback to show the code, since the driver's default writes it to a console this app does not have.

## CHANGELOG

Not edited, per lane convention. Entry text:

- **Adding an Entra MFA server could fail with a Windows broker error that was recorded nowhere** ([#3196]) - `AddServerDialog`'s connection test kept `ex.Message` and never called `AppLogger`, so a failed Entra MFA sign-in left a dialog and no log entry; the reporter of #3196 could not send anything but a screenshot. The failure is now classified by which stage of the WAM broker handshake it died at - the application not supplying a window handle, the broker runtime not loading, or the broker running and refusing - and the whole inner exception chain is logged, since the driver wraps MSAL's exception which wraps the broker's and `Message` is only the outermost layer. The dialog names the resolved log directory, because that path is not guessable from a dialog that does not print it. `ServerManager`'s `SqlException` arm passes the exception rather than its message, matching the generic arm beside it - that is the path a saved Entra MFA server takes on every collection cycle. **The authentication failure itself is not fixed and cannot be from here**: `Microsoft.Data.SqlClient` forces the WAM broker on for any caller using the driver's own Entra application id, `UseWamBroker` is inert in that configuration, MSAL falls back to a browser only when the broker is unavailable rather than when an invoked broker refuses, and the broker's stated reason is redacted to `Context: (pii)` with no seam to enable it. Unverified against a live Entra-MFA tenant, which is the only place this class can be confirmed
