### PR TITLE
Weld concatenated literals before scanning store SQL, and make the PostgreSQL parse-check population what the reader files declare

### DIFF
--- a/Darling/Darling.Tests/CSharpMemberMap.cs
+++ b/Darling/Darling.Tests/CSharpMemberMap.cs
@@ -98,7 +98,8 @@ internal static class CSharpMemberMap
     ///
     /// <para>Types are in the declaration list rather than filtered out of it because a member's range is
     /// bounded by the NEXT declaration of either kind, and a nested type is the next thing after the member
-    /// above it. They are excluded from attribution and from
+    /// above it. They are also what <see cref="EnclosingType"/> answers from. They are excluded from MEMBER
+    /// attribution and from
     /// <c>TsqlConventionGuardTests.TheMemberScan_ReadsEveryDeclarationWhole</c>: a type's body legitimately contains every
     /// declaration below it, which is the exact shape that assertion calls an over-run.</para>
     /// </summary>
@@ -420,14 +421,39 @@ internal static class CSharpMemberMap
     /// <see cref="TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_AndARawCountDoesNot"/>, which is an
     /// arranged case rather than a site on the tree, and that is the honest status of it.</para>
     /// </summary>
-    internal static string EnclosingMember(MemberMap map, int offset)
+    internal static string EnclosingMember(MemberMap map, int offset) =>
+        Enclosing(map, offset, DeclarationKind.Member);
+
+    /// <summary>
+    /// The TYPE a declaration belongs to: the innermost type declaration whose range CONTAINS the
+    /// offset. What <see cref="EnclosingMember"/> answers about members, for the enclosing type — which
+    /// a scan attributing a FIELD needs, because a file declares more than one type and the field
+    /// belongs to whichever body it sits in rather than to the file it is written in.
+    /// </summary>
+    internal static string EnclosingType(MemberMap map, int offset) =>
+        Enclosing(map, offset, DeclarationKind.Type);
+
+    /// <summary>
+    /// The innermost declaration of <paramref name="kind"/> whose range CONTAINS
+    /// <paramref name="offset"/>, or <see cref="Unknown"/>.
+    ///
+    /// <para>ONE implementation for both kinds, which is the whole point of it being here. The two
+    /// entry points differ by a <see cref="DeclarationKind"/> and nothing else, and a second copy of
+    /// this scan would be free to disagree about the part that is a JUDGEMENT rather than a filter:
+    /// an unterminated body (<c>End &lt; 0</c>) escalates to <see cref="Unknown"/> instead of being
+    /// treated as running to EOF, so a declaration the brace walk lost cannot lend its name to
+    /// everything below it. A copy that guessed EOF there would attribute confidently and wrongly,
+    /// and #3094 is the episode where a message-only copy was corrected while the deciding copy was
+    /// left broken.</para>
+    /// </summary>
+    private static string Enclosing(MemberMap map, int offset, DeclarationKind kind)
     {
         var name = Unknown;
         var innermost = -1;
 
         foreach (var declaration in map.Declarations)
         {
-            if (declaration.Kind != DeclarationKind.Member
+            if (declaration.Kind != kind
                 || declaration.End < 0
                 || offset < declaration.Start
                 || offset >= declaration.End

--- a/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
+++ b/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
@@ -232,24 +232,50 @@ public sealed class DarlingPgReadSqlParsesLiveTests
         var storage = Path.GetFullPath(Path.Combine(
             Path.GetDirectoryName(thisFile)!, "..", "PerformanceMonitor.Darling.Storage"));
 
-        var declaration = new Regex(
-            @"(?:const|static\s+readonly)\s+string\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*=",
-            RegexOptions.Compiled);
-
         var fields = new List<string>();
 
         foreach (var path in Directory.EnumerateFiles(storage, "DarlingPg*Reader*.cs", SearchOption.TopDirectoryOnly))
         {
             var map = CSharpMemberMap.Of(File.ReadAllText(path));
 
-            foreach (Match match in declaration.Matches(map.Code))
+            foreach (var declaration in map.Declarations)
             {
-                fields.Add(CSharpMemberMap.EnclosingType(map, match.Index) + "." + match.Groups["name"].Value);
+                /* Anchored at a DECLARATION, not matched anywhere in the file. A free regex for
+                   `const string X =` also matches a LOCAL const inside a method body — C# allows
+                   those — and reflection only ever sees static fields, so such a local would sit in
+                   `missing` permanently and the only way to quiet it would be putting a local into
+                   NotQueryFields, which is for fields that hold no query rather than for things the
+                   pattern over-matched. CSharpMemberMap.DeclarationHead requires an access modifier,
+                   which a local cannot carry, so anchoring here is what excludes them. */
+                if (declaration.Kind != CSharpMemberMap.DeclarationKind.Member
+                    || declaration.NextStart <= declaration.Start)
+                {
+                    continue;
+                }
+
+                var head = map.Code[declaration.Start..Math.Min(declaration.NextStart, map.Code.Length)];
+
+                if (!StaticStringField.IsMatch(head))
+                {
+                    continue;
+                }
+
+                fields.Add(CSharpMemberMap.EnclosingType(map, declaration.Start) + "." + declaration.Name);
             }
         }
 
         return fields;
     }
+
+    /// <summary>A <c>const string</c> or <c>static readonly string</c> field, matched from the START of
+    /// a declaration <see cref="CSharpMemberMap"/> already found — so declaration POSITION comes from the
+    /// shared walk and this pattern only has to say which declarations are static string fields. The
+    /// modifier run is bounded to one line because a wrapped declaration would put the name out of reach
+    /// of the name the map read; the count floor below is what would catch that if one ever wraps.</summary>
+    private static readonly Regex StaticStringField = new(
+        @"\A[ \t]*(?:public|private|protected|internal)\b[^\r\n=]*?"
+        + @"\b(?:const|static[ \t]+readonly|readonly[ \t]+static)[ \t]+string[ \t]+",
+        RegexOptions.Compiled);
 
     [Fact]
     public async Task EveryShippedPostgreSqlReadPassesParseAnalysis()

--- a/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
+++ b/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
@@ -8,8 +8,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
@@ -44,36 +47,187 @@ namespace Darling.Tests;
 public sealed class DarlingPgReadSqlParsesLiveTests
 {
     /// <summary>
-    /// A floor, not a pin. It exists to catch a broken reflection filter, so it must not need editing every
-    /// time a read is added — twelve constants exist today across nine readers.
+    /// A ratchet, not a slack floor, and it sits AT the live population rather than below it. Growth never
+    /// trips it — a read added only ever raises the count — so it still does not need editing when one
+    /// lands; a read REMOVED reds, which is the whole point, because that is the direction a coverage loss
+    /// travels in.
+    ///
+    /// <para><b>What the number replaced.</b> This was 10, against a doc claim of "twelve constants across
+    /// nine readers" that had gone badly stale: measured, 28 reader types ship 49 reads. A floor of 10
+    /// against 49 tolerated a 39-read drop — 79% of the population could leave silently while the guard
+    /// reported a clean pass. That is not a floor catching a broken reflection filter, which is what it was
+    /// written to be; it is a floor that could only catch total filter collapse, and #2530's namespace break
+    /// is the only shape it ever would have seen.</para>
     /// </summary>
-    private const int MinimumExpectedReads = 10;
+    private const int MinimumExpectedReads = 49;
+
+    /// <summary>
+    /// The reader TYPE count, on the same ratchet and for the same reason. Separate from the read count
+    /// because the two fail differently: a namespace or name-pattern break takes every type at once, while
+    /// reads leaving one at a time keep the type count intact.
+    /// </summary>
+    private const int MinimumReaderTypes = 28;
+
+    /// <summary>
+    /// Static string fields on a reader that are NOT queries, so the source census below can tell a field
+    /// that legitimately holds no SQL from a read that has dropped out of reflection's reach. Named
+    /// explicitly rather than inferred, because every rule for inferring it reads the field's VALUE — which
+    /// is reflection, the very thing the census exists to check independently.
+    ///
+    /// <para>Two of the three are SQL FRAGMENTS interpolated into a query rather than queries themselves,
+    /// and the third is the trap that makes a name-shaped rule useless here:
+    /// <c>StaleStatisticsChurnRatioSql</c> is spelled like a query and holds <c>"0.2"</c>. Keyed per SITE
+    /// rather than per name, so the same name on a different reader is not excused by inheritance from
+    /// this one — and the unused-entry clause below makes a move show up as an edit here rather than as
+    /// a silently widened exemption.</para>
+    /// </summary>
+    private static readonly HashSet<string> NotQueryFields = new(StringComparer.Ordinal)
+    {
+        "DarlingPgColumnStatsReader.EvidenceStatusList",
+        "DarlingPgServerConfigReader.SessionScopedSources",
+        "DarlingPgTableBloatReader.StaleStatisticsChurnRatioSql",
+    };
 
     private static string? ConnectionString => Environment.GetEnvironmentVariable("DARLING_TEST_PG");
 
     /// <summary>
-    /// Every <c>const string</c> on a <c>DarlingPg*Reader</c> that is actually a query. Constants are used
-    /// rather than the reader methods because a method would need a connection, a server and a window; the
-    /// constant IS the shipped text, which is the thing under test.
-    /// </summary>
-    /// <para>The namespace comes from a reader TYPE rather than a string literal (#2530), for the reason
-    /// the discovery is reflective in the first place: the readers moved to
+    /// Every reader type the reads are discovered from. Anchored to a reader TYPE rather than a namespace
+    /// string (#2530) for the reason the discovery is reflective at all: the readers moved to
     /// <c>PerformanceMonitor.Darling.Storage</c> so the WPF viewer could run the same query text, and a
-    /// hardcoded namespace matched nothing afterwards. The anti-vacuity floor below caught it — a guard that
-    /// stopped guarding, reported as one — but a filter anchored to a type it must find anyway cannot break
-    /// that way twice.</para>
-    private static IReadOnlyList<(string Name, string Sql)> ShippedReadSql() =>
+    /// hardcoded namespace matched nothing afterwards.
+    /// </summary>
+    private static IReadOnlyList<Type> ReaderTypes() =>
         typeof(DarlingPgStatementReader).Assembly.GetTypes()
             .Where(t => t.Namespace == typeof(DarlingPgStatementReader).Namespace
                         && t.Name.StartsWith("DarlingPg", StringComparison.Ordinal)
                         && t.Name.EndsWith("Reader", StringComparison.Ordinal))
-            .SelectMany(t => t
-                .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
-                .Where(f => f.IsLiteral && f.FieldType == typeof(string))
-                .Select(f => (Name: t.Name + "." + f.Name, Sql: (string?)f.GetRawConstantValue() ?? string.Empty)))
-            .Where(p => p.Sql.Contains("SELECT", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.Name, StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
+    /// Every static string field on a <c>DarlingPg*Reader</c> that is actually a query. Fields rather than
+    /// the reader methods because a method would need a connection, a server and a window; the field IS the
+    /// shipped text, which is the thing under test.
+    ///
+    /// <para><b>Both field kinds, not just <c>const</c>.</b> This read <c>f.IsLiteral</c> only, and a
+    /// <c>static readonly string</c> composed by concatenation is not a literal — so
+    /// <c>DarlingPgColumnStatsReader.CoverageEvidenceSql</c>, a shipped read executed at every column-stats
+    /// coverage call, had never been parse-checked at all. Composing SQL that way is ordinary here (a status
+    /// list and two collector thresholds are interpolated into that one), and it is not a shape a guard can
+    /// ask people to avoid to stay covered.</para>
+    /// </summary>
+    private static IReadOnlyList<(string Name, string Sql)> ShippedReadSql() =>
+        ReaderTypes()
+            .SelectMany(t => QueryFields(t).Select(f => (Name: t.Name + "." + f.Name, Sql: FieldText(f))))
             .OrderBy(p => p.Name, StringComparer.Ordinal)
             .ToList();
+
+    private static IEnumerable<FieldInfo> QueryFields(Type reader) =>
+        reader.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(f => f.FieldType == typeof(string) && (f.IsLiteral || f.IsInitOnly))
+            .Where(f => FieldText(f).Contains("SELECT", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary><c>GetRawConstantValue</c> for a <c>const</c>, <c>GetValue</c> for a <c>static readonly</c>
+    /// — the latter runs the type's initializer, which is exactly what makes the composed text readable.
+    /// </summary>
+    private static string FieldText(FieldInfo field) =>
+        (field.IsLiteral ? (string?)field.GetRawConstantValue() : (string?)field.GetValue(null))
+        ?? string.Empty;
+
+    /// <summary>
+    /// <para>The population itself, asserted without a server so it runs everywhere the suite runs — the
+    /// Windows <c>build</c> job included, where <c>DARLING_TEST_PG</c> is unset and the parse check below
+    /// skips. The anti-vacuity assertion used to live inside that skipped test, so on half the CI matrix
+    /// nothing checked the discovery at all.</para>
+    ///
+    /// <para><b>Three clauses, because they fail differently.</b> A total ratchet catches reads deleted. A
+    /// per-type clause catches a type whose reads all left while the total still cleared — <c>DarlingPgTrendReader</c>
+    /// alone ships 9, so a total floor with any slack cannot see one type emptying. And the SOURCE census is
+    /// the only clause with a denominator from outside reflection: it counts what the reader FILES declare,
+    /// so a read that leaves reflection's reach while its declaration sits in the file — a type renamed off
+    /// the <c>DarlingPg*Reader</c> pattern, a field moved to another namespace, a field kind the filter does
+    /// not read — reds instead of quietly shrinking the population.</para>
+    /// </summary>
+    [Fact]
+    public void TheReadPopulationIsWhatTheReaderFilesDeclare()
+    {
+        var types = ReaderTypes();
+
+        Assert.True(
+            types.Count >= MinimumReaderTypes,
+            $"only {types.Count} DarlingPg*Reader types were found (ratchet {MinimumReaderTypes}); the "
+            + "namespace anchor or the name pattern has stopped matching, so every clause below is vacuous");
+
+        var reads = ShippedReadSql();
+
+        Assert.True(
+            reads.Count >= MinimumExpectedReads,
+            $"only {reads.Count} shipped PostgreSQL reads were discovered (ratchet {MinimumExpectedReads}); "
+            + "reads have left the population, so the parse check below no longer covers what it did");
+
+        var empty = types.Where(t => !QueryFields(t).Any()).Select(t => t.Name).ToList();
+
+        Assert.True(
+            empty.Count == 0,
+            "these reader types contribute no parse-checked read at all, so nothing verifies their SQL "
+            + "resolves: " + string.Join(", ", empty));
+
+        /* The census. Keyed file-stem-to-type-name, which holds because each reader file declares exactly
+           the one reader type it is named for — asserted by the type clause above finding the same 28. */
+        var discovered = new HashSet<string>(reads.Select(r => r.Name), StringComparer.Ordinal);
+        var declared = DeclaredStringFields();
+        var missing = declared.Where(d => !discovered.Contains(d) && !NotQueryFields.Contains(d)).ToList();
+
+        Assert.True(
+            declared.Count >= MinimumExpectedReads,
+            $"only {declared.Count} static string fields were read out of the reader SOURCE (expected at "
+            + $"least the {MinimumExpectedReads} reads reflection finds); the file glob or the declaration "
+            + "pattern has broken, and a census with no denominator cannot fail");
+
+        Assert.True(
+            missing.Count == 0,
+            "these string fields are declared in a DarlingPg*Reader source file but are not in the "
+            + "parse-checked population, so their SQL is shipped unverified — add them to the population, or "
+            + $"to {nameof(NotQueryFields)} if they hold no query: " + string.Join(", ", missing));
+
+        /* A stale allowlist is the same defect one level down: an entry for a field nobody declares any more
+           silently excuses whatever later takes that name. */
+        var unused = NotQueryFields.Where(n => !declared.Contains(n)).ToList();
+
+        Assert.True(
+            unused.Count == 0,
+            $"{nameof(NotQueryFields)} excuses fields no reader declares any more: " + string.Join(", ", unused));
+    }
+
+    /// <summary>
+    /// <c>Type.Field</c> for every <c>const string</c> and <c>static readonly string</c> declared in the
+    /// Storage project's <c>DarlingPg*Reader*.cs</c> files, read from the SOURCE. Read through
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> so a declaration spelled in a doc comment or
+    /// inside a string cannot enter the census — the same instrument the store-SQL pins scan with.
+    /// </summary>
+    private static IReadOnlyList<string> DeclaredStringFields([CallerFilePath] string thisFile = "")
+    {
+        var storage = Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(thisFile)!, "..", "PerformanceMonitor.Darling.Storage"));
+
+        var declaration = new Regex(
+            @"(?:const|static\s+readonly)\s+string\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*=",
+            RegexOptions.Compiled);
+
+        var fields = new List<string>();
+
+        foreach (var path in Directory.EnumerateFiles(storage, "DarlingPg*Reader*.cs", SearchOption.TopDirectoryOnly))
+        {
+            var code = CSharpSourceWalker.StripCommentsAndStrings(File.ReadAllText(path));
+
+            foreach (Match match in declaration.Matches(code))
+            {
+                fields.Add(Path.GetFileNameWithoutExtension(path) + "." + match.Groups["name"].Value);
+            }
+        }
+
+        return fields;
+    }
 
     [Fact]
     public async Task EveryShippedPostgreSqlReadPassesParseAnalysis()
@@ -85,11 +239,14 @@ public sealed class DarlingPgReadSqlParsesLiveTests
         var reads = ShippedReadSql();
 
         /* The anti-vacuity assertion. Without it, a reflection filter that stopped matching would report
-           success over an empty list — a guard that has silently stopped guarding. */
+           success over an empty list — a guard that has silently stopped guarding. Kept here as well as
+           in TheReadPopulationIsWhatTheReaderFilesDeclare because that pin is what makes this number
+           mean anything, and this test is the one that skips: if it ever runs against a shrunken
+           population it should say so itself rather than parse-check a handful of reads and pass. */
         Assert.True(
             reads.Count >= MinimumExpectedReads,
-            $"only {reads.Count} shipped PostgreSQL reads were discovered; the reflection filter has stopped "
-            + "matching, so this test is no longer checking anything");
+            $"only {reads.Count} shipped PostgreSQL reads were discovered (ratchet {MinimumExpectedReads}); "
+            + "the reflection filter has stopped matching, so this test is no longer checking anything");
 
         var ct = TestContext.Current.CancellationToken;
         using var connection = new NpgsqlConnection(cs);

--- a/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
+++ b/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
@@ -189,7 +189,9 @@ public sealed class DarlingPgReadSqlParsesLiveTests
 
         /* Attribution breaking is a different fault from a field being uncovered, and reporting it as
            the latter would send the next reader to the wrong file. */
-        var unattributed = declared.Where(d => d.StartsWith(NoDeclaringType, StringComparison.Ordinal)).ToList();
+        var unattributed = declared
+            .Where(d => d.StartsWith(CSharpMemberMap.Unknown + ".", StringComparison.Ordinal))
+            .ToList();
 
         Assert.True(
             unattributed.Count == 0,
@@ -215,12 +217,15 @@ public sealed class DarlingPgReadSqlParsesLiveTests
     /// <c>Type.Field</c> for every <c>const string</c> and <c>static readonly string</c> declared in the
     /// Storage project's <c>DarlingPg*Reader*.cs</c> files, read from the SOURCE.
     ///
-    /// <para>Read through <see cref="CSharpMemberMap"/> — which walks with
+    /// <para>Read through <see cref="CSharpMemberMap.EnclosingType"/> — which walks with
     /// <see cref="CSharpSourceWalker"/> — so a declaration spelled in a doc comment or inside a string
     /// cannot enter the census, and so each field is attributed to the type that DECLARES it rather
     /// than to the file that holds it. The file stem is not the key: it agrees with the type name only
     /// while no reader file is split, and a partial-class split would key half the fields to a name no
-    /// CLR type has.</para>
+    /// CLR type has. Attribution is the SHARED containment scan rather than a private copy of it, so it
+    /// cannot drift from the member-side answer about an unterminated body — a copy here did exactly
+    /// that, treating one as running to EOF where the shared scan escalates to
+    /// <see cref="CSharpMemberMap.Unknown"/>.</para>
     /// </summary>
     private static IReadOnlyList<string> DeclaredStringFields([CallerFilePath] string thisFile = "")
     {
@@ -239,45 +244,11 @@ public sealed class DarlingPgReadSqlParsesLiveTests
 
             foreach (Match match in declaration.Matches(map.Code))
             {
-                fields.Add(EnclosingType(map, match.Index) + "." + match.Groups["name"].Value);
+                fields.Add(CSharpMemberMap.EnclosingType(map, match.Index) + "." + match.Groups["name"].Value);
             }
         }
 
         return fields;
-    }
-
-    /// <summary>What <see cref="CSharpMemberMap.Unknown"/> is for a member, for a TYPE: the name the
-    /// census keys an unattributable field under, so it fails saying the attribution broke rather than
-    /// saying the field is uncovered.</summary>
-    private const string NoDeclaringType = "<no declaring type>";
-
-    /// <summary>
-    /// The innermost <see cref="CSharpMemberMap.DeclarationKind.Type"/> declaration containing
-    /// <paramref name="offset"/>. Innermost rather than nearest-above because a reader file also
-    /// declares its row types, and a field below one of those belongs to whichever type's BODY it sits
-    /// in — which a scan for the closest preceding declaration would get wrong.
-    /// </summary>
-    private static string EnclosingType(CSharpMemberMap.MemberMap map, int offset)
-    {
-        var name = NoDeclaringType;
-        var innermost = -1;
-
-        foreach (var declaration in map.Declarations)
-        {
-            /* End is -1 when the brace walk never closed the body, which means it runs to EOF. */
-            if (declaration.Kind != CSharpMemberMap.DeclarationKind.Type
-                || declaration.Start > offset
-                || (declaration.End >= 0 && offset >= declaration.End)
-                || declaration.Start <= innermost)
-            {
-                continue;
-            }
-
-            name = declaration.Name;
-            innermost = declaration.Start;
-        }
-
-        return name;
     }
 
     [Fact]

--- a/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
+++ b/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
@@ -172,8 +172,11 @@ public sealed class DarlingPgReadSqlParsesLiveTests
             "these reader types contribute no parse-checked read at all, so nothing verifies their SQL "
             + "resolves: " + string.Join(", ", empty));
 
-        /* The census. Keyed file-stem-to-type-name, which holds because each reader file declares exactly
-           the one reader type it is named for — asserted by the type clause above finding the same 28. */
+        /* The census, keyed by the DECLARING TYPE on both sides. It was keyed by file stem, which held
+           only while every reader file declared exactly the one type it is named for — an invariant
+           nothing asserted, and CONTRIBUTING.md endorses partial classes for large files. Splitting
+           DarlingPgFooReader.cs would have keyed its other half DarlingPgFooReader.Extra.SomeSql,
+           matched nothing, and failed LOUDLY for a field reflection covers fine. */
         var discovered = new HashSet<string>(reads.Select(r => r.Name), StringComparer.Ordinal);
         var declared = DeclaredStringFields();
         var missing = declared.Where(d => !discovered.Contains(d) && !NotQueryFields.Contains(d)).ToList();
@@ -183,6 +186,15 @@ public sealed class DarlingPgReadSqlParsesLiveTests
             $"only {declared.Count} static string fields were read out of the reader SOURCE (expected at "
             + $"least the {MinimumExpectedReads} reads reflection finds); the file glob or the declaration "
             + "pattern has broken, and a census with no denominator cannot fail");
+
+        /* Attribution breaking is a different fault from a field being uncovered, and reporting it as
+           the latter would send the next reader to the wrong file. */
+        var unattributed = declared.Where(d => d.StartsWith(NoDeclaringType, StringComparison.Ordinal)).ToList();
+
+        Assert.True(
+            unattributed.Count == 0,
+            "these declared string fields could not be attributed to a declaring type, so the census "
+            + "cannot be compared against reflection at all: " + string.Join(", ", unattributed));
 
         Assert.True(
             missing.Count == 0,
@@ -201,9 +213,14 @@ public sealed class DarlingPgReadSqlParsesLiveTests
 
     /// <summary>
     /// <c>Type.Field</c> for every <c>const string</c> and <c>static readonly string</c> declared in the
-    /// Storage project's <c>DarlingPg*Reader*.cs</c> files, read from the SOURCE. Read through
-    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> so a declaration spelled in a doc comment or
-    /// inside a string cannot enter the census — the same instrument the store-SQL pins scan with.
+    /// Storage project's <c>DarlingPg*Reader*.cs</c> files, read from the SOURCE.
+    ///
+    /// <para>Read through <see cref="CSharpMemberMap"/> — which walks with
+    /// <see cref="CSharpSourceWalker"/> — so a declaration spelled in a doc comment or inside a string
+    /// cannot enter the census, and so each field is attributed to the type that DECLARES it rather
+    /// than to the file that holds it. The file stem is not the key: it agrees with the type name only
+    /// while no reader file is split, and a partial-class split would key half the fields to a name no
+    /// CLR type has.</para>
     /// </summary>
     private static IReadOnlyList<string> DeclaredStringFields([CallerFilePath] string thisFile = "")
     {
@@ -218,15 +235,49 @@ public sealed class DarlingPgReadSqlParsesLiveTests
 
         foreach (var path in Directory.EnumerateFiles(storage, "DarlingPg*Reader*.cs", SearchOption.TopDirectoryOnly))
         {
-            var code = CSharpSourceWalker.StripCommentsAndStrings(File.ReadAllText(path));
+            var map = CSharpMemberMap.Of(File.ReadAllText(path));
 
-            foreach (Match match in declaration.Matches(code))
+            foreach (Match match in declaration.Matches(map.Code))
             {
-                fields.Add(Path.GetFileNameWithoutExtension(path) + "." + match.Groups["name"].Value);
+                fields.Add(EnclosingType(map, match.Index) + "." + match.Groups["name"].Value);
             }
         }
 
         return fields;
+    }
+
+    /// <summary>What <see cref="CSharpMemberMap.Unknown"/> is for a member, for a TYPE: the name the
+    /// census keys an unattributable field under, so it fails saying the attribution broke rather than
+    /// saying the field is uncovered.</summary>
+    private const string NoDeclaringType = "<no declaring type>";
+
+    /// <summary>
+    /// The innermost <see cref="CSharpMemberMap.DeclarationKind.Type"/> declaration containing
+    /// <paramref name="offset"/>. Innermost rather than nearest-above because a reader file also
+    /// declares its row types, and a field below one of those belongs to whichever type's BODY it sits
+    /// in — which a scan for the closest preceding declaration would get wrong.
+    /// </summary>
+    private static string EnclosingType(CSharpMemberMap.MemberMap map, int offset)
+    {
+        var name = NoDeclaringType;
+        var innermost = -1;
+
+        foreach (var declaration in map.Declarations)
+        {
+            /* End is -1 when the brace walk never closed the body, which means it runs to EOF. */
+            if (declaration.Kind != CSharpMemberMap.DeclarationKind.Type
+                || declaration.Start > offset
+                || (declaration.End >= 0 && offset >= declaration.End)
+                || declaration.Start <= innermost)
+            {
+                continue;
+            }
+
+            name = declaration.Name;
+            innermost = declaration.Start;
+        }
+
+        return name;
     }
 
     [Fact]

--- a/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
+++ b/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
@@ -47,12 +47,18 @@ namespace Darling.Tests;
 /// </summary>
 public sealed class StoreSqlClockDisciplineTests
 {
-    /* Floors, so the scan cannot pass by finding nothing. Measured on dev at the time of writing: 563 files,
-       19,604 string literals, 1,627 of them SQL-shaped, 56 naive timestamp column names. Set well below
-       those so ordinary growth never trips them, but high enough that a broken glob or a desynchronised
-       literal walk fails instead of reporting a clean bill of health. The column-vocabulary floor is the one
-       that matters most: the discriminator needs those names, and a DDL scrape that quietly returned four of
-       them would make every offender below invisible while still reporting thousands of literals scanned. */
+    /* Floors, so the scan cannot pass by finding nothing. Measured on dev: 602 files, 20,843 string literal
+       bodies welded into 1,681 SQL-shaped UNITS (815 units weld two or more bodies; the widest welds 55),
+       57 naive timestamp column names. Set well below those so ordinary growth never trips them, but high
+       enough that a broken glob or a desynchronised literal walk fails instead of reporting a clean bill of
+       health. The column-vocabulary floor is the one that matters most: the discriminator needs those names,
+       and a DDL scrape that quietly returned four of them would make every offender below invisible while
+       still reporting thousands of literals scanned.
+
+       The SQL floor counts welded units, which is FEWER than the bodies it reads - grouping collapsed 1,752
+       per-body matches into 1,681 units while adding eight that no single body was SQL-shaped enough to
+       reach. A drop is therefore not by itself evidence of lost reach; the unit count and the body count are
+       both floored so a walk that desynchronised would fail the second one. */
     private const int MinimumFilesScanned = 200;
     private const int MinimumLiteralsScanned = 12_000;
     private const int MinimumSqlLiteralsScanned = 1_200;
@@ -126,7 +132,7 @@ public sealed class StoreSqlClockDisciplineTests
 
         var files = 0;
         var literals = 0;
-        var sqlLiterals = 0;
+        var sqlUnits = 0;
         var offenders = new List<string>();
 
         foreach (var path in StoreSourceFiles())
@@ -134,44 +140,36 @@ public sealed class StoreSqlClockDisciplineTests
             files++;
             var text = File.ReadAllText(path);
             var name = Path.GetFileName(path);
+            var scan = ScanSource(text, columns);
+
+            literals += scan.Literals;
+            sqlUnits += scan.SqlUnits;
 
             /* Built at most once per file, and only when a finding needs a name. */
             CSharpMemberMap.MemberMap? members = null;
 
-            foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(text))
+            foreach (var (start, finding) in scan.Offenders)
             {
-                literals++;
+                members ??= CSharpMemberMap.Of(text);
+                var member = CSharpMemberMap.EnclosingMember(members, start);
 
-                if (!LooksLikeSql(body))
+                /* The waiver key is file:member, so a wrong member name is a wrong DECISION here and
+                   not merely a wrong message: it can miss a legitimate waiver, or collide with an
+                   unrelated one and swallow a real finding. #3094 replaced the copy of the resolver
+                   this file used to carry, which answered `if`, `using`, `while`, `Select` and
+                   `NpgsqlCommand` at 21 sites in this very tree. */
+                if (Waived.Contains(name + ":" + member))
                 {
                     continue;
                 }
 
-                sqlLiterals++;
-
-                foreach (var finding in MixedClockComparisons(body, columns))
-                {
-                    members ??= CSharpMemberMap.Of(text);
-                    var member = CSharpMemberMap.EnclosingMember(members, start);
-
-                    /* The waiver key is file:member, so a wrong member name is a wrong DECISION here and
-                       not merely a wrong message: it can miss a legitimate waiver, or collide with an
-                       unrelated one and swallow a real finding. #3094 replaced the copy of the resolver
-                       this file used to carry, which answered `if`, `using`, `while`, `Select` and
-                       `NpgsqlCommand` at 21 sites in this very tree. */
-                    if (Waived.Contains(name + ":" + member))
-                    {
-                        continue;
-                    }
-
-                    offenders.Add($"{name}:{member} — {finding}");
-                }
+                offenders.Add($"{name}:{member} — {finding}");
             }
         }
 
         Assert.True(files >= MinimumFilesScanned, $"scanned only {files} store source files (floor {MinimumFilesScanned})");
-        Assert.True(literals >= MinimumLiteralsScanned, $"scanned only {literals} string literals (floor {MinimumLiteralsScanned})");
-        Assert.True(sqlLiterals >= MinimumSqlLiteralsScanned, $"scanned only {sqlLiterals} SQL literals (floor {MinimumSqlLiteralsScanned})");
+        Assert.True(literals >= MinimumLiteralsScanned, $"scanned only {literals} string literal bodies (floor {MinimumLiteralsScanned})");
+        Assert.True(sqlUnits >= MinimumSqlLiteralsScanned, $"scanned only {sqlUnits} SQL-shaped units (floor {MinimumSqlLiteralsScanned})");
 
         Assert.True(
             offenders.Count == 0,
@@ -259,6 +257,378 @@ public sealed class StoreSqlClockDisciplineTests
                 "the discriminator FLAGGED a benign form: " + sql
                     + " => " + string.Join("; ", MixedClockComparisons(sql, columns)));
         }
+    }
+
+    /// <summary>
+    /// The literal GROUPING, pinned against C# SOURCE fixtures rather than SQL strings. The defect it closes
+    /// is not in the discriminator — that reads either half of a split predicate correctly — but in what the
+    /// scan hands it, so a fixture written as SQL could not reach it. Each shape below is one this corpus
+    /// contains.
+    /// </summary>
+    [Fact]
+    public void TheScan_WeldsAPredicateSplitAcrossAConcatenation_AndWeldsNothingElse()
+    {
+        var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "collection_time" };
+
+        /* Split exactly at the operator: the first literal ends at `<`, the second opens with the clock.
+           NEITHER body is a comparison on its own, so read one at a time this reports clean — and the second
+           is not even SQL-shaped, so it never reaches the discriminator at all. */
+        const string bareGlue = @"class C { const string Sql = @""DELETE FROM t WHERE collection_time < "" + @""now() - interval '1 hour'""; }";
+
+        /* The same split with an EXPRESSION in the gap, which is the shape the store's composed SQL actually
+           ships (`QueryStorePlanMap` and `QueryStoreTextStore` interpolate a column-name constant this way,
+           and `DarlingPgColumnStatsReader.CoverageEvidenceSql` interpolates three values). */
+        const string expressionGlue = @"class C { const string Sql = @""SELECT 1 FROM t WHERE collection_time > $1 AND collection_time < "" + Cast + @""now() - interval '1 hour'""; }";
+
+        /* A comment in the gap, carrying both a clock and a `;`. The weld is judged on CODE characters, so
+           neither can split a run the compiler joins — and this repo's SQL comments discuss `now()`
+           constantly. */
+        const string commentedGlue = @"class C { const string Sql = @""DELETE FROM t WHERE collection_time < "" /* not now(); the zone shifts it */ + @""now() - interval '1 hour'""; }";
+
+        foreach (var (label, source) in new[]
+        {
+            ("bare + glue", bareGlue),
+            ("expression glue", expressionGlue),
+            ("comment in the gap", commentedGlue),
+        })
+        {
+            Assert.True(
+                ScanSource(source, columns).Offenders.Count > 0,
+                $"the scan MISSED a predicate split across a concatenation ({label}) — this is the coverage "
+                + "loss the grouping exists to close: " + source);
+        }
+
+        /* Welding these WOULD read as the hazard above, and welding them would be wrong. Each is the same
+           two literals separated by something no concatenation puts between them. */
+        var mustNotWeld = new (string Label, string Source)[]
+        {
+            ("separate statements",
+                @"class C { const string A = @""DELETE FROM t WHERE collection_time < ""; const string B = @""now() - interval '1 hour'""; }"),
+            ("separate arguments",
+                @"class C { void M() { Run(@""DELETE FROM t WHERE collection_time < "", @""now() - interval '1 hour'""); } }"),
+            ("collection elements",
+                @"class C { static readonly string[] Parts = [@""DELETE FROM t WHERE collection_time < "", @""now() - interval '1 hour'""]; }"),
+            /* The two shapes that make the glue test more than a first-character check. Each ends one
+               statement or argument mid-concatenation and opens the next the same way, so the gap holds a
+               `+` — the first at one end, the second at BOTH — and only the breaker between them says they
+               are not one expression. Without these two the corpus stays green with the whole breaker test
+               deleted, which is how a control ends up certifying nothing. */
+            ("a + in the gap, but two statements",
+                @"class C { void M() { var a = @""DELETE FROM t WHERE collection_time < "" + x; var b = @""now() - interval '1 hour'""; } }"),
+            ("a + at BOTH ends of the gap, but two statements",
+                @"class C { void M() { var a = @""DELETE FROM t WHERE collection_time < "" + x; var b = y + @""now() - interval '1 hour'""; } }"),
+            ("a + at both ends of the gap, but two arguments",
+                @"class C { void M() { Run(@""DELETE FROM t WHERE collection_time < "" + x, y + @""now() - interval '1 hour'""); } }"),
+            /* A conditional's two arms. Nothing separates them but the `:`, so the gap holds no statement
+               or argument break at all — these two are the only fixtures the `+`-at-both-ends test and the
+               depth-zero colon test respectively are the sole reason for rejecting, and welding arms that
+               never both run invents a predicate no execution can produce. */
+            ("the two arms of a conditional",
+                @"class C { void M() { var s = flag ? @""DELETE FROM t WHERE collection_time < "" + x : @""now() - interval '1 hour'""; } }"),
+            ("the two arms of a conditional, + at both ends of the gap",
+                @"class C { void M() { var s = flag ? @""DELETE FROM t WHERE collection_time < "" + x : y + @""now() - interval '1 hour'""; } }"),
+            /* A comparison used as a condition, with the second literal concatenated inside the arm it
+               governs. The gap ends with a `+` but does not START with one, and it holds no separator at
+               depth zero at all, so the `+`-at-BOTH-ends test is the only thing that rejects it. Modelled
+               on the real shape in DarlingMcpPgWraparoundTools, whose gap is
+               `&&Rank(multi)>Rank(xid)?worst+`; measured, it and one other are the only two adjacent gaps
+               in the corpus where a bare "the gap contains a +" rule would weld and this one does not. */
+            ("a comparison in a condition, with the arm concatenating the next literal",
+                @"class C { void M() { var s = k == @""DELETE FROM t WHERE collection_time < "" && Rank(m) > Rank(x) ? worst + @""now() - interval '1 hour'"" : other; } }"),
+        };
+
+        foreach (var (label, source) in mustNotWeld)
+        {
+            var found = ScanSource(source, columns).Offenders;
+
+            Assert.True(
+                found.Count == 0,
+                $"the scan WELDED two literals that are not one concatenation ({label}), inventing a "
+                + "predicate the runtime never builds: " + string.Join("; ", found.Select(o => o.Finding)));
+        }
+
+        /* The grouping's own shape, not only its end effect: one welded unit against two separate ones, so a
+           regression that stopped welding while some other change kept the end-to-end assertions passing
+           still fails here. */
+        var welded = Assert.Single(ConcatenatedLiteralUnits(bareGlue));
+        Assert.Equal(2, welded.Bodies);
+        Assert.Contains("collection_time < now()", welded.Text, StringComparison.Ordinal);
+
+        var separate = ConcatenatedLiteralUnits(mustNotWeld[0].Source);
+        Assert.Equal(2, separate.Count);
+        Assert.All(separate, unit => Assert.Equal(1, unit.Bodies));
+
+        /* Nesting, pinned on the SHAPE rather than on a finding. A literal inside an interpolation hole
+           must weld with neither its container nor its container's neighbours — two units, one body each —
+           and 144 bodies in the corpus are nested that way, so grouping by source adjacency alone would
+           splice a body into its own container. Deliberately not asserted through the discriminator: the
+           walker preserves a nested literal's own text inside the container's rendering (only CODE is
+           blanked), so a hole holding a column name is already a finding on the container alone, and a
+           findings-based fixture here would pass whatever the grouping did with it. */
+        var nested = ConcatenatedLiteralUnits(
+            @"class C { void M() { var sql = $@""SELECT a FROM t WHERE {Col(@""collection_time"")} < $1""; } }");
+
+        Assert.Equal(2, nested.Count);
+        Assert.All(nested, unit => Assert.Equal(1, unit.Bodies));
+
+        /* And the composition, which is the part the parent tracking actually buys. Here a container with a
+           hole is concatenated to a following literal: the weld belongs to the CONTAINER, so its unit must
+           carry both halves. Grouped by walk order instead, the nested body would be the run left open when
+           the trailing literal arrives and would weld to THAT — silently dropping the container's own text
+           out of the welded unit while still yielding two units, so a count-only assertion cannot see it. */
+        var weldedContainer = ConcatenatedLiteralUnits(
+            @"class C { void M() { var sql = $@""SELECT {F(@""x"")} FROM t "" + @""WHERE collection_time < now()""; } }");
+
+        Assert.Equal(2, weldedContainer.Count);
+        Assert.Contains(
+            weldedContainer,
+            unit => unit.Bodies == 2 && unit.Text.Contains("FROM t WHERE collection_time", StringComparison.Ordinal));
+
+        /* The two renderings, pinned apart. A bare `+` contributes nothing at runtime, so welding with a
+           space there would invent a token boundary in a statement split across source lines; an expression
+           contributes an unknown string, so a space is the only substitution that changes no adjacency. */
+        Assert.Contains(
+            "collection_time < now()",
+            ConcatenatedLiteralUnits(@"class C { const string S = @""WHERE collection_time < "" + @""now()""; }")[0].Text,
+            StringComparison.Ordinal);
+
+        Assert.Contains(
+            "collection_time <  now()",
+            ConcatenatedLiteralUnits(@"class C { const string S = @""WHERE collection_time < "" + Cast + @""now()""; }")[0].Text,
+            StringComparison.Ordinal);
+    }
+
+    /* ---------------- literal grouping ---------------- */
+
+    /// <summary>
+    /// What one file's scan found: the counters that certify it was not vacuous, and each offender with the
+    /// offset it starts at. One value rather than three out-parameters, so a caller cannot take the
+    /// offenders and drop the counters that are the only evidence they mean anything.
+    /// </summary>
+    internal readonly record struct SourceScan(
+        int Literals, int SqlUnits, IReadOnlyList<(int Start, string Finding)> Offenders);
+
+    /// <summary>
+    /// One C# file's SQL, judged. Internal and FILE-shaped rather than corpus-shaped so the control pin
+    /// above exercises the same grouping, the same SQL-shape filter and the same discriminator the corpus
+    /// scan runs; a control that reconstructed any of the three would certify behaviour this scan does not
+    /// have.
+    /// </summary>
+    internal static SourceScan ScanSource(string text, ISet<string> columns)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        var literals = 0;
+        var sqlUnits = 0;
+        var offenders = new List<(int Start, string Finding)>();
+
+        foreach (var (start, sql, bodies) in ConcatenatedLiteralUnits(text))
+        {
+            literals += bodies;
+
+            if (!LooksLikeSql(sql))
+            {
+                continue;
+            }
+
+            sqlUnits++;
+
+            foreach (var finding in MixedClockComparisons(sql, columns))
+            {
+                offenders.Add((start, finding));
+            }
+        }
+
+        return new SourceScan(literals, sqlUnits, offenders);
+    }
+
+    /// <summary>
+    /// <para>Every string in <paramref name="text"/> as a scanned UNIT: a maximal run of string literals
+    /// welded by C# <c>+</c> concatenation into the one string the runtime builds, with the offset the run
+    /// starts at and how many literal bodies went into it.</para>
+    ///
+    /// <para><b>Why a run and not a body.</b> A predicate assembled as
+    /// <c>@"… WHERE collection_time &lt; " + Bound + @"now() - interval '1 hour'"</c> is several bodies, and
+    /// a bare clock on one side of a <c>+</c> with the naive column on the other is a comparison in NEITHER
+    /// of them. Read one body at a time this scan reports clean on it, which is a pass for the wrong reason.
+    /// Measured on the corpus: 815 runs weld two or more literals, and EIGHT are units no member body is
+    /// even SQL-shaped enough to reach the discriminator — four of those eight are the
+    /// <c>config_alert_log</c> reads in <c>DarlingAlertReader</c> and <c>ViewerDataService.AlertHistory</c>,
+    /// which is the site class this pin's own remarks name as its reason for existing.</para>
+    ///
+    /// <para><b>The gap is rendered by what the runtime puts there.</b> Glue that is a bare <c>+</c>
+    /// contributes nothing, so those bodies weld with nothing — inserting a space would invent a token
+    /// boundary in a statement merely split across source lines. Glue carrying an EXPRESSION contributes an
+    /// unknown string, so those weld with a single space: the same substitution, for the same reason,
+    /// <see cref="CSharpSourceWalker.StringLiteralBodies"/> already makes for an interpolation hole — a
+    /// space changes no adjacency, and eliding it would fuse the tokens either side into one word that
+    /// neither the source nor the database ever contains.</para>
+    ///
+    /// <para><b>What is deliberately not welded</b>, because welding it would invent a predicate the runtime
+    /// never builds: literals in separate statements, in separate arguments or collection elements, or in
+    /// separate blocks, and the two arms of a conditional. A run is recognised by glue that begins and
+    /// ends with <c>+</c> and holds no separator at expression depth zero — see
+    /// <see cref="WeldBetween"/>, which measures what each of those two tests is the sole reason for
+    /// rejecting. Judged on CODE characters only, so a <c>;</c> written in a comment between two
+    /// concatenated literals cannot split a run the compiler joins.</para>
+    ///
+    /// <para><b>Nesting is respected.</b> A literal inside an interpolation hole is a body of its own and
+    /// its container has that hole blanked, so it welds only with its own siblings inside the hole. 144
+    /// bodies in the corpus are nested that way.</para>
+    ///
+    /// <para><b>Stated limit.</b> The glue's VALUE is not resolved, so a hazard whose column or clock lives
+    /// in the interpolated constant rather than in a literal is still outside this scan — welding cannot
+    /// invent text it never sees. Resolving constants across files is a different instrument.</para>
+    /// </summary>
+    internal static IReadOnlyList<(int Start, string Text, int Bodies)> ConcatenatedLiteralUnits(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        /* The same walk the bodies come from, with the literals blanked instead of kept, so the gap between
+           two bodies is read with exactly the walker's notion of what is code. */
+        var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+        var bodies = CSharpSourceWalker.StringLiteralBodies(text)
+            .Select(body => (body.Start, body.Text, End: body.Start + body.Text.Length))
+            .OrderBy(body => body.Start)
+            .ThenByDescending(body => body.End)
+            .ToList();
+
+        /* The innermost body strictly containing each one, or -1 at the top level. A container sorts before
+           its content, so the first enclosing span found walking backwards is the innermost. */
+        var parent = new int[bodies.Count];
+
+        for (var i = 0; i < bodies.Count; i++)
+        {
+            parent[i] = -1;
+
+            for (var j = i - 1; j >= 0; j--)
+            {
+                if (bodies[j].Start <= bodies[i].Start && bodies[i].End <= bodies[j].End)
+                {
+                    parent[i] = j;
+                    break;
+                }
+            }
+        }
+
+        var starts = new List<int>();
+        var texts = new List<StringBuilder>();
+        var counts = new List<int>();
+        var ends = new List<int>();
+
+        /* The run currently open at each nesting level, so a body welds with the previous body under its
+           OWN parent and never with whatever literal happened to be walked most recently. */
+        var open = new Dictionary<int, int>();
+
+        for (var i = 0; i < bodies.Count; i++)
+        {
+            if (open.TryGetValue(parent[i], out var run)
+                && WeldBetween(code, ends[run], bodies[i].Start) is { } weld)
+            {
+                texts[run].Append(weld).Append(bodies[i].Text);
+                counts[run]++;
+                ends[run] = bodies[i].End;
+                continue;
+            }
+
+            starts.Add(bodies[i].Start);
+            texts.Add(new StringBuilder(bodies[i].Text));
+            counts.Add(1);
+            ends.Add(bodies[i].End);
+            open[parent[i]] = starts.Count - 1;
+        }
+
+        var units = new List<(int Start, string Text, int Bodies)>(starts.Count);
+
+        for (var i = 0; i < starts.Count; i++)
+        {
+            units.Add((starts[i], texts[i].ToString(), counts[i]));
+        }
+
+        return units;
+    }
+
+    /// <summary>
+    /// What the runtime puts between two literal bodies — <c>""</c> for a bare <c>+</c>, a single space for
+    /// glue carrying an expression — or null when the two are not one concatenation.
+    ///
+    /// <para><b>Two tests, and each is load-bearing on a shape the other clears.</b> A `+` at BOTH ends is
+    /// what an argument list, a collection initializer and the second arm of a conditional fail. A
+    /// separator at expression depth ZERO is what a gap that ends one statement mid-concatenation and opens
+    /// the next the same way fails — <c>… + x; var b = y + …</c> has a `+` at both ends and is two
+    /// statements. Measured on the corpus: 2,175 gaps have a `+` at both ends and 10 of them are that
+    /// shape, in files whose business is composing SQL (<c>ComposeCompiler</c>, <c>DarlingNetworkConfigEditor</c>).
+    /// Welding one would splice unrelated fragments and could invent an offender.</para>
+    ///
+    /// <para><b>Depth is why the separator test is a walk and not a <c>Contains</c>.</b> A comma inside the
+    /// glue's own call — <c>+ DarlingToolExitCode.Diagnose(exitCode, exePath) +</c>, four times in this
+    /// corpus — is one concatenation, and rejecting it would be a miss for no gain. A comma at depth zero
+    /// is an argument boundary. Same for a colon: parenthesised it is a conditional inside the glue, bare
+    /// it is a conditional's two arms and welding across it splices branches that never both run.</para>
+    /// </summary>
+    private static string? WeldBetween(string code, int end, int start)
+    {
+        if (start < end)
+        {
+            return null;
+        }
+
+        var glue = new StringBuilder(start - end);
+
+        for (var i = end; i < start; i++)
+        {
+            if (!char.IsWhiteSpace(code[i]))
+            {
+                glue.Append(code[i]);
+            }
+        }
+
+        var between = glue.ToString();
+
+        if (between.Length == 0 || between[0] != '+' || between[^1] != '+')
+        {
+            return null;
+        }
+
+        var depth = 0;
+
+        for (var i = 0; i < between.Length; i++)
+        {
+            var c = between[i];
+
+            if (c is '(' or '[' or '{')
+            {
+                depth++;
+            }
+            else if (c is ')' or ']' or '}')
+            {
+                /* Below zero means the gap CLOSED a scope that was already open when it started, so the
+                   two literals sit in different arguments or different blocks. */
+                if (--depth < 0)
+                {
+                    return null;
+                }
+            }
+            else if (depth == 0 && (c is ';' or ','))
+            {
+                return null;
+            }
+            else if (depth == 0 && c == ':')
+            {
+                /* `global::Foo` is the one legitimate top-level colon pair in an expression — the same
+                   carve-out CSharpSourceWalker makes inside an interpolation hole. */
+                if (i + 1 >= between.Length || between[i + 1] != ':')
+                {
+                    return null;
+                }
+
+                i++;
+            }
+        }
+
+        return depth == 0 ? between.Length == 1 ? string.Empty : " " : null;
     }
 
     /* ---------------- the discriminator ---------------- */
