### PR TITLE
Read the store's recorded size for the disk-pressure alert instead of walking the store on the serial loop (#3199)

### DIFF
--- a/Darling/Darling.Tests/AlertReadFailureSurfaceTests.cs
+++ b/Darling/Darling.Tests/AlertReadFailureSurfaceTests.cs
@@ -426,7 +426,7 @@ public sealed class AlertReadFailureSurfaceTests
         ["Failed to record resolution"] = "an audit-row write",
         ["Could not record Postgres alert resolution"] = "a history write",
         ["could not read the store volume free space"] = "a local filesystem read, not a store read",
-        ["could not read pg_database_size"] = "context for the alert text, not the evidence the alert is judged on",
+        ["could not read the recorded store size"] = "context for the alert text, not the evidence the alert is judged on",
         ["Store self-metrics sweep did not finish"] = "a metrics write sweep; no alert is judged on its result",
         ["Store log capture failed"] = "a telemetry write sweep (#3021); no alert is judged on its result, and the capture gap it leaves is reported by get_store_log's own denominator",
         ["Recently-failed-job check errored"] = "reads the monitored server's msdb on its own connection and timeout",

--- a/Darling/Darling.Tests/SerialLoopStoreSizeSourceTests.cs
+++ b/Darling/Darling.Tests/SerialLoopStoreSizeSourceTests.cs
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3199. The store disk-pressure check ran <c>SELECT pg_database_size(current_database())</c> every five
+/// minutes on the collection loop's serial thread, under
+/// <see cref="ServiceCommandDeadlines.SerialLoopSeconds"/> = 5 s. That bound's derivation floored it on
+/// <b>6.2 ms measured against a 4.05 GB store</b>. <c>pg_database_size</c> stats every file in the database
+/// directory, so its cost follows the store: on a 225 GiB production store — 56x the fixture — the same call
+/// measured <b>3,177 ms</b>, 512x the time, leaving 1.57x headroom where the derivation claimed ~806x. The
+/// visible symptom was cancelled statements in the store's own PostgreSQL log; the larger cost was every
+/// iteration that finished under 5 s, logged nothing, and still spent seconds of the whole fleet's cycle.
+///
+/// <para><b>What these tests defend is a CATEGORY, not that one instance.</b> The value 5 is not wrong and
+/// is not changed here — what was wrong is that a regime floored on millisecond reads had acquired a member
+/// whose cost grows with the store, and nothing noticed. <see cref="StartupCommandTimeoutTests"/> counts
+/// DEADLINES, so it passed throughout and would pass again the moment a size-scaling read came back. So the
+/// invariant asserted here is that <b>no command on the serial loop runs a read whose cost scales with the
+/// store</b>, and it is asserted over the population that pin already owns rather than over a hand-copied
+/// list of it.</para>
+///
+/// <para><b>Each test states the scope it is total over</b>, because two of them are source scans and a
+/// source scan's blind spot is the whole question:
+/// <list type="bullet">
+/// <item><see cref="TheDiskCheckExecutesTheRecordedSizeConstant"/> — total for the one member that reads
+/// its SQL from another type: it pins the reference in source AND the referent's shipped value at
+/// runtime, so neither a retyped copy nor a changed constant can slip past.</item>
+/// <item><see cref="NoSerialLoopMemberInlinesAStoreScalingRead"/> — total for SQL written INLINE in any of
+/// the ten members. A member that referenced a size-scaling constant declared elsewhere would not match,
+/// which is what the tree census below is for.</item>
+/// <item><see cref="PgDatabaseSizeRunsOnlyWhereItsCostHasABudget"/> — total for
+/// <c>pg_database_size</c> anywhere in shipped source, wherever the string lives, so no indirection
+/// evades it. Narrower in function coverage, wider in reach; the two overlap deliberately.</item>
+/// </list></para>
+/// </summary>
+public sealed class SerialLoopStoreSizeSourceTests
+{
+    /// <summary>
+    /// Reads whose cost is a function of the STORE rather than of the row they return — every one of them
+    /// walks files or per-relation metadata. This is the family, not just the instance that failed:
+    /// <c>pg_total_relation_size</c> over the payload dimensions and <c>hypertable_detailed_size</c> across
+    /// every hypertable are the two the self-metrics sweep needed a 300 s budget for (#2317), which is the
+    /// direct evidence that these belong nowhere near a 5 s bound.
+    /// </summary>
+    private static readonly Regex s_storeScalingRead = new(
+        @"\b(?:pg_database_size|pg_total_relation_size|pg_table_size|pg_relation_size|pg_indexes_size"
+        + @"|hypertable_detailed_size|hypertable_local_size|hypertable_size|chunk_compression_stats"
+        + @"|hypertable_approximate_size)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Where <c>pg_database_size</c> is allowed to appear in shipped source, and the reason each one is
+    /// allowed to pay for a store-wide walk. Keyed by the file that owns the statement.
+    ///
+    /// <para>The reasons are the assertion, not decoration — a third entry appearing means someone put a
+    /// store-wide walk somewhere new, and the failure message hands them these two so they have to say
+    /// which regime theirs is in.</para>
+    /// </summary>
+    private static readonly (string Relative, int Occurrences, string Why)[] s_pgDatabaseSizeOwners =
+    {
+        (Path.Combine("Darling", "PerformanceMonitor.Darling.Storage", "StoreSelfMetrics.cs"), 1,
+            "the hourly self-metrics sweep's whole-store row — StoreSelfMetrics.SweepTimeoutSeconds is "
+            + "300s, ~94x the 3,177ms measured on a 225GiB store, and #2317 sized it against a production "
+            + "store's own sizing queries rather than a fixture"),
+
+        (Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.ServerStatus.cs"), 1,
+            "the Viewer status bar's Database field — interactive, user-initiated, on the viewer's own "
+            + "fan-out deadline, and nothing waits behind it but the operator who asked"),
+    };
+
+    /// <summary>
+    /// Shipped source: every <c>.cs</c> under the product projects, excluding tests, the deprecated
+    /// suites, the scratch tools and build output. Deliberately the WHOLE product rather than the three
+    /// Darling projects — a store-wide walk introduced in a shared collector or in Lite would be the same
+    /// defect, and scoping the census to where the defect happened to be found is how a census stops
+    /// covering the thing it is named for.
+    /// </summary>
+    private static IEnumerable<string> ShippedSources()
+    {
+        var root = RepoRoot();
+
+        var projects = new[]
+        {
+            Path.Combine(root, "Darling", "PerformanceMonitor.Darling.Service"),
+            Path.Combine(root, "Darling", "PerformanceMonitor.Darling.Storage"),
+            Path.Combine(root, "Darling", "PerformanceMonitor.Darling.Viewer"),
+            Path.Combine(root, "Darling", "PerformanceMonitor.Darling.Analysis"),
+            Path.Combine(root, "Lite"),
+            Path.Combine(root, "PerformanceMonitor.Alerting"),
+            Path.Combine(root, "PerformanceMonitor.Analysis"),
+            Path.Combine(root, "PerformanceMonitor.Collectors"),
+            Path.Combine(root, "PerformanceMonitor.Common"),
+            Path.Combine(root, "PerformanceMonitor.Notifications"),
+            Path.Combine(root, "PerformanceMonitor.PlanAnalysis"),
+            Path.Combine(root, "PerformanceMonitor.Ui"),
+        };
+
+        foreach (var project in projects)
+        {
+            /* A moved or renamed project must fail loudly rather than silently shrinking the census to the
+               directories that still resolve — an empty sweep is how a source scan starts reporting clean. */
+            Assert.True(Directory.Exists(project), $"shipped project directory not found: {project}");
+
+            foreach (var file in Directory.EnumerateFiles(project, "*.cs", SearchOption.AllDirectories))
+            {
+                var segments = file.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+                if (segments.Contains("bin") || segments.Contains("obj"))
+                {
+                    continue;
+                }
+
+                yield return file;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Every string literal in <paramref name="source"/>, joined — so a scan sees the SQL the code actually
+    /// sends and CANNOT see an explanatory comment about it.
+    ///
+    /// <para>The direction matters here more than in most of these pins. This file's own subject is
+    /// discussed at length in comments right beside the code — the worker's doc comment names
+    /// <c>pg_database_size</c> four times explaining why it no longer runs it — so a scan over raw source
+    /// would report the fixed code as the defect. Stripping in the other direction is just as wrong:
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> removes the literals, which is where every
+    /// query lives. Literal bodies only is the one reading that answers the question asked.</para>
+    /// </summary>
+    private static string LiteralsOf(string source) =>
+        string.Join("\n", CSharpSourceWalker.StringLiteralBodies(source).Select(l => l.Text));
+
+    /// <summary>
+    /// The one member that reads its SQL from another type, pinned twice: the source says it references
+    /// <see cref="StoreSelfMetrics.LatestStoreSizeSql"/>, and the shipped constant itself says what that
+    /// resolves to.
+    ///
+    /// <para>Both halves are load-bearing. Without the source half the member could go back to an inline
+    /// literal and the constant would still read clean. Without the runtime half the constant could be
+    /// changed to walk the store and the reference would still read clean. This is the "run the shipped
+    /// string, not a retyped copy" rule applied to a pin instead of to a probe.</para>
+    /// </summary>
+    [Fact]
+    public void TheDiskCheckExecutesTheRecordedSizeConstant()
+    {
+        var body = StartupCommandTimeoutTests.SerialLoopMemberBody(
+            "DarlingWorker.cs", "ReadStoreSizeBytesAsync");
+        var code = CSharpSourceWalker.StripCommentsAndStrings(body);
+
+        Assert.Contains("StoreSelfMetrics.LatestStoreSizeSql", code, StringComparison.Ordinal);
+
+        /* And the deadline regime is unchanged — this member is still one of the ten, so the chain
+           arithmetic StartupCommandTimeoutTests defends still describes the same population. Asserted here
+           too because the fix would look equally "done" if the site had been moved out of the regime
+           instead, and that is a different change with a different justification. */
+        Assert.Contains(
+            "CommandTimeout = ServiceCommandDeadlines.SerialLoopSeconds",
+            code,
+            StringComparison.Ordinal);
+
+        /* The referent, at runtime. */
+        var sql = StoreSelfMetrics.LatestStoreSizeSql;
+
+        Assert.False(
+            s_storeScalingRead.IsMatch(sql),
+            "StoreSelfMetrics.LatestStoreSizeSql runs a read whose cost scales with the store, on the "
+            + "collection loop's serial thread under a 5s bound floored on millisecond reads — the #3199 "
+            + $"defect, from the other side: {sql}");
+
+        Assert.Contains("collect.store_metrics", sql, StringComparison.Ordinal);
+
+        /* Bounded and ordered, so "newest" is a property of the query rather than of whatever order the
+           heap happened to be in. A LIMIT-less version returns every whole-store row ever recorded — 737
+           over 30 days on the dogfood store, ~9,600 at the 400-day horizon — and ExecuteScalarAsync would
+           silently take the first, which is the OLDEST under an ascending scan. Correct-looking, wrong
+           value, no error. */
+        Assert.Contains("ORDER BY metric_time DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The category invariant, over the ten members
+    /// <see cref="ServiceCommandDeadlines.SerialLoopSeconds"/> bounds: none of them may INLINE a read whose
+    /// cost scales with the store.
+    ///
+    /// <para>The population is projected from <see cref="StartupCommandTimeoutTests.SerialLoopMembers"/>
+    /// rather than re-listed, so this pin cannot end up asserting over nine members while that one counts
+    /// ten. It also inherits that helper's loud failure when a member is renamed or gains an
+    /// overload.</para>
+    /// </summary>
+    [Fact]
+    public void NoSerialLoopMemberInlinesAStoreScalingRead()
+    {
+        var offenders = new List<string>();
+        var members = 0;
+        var sites = 0;
+
+        foreach (var (file, member, memberSites) in StartupCommandTimeoutTests.SerialLoopMembers)
+        {
+            var literals = LiteralsOf(StartupCommandTimeoutTests.SerialLoopMemberBody(file, member));
+            members++;
+            sites += memberSites;
+
+            foreach (Match hit in s_storeScalingRead.Matches(literals))
+            {
+                offenders.Add($"{file} {member}: {hit.Value.TrimEnd('(')}");
+            }
+        }
+
+        /* The scan having covered the WHOLE regime, before its result is believed. A projection that came
+           back empty — or short by a member — would make the assertion below pass by scanning less than it
+           claims, which is the failure this file exists to make impossible for the deadline census.
+           Asserted as the site TOTAL rather than as a member count, and tied back to the census's own
+           independently-asserted number instead of to a literal: nine members hold the ten commands, so a
+           count of members is arithmetic nobody can check by eye. */
+        Assert.Equal(StartupCommandTimeoutTests.ExpectedSerialLoopSites, sites);
+        Assert.True(members > 0, "the serial-loop member projection came back empty");
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} command(s) awaited inline on the collection loop's serial thread run a read "
+            + "whose cost scales with the store, under ServiceCommandDeadlines.SerialLoopSeconds — a bound "
+            + "floored on 16.1ms for five config reads together. #3199 is what that costs: pg_database_size "
+            + "measured 6.2ms on the 4.05GB fixture the bound was sized against and 3,177ms on a 225GiB "
+            + "production store, so the whole fleet's cycle waited seconds behind it every five minutes. "
+            + "Such a read belongs on a cadence with its own budget: "
+            + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// <c>pg_database_size</c> tree-wide, wherever the string lives, against the two owners that have a
+    /// budget for it. This is the half that no indirection evades — a member referencing a constant in
+    /// another file is invisible to
+    /// <see cref="NoSerialLoopMemberInlinesAStoreScalingRead"/> and counted here.
+    ///
+    /// <para>The count is a REVIEW GATE rather than a fact worth knowing: a third occurrence fails the
+    /// build and the message hands the author the two existing regimes so they have to say which one
+    /// theirs is. It fails on a removal too, which is the right direction to be noisy in — losing the
+    /// series' own size row would silently blank the disk-pressure alert's only size number.</para>
+    /// </summary>
+    [Fact]
+    public void PgDatabaseSizeRunsOnlyWhereItsCostHasABudget()
+    {
+        var byFile = new Dictionary<string, int>(StringComparer.Ordinal);
+        var scanned = 0;
+        var root = RepoRoot();
+
+        foreach (var path in ShippedSources())
+        {
+            scanned++;
+            var hits = Regex.Matches(
+                LiteralsOf(File.ReadAllText(path)),
+                @"\bpg_database_size\s*\(",
+                RegexOptions.CultureInvariant).Count;
+
+            if (hits > 0)
+            {
+                byFile[Path.GetRelativePath(root, path)] = hits;
+            }
+        }
+
+        /* The census having covered the product, before its emptiness means anything. */
+        Assert.True(
+            scanned > 500,
+            $"the shipped-source census only reached {scanned} files, so an empty result says nothing "
+            + "about where pg_database_size runs");
+
+        var expected = s_pgDatabaseSizeOwners.ToDictionary(
+            o => o.Relative, o => o.Occurrences, StringComparer.Ordinal);
+
+        var unexpected = byFile.Keys.Where(f => !expected.ContainsKey(f)).ToList();
+
+        /* Unexpected owners BEFORE the totals, so a genuinely new store-wide walk reports as itself rather
+           than as an off-by-one on a count that says nothing about where it is. */
+        Assert.True(
+            unexpected.Count == 0,
+            $"{unexpected.Count} file(s) run pg_database_size, which walks every file in the store "
+            + "(measured 3,177ms on a 225GiB store, and it tracks file count rather than bytes). The two "
+            + "places that may pay for it, and why, are: "
+            + string.Join("; ", s_pgDatabaseSizeOwners.Select(o => $"{o.Relative} — {o.Why}"))
+            + ". Say which regime yours is in, or read the recorded value from "
+            + "StoreSelfMetrics.LatestStoreSizeSql instead: " + string.Join(", ", unexpected));
+
+        foreach (var (relative, occurrences, why) in s_pgDatabaseSizeOwners)
+        {
+            Assert.True(
+                byFile.TryGetValue(relative, out var actual) && actual == occurrences,
+                $"{relative} was expected to run pg_database_size {occurrences}x ({why}) but runs it "
+                + $"{(byFile.TryGetValue(relative, out var got) ? got : 0)}x");
+        }
+    }
+
+    /// <summary>
+    /// The reader and the writer cannot disagree about which row is the whole-store row.
+    ///
+    /// <para>This is the honest-empty trap on a value the shipped store already holds 400 days of: a
+    /// reader filtering on a kind the writer stopped writing gets ZERO ROWS, not an error, and
+    /// <c>ExecuteScalarAsync</c> renders that as the same null a store that has never swept produces. The
+    /// alert text would quietly lose its size number and nothing anywhere would say why. So the kind is
+    /// one const with six consumers, and its VALUE is part of the on-disk contract — renaming it orphans
+    /// every recorded row.</para>
+    /// </summary>
+    [Fact]
+    public void TheRecordedSizeReaderAndWriterCannotDisagreeAboutTheKind()
+    {
+        Assert.Equal("store", StoreSelfMetrics.StoreObjectKind);
+
+        var quoted = $"'{StoreSelfMetrics.StoreObjectKind}'";
+
+        Assert.Contains(quoted, StoreSelfMetrics.StoreInsertSql, StringComparison.Ordinal);
+        Assert.Contains(quoted, StoreSelfMetrics.LatestStoreSizeSql, StringComparison.Ordinal);
+
+        /* And the four C# consumers partition their response on the same const rather than on a retyped
+           copy of its value. Scanned over stripped source so a "store" written in a comment cannot
+           satisfy it, and asserted as an ABSENCE of the bare literal — because the presence of the const
+           somewhere in the file would be satisfied by one call site while three others drifted. */
+        var toolsPath = Path.Combine(
+            RepoRoot(), "Darling", "PerformanceMonitor.Darling.Service", "Mcp",
+            "DarlingMcpStoreMetricsTools.cs");
+        Assert.True(File.Exists(toolsPath), $"store-metrics MCP tool source not found: {toolsPath}");
+
+        var toolsCode = CSharpSourceWalker.StripCommentsAndStrings(File.ReadAllText(toolsPath));
+
+        Assert.DoesNotContain(
+            "ObjectKind == \"", toolsCode, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "ObjectKind != \"", toolsCode, StringComparison.Ordinal);
+        Assert.Contains(
+            "StoreSelfMetrics.StoreObjectKind", toolsCode, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The positive controls, run through the IDENTICAL scan the three tests above use. Without these,
+    /// every one of them could match nothing and report clean — which is precisely how the deadline census
+    /// stayed green across the whole life of this defect.
+    ///
+    /// <para>The two fixtures are the two directions this scan can be wrong in, and both have occurred in
+    /// this repo: SQL in a literal must be SEEN (a scan over stripped source misses every query), and the
+    /// same function named in a comment must NOT be (a scan over raw source reports the fix as the
+    /// defect — and this change's own doc comments name <c>pg_database_size</c> six times).</para>
+    /// </summary>
+    [Theory]
+    [InlineData("var sql = \"SELECT pg_database_size(current_database())\";\n", true)]
+    [InlineData("var sql = @\"SELECT sum(pg_total_relation_size(c.oid)) FROM pg_class c\";\n", true)]
+    [InlineData("var sql = $@\"SELECT hypertable_detailed_size('{name}'::regclass)\";\n", true)]
+    [InlineData("/* This deliberately does NOT call pg_database_size(current_database()). */\n", false)]
+    [InlineData("/// <summary>Why pg_total_relation_size(oid) is not used here.</summary>\n", false)]
+    [InlineData("var sql = \"SELECT total_bytes FROM collect.store_metrics ORDER BY metric_time DESC\";\n", false)]
+    public void TheScanner_ReadsQueriesAndNotProseAboutThem(string source, bool expectedHit)
+    {
+        Assert.Equal(expectedHit, s_storeScalingRead.IsMatch(LiteralsOf(source)));
+    }
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+
+        while (dir is not null
+               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
+               && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.False(
+            dir is null,
+            "could not locate the repository root from " + thisFile);
+
+        return dir!;
+    }
+}

--- a/Darling/Darling.Tests/SerialLoopStoreSizeSourceTests.cs
+++ b/Darling/Darling.Tests/SerialLoopStoreSizeSourceTests.cs
@@ -325,23 +325,67 @@ public sealed class SerialLoopStoreSizeSourceTests
         Assert.Contains(quoted, StoreSelfMetrics.StoreInsertSql, StringComparison.Ordinal);
         Assert.Contains(quoted, StoreSelfMetrics.LatestStoreSizeSql, StringComparison.Ordinal);
 
-        /* And the four C# consumers partition their response on the same const rather than on a retyped
-           copy of its value. Scanned over stripped source so a "store" written in a comment cannot
-           satisfy it, and asserted as an ABSENCE of the bare literal — because the presence of the const
-           somewhere in the file would be satisfied by one call site while three others drifted. */
+        /* And the C# consumers partition their response on the same const rather than on a retyped copy
+           of its value.
+
+           The first draft of this asserted DoesNotContain("ObjectKind == \"") over STRIPPED source, and a
+           mutation restoring a bare literal came back green: stripping blanks the literal INCLUDING its
+           opening quote, so that pattern cannot appear in stripped source at all and the assertion could
+           not fail. Asserting a pattern that the transform it reads has already removed is a pin that
+           passes on every input — which is why the mutation table below has a row for the instrument and
+           not only for the subject.
+
+           What replaces it asserts the invariant directly: EVERY ObjectKind comparison in the file has the
+           const on its right-hand side. Over stripped source a comparison against a literal reads as
+           "==" followed by blanks, so the next code token is not the const and the site is reported. */
         var toolsPath = Path.Combine(
             RepoRoot(), "Darling", "PerformanceMonitor.Darling.Service", "Mcp",
             "DarlingMcpStoreMetricsTools.cs");
         Assert.True(File.Exists(toolsPath), $"store-metrics MCP tool source not found: {toolsPath}");
 
-        var toolsCode = CSharpSourceWalker.StripCommentsAndStrings(File.ReadAllText(toolsPath));
+        var toolsRaw = File.ReadAllText(toolsPath);
+        var (compared, literal) = ObjectKindComparisons(toolsRaw);
 
-        Assert.DoesNotContain(
-            "ObjectKind == \"", toolsCode, StringComparison.Ordinal);
-        Assert.DoesNotContain(
-            "ObjectKind != \"", toolsCode, StringComparison.Ordinal);
-        Assert.Contains(
-            "StoreSelfMetrics.StoreObjectKind", toolsCode, StringComparison.Ordinal);
+        Assert.True(
+            compared > 0,
+            "no ObjectKind comparison found in DarlingMcpStoreMetricsTools.cs — the scan this assertion "
+            + "rests on matched nothing, so its result says nothing");
+
+        Assert.True(
+            literal.Count == 0,
+            $"{literal.Count} ObjectKind comparison(s) in DarlingMcpStoreMetricsTools.cs compare against "
+            + "something other than StoreSelfMetrics.StoreObjectKind. The kind is one const with six "
+            + "consumers because a reader filtering on a kind the writer stopped writing returns zero "
+            + $"rows rather than erroring: {string.Join(", ", literal)}");
+    }
+
+    /// <summary>
+    /// Every <c>.ObjectKind ==</c> / <c>!=</c> comparison in <paramref name="source"/>: how many there are,
+    /// and the ones whose right-hand side is not
+    /// <see cref="StoreSelfMetrics.StoreObjectKind"/>. Read over STRIPPED source, where a literal
+    /// right-hand side survives as blanks — so the next code token after the operator is not the const,
+    /// and the site is reported.
+    /// </summary>
+    private static (int Compared, List<string> NotTheConst) ObjectKindComparisons(string source)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var offenders = new List<string>();
+        var compared = 0;
+
+        foreach (Match m in Regex.Matches(
+            code, @"\.ObjectKind\s*[!=]=\s*", RegexOptions.CultureInvariant))
+        {
+            compared++;
+            var rest = code[(m.Index + m.Length)..];
+
+            if (!rest.TrimStart().StartsWith("StoreSelfMetrics.StoreObjectKind", StringComparison.Ordinal))
+            {
+                var line = code.Take(m.Index).Count(c => c == '\n') + 1;
+                offenders.Add($"line {line}");
+            }
+        }
+
+        return (compared, offenders);
     }
 
     /// <summary>
@@ -364,6 +408,33 @@ public sealed class SerialLoopStoreSizeSourceTests
     public void TheScanner_ReadsQueriesAndNotProseAboutThem(string source, bool expectedHit)
     {
         Assert.Equal(expectedHit, s_storeScalingRead.IsMatch(LiteralsOf(source)));
+    }
+
+    /// <summary>
+    /// The positive control for <see cref="ObjectKindComparisons"/>, and it exists because its predecessor
+    /// had none and was therefore unfalsifiable — a mutation restoring a bare <c>"store"</c> literal to one
+    /// of the four call sites came back GREEN, because the pattern being asserted absent had already been
+    /// removed by the transform the assertion read.
+    ///
+    /// <para>Both counts are asserted, not just the offender count. A scan that found no comparisons at all
+    /// would report zero offenders and read exactly like a clean file, which is the same failure one layer
+    /// down. The third and fourth fixtures are the mutation that got through; the fifth is the other
+    /// direction, where the retired form written in a COMMENT must not be reported.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("if (r.ObjectKind == StoreSelfMetrics.StoreObjectKind) { }\n", 1, 0)]
+    [InlineData("if (p.ObjectKind != StoreSelfMetrics.StoreObjectKind) { }\n", 1, 0)]
+    [InlineData("if (r.ObjectKind == \"store\") { }\n", 1, 1)]
+    [InlineData("if (r.ObjectKind != \"store\") { }\n", 1, 1)]
+    [InlineData("/* r.ObjectKind == \"store\" is what this used to do. */\n", 0, 0)]
+    [InlineData("var storeLatest = latest.FirstOrDefault();\n", 0, 0)]
+    public void TheObjectKindScanner_SeesALiteralRightHandSide(
+        string source, int expectedCompared, int expectedOffenders)
+    {
+        var (compared, offenders) = ObjectKindComparisons(source);
+
+        Assert.Equal(expectedCompared, compared);
+        Assert.Equal(expectedOffenders, offenders.Count);
     }
 
     private static string RepoRoot([CallerFilePath] string thisFile = "")

--- a/Darling/Darling.Tests/SerialLoopStoreSizeSourceTests.cs
+++ b/Darling/Darling.Tests/SerialLoopStoreSizeSourceTests.cs
@@ -146,6 +146,23 @@ public sealed class SerialLoopStoreSizeSourceTests
         string.Join("\n", CSharpSourceWalker.StringLiteralBodies(source).Select(l => l.Text));
 
     /// <summary>
+    /// The store-scaling reads one member's body sends, labelled. Extracted so
+    /// <see cref="NoSerialLoopMemberInlinesAStoreScalingRead"/> and its positive control run the SAME code
+    /// over the real population and over a planted body.
+    ///
+    /// <para>That is not tidiness. The first form inlined this loop, and deleting its one recording
+    /// statement left the whole suite green: a negative census over a population that (correctly) contains
+    /// nothing never executes its own loop body, so nothing observes whether that body works. Sharing the
+    /// scan with a fixture that DOES contain something is what makes the absence mean anything —
+    /// <c>StartupCommandTimeoutTests.TheExclusionScan_CanSeeABootstrapStamp</c> is the same construction
+    /// for the same reason.</para>
+    /// </summary>
+    private static List<string> ScanForStoreScalingReads(string label, string body) =>
+        s_storeScalingRead.Matches(LiteralsOf(body))
+            .Select(hit => $"{label}: {hit.Value.TrimEnd('(')}")
+            .ToList();
+
+    /// <summary>
     /// The one member that reads its SQL from another type, pinned twice: the source says it references
     /// <see cref="StoreSelfMetrics.LatestStoreSizeSql"/>, and the shipped constant itself says what that
     /// resolves to.
@@ -212,14 +229,11 @@ public sealed class SerialLoopStoreSizeSourceTests
 
         foreach (var (file, member, memberSites) in StartupCommandTimeoutTests.SerialLoopMembers)
         {
-            var literals = LiteralsOf(StartupCommandTimeoutTests.SerialLoopMemberBody(file, member));
             members++;
             sites += memberSites;
-
-            foreach (Match hit in s_storeScalingRead.Matches(literals))
-            {
-                offenders.Add($"{file} {member}: {hit.Value.TrimEnd('(')}");
-            }
+            offenders.AddRange(ScanForStoreScalingReads(
+                $"{file} {member}",
+                StartupCommandTimeoutTests.SerialLoopMemberBody(file, member)));
         }
 
         /* The scan having covered the WHOLE regime, before its result is believed. A projection that came
@@ -386,6 +400,44 @@ public sealed class SerialLoopStoreSizeSourceTests
         }
 
         return (compared, offenders);
+    }
+
+    /// <summary>
+    /// <see cref="NoSerialLoopMemberInlinesAStoreScalingRead"/>'s own control: the same
+    /// <see cref="ScanForStoreScalingReads"/> call, over a body written the way the defect was actually
+    /// written — the shape <c>ReadStoreSizeBytesAsync</c> had before this change, comment and all.
+    ///
+    /// <para>Without this the census is an assertion that happens to hold. Its population correctly
+    /// contains no store-scaling read, so its loop body never runs on the real tree, and a mutation
+    /// deleting the recording statement left the whole suite green — measured, not assumed. The label is
+    /// asserted too, because an offender list that reports the finding without saying WHERE sends the next
+    /// person to the wrong file.</para>
+    /// </summary>
+    [Fact]
+    public void TheMemberScan_ReportsAPlantedStoreScalingRead()
+    {
+        const string planted = """
+            private async Task<long?> ReadStoreSizeBytesAsync(CancellationToken cancellationToken)
+            {
+                /* Context for the alert text; pg_database_size is cheap. */
+                using var command = new NpgsqlCommand("SELECT pg_database_size(current_database())", connection)
+                    { CommandTimeout = ServiceCommandDeadlines.SerialLoopSeconds };
+                return (long?)await command.ExecuteScalarAsync(cancellationToken);
+            }
+            """;
+
+        var offenders = ScanForStoreScalingReads("DarlingWorker.cs ReadStoreSizeBytesAsync", planted);
+
+        Assert.Single(offenders);
+        Assert.Contains("ReadStoreSizeBytesAsync", offenders[0], StringComparison.Ordinal);
+        Assert.Contains("pg_database_size", offenders[0], StringComparison.Ordinal);
+
+        /* And the clean shape reports nothing, so the control is not simply "always reports". */
+        Assert.Empty(ScanForStoreScalingReads(
+            "clean",
+            """
+            using var command = new NpgsqlCommand(StoreSelfMetrics.LatestStoreSizeSql, connection);
+            """));
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/SerialLoopStoreSizeSourceTests.cs
+++ b/Darling/Darling.Tests/SerialLoopStoreSizeSourceTests.cs
@@ -288,7 +288,15 @@ public sealed class SerialLoopStoreSizeSourceTests
             }
         }
 
-        /* The census having covered the product, before its emptiness means anything. */
+        /* The census having covered the product, before its emptiness means anything — and the two guards
+           on that cover DIFFERENT failures, which is worth saying because this floor alone would not do it.
+           A project REMOVED or RENAMED is caught by name in ShippedSources()'s per-project
+           Assert.True(Directory.Exists(...)), loudly and without a threshold. This floor is only a belt
+           against the enumeration itself producing nothing — a glob that matches no files, a base directory
+           that resolves somewhere empty — which is a failure the per-project check cannot see. It is
+           deliberately far below the ~1,050 files the tree actually holds, because a count anywhere near
+           that would fail on ordinary file churn and buy nothing the existence check does not already
+           give. */
         Assert.True(
             scanned > 500,
             $"the shipped-source census only reached {scanned} files, so an empty result says nothing "

--- a/Darling/Darling.Tests/StartupCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/StartupCommandTimeoutTests.cs
@@ -96,7 +96,10 @@ public sealed class StartupCommandTimeoutTests
     /// dual-caller site's two bounds has to win, and it is not this one.</para>
     ///
     /// <para><c>DarlingWorker.ReadStoreSizeBytesAsync</c> runs on the same serial loop thread on the
-    /// 5-minute <c>s_diskCheckInterval</c> and fails to null at Debug. <c>ReadLatestCpuAsync</c> belongs
+    /// 5-minute <c>s_diskCheckInterval</c> and fails to null at Debug. Its statement is the newest-row
+    /// <c>collect.store_metrics</c> lookup and NOT <c>pg_database_size</c> — asserted by
+    /// <see cref="SerialLoopStoreSizeSourceTests"/>, because this census counts deadlines and would pass
+    /// unchanged if the statement went back to walking the store (#3199). <c>ReadLatestCpuAsync</c> belongs
     /// to #2882's alert pass (10 s), a site that pin's file-scoped list missed.
     /// <c>DarlingObservability.LogRetentionRunAsync</c> WAS the last unowned site in these two files —
     /// group E's audit listed it as residue — and the token test puts it in the serial-loop regime rather
@@ -157,7 +160,34 @@ public sealed class StartupCommandTimeoutTests
 
     private const int ExpectedConnectProbeSites = 2;
 
-    private const int ExpectedSerialLoopSites = 10;
+    internal const int ExpectedSerialLoopSites = 10;
+
+    /// <summary>
+    /// The serial-loop regime's members, projected out of the census above so a second pin over the same
+    /// population cannot freeze a stale copy of it.
+    ///
+    /// <para>Read by <see cref="SerialLoopStoreSizeSourceTests"/>, which asserts a property of what these
+    /// members RUN rather than of the deadline they set. Exposed as a projection rather than as a second
+    /// list because a hand-copied enumeration of ten members is a counted claim with a numeral welded on:
+    /// it would keep passing over nine of them after the tenth moved, and the pin's message would name the
+    /// wrong population. The per-member SITE COUNT travels with it for the same reason: nine members
+    /// hold the regime's ten commands (<c>SyncServerEnabledStatesAsync</c> builds two), so a consumer
+    /// counting members would silently disagree with <see cref="ExpectedSerialLoopSites"/> and could
+    /// not tell a dropped member from that arithmetic.</para>
+    /// </summary>
+    internal static IEnumerable<(string File, string Member, int Sites)> SerialLoopMembers =>
+        s_startupMembers.Where(m => m.SerialLoop > 0).Select(m => (m.File, m.Member, m.SerialLoop));
+
+    /// <summary>
+    /// One serial-loop member's body as written, resolved and brace-matched through the SAME helpers the
+    /// census uses — so a sibling pin cannot disagree with this file about where a member begins and ends,
+    /// and inherits the loud failure when a member is renamed or overloaded.
+    /// </summary>
+    internal static string SerialLoopMemberBody(string file, string member)
+    {
+        var path = SourcePath(file);
+        return MemberBody(File.ReadAllText(path), member, path);
+    }
 
     /// <summary>
     /// Members whose command sites must NOT carry either bootstrap deadline — the exclusions above,
@@ -435,7 +465,8 @@ public sealed class StartupCommandTimeoutTests
             seconds >= 2,
             $"serial-loop deadline {seconds}s leaves too little over the measured cold worst case — "
             + "LoadViewAsync's five commands at 16.1 ms together, SyncServerEnabledStatesAsync's two at "
-            + "3.8 ms, pg_database_size at 6.2 ms — on a thread whose reload body silently LOSES an "
+            + "3.8 ms, and the disk check's newest-row store_metrics lookup — on a thread whose reload "
+            + "body silently LOSES an "
             + "operator's config change if it fires, because the beacon advances _lastConfigVersion "
             + "before the reload runs");
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -46,7 +46,7 @@ namespace PerformanceMonitor.Darling.Service;
 ///   Dashboard's #1086 "Capture Down", <c>NocHealth.GetMissingCaptureSessionsAsync</c>).</item>
 /// <item><b>Store Disk Pressure</b> — the volume hosting the Darling store is nearly full. Unlike the
 ///   other three (per monitored server), this is a FLEET-level condition polled once per sweep from the
-///   store itself (<c>pg_database_size</c> for context) and the store volume's free space: when a headless
+///   store itself (its last recorded size, for context) and the store volume's free space: when a headless
 ///   service's disk fills, collection and every write stop for the WHOLE fleet, and nobody is watching. The
 ///   flagship-appropriate maintenance backstop the daily time-based purge otherwise lacks — deliberately
 ///   NOT Lite's 512MB archive-then-reset (Postgres has no single-file INSERT cliff, and a blanket reset
@@ -1429,8 +1429,10 @@ internal sealed class DarlingSelfAlertEvaluator
     /// Resolved" history row on recovery (mirrors the per-server conditions' edge shape). Gated on the master
     /// alerts switch. NO-OPS when free/total are null — a remote BYO store whose volume the service can't see —
     /// so it never false-alarms; the managed store's own volume is what it exists to protect.
-    /// <paramref name="storeSizeBytes"/> (pg_database_size) is context for the alert text only, never the
-    /// trigger. Internal (tested directly, like the sibling Apply methods); the worker calls the isolating
+    /// <paramref name="storeSizeBytes"/> is the last size the hourly self-metrics sweep recorded — context
+    /// for the alert text only, never the trigger, which is why the sentence it renders names the sample
+    /// rather than claiming the current byte count (#3199).
+    /// Internal (tested directly, like the sibling Apply methods); the worker calls the isolating
     /// <see cref="EvaluateDiskPressureAsync"/>. Testable directly with a recording deliverer + a controllable clock.
     /// </summary>
     internal async Task ApplyDiskPressureAsync(
@@ -1473,7 +1475,16 @@ internal sealed class DarlingSelfAlertEvaluator
             {
                 _lastDiskPressureAlert[DiskKey] = now;
                 _lastAlertedDiskPressurePercent[DiskKey] = percentFree;
-                var storeText = storeSizeBytes is long size ? $" The store currently holds {FormatGb(size)}." : "";
+                /* Names the sample rather than claiming currency: the size is the self-metrics series'
+                   newest whole-store row, not a live measurement (#3199 — measuring it live cost a
+                   filesystem walk on the collection loop's serial thread every five minutes, 3,177 ms of
+                   a 5 s bound on a 225 GiB store). "currently" would be a claim this value cannot make.
+                   The word "hourly" is deliberately absent too: that is the sweep's CADENCE, and measured
+                   gaps in the series run past it, so naming it here would imply an age the row does not
+                   carry. */
+                var storeText = storeSizeBytes is long size
+                    ? $" The store measured {FormatGb(size)} at its last self-metrics sample."
+                    : "";
                 await FireAsync(
                     DiskKey, StoreServerLabel, DiskPressureMetric, reason,
                     $"{warnPercent.ToString("0.#", CultureInfo.InvariantCulture)}% free",

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -76,8 +76,15 @@ public sealed class DarlingWorker : BackgroundService
     private static readonly TimeSpan s_commandPollInterval = TimeSpan.FromSeconds(5);
 
     /* The store disk-pressure self-alert's poll cadence (fleet-level, Stage 4). Disk fills slowly, and the
-       check is one pg_database_size + one DriveInfo syscall, so 5 minutes is ample and cheap — no need to
-       run it on the 30-second alert sweep. */
+       check is one DriveInfo syscall plus one narrow store_metrics lookup, so 5 minutes is ample and cheap —
+       no need to run it on the 30-second alert sweep.
+
+       Cheap is load-bearing here rather than incidental, and #3199 is what it costs when it is not: the size
+       number came from pg_database_size, which walks every file in the store, and measured 2,090-3,745 ms on
+       a 225 GiB store against a 5 s CommandTimeout floored on 6.2 ms. ~288 nominal iterations a day (this
+       gate is start-to-start 5 minutes, stamped before the check runs and quantised to the loop's own
+       finish-to-start tick, so the delivered count sits just under that) at ~2.5 s each is ~11.9 min/day of
+       this loop's wall time, of which the ~2% that crossed 5 s were the only part that logged anything. */
     private static readonly TimeSpan s_diskCheckInterval = TimeSpan.FromMinutes(5);
 
     /* The compression-job self-heal check's cadence (fleet-level, #1581). Compression is a slow archival tier
@@ -4313,7 +4320,8 @@ LIMIT 1";
 
     /// <summary>
     /// Gathers the store disk-pressure sample and hands it to the Stage 4 evaluator (fleet-level). The store
-    /// size (<c>pg_database_size</c>, context only) is always readable; the store volume's free/total space is
+    /// size is context only, read from the hourly self-metrics series rather than measured here (#3199); the
+    /// store volume's free/total space is
     /// resolved from the MANAGED data directory's drive — the bundled store this service owns and must protect.
     /// In bring-your-own mode the store can be a remote Postgres whose disk the service cannot see, so
     /// free/total stay null and the evaluator no-ops (never a false alarm — the operator owns their own
@@ -4359,16 +4367,53 @@ LIMIT 1";
     }
 
     /// <summary>
-    /// The store database's on-disk size in bytes (<c>pg_database_size</c>) — context for the disk-pressure
-    /// alert text, the same read the Viewer's status bar uses. Failure-isolated to null (Debug) so a transient
+    /// The store database's on-disk size in bytes — context for the disk-pressure alert text, read from the
+    /// whole-store row the hourly self-metrics sweep records
+    /// (<see cref="StoreSelfMetrics.LatestStoreSizeSql"/>). Failure-isolated to null (Debug) so a transient
     /// store hiccup never breaks the disk-pressure check.
+    ///
+    /// <para><b>Why this is not <c>pg_database_size</c> (#3199).</b> This method is one of the ten commands
+    /// awaited inline on the collection loop's serial thread, under
+    /// <see cref="ServiceCommandDeadlines.SerialLoopSeconds"/> — and running <c>pg_database_size</c> here
+    /// made it the only one of the ten whose cost scaled with the store, against a bound floored on 6.2 ms
+    /// measured on a 4.05 GB fixture. On a 225 GiB production store the same call measured
+    /// <b>3,177 ms</b> — 64% of the 5 s bound, 1.57x headroom where the derivation claimed ~806x.</para>
+    ///
+    /// <para><b>The cancelled statements are the visible 2%; the cost is the other 98%.</b> Thirteen
+    /// samples on that store spanned 2,090-3,745 ms (mean ~2.5 s) and NONE crossed 5 s, while cancels for
+    /// this statement ran 0-9 a day over six days — mean 5.8 against a nominal ~288 iterations, so 2.0%.
+    /// The remaining 98% cost ~2.5 s each and leave no trace at all: under the deadline so no cancel, not a
+    /// collector run so no <c>collection_log</c> row. That is ~11.9 minutes a day of this loop's wall time
+    /// spent computing a number the store already holds, and it is the finding — not the eight log lines
+    /// that started it, and it does not depend on knowing what ends a cluster, the question #3199's own
+    /// correction left open.</para>
+    ///
+    /// <para><b>What that stall does and does not displace, because the difference matters.</b> This check
+    /// runs AFTER the per-server launches fan out in the same tick, and
+    /// <see cref="SweepWatchdogSeconds"/> clocks per-server BODIES from their own launch rather than
+    /// clocking this loop — so 2.5 s here consumes no watchdog budget and delays no already-launched body.
+    /// What it does is stretch one collection tick in twenty from <see cref="s_sweepInterval"/> to ~17.5 s,
+    /// pushing that tick's remaining maintenance and the NEXT tick's launches out by that much on a
+    /// single-threaded loop whose delivered cadence already runs behind its schedule at fleet scale. The
+    /// bound genuinely at risk is the command's own: at 42-75% of a 5 s <c>CommandTimeout</c> floored on
+    /// millisecond reads, anything competing takes the rest.</para>
+    ///
+    /// <para><b>The walk is relocated, not eliminated.</b> The row this reads is written by
+    /// <see cref="StoreSelfMetrics.StoreInsertSql"/>, which runs <c>pg_database_size</c> itself — so the
+    /// store-wide walk still happens, hourly, under
+    /// <see cref="StoreSelfMetrics.SweepTimeoutSeconds"/> (300 s, ~120x the mean measured cost, sized by
+    /// #2317 against a production store rather than a fixture). That sweep is awaited on this same thread,
+    /// so what changes is the frequency and the budget, not the isolation: ~312 executions a day become 24,
+    /// and the ~11.9 min/day leaves the 5 s regime specifically. The ~31,000x is the single read's latency
+    /// on this path (3,177 ms against 0.101 ms cold, same store) and is never the change's overall
+    /// effect.</para>
     /// </summary>
     private async Task<long?> ReadStoreSizeBytesAsync(CancellationToken cancellationToken)
     {
         try
         {
             await using var connection = await _postgres!.OpenConnectionAsync(cancellationToken);
-            using var command = new NpgsqlCommand("SELECT pg_database_size(current_database())", connection) { CommandTimeout = ServiceCommandDeadlines.SerialLoopSeconds };
+            using var command = new NpgsqlCommand(StoreSelfMetrics.LatestStoreSizeSql, connection) { CommandTimeout = ServiceCommandDeadlines.SerialLoopSeconds };
             var result = await command.ExecuteScalarAsync(cancellationToken);
             return result is null || result == DBNull.Value ? null : Convert.ToInt64(result, CultureInfo.InvariantCulture);
         }
@@ -4377,7 +4422,7 @@ LIMIT 1";
             /* NOT counted by #3013's swallowed-read counter: this read is CONTEXT for the alert text, not the
                evidence the alert is judged on - that is freeBytes/totalBytes above. Losing it costs the message a
                number; it does not make the condition unjudgeable. */
-            _logger.LogDebug("Store disk-pressure check: could not read pg_database_size: {Message}", ex.Message);
+            _logger.LogDebug("Store disk-pressure check: could not read the recorded store size: {Message}", ex.Message);
             return null;
         }
     }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpStoreMetricsTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpStoreMetricsTools.cs
@@ -61,12 +61,12 @@ public sealed class DarlingMcpStoreMetricsTools
                 postgres, DateTime.UtcNow.AddDays(-days_back));
 
             var storeDaily = daily
-                .Where(p => p.ObjectKind == "store")
+                .Where(p => p.ObjectKind == StoreSelfMetrics.StoreObjectKind)
                 .OrderBy(p => p.Day)
                 .ToList();
             var growth = DarlingStoreMetricsReader.ComputeDailyGrowth(storeDaily);
 
-            var storeLatest = latest.FirstOrDefault(r => r.ObjectKind == "store");
+            var storeLatest = latest.FirstOrDefault(r => r.ObjectKind == StoreSelfMetrics.StoreObjectKind);
 
             /* #2813: retention holds are read LIVE from the catalog, not from the series, because the
                series does not carry them. StoreSelfMetrics records total_runs and total_failures but not
@@ -157,7 +157,7 @@ public sealed class DarlingMcpStoreMetricsTools
                     note = JobHistoryNote(jobLogging),
                 },
                 objects = latest
-                    .Where(r => r.ObjectKind != "store")
+                    .Where(r => r.ObjectKind != StoreSelfMetrics.StoreObjectKind)
                     .OrderByDescending(r => r.TotalBytes ?? 0)
                     .Select(r => new
                     {
@@ -186,7 +186,7 @@ public sealed class DarlingMcpStoreMetricsTools
                         total_failures = r.TotalFailures,
                     }),
                 daily = daily
-                    .Where(p => p.ObjectKind != "store")
+                    .Where(p => p.ObjectKind != StoreSelfMetrics.StoreObjectKind)
                     .GroupBy(p => (p.ObjectKind, p.ObjectName))
                     .OrderBy(g => g.Key.ObjectKind, StringComparer.Ordinal)
                     .ThenBy(g => g.Key.ObjectName, StringComparer.Ordinal)

--- a/Darling/PerformanceMonitor.Darling.Service/ServiceCommandDeadlines.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/ServiceCommandDeadlines.cs
@@ -317,8 +317,8 @@ public static class ServiceCommandDeadlines
     /// The store commands awaited INLINE on the serial collection-loop thread, ahead of every per-server
     /// launch: the control-plane reload body — <c>StoreConfigProvider.LoadViewAsync</c>'s five config
     /// reads, <c>DarlingObservability.SyncServerEnabledStatesAsync</c>'s two registry statements and the
-    /// managed-role <c>statement_timeout</c> re-assert — plus the store-size read behind the disk-pressure
-    /// check and the daily retention sweep's own run-record.
+    /// managed-role <c>statement_timeout</c> re-assert — plus the store-size lookup behind the
+    /// disk-pressure check and the daily retention sweep's own run-record.
     ///
     /// <para><b>The regime, by the token test.</b> Every one of these is awaited directly inside
     /// <c>DarlingWorker</c>'s <c>while (!stoppingToken.IsCancellationRequested)</c> body, on the plain
@@ -337,11 +337,30 @@ public static class ServiceCommandDeadlines
     /// <para><b>ABOVE the measured cold worst case.</b> Measured against a 4.05 GB store built by the
     /// product's own <c>MigrateAsync</c> and seeded through <c>SeedIfEmptyAsync</c>, shared buffers
     /// dropped before the first run: <c>LoadViewAsync</c>'s five commands together took <b>16.1 ms</b>
-    /// cold (3.4-4.8 ms warm), <c>SyncServerEnabledStatesAsync</c>'s two <b>3.8 ms</b>, and
-    /// <c>pg_database_size</c> <b>6.2 ms</b> — so the worst SINGLE command on this thread is a
-    /// single-digit-millisecond read and 5 s is roughly three orders of magnitude above it. The
-    /// <c>ALTER ROLE</c> re-assert is one statement out of the 63-statement provisioning batch that
-    /// measured 79 ms in total, so it is in the same class.</para>
+    /// cold (3.4-4.8 ms warm) and <c>SyncServerEnabledStatesAsync</c>'s two <b>3.8 ms</b> — so the worst
+    /// SINGLE command on this thread is a single-digit-millisecond read and 5 s is roughly three orders of
+    /// magnitude above it. The <c>ALTER ROLE</c> re-assert is one statement out of the 63-statement
+    /// provisioning batch that measured 79 ms in total, so it is in the same class.</para>
+    ///
+    /// <para><b>And every one of them is INDEPENDENT of store size, which the floor above silently
+    /// assumed (#3199).</b> Nine of the ten are keyed single-row reads on <c>config</c> tables, one
+    /// <c>ALTER ROLE</c>, and one single-row <c>INSERT</c>; the tenth — the disk-pressure check's store-size
+    /// lookup — is now a newest-row read over <c>collect.store_metrics</c>' <c>(metric_time)</c> index
+    /// (<c>StoreSelfMetrics.LatestStoreSizeSql</c>, measured 0.101 ms cold / 0.018 ms warm on a 225 GiB
+    /// store). It USED to be <c>pg_database_size</c>, whose 6.2 ms on the 4.05 GB fixture is exactly what
+    /// makes this the interesting entry rather than a footnote: that function stats every file in the
+    /// database directory, so its cost tracks the store while the floor derived from it did not. Measured
+    /// on that same 225 GiB store — 56x the fixture — thirteen samples spanned <b>2,090-3,745 ms</b>, which
+    /// leaves <b>1.3-2.4x</b> of the ~806x this paragraph used to claim. A three-orders-of-magnitude margin
+    /// over a measurement taken on a fixture is not a margin at all if the measured quantity grows and the
+    /// fixture does not. Note which way the evidence ran: none of the thirteen breached the bound, so the
+    /// cancelled statements that found this were the 2% tail and the regime's real cost was 98% invisible.
+    /// A deadline nobody trips is not a deadline nobody needs.
+    /// So the standing invariant on this regime is not the millisecond figures — it is that <b>no command
+    /// on this thread may run a read whose cost scales with the store</b>, which is what
+    /// <c>SerialLoopStoreSizeSourceTests</c> asserts as a scan rather than leaving as prose. A member that
+    /// needs such a read belongs on a cadence with its own budget and its own connection, the way the
+    /// hourly self-metrics sweep already owned this one at <c>StoreSelfMetrics.SweepTimeoutSeconds</c>.</para>
     ///
     /// <para><b>BELOW the point where a stalled chain reports as a hang.</b> The ten run SEQUENTIALLY on
     /// one thread, so the bound that matters is the chain's, not one command's: 10 x 5 s = 50 s stays

--- a/Darling/PerformanceMonitor.Darling.Storage/StoreSelfMetrics.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StoreSelfMetrics.cs
@@ -178,20 +178,103 @@ SELECT
     (SELECT count(*) FROM collect.{PayloadDimensions.QueryPlanDimTable})";
 
     /// <summary>
-    /// The whole-store summary row. <c>pg_database_size</c> is the same read the disk-pressure check and
-    /// the Viewer's status bar use; <c>is_enabled</c> over the servers registry is the fleet reader's own
-    /// enabled predicate, so "per-server" here means exactly the servers the fleet surfaces count.
-    /// $1 metric_time.
+    /// The <c>object_kind</c> the whole-store summary row carries, named ONCE because the string now has
+    /// six consumers that must never disagree: this sweep writes it (<see cref="StoreInsertSql"/>), the
+    /// disk-pressure check filters on it (<see cref="LatestStoreSizeSql"/>), and
+    /// <c>DarlingMcpStoreMetricsTools</c> partitions its response by it in four places — the store summary
+    /// is the one row those reads must separate from the per-hypertable and per-dimension rows.
+    ///
+    /// <para><b>Why a const and not six literals.</b> A reader filtering on a kind the writer stopped
+    /// writing returns ZERO ROWS, not an error, and every consumer here maps zero rows to a null or an
+    /// omitted section. So a drifted spelling is indistinguishable from a store that has not swept yet —
+    /// the honest-empty trap, on a value the shipped store already holds 400 days of. The value itself is
+    /// therefore also part of the on-disk contract and cannot be renamed without orphaning that history.
+    /// Same reasoning as <see cref="JobExecutionLoggingSetting"/>, one file over.</para>
     /// </summary>
-    public const string StoreInsertSql = @"
+    public const string StoreObjectKind = "store";
+
+    /// <summary>
+    /// The whole-store summary row. <c>pg_database_size</c> here is the ONLY place the product runs it on a
+    /// cadence: it walks every file in the database directory, so its cost scales with the store rather
+    /// than with the row it produces, and this sweep is where that cost belongs: hourly rather than every
+    /// five minutes, on its own connection, and under <see cref="SweepTimeoutSeconds"/> — a budget #2317
+    /// sized against a production store's own sizing queries rather than against a fixture. It is NOT off
+    /// the collection loop's serial thread: the worker awaits this sweep inline, so its worst case still
+    /// stalls per-server dispatch. What the sweep buys is 300 s of room and 1/12th the frequency, not
+    /// isolation.
+    /// <c>is_enabled</c> over the servers registry is the fleet reader's own enabled predicate, so
+    /// "per-server" here means exactly the servers the fleet surfaces count. $1 metric_time.
+    /// </summary>
+    public const string StoreInsertSql = $@"
 INSERT INTO collect.store_metrics
     (metric_time, object_name, object_kind, total_bytes, enabled_server_count)
 SELECT
     $1,
     current_database(),
-    'store',
+    '{StoreObjectKind}',
     pg_database_size(current_database()),
     (SELECT count(*)::integer FROM collect.servers WHERE is_enabled)";
+
+    /// <summary>
+    /// The newest recorded whole-store size in bytes — what the store disk-pressure check reads to
+    /// decorate its alert text with, instead of running <c>pg_database_size</c> itself every five minutes
+    /// on the collection loop's serial thread (#3199).
+    ///
+    /// <para><b>Why the recorded value and not the live one.</b> <c>pg_database_size</c> stats every file
+    /// in the database directory, so it is the one read on that thread whose cost scales with the store,
+    /// and the 5 s bound it inherited from <c>ServiceCommandDeadlines.SerialLoopSeconds</c> was floored on
+    /// 6.2 ms measured against a 4.05 GB fixture. Measured on a 225 GiB production store — 56x the fixture
+    /// — thirteen samples of that same call spanned <b>2,090-3,745 ms</b> (mean ~2.5 s, one reading
+    /// 3,177 ms): ~400-600x the time for 56x the size, because the cost tracks file count and a TimescaleDB
+    /// store's file count follows chunks rather than bytes. That leaves 1.3-2.4x headroom under a bound
+    /// whose derivation claimed ~806x. NONE of the thirteen crossed 5 s, which is the point: cancels ran
+    /// mean 5.8/day against a nominal ~288 iterations (2.0%), so the visible failures were the tail and the
+    /// other 98% paid ~2.5 s silently — under the deadline so no cancel, not a collector run so no
+    /// <c>collection_log</c> row. This read, measured on the same store, is <b>0.101 ms</b> cold and
+    /// 0.018 ms warm over three buffers — an <c>Index Scan Backward</c> on the existing V53
+    /// <c>(metric_time)</c> index, adding none — and its cost does not move when the store grows.</para>
+    ///
+    /// <para><b>The walk is RELOCATED, not eliminated, and the honest claim is about which path pays
+    /// it.</b> The row this reads is produced by <see cref="StoreInsertSql"/>, which runs
+    /// <c>pg_database_size</c> itself — so the store-wide walk still happens, once an hour, inside a sweep
+    /// that has room for it: <see cref="SweepTimeoutSeconds"/> is 300 s, ~120x the mean measured cost, and
+    /// #2317 sized it against this very store's sizing queries rather than against a fixture. What changes
+    /// is the count and the regime: ~312 executions a day, ~288 of them under a 5 s bound on the collection
+    /// loop's serial thread, down to the 24 a day that were already being paid where the budget is. The
+    /// per-read speedup is ~31,000x and applies to THAT read's latency, never to the change's overall
+    /// effect — 92% fewer executions is that number.</para>
+    ///
+    /// <para><b>What it costs.</b> The value is the newest recorded sample rather than the current byte
+    /// count, which is why the alert text names the sample instead of claiming currency. Priced against
+    /// what the value is FOR: <c>DarlingSelfAlertEvaluator.ApplyDiskPressureAsync</c> uses it in exactly
+    /// one place — one sentence of the alert detail — and never in a threshold, a comparison or a stored
+    /// numeric value; the condition is judged on the store volume's free/total from <c>DriveInfo</c>,
+    /// resolved on the same tick. So a stale figure cannot make the condition unjudgeable and cannot miss
+    /// a fast fill. Deliberately NOT age-bounded: an interval past which the number is suppressed would be
+    /// one more constant nobody measured, which is the defect #3199 is about; a stale sweep is reported by
+    /// the sweep's own surfaces (its Warning line, <c>get_store_metrics</c>' series, and #3175's
+    /// job-cadence self-alert) rather than by silently blanking a field here.</para>
+    ///
+    /// <para><b>How stale it actually gets is an observation, not a bound.</b> Over 30 days on one
+    /// production store the series held 737 whole-store rows across 713 distinct hours — dense, so this is
+    /// not a sparse source — with a mean gap of 58.6 minutes and the largest gap that HAPPENED to occur
+    /// being 8,890.8 s (2.47 h). That maximum is a window artifact: it is the worst case in that sample on
+    /// that store, it cannot decay, and nothing here guarantees it. Quote the cadence and the provenance,
+    /// never "worst case is 2.47 hours".</para>
+    ///
+    /// <para><c>total_bytes IS NOT NULL</c> because the column is nullable for the per-hypertable rows'
+    /// sake: without it a hypothetical NULL newest row would mask a good older one, and both would arrive
+    /// as the same null. On a store that has never completed a sweep this returns no row and the alert text
+    /// simply carries no size — which is the first loop tick of a brand-new store, the disk check running
+    /// ahead of the self-metrics sweep in the same tick. No parameters.</para>
+    /// </summary>
+    public const string LatestStoreSizeSql = $@"
+SELECT total_bytes
+FROM collect.store_metrics
+WHERE object_kind = '{StoreObjectKind}'
+AND   total_bytes IS NOT NULL
+ORDER BY metric_time DESC
+LIMIT 1";
 
     /// <summary>The sweep's own retention — one bounded DELETE, no policy machinery. $1 cutoff (naive UTC,
     /// metric_time minus <see cref="RetentionDays"/> days).</summary>

--- a/Lite.Tests/AlertReadFailureSurfaceTests.cs
+++ b/Lite.Tests/AlertReadFailureSurfaceTests.cs
@@ -240,7 +240,7 @@ public sealed class AlertReadFailureSurfaceTests
         Assert.Contains("background-job health", inventory, StringComparison.Ordinal);
 
         /* And the phantom stays gone. Disk pressure's feed reads are exempt — a local filesystem read and a
-           pg_database_size read that is context for the alert text — so naming it here would send an
+           recorded-store-size lookup that is context for the alert text — so naming it here would send an
            operator after a read that cannot fail into this number. */
         Assert.DoesNotContain("disk pressure", inventory, StringComparison.OrdinalIgnoreCase);
 

--- a/PerformanceMonitor.Alerting/AlertReadFailureCounter.cs
+++ b/PerformanceMonitor.Alerting/AlertReadFailureCounter.cs
@@ -448,7 +448,7 @@ public sealed class AlertReadFailureCounter
     /// const-string concatenation is a compile-time constant — so the set cannot grow in one place and
     /// go stale in three. The first draft hand-maintained it and was wrong in both directions at once:
     /// it listed store DISK PRESSURE, whose two feed reads are both exempt (a local filesystem read,
-    /// and a <c>pg_database_size</c> read that is context for the alert text rather than the evidence
+    /// and a recorded-store-size lookup that is context for the alert text rather than the evidence
     /// it is judged on), so that condition can never contribute a failure here; and it omitted the
     /// collector-cost regression self-alert, which does. An operator reading the phantom list would
     /// have hunted a disk-pressure read that cannot fail into this number, and would not have thought


### PR DESCRIPTION
Closes #3199 — and `dev` is the base, so the keyword will not fire on merge; close it explicitly.

The store disk-pressure check ran `SELECT pg_database_size(current_database())` every five minutes on the collection loop's serial thread, under `ServiceCommandDeadlines.SerialLoopSeconds` = 5 s — a bound whose derivation floored it on **6.2 ms measured against a 4.05 GB store**. That function stats every file in the database directory, so its cost follows the store, not the single row it returns.

## What it actually cost, measured

On a 225 GiB production store — 56x the fixture — thirteen samples of the same call spanned **2,090–3,745 ms** (mean ~2.5 s; five in-session, eight on separate connections). That is 1.3–2.4x headroom under a bound whose derivation claimed ~806x.

**None of the thirteen crossed 5 s, and that is the finding.** Cancels for this statement, counted from the store's own daily log files, ran 7 / 0 / 3 / 8 / 9 / 8 over six days — mean 5.8 against a nominal ~288 iterations a day, so **2.0%**. The other 98% cost ~2.5 s each and leave no trace anywhere: under the deadline so no cancel, not a collector run so no `collection_log` row. That is **~11.9 minutes a day** of a single-threaded loop's wall time spent computing a number the store already held, and it does not depend on knowing what starts or ends a cluster — the question #3199's own correction correctly left open.

The eight cancelled statements that found this were the symptom. The invisible 98% is the defect.

### What that stall does and does not displace

Worth stating precisely, because the strong version of the claim is not true. The disk check runs **after** the per-server launches fan out in the same tick, and `SweepWatchdogSeconds` (60 s) clocks per-server **bodies** from their own launch rather than clocking this loop — so 2.5 s here consumes no watchdog budget and delays no already-launched body. What it does is stretch one collection tick in twenty from `s_sweepInterval` (15 s) to ~17.5 s, pushing that tick's remaining maintenance and the next tick's launches out by that much, on a loop whose delivered cadence already runs behind its schedule at fleet scale.

The bound genuinely at risk is the command's own `CommandTimeout`: at 42–75% of a 5 s deadline floored on millisecond reads, anything competing takes the rest.

## The change

`collect.store_metrics` has carried the whole-store size hourly since V53 (`StoreSelfMetrics.StoreInsertSql`, `object_kind = 'store'`), so the check reads the newest recorded row instead of measuring it again. Measured on the same store: **0.101 ms cold / 0.018 ms warm**, three buffers, `Index Scan Backward using idx_store_metrics_time` — the existing V53 index, **no new index**.

**The walk is relocated, not eliminated.** `StoreInsertSql` runs `pg_database_size` itself, so the store-wide walk still happens hourly under `StoreSelfMetrics.SweepTimeoutSeconds` = 300 s (~120x the mean measured cost, and #2317 sized that budget against this very store's sizing queries rather than against a fixture). That sweep is also awaited on the serial thread, so what changes is the frequency and the budget, **not the isolation**:

| | executions/day | where |
|---|---|---|
| before | 288 disk check + 24 sweep = **312** | 288 of them under a 5 s bound |
| after | 288 × 0.1 ms lookup + 24 sweep = **24** walks | all 24 under the 300 s budget |

**92% fewer executions, and the ~11.9 min/day leaves the 5 s regime.** The ~31,000x figure is the single read's latency on that path (3,177 ms against 0.101 ms) and is never the change's overall effect.

## Why not the other two options

**Raise the deadline.** The shared constant cannot move: `TheSerialLoopDeadline_KeepsItsWholeChainInsideTheWatchdog` asserts `10 sites × N < 60`, so `N < 6` and it is already 5. Giving this one call its own larger constant leaves `9 × 5 + N < 60`, i.e. **N ≤ 14** — and nothing measured says 14 s is enough, because the samples say the call costs seconds and the tail is unbounded from above. It is also the move that made the constant wrong in the first place: a second number sized on one store. Sizing it on the 225 GiB store would be sizing it on the largest store anyone has, which is a fixture with a different name.

**Make the timeout non-fatal.** It already is — the catch returns null at Debug and the alert still fires, because the condition is judged on `DriveInfo` free/total. Making failure cheaper does not stop paying ~2.5 s for it 288 times a day.

## Every other caller of the shared deadline

Ten command sites across nine members. This change swaps one site's **statement**; it does not move the site, change the constant, or change the count, so the chain arithmetic (`10 × 5 s = 50 s`) is untouched.

| Member | Sites |
|---|---|
| `StoreConfigProvider.ReadServiceRowAsync` | 1 |
| `StoreConfigProvider.ReadAlertSettingsAsync` | 1 |
| `StoreConfigProvider.ReadNotificationAsync` | 1 |
| `StoreConfigProvider.ReadMonitoredServersAsync` | 1 |
| `StoreConfigProvider.ReadScheduleOverridesAsync` | 1 |
| `DarlingObservability.SyncServerEnabledStatesAsync` | 2 |
| `DarlingManagedRoles.ReassertComposeStatementTimeoutAsync` | 1 |
| `DarlingObservability.LogRetentionRunAsync` | 1 |
| `DarlingWorker.ReadStoreSizeBytesAsync` | 1 ← this one |

`ViewerDataService.StoreSizeSql` runs the same query but is a **different regime** — interactive, user-initiated, on the viewer's own fan-out deadline, with nothing waiting behind it but the operator who asked. Left alone deliberately.

`CollectionSweepCommandTimeoutTests`' reasoning was read before touching any of this: `CollectionSweepSeconds` is floored on a measured 1.53 s store write projected to ~3.1 s at `max_concurrent_sweeps=8`, which is exactly why a 54 s probe was declined into `store_duration_ms` last night. Nothing here touches that constant or that column.

## The pin is on the category, not the instance

`5` is not wrong and is not changed. What was wrong is that a regime floored on millisecond reads had acquired a member whose cost grows with the store, and **nothing noticed for the whole life of the defect** — `StartupCommandTimeoutTests` counts *deadlines*, so it was green throughout and would be green again the moment a size-scaling read came back.

`SerialLoopStoreSizeSourceTests` asserts the invariant instead: **no command on the serial loop may run a read whose cost scales with the store** — over the population `StartupCommandTimeoutTests` already owns, projected rather than re-listed, with the per-member site count travelling along so the projection ties back to that pin's own `ExpectedSerialLoopSites` and cannot cover nine members while claiming ten.

Each test names the scope it is total over, because a source scan's blind spot is the whole question:

- `TheDiskCheckExecutesTheRecordedSizeConstant` — total for the one member that reads its SQL from another type: the reference is pinned in source **and** the referent's shipped value at runtime. Neither half alone is enough, and the mutation table shows exactly which mutation each half catches.
- `NoSerialLoopMemberInlinesAStoreScalingRead` — total for SQL written inline in any of the ten sites, over the whole size-read family (`pg_database_size`, `pg_total_relation_size`, `hypertable_detailed_size`, …), not just the instance that failed.
- `PgDatabaseSizeRunsOnlyWhereItsCostHasABudget` — total for `pg_database_size` anywhere in shipped source (twelve product projects, ~1,050 files), so no indirection evades it. Its two coverage guards catch different failures and the test says which: a project removed or renamed fails by name in the per-project `Directory.Exists` assertion, while the `scanned > 500` floor only catches the enumeration producing nothing at all — deliberately far below the real count, because a threshold near it would fail on ordinary churn and add nothing the existence check does not already give. Narrower in function coverage, wider in reach; the overlap is deliberate. The count is a review gate: a third occurrence fails the build and the message hands the author the two existing regimes and their reasons.
- `TheRecordedSizeReaderAndWriterCannotDisagreeAboutTheKind` — the honest-empty trap on 400 days of recorded rows. A reader filtering on a kind the writer stopped writing gets **zero rows, not an error**, and every consumer renders that as the same null a never-swept store produces. The kind is now one const with six consumers, and its *value* is part of the on-disk contract.

## Two of my own pins could not fail, and the mutation table is why

Both were found by mutating the instrument rather than the subject, and both are fixed in their own commits so the sequence is legible:

1. `Assert.DoesNotContain("ObjectKind == \"")` was read over source that `StripCommentsAndStrings` had already run over — stripping blanks a literal *including its opening quote*, so the pattern could never appear and the assertion passed on every input. Restoring a bare `"store"` literal to one of the four call sites came back **green**. It now asserts the invariant directly (every `ObjectKind` comparison has the const on its right-hand side, with the comparison count asserted too, so a scan that matched nothing cannot read as a clean file).

2. `NoSerialLoopMemberInlinesAStoreScalingRead` inlined its scan. Its population correctly contains no store-scaling read, so its loop body never runs on the real tree — and deleting its one recording statement left the whole suite **green**. The scan is now shared with `TheMemberScan_ReportsAPlantedStoreScalingRead`, which runs it over a body written the way the defect actually was and over the clean shape, so the control is not simply "always reports".

## Mutation table

Baseline, all runs: **Total: 54, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0**. Compiled from the real shipped `.cs` into a `net10.0` xunit.v3 harness named `Darling.Tests` (the suite targets `net10.0-windows` and cannot run on macOS), covering `SerialLoopStoreSizeSourceTests`, `StartupCommandTimeoutTests` and `AlertReadFailureSurfaceTests` — 54 tests across 3 classes.

| # | Mutation | Failed | Caught by |
|---|---|---|---|
| M1 | worker back to an inline `pg_database_size` literal | 3 | member scan, tree census, source half of the constant pin |
| M2 | `LatestStoreSizeSql` itself walks the store | 2 | **runtime** half of the constant pin, tree census (source half passes — that is why both exist) |
| M3 | `LIMIT 1` removed | 1 | constant pin |
| M4 | `ORDER BY metric_time DESC` → `ASC` (newest becomes oldest) | 1 | constant pin |
| M5 | `StoreObjectKind` renamed, writer and reader still agreeing | 1 | kind pin's **value** assertion (the agreement assertions pass) |
| M6 | one MCP consumer back to a bare `"store"` literal | **0 → 1** | nothing, then the rewritten kind pin |
| M7 | stale `"could not read pg_database_size"` exemption key restored | 1 | `EverySwallowedAlertingRead_IsCountedOrExplicitlyExempt` |
| I1a | first alternative of the size-read matcher renamed to something that never occurs | 1 | scanner control |
| I1b | `LiteralsOf` returns `string.Empty` (scan reads nothing) | 4 | scanner control, tree census coverage guard |
| I1c | `LiteralsOf` returns raw source (prose counts as a query) | 2 | scanner control's negative cases |
| I2 | serial-loop projection silently drops one member | 1 | site-total tie to `ExpectedSerialLoopSites` |
| I3 | `ShippedSources()` yields nothing | 1 | census coverage guard (`scanned > 500`) |
| I4 | member scan discards what it finds | **0 → 1** | nothing, then `TheMemberScan_ReportsAPlantedStoreScalingRead` |

**Not pinned, deliberately:** the alert sentence's wording. A mutation restoring `" The store currently holds …"` survives. Alert *prose* is not a consumer API here — the fact names and `numericCurrentValue` / `numericThresholdValue` are, and those are untouched (`percentFree` and `warnPercent`).

## Staleness, priced against what the value is for

The recorded value can be older than the current byte count, so the alert sentence names the sample instead of claiming currency, and the word "hourly" is deliberately absent from it — that is the sweep's *cadence*, and measured gaps run past it.

Read the consumer: `storeSizeBytes` has **exactly one use** inside `ApplyDiskPressureAsync` — one sentence of the alert detail. It feeds no threshold, no comparison, and neither stored numeric value; the condition is judged on `DriveInfo` free/total resolved on the same tick. So a stale figure cannot make the condition unjudgeable and **cannot miss a fast fill**.

How stale it actually gets is an **observation, not a bound**: over 30 days on one production store the series held 737 whole-store rows across 713 distinct hours — dense, so this is not a sparse source — with a mean gap of 3,518.2 s (58.6 min) and the largest gap that *happened to occur* being 8,890.8 s (2.47 h). That maximum is a window artifact: it is the worst case in that sample on that store, it cannot decay, and nothing here guarantees it. Same defect as #3188's ceiling constants, so the doc quotes the cadence and the provenance rather than "worst case is 2.47 hours".

The read is deliberately **not** age-bounded. An interval past which the number is suppressed would be one more constant nobody measured, which is the defect this PR is about. A stale sweep is reported by the sweep's own surfaces — its Warning line, `get_store_metrics`' series, and #3175's job-cadence self-alert — rather than by silently blanking a field here.

## Scope notes

- **Not claimed:** this does not fix the store's cancel noise. On the day with the most cancels, 23 of them were in the log and only 7 were `pg_database_size`; the other 16 are a separate source being run down elsewhere.
- **Considered and declined:** the size read still runs when `config.Postgres.Managed && OperatingSystem.IsWindows()` is false, where `ApplyDiskPressureAsync` provably discards it (already pinned by `DarlingSelfAlertTests`' `(null, null, 999 GiB)` case). Gating it would remove one store read per five minutes on BYO deployments — but after this change that read is 0.1 ms, and the only ways to pin the gate are a fragile source-order scan or a duplicated copy of the evaluator's own predicate. Not worth a pin that cannot fail meaningfully.
- **Observed, not changed:** `SerialLoopSeconds`' own derivation justifies its chain bound as "10 × 5 s = 50 s stays inside `SweepWatchdogSeconds`". That analogy is looser than it reads — the watchdog clocks per-server bodies from their own launch, not the serial chain — so a stalled chain does not actually consume watchdog budget. Pre-existing, load-bearing for a constant this PR does not touch, and re-deriving it is its own change.

## CHANGELOG

Not edited, per the standing rule. Entry text for the coordinator:

- **The store disk-pressure check stopped walking the whole store every five minutes to decorate an alert message** ([#3199]) - `SELECT pg_database_size(current_database())` ran on the collection loop's serial thread under `ServiceCommandDeadlines.SerialLoopSeconds` = 5 s, a bound floored on **6.2 ms measured against a 4.05 GB store**. That function stats every file in the database directory, so its cost follows the store rather than the single row it returns: on a **225 GiB** production store — 56x the fixture — thirteen samples spanned **2,090-3,745 ms**, leaving 1.3-2.4x of the ~806x the derivation claimed. **None of the thirteen crossed 5 s, and that is the finding.** Cancels for the statement ran mean **5.8/day** against a nominal ~288 iterations (**2.0%**), so the eight cancelled statements that found this were the visible tail and the other 98% cost ~2.5 s each while leaving no trace anywhere - under the deadline so no cancel, not a collector run so no `collection_log` row - which is **~11.9 min/day** of a single-threaded loop's wall time spent computing a number the store already held. `collect.store_metrics` has carried the whole-store size hourly since V53, so the check now reads the newest recorded row: **0.101 ms** cold, three buffers, `Index Scan Backward` on the existing V53 index, **no new index**. **The walk is relocated rather than eliminated** and the honest claim is about which path pays it - `StoreSelfMetrics.StoreInsertSql` runs `pg_database_size` itself, so 312 executions a day become 24, all of them under the 300 s budget #2317 sized against this same store's sizing queries; the ~31,000x is the single read's latency and never the change's overall effect. Raising the deadline was arithmetically closed rather than merely unattractive: the shared constant is pinned at `10 sites × N < 60 s`, so `N < 6`, and a private constant for this one call caps at 14 s with nothing measured saying 14 is enough. The `object_kind` literal became one const with six consumers, because a reader filtering on a kind the writer stopped writing returns **zero rows rather than erroring** and every consumer renders that as the same null a never-swept store produces. `SerialLoopStoreSizeSourceTests` pins the **category** - no command on the serial loop may run a read whose cost scales with the store - over the population `StartupCommandTimeoutTests` already owns, projected rather than re-listed so it cannot cover nine members while claiming ten: that pin counts DEADLINES, which is why it stayed green across the whole life of this defect and would go green again the moment a size-scaling read came back. **Two of the new pins could not fail and were found by mutating the instrument rather than the subject** - an `Assert.DoesNotContain` read over source whose transform had already removed the pattern it asserted absent, and a negative census whose loop body never runs on a population that correctly contains nothing - so both now share their scan with a positive control over a planted body.