@@ -535,7 +905,12 @@ public sealed class StoreSqlClockDisciplineTests
         {
             var text = File.ReadAllText(path);
 
-            foreach (var (_, body) in CSharpSourceWalker.StringLiteralBodies(text))
+            /* The same welded units the SQL scan reads, not raw bodies, because a DDL literal assembled by
+               concatenation splits its own column list and this vocabulary is what the discriminator has -
+               a name it never learns is an offender it cannot see. Measured, this changes nothing today:
+               57 names either way, because every rung's DDL is one literal. It is here so the two sites
+               cannot disagree about what a literal IS, which is the way the split above went unnoticed. */
+            foreach (var (_, body, _) in ConcatenatedLiteralUnits(text))
             {
                 foreach (Match match in declaration.Matches(body))
                 {
@@ -639,12 +1014,9 @@ public sealed class StoreSqlClockDisciplineTests
     /// recognised by carrying both a clock and a comparison, which is all the discriminator needs to judge
     /// it.</para>
     ///
-    /// <para>Known limit, stated rather than papered over: the scan reads ONE literal at a time, so a
-    /// predicate whose column sits in one literal and whose clock sits in another — welded together only by
-    /// concatenation — is outside it. No such split exists in the corpus today; the one fragment pairing a
-    /// clock with a column, <c>ViewerDataService.MonitoredServers</c>, already uses the rescued
-    /// <c>AT TIME ZONE 'UTC'</c> form. Catching it would mean resolving concatenation rather than reading
-    /// literals.</para>
+    /// <para>Applied to a welded UNIT, not to one literal body, so a fragment whose column sits in one
+    /// literal and whose clock sits in the next is read as the predicate it is — see
+    /// <see cref="ConcatenatedLiteralUnits"/> for why, and for the limit that remains.</para>
     /// </summary>
     private static bool LooksLikeSql(string body) =>
         body.Contains("SELECT ", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Two source-scanning guards each reported a clean pass over a population that had a real thing outside it. Neither weakness came from #3216; both are pre-existing, and both are the shape where the guard's own output is indistinguishable from success.

## 1. `StoreSqlClockDisciplineTests` scanned per literal BODY, so a concatenated predicate was split for the scan

The pin flags store SQL comparing a naive collector timestamp against a bare clock function, because PostgreSQL resolves the mixed comparison at the store session's TimeZone — a documented one-hour predicate spanning five under `America/New_York`. It iterated `CSharpSourceWalker.StringLiteralBodies` one body at a time, so a statement assembled as `@"… WHERE collection_time < " + Bound + @"now() - interval '1 hour'"` put the column in one body and the clock in another. The comparison is in neither, and the second body is not even SQL-shaped, so it never reached the discriminator at all.

The scan now reads maximal runs of literals welded by C# `+` concatenation, rendered as the string the runtime builds: nothing between a bare `+` (which contributes nothing, so inserting a space would invent a token boundary in a statement merely split across source lines), and a single space where the glue carries an expression whose value is unknown — the substitution `StringLiteralBodies` already makes for an interpolation hole, for the same reason.

**Reachability, measured, not argued.** 815 runs in the corpus weld two or more literals, and **8 are units no member body was SQL-shaped enough to reach the discriminator**. Four of those eight are the `config_alert_log` reads in `DarlingAlertReader` and `ViewerDataService.AlertHistory` — the exact site class this pin's own remarks name as its reason for existing ("two of the sites this pin was written for are alert reads and an alert that returns no rows never fires"). All four bind their bounds and are clean. None had ever been read.

**No false positive.** Offenders are 1 before and 1 after (the arithmetic-waived `DarlingModuleMap.RefreshSql`). That holds with #3216's three composed `TouchAndProbeSql` sites in the tree, which this scan now welds and reads for the first time — confirming they are inert rather than taking it on trust.

The `LooksLikeSql` remarks that stated this limit are replaced rather than left to contradict the code.

**What is deliberately not welded**, because welding it would invent a predicate the runtime never builds: separate statements, separate arguments or collection elements, separate blocks, and the two arms of a conditional. Two tests do that, and each is load-bearing on a shape the other clears:

- A `+` at **both** ends of the gap. 2,175 gaps have one; the two the alternative "gap contains a `+`" rule would additionally weld are real corpus shapes (`DarlingMcpPgWraparoundTools`' `&&Rank(multi)>Rank(xid)?worst+`), and one of them is the fixture for this clause.
- A separator at expression **depth zero**. `… + x; var b = y + …` has a `+` at both ends and is two statements; 10 corpus gaps are that shape, in `ComposeCompiler` and `DarlingNetworkConfigEditor` — files whose business is composing SQL, where a false weld could invent an offender.

Depth is why the separator test is a walk and not a `Contains`: a comma inside the glue's own call (`+ DarlingToolExitCode.Diagnose(exitCode, exePath) +`, four times here) is one concatenation, and a depth-blind rule splits it for no gain.

Nesting is respected — a literal inside an interpolation hole welds only with its own siblings, and 144 bodies are nested that way.

The DDL column scrape reads the same welded units. Measured, that changes nothing today (57 names either way, because every rung's DDL is one literal); it is there so the two sites cannot disagree about what a literal *is*, which is how the split went unnoticed.

## 2. `DarlingPgReadSqlParsesLiveTests` had a floor of 10 against a population of 49, and one shipped read was outside it

This is the suite that `PREPARE`s every shipped PostgreSQL read against a real server. The defect it exists for (#2554: an ambiguous `LEFT JOIN` column, 42702, throwing on every call for months while a dozen text assertions passed) is invisible to every other instrument, so a read that drops out of this population loses its only parse check.

**The population claim was wrong.** Its doc said "twelve constants exist today across nine readers". Measured: **28 reader types ship 49 reads.** A floor of 10 against 49 tolerated a 39-read drop — 79% of the population could leave while the guard reported a clean pass.

**And one read was already outside.** Discovery filtered on `f.IsLiteral`, and a `static readonly string` composed by concatenation is not a literal. `DarlingPgColumnStatsReader.CoverageEvidenceSql` — a shipped read, executed at every column-stats coverage call, interpolating a status list and two collector thresholds — had never been parse-checked. Discovery now reads `const` and `static readonly` alike; that read passes `PREPARE` against PostgreSQL 17.11, verified rather than assumed.

The single floor is replaced by three clauses that fail differently:

- a **ratchet at the live population** (49). Growth never trips it, so it still needs no edit when a read lands; a read removed reds, which is the direction a coverage loss travels in.
- a **per-type clause**: every matched reader type must contribute at least one read. `DarlingPgTrendReader` alone ships 9, so no total with slack can see one type emptying.
- a **source census**: every `const string` / `static readonly string` declared in the Storage project's `DarlingPg*Reader*.cs` files must be in the parse-checked population or in a named, per-site `NotQueryFields` set. This is the only clause whose denominator comes from outside reflection, so it is the only one that sees a read leave reflection's reach while its declaration sits in the file — a type renamed off the pattern, a field moved, a field kind the filter does not read. A stale allowlist entry reds too.

`NotQueryFields` holds three: two SQL fragments interpolated into a query, and `DarlingPgTableBloatReader.StaleStatisticsChurnRatioSql`, which is spelled like a query and holds `"0.2"` — the trap that makes any name-shaped rule useless here.

The census runs **without a server**. The old floor lived inside the `DARLING_TEST_PG`-gated test, so on the Windows `build` job nothing checked the discovery at all.

### Census keying: by declaring type, not file stem

The census originally keyed source-declared fields by `Path.GetFileNameWithoutExtension`, and its comment justified that with a 1-file-per-type invariant **nothing asserted**. `CONTRIBUTING.md` endorses partial classes for large files, so splitting `DarlingPgFooReader.cs` would key half its fields `DarlingPgFooReader.Extra.SomeSql`, match nothing, and fail **loudly** for a field that reflection and the parse check both cover — a false failure in a pin whose whole subject is guards that report the wrong thing.

Reproduced both ways. With `DarlingPgTrendReader` made partial and an `ExtraProbeSql` added in `DarlingPgTrendReader.Extra.cs`:

| Census keying | Result |
|---|---|
| file stem | **1 failed** — "not in the parse-checked population: `DarlingPgTrendReader.Extra.ExtraProbeSql`" |
| declaring type | **0 failed**, read count rises to 50 |

Attribution runs through `CSharpMemberMap`, so it walks with `CSharpSourceWalker` like the other source pins, and takes the **innermost** enclosing type — a reader file also declares its row types, so nearest-declaration-above would get it wrong. A field that cannot be attributed asserts as an *attribution* failure rather than as an uncovered read, because reporting it as the latter sends the next reader to the wrong file.

### One containment scan, not a third copy

Resolving the declaring type was first done with a private copy of `CSharpMemberMap.EnclosingMember`'s containment scan, differing only by a `DeclarationKind` — a third copy of the shape #2913 consolidated from five and #3094 fixed a half-corrected copy of.

It was also not a faithful copy. `EnclosingMember` escalates an unterminated body (`End < 0`) to `Unknown` rather than guess; the copy treated one as running to EOF and would have attributed a field to a type the brace walk had lost. Inert today (0 unattributed either way), and precisely the quiet divergence between two copies that #3094 was about.

`CSharpMemberMap` now exposes `EnclosingType` beside `EnclosingMember`, both delegating to one private `Enclosing(map, offset, kind)`, so the `End < 0` judgement is made once. `DeclarationKind`'s doc claimed types are "excluded from attribution", which `EnclosingType` makes untrue; it now says excluded from *member* attribution.

**Proved behaviour-preserving for the six pins that already call `EnclosingMember`**: the pre-refactor body and the delegated call agree at **all 673,093 probed offsets across 2,229 files** — every literal start and end, every declaration boundary, and a coarse sweep besides. `EnclosingType` resolves to a type at 633,459 of those offsets, so it is not degenerate.

### The census pattern is anchored to a declaration

It first matched `const string X =` anywhere in the stripped source. C# allows a **local** `const string`, and reflection only ever sees static fields — so a local added to any reader method would sit in `missing` permanently, and the only way to quiet it would be putting a local into `NotQueryFields`, which is for fields that hold no query rather than for what the pattern over-matched.

The scan now walks the declarations `CSharpMemberMap` already found and asks which of them are static string fields, instead of pattern-matching positions of its own. `DeclarationHead` requires an access modifier, which a local cannot carry, so anchoring is what excludes them.

Reproduced with `const string UnrelatedLocal = "not a query";` added inside `DarlingPgXminReader`'s read method:

| Census pattern | Result |
|---|---|
| free regex over the file | **1 failed** — "not in the parse-checked population: `DarlingPgXminReader.UnrelatedLocal`" |
| anchored to a declaration | **0 failed** |

The population is unchanged either way — 52 declared, 49 discovered, the 3 remaining being exactly the `NotQueryFields` entries — so anchoring costs no reach.

## Mutation evidence

Baseline on this branch, xUnit v3 in-process runner over both guard files against live PostgreSQL 17.11 (`timescale/timescaledb:latest-pg17`, `initdb -U darling` as CI does): **`Total: 5, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0`**.

| Mutation | Result |
|---|---|
| weld crippled to pre-change per-body behaviour | **1 failed** — "the scan MISSED a predicate split across a concatenation (bare + glue)" |
| depth-zero separator test removed | **1 failed** — two statements welded |
| both-ends `+` weakened to contains-a-`+` | **1 failed** — a comparison-in-condition welded |
| depth-zero colon test removed | **1 failed** — a conditional's arms welded |
| nesting ignored (every body top level) | **1 failed** — the container's weld goes to the nested body |
| weld rendering collapsed to always-a-space | **1 failed** — bare-`+` rendering invents a token boundary |
| **discovery narrowed to `const` only (= `dev` before this PR)** | **2 failed** — 48 against the 49 ratchet |
| same, both ratchets lowered to isolate the census | **1 failed** — names `DarlingPgColumnStatsReader.CoverageEvidenceSql` |
| syntax error injected into `CoverageEvidenceSql` | **1 failed** — "1 of 49 shipped PostgreSQL reads do not parse", so the widened population is really `PREPARE`d and not merely counted |
| one reader type leaves reflection's reach | **2 failed** — type ratchet at 27/28 and the read ratchet |
| same, both ratchets lowered to isolate the census | **1 failed** — names `DarlingPgXminReader.PgXminHorizonSql` |
| one read leaves the field-kind filter (`const` → plain `static`) | **2 failed** — read ratchet at 48/49 |
| shared `EnclosingType` filters `Member` instead of `Type` | **1 failed** — fields keyed by their own member name, matching nothing |
| census file glob broken | **1 failed** — "only 0 static string fields were read out of the reader SOURCE" |

Three results are green **by design**, and each says something:

| Mutation | Result | What it establishes |
|---|---|---|
| `const string` → `static readonly string` (the shape this PR was briefed on) | **0 failed** | widening the filter **removes** that failure mode rather than detecting it. It is no longer a coverage loss, so it cannot be its own red-proof — the pre-fix state above is. |
| separator test made depth-blind | **0 failed** | its cost is precision, not coverage: 4 genuine concatenations split, none of them SQL. The corpus measurement is the evidence, not a test. |
| the new control fact disabled, grouping kept | **0 failed** | the corpus scan is green before and after the grouping change, so it is **not** evidence for it. The control fact is the only instrument. |

Every mutation applied by byte-level replace with a `count == 1` anchor, verified changed by sha256, rebuilt, run, restored, restore confirmed by sha256. Tree ended byte-identical to HEAD on all five touched files.

Two mutations in an earlier pass did not compile (a type rename and a field deletion break their callers); both were replaced by shapes that isolate the same coverage loss and do compile, rather than reported as passes.

**Three of my own controls were originally not load-bearing** and the battery is what showed it: the separator test, the both-ends test and the nesting logic each had every fixture cleared by a different clause. The fixtures that now discriminate them are modelled on real corpus gaps, and the nesting case was rewritten as a composition assertion after the findings-based version turned out to be flagging pre-existing walker behaviour rather than anything the grouping did.

## Scope

Test-only; no product code changes. `Darling.Tests` builds on macOS with `EnableWindowsTargeting` and each commit builds independently. The suites themselves cannot run on macOS, so both guard files were compiled and executed through a scratch `net10.0` xUnit project that **links the real source files** — `[CallerFilePath]` therefore resolves to the real tree and the scans read the real corpus. CI is the arbiter for the rest of the suite.
