### PR TITLE
Record which credential DefaultAzureCredential selected, on an event-id allowlist (#3218 follow-up)

### DIFF
--- a/Lite.Tests/EntraCredentialSelectionModeGateTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionModeGateTests.cs
@@ -33,6 +33,21 @@ namespace PerformanceMonitorLite.Tests;
 /// Windows-only credential storage; the listener pins themselves need none of that and run in a
 /// plain <c>net10.0</c> harness on any platform.</para>
 /// </summary>
+/// <remarks>
+/// <para><b>In <c>app-logger-statics</c> for the event source, not for the log.</b> Nothing here
+/// touches <see cref="PerformanceMonitorLite.Services.AppLogger"/> — but both pins call
+/// <c>Begin</c>, which constructs a real <see cref="System.Diagnostics.Tracing.EventListener"/> over
+/// <c>Azure.Identity</c>'s process-wide event source, and <c>EntraCredentialSelectionTests</c> raises
+/// real events on that same source. A raised event reaches every listener attached to it anywhere in
+/// the process.</para>
+///
+/// <para>It changes no assertion here today, because these pins only ask whether <c>Begin</c> returned
+/// a listener and never read what one captured. Joined anyway, and joined to THAT name rather than a
+/// new one: a class can only be in one collection, so a separate event-source collection would leave
+/// the one pairing that matters — this class against the class that raises the events —
+/// unserialised.</para>
+/// </remarks>
+[Collection("app-logger-statics")]
 public class EntraCredentialSelectionModeGateTests
 {
     /// <summary>

--- a/Lite.Tests/EntraCredentialSelectionModeGateTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionModeGateTests.cs
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite.Helpers;
+using PerformanceMonitorLite.Models;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// The one link <see cref="EntraCredentialSelectionTests"/> cannot make: that the app's OWN
+/// authentication mode reaches the credential-selection listener.
+///
+/// <para><c>EntraCredentialSelectionLog.Begin</c> keys off
+/// <see cref="SqlConnectionStringBuilder.Authentication"/> rather than off the mode string, because
+/// that is the keyword the driver acts on and it therefore cannot disagree with the connection
+/// string. The cost of that choice is one degree of indirection between
+/// <see cref="AuthenticationTypes.EntraDefaultCredential"/> and the gate — so these pins run the
+/// real <see cref="ServerConnection.ApplyAuthentication"/> and close it.</para>
+///
+/// <para>Separate file because it needs <see cref="ServerConnection"/>, whose closure reaches
+/// Windows-only credential storage; the listener pins themselves need none of that and run in a
+/// plain <c>net10.0</c> harness on any platform.</para>
+/// </summary>
+public class EntraCredentialSelectionModeGateTests
+{
+    /// <summary>
+    /// <para>Derived from <see cref="AuthenticationTypes"/> by reflection rather than from a list
+    /// typed here, so a seventh mode is a decision this test forces rather than a row nobody added.
+    /// The count FLOOR is the positive control: "exactly one mode is instrumented" is also true of a
+    /// reflection helper that enumerated one mode, or none — #3218 shipped a count pin whose helper
+    /// enumerated nothing and passed.</para>
+    ///
+    /// <para>Every arm is handed a username, a password, an Azure client id AND a managed-identity
+    /// client id, so a mode whose arm was copied from a neighbour still gets everything it could
+    /// need and the gate's answer is about the mode rather than about missing inputs.</para>
+    /// </summary>
+    [Fact]
+    public void ExactlyOneAuthenticationMode_AttachesTheListener()
+    {
+        var modes = AllAuthenticationModes();
+
+        Assert.True(
+            modes.Count >= 6,
+            $"reflected {modes.Count} authentication modes off AuthenticationTypes; the sweep below is "
+                + "vacuous unless it is enumerating the real set");
+
+        var instrumented = new List<string>();
+        foreach (var mode in modes)
+        {
+            var builder = new SqlConnectionStringBuilder { DataSource = "example-server" };
+            ServerConnection.ApplyAuthentication(
+                builder,
+                mode,
+                username: "someone",
+                password: "a-secret",
+                azureClientId: "an-azure-client-id",
+                managedIdentityClientId: "a-managed-identity-client-id");
+
+            using var listener = EntraCredentialSelectionLog.Begin(builder);
+            if (listener is not null)
+            {
+                instrumented.Add(mode);
+            }
+        }
+
+        Assert.Equal(new[] { AuthenticationTypes.EntraDefaultCredential }, instrumented);
+    }
+
+    /// <summary>
+    /// The same claim stated positively and on its own, so a sweep that silently stopped covering
+    /// this mode cannot leave the feature untested — <c>Assert.Equal</c> on an empty list against an
+    /// empty expectation is not a failure any sweep would report here, but it is a failure of this.
+    /// </summary>
+    [Fact]
+    public void TheEntraDefaultCredentialMode_AttachesTheListener()
+    {
+        var builder = new SqlConnectionStringBuilder { DataSource = "example-server" };
+        ServerConnection.ApplyAuthentication(
+            builder,
+            AuthenticationTypes.EntraDefaultCredential,
+            username: "someone",
+            password: "a-secret",
+            azureClientId: "an-azure-client-id",
+            managedIdentityClientId: "a-managed-identity-client-id");
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryDefault, builder.Authentication);
+
+        using var listener = EntraCredentialSelectionLog.Begin(builder);
+        Assert.NotNull(listener);
+    }
+
+    private static List<string> AllAuthenticationModes() =>
+        typeof(AuthenticationTypes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .ToList();
+}

--- a/Lite.Tests/EntraCredentialSelectionOrderingTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionOrderingTests.cs
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Darling.Tests;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// The ordering the credential-selection listener's NARROW WINDOW depends on, pinned because it
+/// lives in a file this feature does not otherwise touch.
+///
+/// <para><c>Azure.Identity</c> reports the selected credential once per credential instance and
+/// SqlClient caches that instance in a process-wide static, so the event fires at most once per
+/// process — whichever code opens the first <c>ActiveDirectoryDefault</c> connection is the only
+/// one that can ever observe it. The listener is attached at
+/// <c>ServerManager.CheckConnectionAsync</c> and at the connection dialog's Test button, and NOT at
+/// the other <c>SqlConnection</c> sites in Lite, which is only sound because
+/// <c>CollectionBackgroundService</c> checks connections before it collects.</para>
+///
+/// <para><b>A reorder there breaks observability silently</b> — the app would connect identically,
+/// the listener would attach identically, and the event would already have been raised and
+/// discarded by the collector. There is no failure to notice, which is the definition of something
+/// that needs a pin rather than a comment.</para>
+/// </summary>
+public class EntraCredentialSelectionOrderingTests
+{
+    [Fact]
+    public void TheCollectionLoop_ChecksConnections_BeforeItCollects()
+    {
+        /* Stripped, so the several comments in that method discussing the connection check and the
+           collectors cannot satisfy the ordering below on their own. */
+        var source = CSharpSourceWalker.StripCommentsAndStrings(
+            ReadRepoFile("Lite/Services/CollectionBackgroundService.cs"));
+
+        var signature = source.IndexOf("ExecuteAsync(CancellationToken stoppingToken)", StringComparison.Ordinal);
+        Assert.True(signature >= 0, "CollectionBackgroundService.ExecuteAsync is the collection loop and must exist");
+
+        var brace = source.IndexOf('{', signature);
+        Assert.True(brace > signature, "ExecuteAsync must have a body");
+
+        var body = CSharpSourceWalker.BraceBalanced(source, brace);
+
+        var check = body.IndexOf("CheckAllConnectionsAsync", StringComparison.Ordinal);
+        var collect = body.IndexOf("RunDueCollectorsAsync", StringComparison.Ordinal);
+
+        Assert.True(check >= 0, "ExecuteAsync must run the connection check; the credential-selection listener is attached inside it");
+        Assert.True(collect >= 0, "ExecuteAsync must run the due collectors, or this ordering assertion has nothing to order");
+
+        Assert.True(
+            check < collect,
+            "CollectionBackgroundService must check connections BEFORE running collectors. The "
+                + "credential-selection listener (EntraCredentialSelectionLog) is attached only at the "
+                + "connectivity check and the connection dialog, on the grounds that the check gets "
+                + "there first — and Azure.Identity raises the selected-credential event at most once "
+                + "per process, so if a collector opens the first ActiveDirectoryDefault connection "
+                + "the selection is never observable again. Nothing about that failure is visible at "
+                + "runtime: the app connects normally and the log is simply missing a line.");
+    }
+
+    /// <summary>
+    /// And that the connectivity check is still the thing the listener is attached inside — so the
+    /// ordering above is about the right method. A rename of the attach site with this pin left
+    /// alone would otherwise order two things that no longer matter to each other.
+    /// </summary>
+    [Fact]
+    public void TheConnectivityCheck_IsWhereTheListenerIsAttached()
+    {
+        var manager = CSharpSourceWalker.StripCommentsAndStrings(
+            ReadRepoFile("Lite/Services/ServerManager.cs"));
+
+        var sweep = manager.IndexOf("CheckAllConnectionsAsync", StringComparison.Ordinal);
+        Assert.True(sweep >= 0, "ServerManager must still expose the sweep the collection loop calls");
+
+        Assert.Contains("CheckConnectionAsync", manager, StringComparison.Ordinal);
+        Assert.Contains("EntraCredentialSelectionLog.Begin", manager, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepoFile(string relativePath, [CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        var parts = relativePath.Split('/');
+        while (dir is not null && !File.Exists(Path.Combine(new[] { dir }.Concat(parts).ToArray())))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return File.ReadAllText(Path.Combine(new[] { dir! }.Concat(parts).ToArray()));
+    }
+}

--- a/Lite.Tests/EntraCredentialSelectionOrderingTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionOrderingTests.cs
@@ -37,8 +37,12 @@ public class EntraCredentialSelectionOrderingTests
     [Fact]
     public void TheCollectionLoop_ChecksConnections_BeforeItCollects()
     {
-        /* Stripped, so the several comments in that method discussing the connection check and the
-           collectors cannot satisfy the ordering below on their own. */
+        /* Stripped, and the strip is load-bearing rather than habit. No comment in that file names
+           either identifier TODAY, so the strip changes nothing today - but measured: with the loop
+           genuinely inverted AND one comment added naming CheckAllConnectionsAsync ahead of the
+           collector call, this pin passes on raw text and fails on stripped text. A one-line
+           ordering note of exactly that shape is the most natural thing for someone to write while
+           reordering this loop, which is the case where the pin has to still work. */
         var source = CSharpSourceWalker.StripCommentsAndStrings(
             ReadRepoFile("Lite/Services/CollectionBackgroundService.cs"));
 

--- a/Lite.Tests/EntraCredentialSelectionTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionTests.cs
@@ -321,6 +321,27 @@ public sealed class EntraCredentialSelectionTests : IDisposable
     public void IsCredentialTypeName_RejectsEverySensitiveSiblingShape(string? value) =>
         Assert.False(EntraCredentialSelectionLog.IsCredentialTypeName(value));
 
+    /// <summary>
+    /// <para>The character rule, isolated. Every case above that a real sibling payload looks like is
+    /// ALSO missing a dot, so the dot requirement alone rejects it and the character allowlist is
+    /// never the thing under test — measured: widening the allowlist by a hyphen left the whole suite
+    /// green. Each row here is a well-formed dotted name differing from an acceptable one by exactly
+    /// one illegal character, so each character in that allowlist is load-bearing.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("Azure.Identity.Cli-Credential")]                 // hyphen: tenant/subscription ids
+    [InlineData("Azure.Identity Credential")]                     // space: any message or log line
+    [InlineData("Azure.Identity/Credential")]                     // slash: a scope or resource path
+    [InlineData("Azure.Identity:Credential")]                     // colon: a scheme or a scope
+    [InlineData("Azure.Identity@Credential")]                     // at: an account upn
+    [InlineData("Azure.Identity\\Credential")]                     // backslash: a down-level logon name
+    [InlineData("Azure.Identity,Credential")]                     // comma: an assembly-qualified name
+    [InlineData("Azure.Identity=Credential")]                     // equals: a connection-string fragment
+    [InlineData("Azure.Identity\tCredential")]                    // tab: a delimiter in a rendered payload
+    [InlineData("Azure.Identity\nCredential")]                    // newline: would split the log line in two
+    public void IsCredentialTypeName_RejectsADottedNameCarryingOneIllegalCharacter(string value) =>
+        Assert.False(EntraCredentialSelectionLog.IsCredentialTypeName(value));
+
     [Fact]
     public void IsCredentialTypeName_RejectsSomethingLongerThanAnyTypeName() =>
         Assert.False(EntraCredentialSelectionLog.IsCredentialTypeName(
@@ -348,6 +369,12 @@ public sealed class EntraCredentialSelectionTests : IDisposable
         Assert.Null(listener.SelectedCredentialType);
         Assert.True(listener.RejectedPayload);
 
+        /* Note what this can and cannot show. The refused value never LEAVES OnEventWritten - the
+           listener stores a bool, not the string - so Decide structurally cannot name it, and the
+           DoesNotContain below is a consequence of that rather than an independent check of it.
+           Measured: interpolating the value into that message changed nothing, because there is no
+           value here to interpolate. The independent checks are the two assertions above, and
+           Decide_RefusesAValueThatIsNotATypeName_EvenWhenTheListenerDidNot below. */
         var line = EntraCredentialSelectionLog.Decide(
             listener.SelectedCredentialType, listener.RejectedPayload, lastReported: null);
 
@@ -411,6 +438,26 @@ public sealed class EntraCredentialSelectionTests : IDisposable
         EntraCredentialSelectionLog.Report(null);
 
     // ---- What gets written, and at which level -------------------------------------------
+
+    /// <summary>
+    /// <para><b><see cref="EntraCredentialSelectionLog.Decide"/> re-reads the rule rather than
+    /// trusting the listener's verdict</b>, and this is the pin that makes that re-read load-bearing.
+    /// Handed a value that is not a type name with <c>rejectedPayload: false</c> — the shape a
+    /// listener that stopped applying the rule would produce — it must still refuse to log it.
+    /// Without this, keying the refusal off the bool alone leaves every other pin here green.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    [InlineData("someone@example.com")]
+    [InlineData("https://database.windows.net/.default")]
+    public void Decide_RefusesAValueThatIsNotATypeName_EvenWhenTheListenerDidNot(string value)
+    {
+        var line = EntraCredentialSelectionLog.Decide(value, rejectedPayload: false, lastReported: null);
+
+        Assert.Equal(LogLevel.Debug, line.Level);
+        Assert.DoesNotContain(value, line.Message, StringComparison.Ordinal);
+        Assert.Null(line.Reported);
+    }
 
     [Fact]
     public void Decide_ReportsAFirstObservationAtInformation()

--- a/Lite.Tests/EntraCredentialSelectionTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionTests.cs
@@ -60,9 +60,31 @@ namespace PerformanceMonitorLite.Tests;
 /// the <see cref="LogLevel.Information"/> line this class expects to be admitted is never enqueued
 /// at all. Sharing the collection name serialises the two classes, which is the whole mechanism.</para>
 ///
-/// <para><c>EntraCredentialSelectionModeGateTests</c> and <c>EntraCredentialSelectionOrderingTests</c>
-/// deliberately do NOT join: neither touches <see cref="AppLogger"/>, and a collection name that
-/// serialises classes which cannot race with each other costs suite time for nothing.</para>
+/// <para><b>And a SECOND process-wide static, which is why that collection name now covers more than
+/// its name says.</b> This class raises real events on <c>Azure.Identity</c>'s
+/// <c>AzureIdentityEventSource</c> singleton and constructs <see cref="EventListener"/>s over it, and
+/// both are process-wide: enabling an <see cref="EventSource"/> is a global effect, and a raised event
+/// is delivered to EVERY listener attached to that source anywhere in the process.
+/// <c>EntraCredentialSelectionModeGateTests</c> calls <c>Begin</c>, so it constructs real listeners on
+/// the same source — it therefore joins the same collection. Not because it touches
+/// <see cref="AppLogger"/>, which it does not, but because a class cannot be in two collections: a
+/// separate name for the event-source hazard would fail to serialise it against THIS class, which is
+/// the one pairing that matters.</para>
+///
+/// <para>Harmless today and that is a separate fact from being safe: the mode-gate class never reads a
+/// listener's captured state and never calls <c>Report</c>, so a synthetic event landing in its
+/// listener changes no assertion of its own. The condition that would make it bite is that class — or
+/// any future one — reading <c>SelectedCredentialType</c>, <c>RejectedPayload</c>, or calling
+/// <c>Report</c>. Serialising now costs two small classes' parallelism and removes the question.</para>
+///
+/// <para><c>EntraCredentialSelectionOrderingTests</c> stays out, and is the case that shows the rule is
+/// about REACH rather than about subject matter: it is entirely about this feature, and it reads source
+/// files only — no <see cref="AppLogger"/>, no listener, no event source, nothing process-wide to
+/// share.</para>
+///
+/// <para>These are the only <see cref="EventListener"/> subclasses and the only <c>Azure-Identity</c>
+/// consumers anywhere in the repository, measured rather than assumed, so no third party can observe
+/// the events raised here today.</para>
 /// </remarks>
 [Collection("app-logger-statics")]
 public sealed class EntraCredentialSelectionTests : IDisposable

--- a/Lite.Tests/EntraCredentialSelectionTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionTests.cs
@@ -651,6 +651,50 @@ public sealed class EntraCredentialSelectionTests : IDisposable
     }
 
     /// <summary>
+    /// <para><b>A listener that observed no selection writes NOTHING at the default configuration.</b>
+    /// This is the acceptance criterion for the case where the credential chain found nothing, or where
+    /// the driver's cache means this connection raised no event: it must not record a selection that
+    /// did not happen — not an empty type name, not "unknown", not a line at all on a default
+    /// install.</para>
+    ///
+    /// <para>The <see cref="LogLevel.Debug"/> explanation exists and is asserted separately below, at a
+    /// lowered minimum, because an operator who goes looking should find "the event fires once per
+    /// process" rather than silence. Two different questions, and only this one is about what a shipped
+    /// install writes.</para>
+    ///
+    /// <para>The positive control is the first assertion: a first observation on the same listener type
+    /// at the same level does reach the log, so the emptiness below is a decision about having nothing
+    /// to say rather than a sink that was never wired up.</para>
+    /// </summary>
+    [Fact]
+    public void Report_WritesNothingAtTheDefaultLevel_WhenNoSelectionWasObserved()
+    {
+        Singleton();
+        EntraCredentialSelectionLog.ResetForTests();
+        Assert.Equal(LogLevel.Information, AppLogger.MinimumLevel);
+        AppLogger.DrainBufferedLines();
+
+        using (var observed = new EntraCredentialSelectionListener())
+        {
+            Raise(SelectedMethod, CliCredential);
+            EntraCredentialSelectionLog.Report(observed);
+        }
+
+        Assert.Single(Ours());
+
+        EntraCredentialSelectionLog.ResetForTests();
+
+        using (var silent = new EntraCredentialSelectionListener())
+        {
+            Assert.Null(silent.SelectedCredentialType);
+            Assert.False(silent.RejectedPayload);
+            EntraCredentialSelectionLog.Report(silent);
+        }
+
+        Assert.Empty(Ours());
+    }
+
+    /// <summary>
     /// The same repeat, with the minimum lowered — so "not written at the default" above is a level
     /// decision rather than a <see cref="Report"/> that produced no line at all.
     /// </summary>

--- a/Lite.Tests/EntraCredentialSelectionTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionTests.cs
@@ -128,8 +128,11 @@ public sealed class EntraCredentialSelectionTests : IDisposable
     ///
     /// <para>Read off <see cref="EventWrittenEventArgs.PayloadNames"/> rather than the reflected
     /// method signature, because the name the runtime reports is what actually accompanies the
-    /// payload — and the two can disagree. The count assertion is the control: an empty
-    /// <c>PayloadNames</c> (which some event formats produce) would make an index check vacuous.</para>
+    /// payload — and the two can disagree. Some event formats carry no payload names at all, so the
+    /// count is asserted first for the MESSAGE rather than as a control: an empty list makes
+    /// <c>names[0]</c> throw, which fails either way — measured, by discarding the names and
+    /// deleting the count assertion — so this says "this pin needs rewriting" instead of leaving
+    /// someone an index-out-of-range to diagnose.</para>
     /// </summary>
     [Fact]
     public void PayloadSlotZero_IsTheCredentialType_OnARealWrittenEvent()

--- a/Lite.Tests/EntraCredentialSelectionTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionTests.cs
@@ -46,6 +46,25 @@ namespace PerformanceMonitorLite.Tests;
 /// <c>az login</c> session through this path — still unverified, still needs a tenant and a Windows
 /// host. This file answers only for what the listener does with the event once it is raised.</para>
 /// </summary>
+/// <remarks>
+/// <para><b>In <c>app-logger-statics</c> because this class READS the sink.</b> Two pins here drain
+/// <see cref="AppLogger"/>'s process-wide buffer and assert on what came out, and one of them moves
+/// the process-wide minimum. <c>LiteLogLevelGateTests</c> created that collection for exactly this
+/// case and named the condition that would make the hazard bite: a second class reading the log.
+/// This is that class.</para>
+///
+/// <para>Two ways it would fail otherwise, both intermittent and neither reproducible on demand.
+/// <c>DrainBufferedLines</c> is destructive, so a concurrent sweep there dequeues the line this
+/// class is about to look for — and tag-filtering on the log source cannot recover a line another
+/// reader already took. And those sweeps set the minimum as far as <see cref="LogLevel.None"/>, so
+/// the <see cref="LogLevel.Information"/> line this class expects to be admitted is never enqueued
+/// at all. Sharing the collection name serialises the two classes, which is the whole mechanism.</para>
+///
+/// <para><c>EntraCredentialSelectionModeGateTests</c> and <c>EntraCredentialSelectionOrderingTests</c>
+/// deliberately do NOT join: neither touches <see cref="AppLogger"/>, and a collection name that
+/// serialises classes which cannot race with each other costs suite time for nothing.</para>
+/// </remarks>
+[Collection("app-logger-statics")]
 public sealed class EntraCredentialSelectionTests : IDisposable
 {
     /* Azure.Identity 1.18.0, AzureIdentityEventSource.cs — every id and signature reflected below is

--- a/Lite.Tests/EntraCredentialSelectionTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionTests.cs
@@ -1,0 +1,695 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Darling.Tests;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using PerformanceMonitorLite.Helpers;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #3218 shipped <c>EntraDefaultCredential</c> and disclosed, in dialog text, that the credential
+/// search order is the driver's and that a machine with several Azure identities connects as
+/// whichever comes first. Nothing recorded WHICH. This is the recording.
+///
+/// <para><b>Every pin here raises the real event on the real event source.</b>
+/// <c>Azure.Identity</c>'s <c>AzureIdentityEventSource</c> is reached by reflection — it is
+/// <c>internal</c>, so this is the only way in from outside the assembly — and its actual
+/// <c>DefaultAzureCredentialCredentialSelected</c> method is invoked. So the id, the level, the
+/// payload shape and the source name are the ones that ship rather than a stand-in's, and an
+/// upstream move fails these tests instead of passing them.</para>
+///
+/// <para><b>The failure mode this file exists to avoid.</b> A listener test that constructs a
+/// listener and asserts nothing was logged passes trivially in a harness where no
+/// <c>DefaultAzureCredential</c> ever runs — the shape that put two vacuous pins into #3218. So
+/// every negative here is paired with a positive on the SAME listener: the sibling event is raised
+/// first and must not be forwarded, then event 13 is raised and must be. A listener that received
+/// nothing fails the second half, which is what makes the first half evidence.</para>
+///
+/// <para><b>What is NOT claimed.</b> That a real Entra tenant issues a token to a real
+/// <c>az login</c> session through this path — still unverified, still needs a tenant and a Windows
+/// host. This file answers only for what the listener does with the event once it is raised.</para>
+/// </summary>
+public sealed class EntraCredentialSelectionTests : IDisposable
+{
+    /* Azure.Identity 1.18.0, AzureIdentityEventSource.cs — every id and signature reflected below is
+       read from that file at tag Azure.Identity_1.18.0, which is what this repository resolves
+       transitively through Microsoft.Data.SqlClient.Extensions.Azure 7.0.2 (see #3219: it is not
+       pinned, which is exactly why the upstream contract is pinned HERE). */
+    private const string EventSourceTypeName = "Azure.Identity.AzureIdentityEventSource, Azure.Identity";
+
+    /// <summary>:307 — the event this listener exists for. One <c>string credentialType</c>.</summary>
+    private const string SelectedMethod = "DefaultAzureCredentialCredentialSelected";
+
+    /// <summary>
+    /// :371 — event 18, <c>Informational</c>, and it carries TENANT IDS. The sibling that says why
+    /// the callback filter has to be the barrier.
+    /// </summary>
+    private const string TenantIdMethod = "TenantIdDiscoveredAndUsed";
+
+    /// <summary>
+    /// :427 — event 26, <c>Informational</c>, and its FIRST payload slot is also called
+    /// <c>credentialType</c> and holds a real credential type name. The sharpest negative control
+    /// available: it passes the type-name shape check, it passes the level, it passes the source
+    /// name, and the ONLY thing that keeps it out of the log is the event-id allowlist.
+    /// </summary>
+    private const string ManagedIdentitySelectedMethod = "ManagedIdentityCredentialSelected";
+
+    /// <summary>:399 — event 21, <c>Warning</c>. Proves the level admits MORE than Informational.</summary>
+    private const string WarningMethod = "UserAssignedManagedIdentityNotSupported";
+
+    /// <summary>A plausible winner, and the value every positive assertion looks for.</summary>
+    private const string CliCredential = "Azure.Identity.AzureCliCredential";
+
+    /// <summary>
+    /// The process-wide minimum is restored, and the last-reported name forgotten, because both are
+    /// static and a leak from here would change what a neighbouring test observes.
+    /// </summary>
+    public void Dispose()
+    {
+        AppLogger.SetMinimumLevel(AppLogger.DefaultMinimumLevel);
+        EntraCredentialSelectionLog.ResetForTests();
+    }
+
+    // ---- The upstream contract this listener is built on ---------------------------------
+
+    /// <summary>
+    /// The four facts the listener hard-codes, read off the shipped assembly rather than off a
+    /// version note. <c>Azure.Identity</c> arrives transitively and unpinned (#3219), so a SqlClient
+    /// bump can move it with no code change anywhere — this is the test that makes such a move loud.
+    /// </summary>
+    [Fact]
+    public void TheUpstreamEventContract_IsWhatTheListenerAssumes()
+    {
+        var type = EventSourceType();
+        var source = Singleton();
+
+        Assert.Equal(
+            EntraCredentialSelectionListener.AzureIdentitySourceName,
+            source.Name);
+
+        var method = type.GetMethod(SelectedMethod, BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var parameters = method!.GetParameters();
+        Assert.Single(parameters);
+        Assert.Equal(typeof(string), parameters[0].ParameterType);
+
+        var attribute = method.GetCustomAttribute<EventAttribute>();
+        Assert.NotNull(attribute);
+        Assert.Equal(EntraCredentialSelectionListener.CredentialSelectedEventId, attribute!.EventId);
+        Assert.Equal(EventLevel.Informational, attribute.Level);
+    }
+
+    /// <summary>
+    /// <para><b>Why the filter is an allowlist and not a level or a keyword.</b> Not one event in
+    /// that source declares <c>Keywords</c>, so <c>EnableEvents</c> has no dimension to exclude the
+    /// sensitive siblings on; and event 13 is itself <c>Informational</c>, so there is no level that
+    /// admits it and not them.</para>
+    ///
+    /// <para>The positive control is the event COUNT: "no event declares keywords" is also true of a
+    /// type with no events, which is not the claim. And the second assertion is a FLOOR on how many
+    /// events share event 13's level, not the exact number — the exact number (20 of 29 at
+    /// <c>Informational</c> in 1.18.0) is a measurement that goes stale on any upstream bump, while
+    /// "event 13 is not alone at its level" is the property the design rests on and does not.</para>
+    /// </summary>
+    [Fact]
+    public void NoEventInThatSourceDeclaresKeywords_AndEventThirteenIsNotAloneAtItsLevel()
+    {
+        var events = EventSourceType()
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .Select(m => m.GetCustomAttribute<EventAttribute>())
+            .Where(a => a is not null)
+            .Select(a => a!)
+            .ToList();
+
+        Assert.True(
+            events.Count > 1,
+            $"reflected {events.Count} [Event]-attributed methods on the Azure-Identity source; the "
+                + "keyword assertion below is vacuous unless there are events to assert about");
+
+        var withKeywords = events
+            .Where(a => a.Keywords != EventKeywords.None)
+            .Select(a => a.EventId)
+            .ToList();
+
+        Assert.True(
+            withKeywords.Count == 0,
+            "an event in Azure-Identity now declares Keywords (ids: "
+                + string.Join(", ", withKeywords)
+                + "). EnableEvents could then exclude the sensitive siblings on that dimension, which "
+                + "is a better barrier than a callback filter — reconsider the design rather than "
+                + "just updating this number.");
+
+        var atInformational = events
+            .Count(a => a.Level == EventLevel.Informational);
+
+        Assert.True(
+            atInformational > 1,
+            "event 13 is now the only Informational event in Azure-Identity, so the level alone would "
+                + $"isolate it (counted {atInformational}). The allowlist is still correct but its "
+                + "stated reason has changed.");
+    }
+
+    // ---- The mechanism working, and the sibling that must not ----------------------------
+
+    /// <summary>
+    /// <para>The positive half, and the hazard-1 falsifier at the same time. The event source is
+    /// forced to EXIST before the listener is constructed, so
+    /// <c>EventListener.OnEventSourceCreated</c> is reached from the BASE CONSTRUCTOR — the path on
+    /// which a derived field assigned in a constructor body is still null. If the listener ever grows
+    /// a constructor that the callback depends on, it stops enabling the source and this test goes
+    /// red rather than the app going quietly blind.</para>
+    /// </summary>
+    [Fact]
+    public void EventThirteen_ArrivesAsTheCredentialTypeName_WithTheSourceAlreadyCreated()
+    {
+        var source = Singleton();
+        Assert.Equal(EntraCredentialSelectionListener.AzureIdentitySourceName, source.Name);
+
+        using var listener = new EntraCredentialSelectionListener();
+
+        Raise(SelectedMethod, CliCredential);
+
+        Assert.Equal(CliCredential, listener.SelectedCredentialType);
+        Assert.False(listener.RejectedPayload);
+    }
+
+    /// <summary>
+    /// <para><b>Both directions on one listener, which is the whole point.</b> Three siblings are
+    /// raised first and none may be forwarded; then event 13 is raised and must be. A listener that
+    /// simply received nothing — the vacuous shape — fails the final assertion, so the three
+    /// preceding ones are evidence of filtering rather than of silence.</para>
+    ///
+    /// <para>The siblings are chosen to defeat each barrier in turn:
+    /// <c>ManagedIdentityCredentialSelected</c>'s first payload slot IS a valid credential type name,
+    /// so only the id keeps it out; <c>TenantIdDiscoveredAndUsed</c> carries tenant ids, which is the
+    /// value that must never reach the log; and <c>UserAssignedManagedIdentityNotSupported</c> is at
+    /// <c>Warning</c>, proving the enabled level admits events more severe than the one requested and
+    /// not merely the one asked for.</para>
+    /// </summary>
+    [Fact]
+    public void SensitiveSiblings_AreNotForwarded_AndTheSameListenerStillCapturesEventThirteen()
+    {
+        Singleton();
+        using var listener = new EntraCredentialSelectionListener();
+
+        Raise(ManagedIdentitySelectedMethod, "Azure.Identity.ManagedIdentityCredential", "some-id");
+        Assert.Null(listener.SelectedCredentialType);
+        Assert.False(listener.RejectedPayload);
+
+        Raise(TenantIdMethod, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111");
+        Assert.Null(listener.SelectedCredentialType);
+
+        Raise(WarningMethod, "SomeEnvironment");
+        Assert.Null(listener.SelectedCredentialType);
+
+        /* The discriminator. Everything above is consistent with a listener that never enabled the
+           source at all until this line succeeds. */
+        Raise(SelectedMethod, CliCredential);
+        Assert.Equal(CliCredential, listener.SelectedCredentialType);
+    }
+
+    /// <summary>
+    /// <para>An INDEPENDENT instrument for the claim the allowlist rests on: that the siblings really
+    /// do reach a callback at this level, rather than being filtered out before it. A recording
+    /// listener enabling the same source at the same level records every id it sees; the production
+    /// listener over the identical three events keeps one.</para>
+    ///
+    /// <para>Without this, "the sibling was not forwarded" could equally mean the level never
+    /// delivered it — in which case the callback filter would be doing nothing and could be deleted
+    /// without any test noticing.</para>
+    /// </summary>
+    [Fact]
+    public void TheEnabledLevelDeliversTheSiblingsToTheCallback_AndOnlyEventThirteenIsKept()
+    {
+        Singleton();
+
+        using var recorder = new RecordingListener();
+        using var listener = new EntraCredentialSelectionListener();
+
+        Raise(SelectedMethod, CliCredential);
+        Raise(TenantIdMethod, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111");
+        Raise(WarningMethod, "SomeEnvironment");
+
+        var seen = recorder.SeenEventIds;
+
+        Assert.Contains(EntraCredentialSelectionListener.CredentialSelectedEventId, seen);
+        Assert.True(
+            seen.Count >= 3,
+            "the recording listener saw " + string.Join(", ", seen.Order())
+                + " — fewer than the three events raised, so the level did not deliver the siblings and "
+                + "the allowlist below is not what excluded them");
+
+        Assert.Equal(CliCredential, listener.SelectedCredentialType);
+    }
+
+    /// <summary>
+    /// <para><b>The listener enables Azure-Identity and nothing else.</b> Enabling an
+    /// <see cref="EventSource"/> is process-global in effect — once enabled, <c>IsEnabled()</c>
+    /// answers true inside the owning library and it performs formatting work it otherwise skips. A
+    /// name check dropped from <c>OnEventSourceCreated</c> would turn this into a listener that
+    /// enables EVERY event source in the process at <c>Informational</c>, and every other pin in this
+    /// file would stay green: the callback allowlist would still keep the log clean, so the only
+    /// symptom would be cost paid forever by every instrumented library in the app.</para>
+    ///
+    /// <para>The control is the first assertion: a source that is not enabled while the listener is
+    /// alive is only evidence if some source demonstrably IS.</para>
+    /// </summary>
+    [Fact]
+    public void TheListenerEnablesAzureIdentity_AndNoOtherEventSource()
+    {
+        var azureIdentity = Singleton();
+        using var bystander = new BystanderEventSource();
+
+        using var listener = new EntraCredentialSelectionListener();
+
+        Assert.True(
+            azureIdentity.IsEnabled(EventLevel.Informational, EventKeywords.None),
+            "the listener did not enable Azure-Identity, so the assertion below proves nothing");
+
+        Assert.False(
+            bystander.IsEnabled(),
+            $"the listener enabled {bystander.Name} as well as Azure-Identity. Enabling a source is "
+                + "process-global in effect, so this is formatting work paid by an unrelated library "
+                + "on every event for the life of every connection attempt.");
+    }
+
+    // ---- The shape check, which is the barrier against a payload REORDER -----------------
+
+    [Theory]
+    [InlineData("Azure.Identity.AzureCliCredential")]
+    [InlineData("Azure.Identity.EnvironmentCredential")]
+    [InlineData("Azure.Identity.Outer+Inner")]
+    [InlineData("A.B")]
+    [InlineData("Azure.Identity.Some_Credential2")]
+    public void IsCredentialTypeName_TakesATypeName(string value) =>
+        Assert.True(EntraCredentialSelectionLog.IsCredentialTypeName(value));
+
+    /// <summary>
+    /// Every rejected case is the shape of a real payload carried by a sibling event in that source
+    /// at a level this listener enables, so each one is a value that a reordered or reshaped payload
+    /// could actually put in front of the read.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]   // a tenant id: hyphens
+    [InlineData("someone@example.com")]                     // an account upn: @
+    [InlineData("https://database.windows.net/.default")]   // a scope: : and /
+    [InlineData("DefaultAzureCredential failed to retrieve a token")] // a message: spaces
+    [InlineData("AzureCliCredential")]                      // no namespace at all
+    [InlineData(".Leading")]
+    [InlineData("Trailing.")]
+    [InlineData("Azure.Identity.Thing`1[[System.String, System.Private.CoreLib]]")]
+    public void IsCredentialTypeName_RejectsEverySensitiveSiblingShape(string? value) =>
+        Assert.False(EntraCredentialSelectionLog.IsCredentialTypeName(value));
+
+    [Fact]
+    public void IsCredentialTypeName_RejectsSomethingLongerThanAnyTypeName() =>
+        Assert.False(EntraCredentialSelectionLog.IsCredentialTypeName(
+            "Azure.Identity." + new string('x', EntraCredentialSelectionLog.MaxCredentialTypeNameLength)));
+
+    /// <summary>
+    /// <para>A real event 13 whose payload is a tenant id rather than a type name — which is what a
+    /// future upstream parameter reorder looks like from here. It must be declined, the value must
+    /// not be retained, and the resulting log line must not contain it.</para>
+    ///
+    /// <para>The positive control is the second half: the same listener then takes a well-shaped
+    /// value, so "declined" is a decision about the payload and not a listener that stopped
+    /// working.</para>
+    /// </summary>
+    [Fact]
+    public void AReorderedPayload_IsDeclinedAndNeverReachesTheLine()
+    {
+        const string TenantIdShaped = "00000000-0000-0000-0000-000000000000";
+
+        Singleton();
+        using var listener = new EntraCredentialSelectionListener();
+
+        Raise(SelectedMethod, TenantIdShaped);
+
+        Assert.Null(listener.SelectedCredentialType);
+        Assert.True(listener.RejectedPayload);
+
+        var line = EntraCredentialSelectionLog.Decide(
+            listener.SelectedCredentialType, listener.RejectedPayload, lastReported: null);
+
+        Assert.Equal(LogLevel.Debug, line.Level);
+        Assert.DoesNotContain(TenantIdShaped, line.Message, StringComparison.Ordinal);
+        Assert.Null(line.Reported);
+
+        Raise(SelectedMethod, CliCredential);
+        Assert.Equal(CliCredential, listener.SelectedCredentialType);
+    }
+
+    // ---- The gate: this mode and no other ------------------------------------------------
+
+    [Fact]
+    public void Begin_ReturnsAListener_ForActiveDirectoryDefault()
+    {
+        using var listener = EntraCredentialSelectionLog.Begin(
+            new SqlConnectionStringBuilder { Authentication = SqlAuthenticationMethod.ActiveDirectoryDefault });
+
+        Assert.NotNull(listener);
+    }
+
+    /// <summary>
+    /// Every other <see cref="SqlAuthenticationMethod"/> the driver defines, swept rather than
+    /// sampled, plus a builder that sets no keyword at all and a null builder. A mode added to the
+    /// enum upstream lands here as a new theory row automatically, and lands on the null arm — which
+    /// is the safe direction: it enables no event source.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(EveryOtherAuthenticationMethod))]
+    public void Begin_ReturnsNull_ForEveryOtherAuthenticationMethod(SqlAuthenticationMethod method)
+    {
+        var builder = new SqlConnectionStringBuilder { Authentication = method };
+
+        Assert.Null(EntraCredentialSelectionLog.Begin(builder));
+    }
+
+    public static TheoryData<SqlAuthenticationMethod> EveryOtherAuthenticationMethod()
+    {
+        var data = new TheoryData<SqlAuthenticationMethod>();
+        foreach (var method in Enum.GetValues<SqlAuthenticationMethod>())
+        {
+            if (method != SqlAuthenticationMethod.ActiveDirectoryDefault)
+            {
+                data.Add(method);
+            }
+        }
+
+        return data;
+    }
+
+    [Fact]
+    public void Begin_ReturnsNull_ForABuilderWithNoAuthenticationKeywordAndForNull()
+    {
+        Assert.Null(EntraCredentialSelectionLog.Begin(new SqlConnectionStringBuilder()));
+        Assert.Null(EntraCredentialSelectionLog.Begin(null));
+    }
+
+    [Fact]
+    public void Report_DoesNothingForANullListener() =>
+        EntraCredentialSelectionLog.Report(null);
+
+    // ---- What gets written, and at which level -------------------------------------------
+
+    [Fact]
+    public void Decide_ReportsAFirstObservationAtInformation()
+    {
+        var line = EntraCredentialSelectionLog.Decide(CliCredential, rejectedPayload: false, lastReported: null);
+
+        Assert.Equal(LogLevel.Information, line.Level);
+        Assert.Contains(CliCredential, line.Message, StringComparison.Ordinal);
+        Assert.Equal(CliCredential, line.Reported);
+    }
+
+    [Fact]
+    public void Decide_ReportsAnUnchangedRepeatAtDebug_AndRemembersNothingNew()
+    {
+        var line = EntraCredentialSelectionLog.Decide(
+            CliCredential, rejectedPayload: false, lastReported: CliCredential);
+
+        Assert.Equal(LogLevel.Debug, line.Level);
+        Assert.Null(line.Reported);
+    }
+
+    /// <summary>
+    /// A CHANGED selection is the one thing here worth an <see cref="LogLevel.Information"/> line
+    /// after the first: the driver clears its static credential cache, so a different source
+    /// genuinely can start winning mid-process, and that is a different identity connecting.
+    /// </summary>
+    [Fact]
+    public void Decide_ReportsAChangeAtInformation()
+    {
+        var line = EntraCredentialSelectionLog.Decide(
+            "Azure.Identity.EnvironmentCredential",
+            rejectedPayload: false,
+            lastReported: CliCredential);
+
+        Assert.Equal(LogLevel.Information, line.Level);
+        Assert.Contains("Azure.Identity.EnvironmentCredential", line.Message, StringComparison.Ordinal);
+        Assert.Equal("Azure.Identity.EnvironmentCredential", line.Reported);
+    }
+
+    /// <summary>
+    /// Nothing observed is a line saying so, not silence — and it names the reason, because "no line"
+    /// and "the event fires once per process" are indistinguishable to whoever reads the log.
+    /// </summary>
+    [Fact]
+    public void Decide_SaysNothingWasObserved_RatherThanSayingNothing()
+    {
+        var line = EntraCredentialSelectionLog.Decide(null, rejectedPayload: false, lastReported: null);
+
+        Assert.Equal(LogLevel.Debug, line.Level);
+        Assert.False(string.IsNullOrWhiteSpace(line.Message));
+        Assert.Null(line.Reported);
+    }
+
+    /// <summary>
+    /// <para><b>End to end through the real <see cref="AppLogger"/>, at the level a default install
+    /// runs at.</b> The first observation must actually reach the log; the unchanged repeat must not.
+    /// Nothing else in this file would catch a <see cref="Report"/> that wrote every line at
+    /// <see cref="LogLevel.Debug"/> — the messages would still be correct and the whole feature would
+    /// be invisible on every shipped install.</para>
+    /// </summary>
+    [Fact]
+    public void Report_WritesTheFirstObservationAtTheDefaultLevel_AndNotTheRepeat()
+    {
+        Singleton();
+        EntraCredentialSelectionLog.ResetForTests();
+        Assert.Equal(LogLevel.Information, AppLogger.MinimumLevel);
+
+        AppLogger.DrainBufferedLines();
+
+        using (var first = new EntraCredentialSelectionListener())
+        {
+            Raise(SelectedMethod, CliCredential);
+            EntraCredentialSelectionLog.Report(first);
+        }
+
+        var written = Ours();
+        Assert.Single(written);
+        Assert.Contains(CliCredential, written[0], StringComparison.Ordinal);
+        Assert.Contains("INFO", written[0], StringComparison.Ordinal);
+
+        using (var again = new EntraCredentialSelectionListener())
+        {
+            Raise(SelectedMethod, CliCredential);
+            EntraCredentialSelectionLog.Report(again);
+        }
+
+        Assert.Empty(Ours());
+    }
+
+    /// <summary>
+    /// The same repeat, with the minimum lowered — so "not written at the default" above is a level
+    /// decision rather than a <see cref="Report"/> that produced no line at all.
+    /// </summary>
+    [Fact]
+    public void Report_WritesTheRepeatAndTheNotObservedLine_OnceDebugIsAdmitted()
+    {
+        Singleton();
+        EntraCredentialSelectionLog.ResetForTests();
+        AppLogger.SetMinimumLevel(LogLevel.Debug);
+        AppLogger.DrainBufferedLines();
+
+        using (var first = new EntraCredentialSelectionListener())
+        {
+            Raise(SelectedMethod, CliCredential);
+            EntraCredentialSelectionLog.Report(first);
+        }
+
+        Assert.Single(Ours());
+
+        using (var again = new EntraCredentialSelectionListener())
+        {
+            Raise(SelectedMethod, CliCredential);
+            EntraCredentialSelectionLog.Report(again);
+        }
+
+        var repeat = Ours();
+        Assert.Single(repeat);
+        Assert.Contains("DEBUG", repeat[0], StringComparison.Ordinal);
+
+        /* And the third arm: a listener that observed nothing at all, which is what every connection
+           after the first actually looks like. */
+        using (var silent = new EntraCredentialSelectionListener())
+        {
+            EntraCredentialSelectionLog.Report(silent);
+        }
+
+        var absent = Ours();
+        Assert.Single(absent);
+        Assert.Contains("DEBUG", absent[0], StringComparison.Ordinal);
+        Assert.DoesNotContain(CliCredential, absent[0], StringComparison.Ordinal);
+    }
+
+    // ---- Both connection-open sites are instrumented, in the right order -----------------
+
+    /// <summary>
+    /// <para>Behavioural coverage cannot reach either site: one is a WPF <c>Window</c> needing a
+    /// dispatcher and a live form, the other needs a reachable SQL Server. So the call sites are
+    /// asserted in source, on <c>StripCommentsAndStrings</c>' output — which is what makes this a
+    /// check on CODE rather than on my own comments. Both sites carry a comment naming
+    /// <c>EntraCredentialSelectionLog</c> and explaining it, so a raw substring search over either
+    /// file would be satisfied by the comment alone and would pass with every call deleted. #3201's
+    /// equivalent pin did exactly that until the strip was added.</para>
+    ///
+    /// <para><b>The ORDER is the discriminating assertion.</b> Both names being present is satisfied
+    /// by a <c>Report</c> placed before the open, which would capture nothing on every connection
+    /// forever while reading as fully instrumented.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("Lite/Services/ServerManager.cs", "CheckConnectionAsync(string serverId")]
+    [InlineData("Lite/Windows/AddServerDialog.xaml.cs", "RunConnectionTestAsync()")]
+    public void EveryConnectionOpenSite_BeginsBeforeTheOpenAndReportsAfterIt(
+        string relativePath, string methodAnchor)
+    {
+        var source = CSharpSourceWalker.StripCommentsAndStrings(ReadRepoFile(relativePath));
+
+        var signature = source.IndexOf(methodAnchor, StringComparison.Ordinal);
+        Assert.True(signature >= 0, $"{methodAnchor} is the connection-open method in {relativePath} and must exist");
+
+        var brace = source.IndexOf('{', signature);
+        Assert.True(brace > signature, $"{methodAnchor} must have a body");
+
+        var body = CSharpSourceWalker.BraceBalanced(source, brace);
+
+        var begin = body.IndexOf("EntraCredentialSelectionLog.Begin", StringComparison.Ordinal);
+        var open = body.IndexOf("connection.OpenAsync", StringComparison.Ordinal);
+        var report = body.IndexOf("EntraCredentialSelectionLog.Report", StringComparison.Ordinal);
+
+        Assert.True(open >= 0, $"{relativePath} must still open the connection in {methodAnchor}");
+        Assert.True(begin >= 0, $"{relativePath} must attach the credential-selection listener in {methodAnchor}");
+        Assert.True(report >= 0, $"{relativePath} must report the credential selection in {methodAnchor}");
+
+        Assert.True(
+            begin < open,
+            "the listener must be attached BEFORE the open, or Azure.Identity raises event 13 with "
+                + "nothing subscribed and the selection is never observed");
+        Assert.True(
+            open < report,
+            "the selection must be reported AFTER the open, or it is read before the event that "
+                + "produces it and every connection reports nothing");
+    }
+
+    // ---- Helpers -------------------------------------------------------------------------
+
+    /// <summary>
+    /// <c>Azure.Identity</c>'s event source type. Asserted non-null rather than skipped: this whole
+    /// file is about a specific upstream event, and a harness that cannot see the assembly must fail
+    /// loudly rather than report an absence it has no instrument for (the #3218 lesson).
+    /// </summary>
+    private static Type EventSourceType()
+    {
+        var type = Type.GetType(EventSourceTypeName, throwOnError: false);
+
+        Assert.NotNull(type);
+        return type!;
+    }
+
+    /// <summary>
+    /// The real singleton, which also FORCES the event source to exist — so a listener constructed
+    /// after this call reaches <c>OnEventSourceCreated</c> from the base constructor.
+    /// </summary>
+    private static EventSource Singleton()
+    {
+        var property = EventSourceType().GetProperty("Singleton", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(property);
+
+        var value = property!.GetValue(null) as EventSource;
+        Assert.NotNull(value);
+        return value!;
+    }
+
+    /// <summary>Invokes one of the source's real event methods, so a real event is written.</summary>
+    private static void Raise(string methodName, params object[] arguments)
+    {
+        var method = EventSourceType().GetMethod(
+            methodName,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            arguments.Select(a => a.GetType()).ToArray());
+
+        Assert.NotNull(method);
+        method!.Invoke(Singleton(), arguments);
+    }
+
+    /// <summary>
+    /// This feature's lines out of the process-wide buffer, so a concurrently-running test's lines
+    /// are not mistaken for these and these are not mistaken for theirs.
+    /// </summary>
+    private static List<string> Ours() =>
+        AppLogger.DrainBufferedLines()
+            .Where(l => l.Contains($"[{EntraCredentialSelectionLog.LogSource}]", StringComparison.Ordinal))
+            .ToList();
+
+    private static string ReadRepoFile(string relativePath, [CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        var parts = relativePath.Split('/');
+        while (dir is not null && !File.Exists(Path.Combine(new[] { dir }.Concat(parts).ToArray())))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return File.ReadAllText(Path.Combine(new[] { dir! }.Concat(parts).ToArray()));
+    }
+
+    /// <summary>
+    /// An independent instrument: records every event id the enabled level actually delivers, so the
+    /// production listener's filtering can be told apart from a level that delivered nothing.
+    ///
+    /// <para>The bag is a FIELD INITIALISER, which in C# runs BEFORE the base constructor — the same
+    /// hazard the production listener avoids with consts. Assigned in a constructor body it would be
+    /// null when <see cref="OnEventSourceCreated"/> fires for an already-existing source, which is
+    /// exactly the case every test here sets up.</para>
+    /// </summary>
+    /// <summary>
+    /// An unrelated event source, existing only so "the listener enabled nothing else" has something
+    /// to be false about. Named outside the <c>Azure-</c> family on purpose.
+    /// </summary>
+    [EventSource(Name = "PerformanceMonitorLite-Tests-Bystander")]
+    private sealed class BystanderEventSource : EventSource
+    {
+    }
+
+    private sealed class RecordingListener : EventListener
+    {
+        private readonly ConcurrentBag<int> _seen = new();
+
+        internal List<int> SeenEventIds => _seen.ToList();
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (string.Equals(
+                    eventSource?.Name,
+                    EntraCredentialSelectionListener.AzureIdentitySourceName,
+                    StringComparison.Ordinal))
+            {
+                EnableEvents(eventSource!, EventLevel.Informational);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData) => _seen.Add(eventData.EventId);
+    }
+}

--- a/Lite.Tests/EntraCredentialSelectionTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionTests.cs
@@ -480,6 +480,25 @@ public sealed class EntraCredentialSelectionTests : IDisposable
     public void Report_DoesNothingForANullListener() =>
         EntraCredentialSelectionLog.Report(null);
 
+    /// <summary>
+    /// <para><b>A captured selection is reported whether or not the connection then succeeded.</b>
+    /// <see cref="EntraCredentialSelectionLog.Report"/> takes nothing but the listener — it has no
+    /// success argument to get wrong — and this pins that, because the call sites now invoke it from
+    /// a <c>finally</c> and the reason they do is that the failing case is the one that matters. The
+    /// call sites' own half is <see cref="EveryConnectionOpenSite_AttachesBeforeTheOpenAndReportsOnBothPaths"/>;
+    /// this is the half that shows there is nothing here for a failure to suppress.</para>
+    /// </summary>
+    [Fact]
+    public void Report_TakesNoSuccessArgument_SoAFailedOpenCannotSuppressIt()
+    {
+        var parameters = typeof(EntraCredentialSelectionLog)
+            .GetMethod(nameof(EntraCredentialSelectionLog.Report), BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetParameters();
+
+        Assert.Single(parameters);
+        Assert.Equal(typeof(EntraCredentialSelectionListener), parameters[0].ParameterType);
+    }
+
     // ---- What gets written, and at which level -------------------------------------------
 
     /// <summary>
@@ -644,14 +663,25 @@ public sealed class EntraCredentialSelectionTests : IDisposable
     /// file would be satisfied by the comment alone and would pass with every call deleted. #3201's
     /// equivalent pin did exactly that until the strip was added.</para>
     ///
-    /// <para><b>The ORDER is the discriminating assertion.</b> Both names being present is satisfied
-    /// by a <c>Report</c> placed before the open, which would capture nothing on every connection
-    /// forever while reading as fully instrumented.</para>
+    /// <para><b>Three discriminating assertions, and the third is the one review found missing.</b>
+    /// Both names being present is satisfied by a <c>Report</c> placed before the open, which would
+    /// capture nothing on every connection forever while reading as fully instrumented — so the
+    /// order is asserted. And <c>Begin</c> before the open with <c>Report</c> after it is satisfied
+    /// by a <c>Report</c> on the SUCCESS TAIL, which drops the selection on every failed open. That
+    /// is not a corner: <c>Azure.Identity</c> raises the event when it acquires a token, before SQL
+    /// Server has accepted or rejected the identity that token names, so the wrong-ambient-identity
+    /// case this feature exists for arrives as a login failure with the selection already captured —
+    /// and the driver caches the credential as soon as the token exists, so there is no second
+    /// chance. Hence the third assertion: a <c>finally</c> between the attach and the report.</para>
+    ///
+    /// <para>Asserted on the WINDOW between <c>Begin</c> and <c>Report</c> rather than on the body,
+    /// so an unrelated <c>finally</c> elsewhere in the method cannot satisfy it —
+    /// <c>RunConnectionTestAsync</c> already had one, for re-enabling its buttons.</para>
     /// </summary>
     [Theory]
     [InlineData("Lite/Services/ServerManager.cs", "CheckConnectionAsync(string serverId")]
     [InlineData("Lite/Windows/AddServerDialog.xaml.cs", "RunConnectionTestAsync()")]
-    public void EveryConnectionOpenSite_BeginsBeforeTheOpenAndReportsAfterIt(
+    public void EveryConnectionOpenSite_AttachesBeforeTheOpenAndReportsOnBothPaths(
         string relativePath, string methodAnchor)
     {
         var source = CSharpSourceWalker.StripCommentsAndStrings(ReadRepoFile(relativePath));
@@ -672,6 +702,15 @@ public sealed class EntraCredentialSelectionTests : IDisposable
         Assert.True(begin >= 0, $"{relativePath} must attach the credential-selection listener in {methodAnchor}");
         Assert.True(report >= 0, $"{relativePath} must report the credential selection in {methodAnchor}");
 
+        /* One of each, so a duplicate call cannot make the window assertions read off the wrong
+           pair of indices. */
+        Assert.Equal(
+            begin,
+            body.LastIndexOf("EntraCredentialSelectionLog.Begin", StringComparison.Ordinal));
+        Assert.Equal(
+            report,
+            body.LastIndexOf("EntraCredentialSelectionLog.Report", StringComparison.Ordinal));
+
         Assert.True(
             begin < open,
             "the listener must be attached BEFORE the open, or Azure.Identity raises event 13 with "
@@ -680,6 +719,11 @@ public sealed class EntraCredentialSelectionTests : IDisposable
             open < report,
             "the selection must be reported AFTER the open, or it is read before the event that "
                 + "produces it and every connection reports nothing");
+
+        var window = body[begin..report];
+
+        Assert.Contains("finally", window, StringComparison.Ordinal);
+        Assert.Contains("try", window, StringComparison.Ordinal);
     }
 
     // ---- Helpers -------------------------------------------------------------------------

--- a/Lite.Tests/EntraCredentialSelectionTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionTests.cs
@@ -790,15 +790,6 @@ public sealed class EntraCredentialSelectionTests : IDisposable
     }
 
     /// <summary>
-    /// An independent instrument: records every event id the enabled level actually delivers, so the
-    /// production listener's filtering can be told apart from a level that delivered nothing.
-    ///
-    /// <para>The bag is a FIELD INITIALISER, which in C# runs BEFORE the base constructor — the same
-    /// hazard the production listener avoids with consts. Assigned in a constructor body it would be
-    /// null when <see cref="OnEventSourceCreated"/> fires for an already-existing source, which is
-    /// exactly the case every test here sets up.</para>
-    /// </summary>
-    /// <summary>
     /// An unrelated event source, existing only so "the listener enabled nothing else" has something
     /// to be false about. Named outside the <c>Azure-</c> family on purpose.
     /// </summary>
@@ -848,6 +839,15 @@ public sealed class EntraCredentialSelectionTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// An independent instrument: records every event id the enabled level actually delivers, so the
+    /// production listener's filtering can be told apart from a level that delivered nothing.
+    ///
+    /// <para>The bag is a FIELD INITIALISER, which in C# runs BEFORE the base constructor — the same
+    /// hazard the production listener avoids with consts. Assigned in a constructor body it would be
+    /// null when <see cref="OnEventSourceCreated"/> fires for an already-existing source, which is
+    /// exactly the case every test here sets up.</para>
+    /// </summary>
     private sealed class RecordingListener : EventListener
     {
         private readonly ConcurrentBag<int> _seen = new();

--- a/Lite.Tests/EntraCredentialSelectionTests.cs
+++ b/Lite.Tests/EntraCredentialSelectionTests.cs
@@ -118,6 +118,46 @@ public sealed class EntraCredentialSelectionTests : IDisposable
     }
 
     /// <summary>
+    /// <para><b>Payload slot 0 is the credential type, asserted by NAME on a real written event.</b>
+    /// The listener reads <c>Payload[0]</c> positionally, so a future upstream parameter added or
+    /// reordered ahead of <c>credentialType</c> would silently change what that index means — and
+    /// <c>Azure.Identity</c> arrives transitively and unpinned (#3219), so such a move needs no code
+    /// change here to happen. The runtime barrier against it is the type-name shape check, which
+    /// declines the value rather than logging it; this is the pin that makes the move LOUD instead of
+    /// merely survivable.</para>
+    ///
+    /// <para>Read off <see cref="EventWrittenEventArgs.PayloadNames"/> rather than the reflected
+    /// method signature, because the name the runtime reports is what actually accompanies the
+    /// payload — and the two can disagree. The count assertion is the control: an empty
+    /// <c>PayloadNames</c> (which some event formats produce) would make an index check vacuous.</para>
+    /// </summary>
+    [Fact]
+    public void PayloadSlotZero_IsTheCredentialType_OnARealWrittenEvent()
+    {
+        Singleton();
+        using var recorder = new PayloadNameListener();
+
+        Raise(SelectedMethod, CliCredential);
+
+        var captured = recorder.Captured
+            .Where(c => c.EventId == EntraCredentialSelectionListener.CredentialSelectedEventId)
+            .ToList();
+
+        Assert.Single(captured);
+
+        var (_, names, payload) = captured[0];
+
+        Assert.True(
+            names.Count > 0,
+            "the runtime reported no payload names for event 13, so an index assertion on them would "
+                + "be vacuous — this event format does not carry them and this pin needs rewriting");
+
+        Assert.Equal("credentialType", names[0]);
+        Assert.Single(payload);
+        Assert.Equal(CliCredential, payload[0]);
+    }
+
+    /// <summary>
     /// <para><b>Why the filter is an allowlist and not a level or a keyword.</b> Not one event in
     /// that source declares <c>Keywords</c>, so <c>EnableEvents</c> has no dimension to exclude the
     /// sensitive siblings on; and event 13 is itself <c>Informational</c>, so there is no level that
@@ -718,6 +758,47 @@ public sealed class EntraCredentialSelectionTests : IDisposable
     [EventSource(Name = "PerformanceMonitorLite-Tests-Bystander")]
     private sealed class BystanderEventSource : EventSource
     {
+    }
+
+    /// <summary>
+    /// Captures the event id together with the runtime's own payload NAMES and values, so the
+    /// positional read the production listener performs can be checked against the name the runtime
+    /// attaches to that position.
+    /// </summary>
+    private sealed class PayloadNameListener : EventListener
+    {
+        private readonly List<(int EventId, IReadOnlyList<string> Names, IReadOnlyList<string> Payload)> _captured = new();
+
+        internal IReadOnlyList<(int EventId, IReadOnlyList<string> Names, IReadOnlyList<string> Payload)> Captured
+        {
+            get { lock (_captured) { return _captured.ToList(); } }
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (string.Equals(
+                    eventSource?.Name,
+                    EntraCredentialSelectionListener.AzureIdentitySourceName,
+                    StringComparison.Ordinal))
+            {
+                EnableEvents(eventSource!, EventLevel.Informational);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            var names = eventData.PayloadNames is null
+                ? Array.Empty<string>()
+                : eventData.PayloadNames.ToArray();
+            var payload = eventData.Payload is null
+                ? Array.Empty<string>()
+                : eventData.Payload.Select(o => o?.ToString() ?? string.Empty).ToArray();
+
+            lock (_captured)
+            {
+                _captured.Add((eventData.EventId, names, payload));
+            }
+        }
     }
 
     private sealed class RecordingListener : EventListener

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -53,15 +53,19 @@ namespace PerformanceMonitorLite.Tests;
 /// line that was never enqueued. That is the #1965 shape, which <c>app-alert-statics</c> was created
 /// for.</para>
 ///
-/// <para><b>The interaction is real and currently harmless, which are two separate facts.</b> Five other
-/// classes hand an <see cref="AppLoggerAdapter{T}"/> to a service that logs —
-/// <c>AnalysisNotificationTests</c>, <c>MuteRuleServiceTests</c>, <c>PagerDutyWebhookTests</c>,
-/// <c>RemainingEmptyReadsToolTests</c> and <c>WebhookCooldownSeedTests</c>, against 28 log sites across
-/// four services — and each sits in its own default collection, so they run in parallel with the sweeps
-/// here and their lines really can be dropped. Nothing fails, because this class is the only reader of
-/// the sink anywhere in the suite: no other test asserts on log output, so a dropped line changes no
-/// assertion. The condition that would make it bite is any of those five reading the log, and then they
-/// join <c>app-logger-statics</c>.</para>
+/// <para><b>The interaction is real, and it now has a second party.</b> Five other classes hand an
+/// <see cref="AppLoggerAdapter{T}"/> to a service that logs — <c>AnalysisNotificationTests</c>,
+/// <c>MuteRuleServiceTests</c>, <c>PagerDutyWebhookTests</c>, <c>RemainingEmptyReadsToolTests</c> and
+/// <c>WebhookCooldownSeedTests</c>, against 28 log sites across four services — and each sits in its own
+/// default collection, so they run in parallel with the sweeps here and their lines really can be
+/// dropped. Nothing fails for those five, because none of them READS the sink: a dropped line changes no
+/// assertion of theirs.</para>
+///
+/// <para><b>This class is no longer the only reader, which is what the condition below was waiting
+/// for.</b> <c>EntraCredentialSelectionTests</c> drains the buffer and asserts on what came out, so it
+/// joins <c>app-logger-statics</c> — which means the name now serialises two classes rather than
+/// nothing. Any further class that reads the log joins it too; a class that merely WRITES through the
+/// adapter still does not need to, and adding it would serialise the suite for no benefit.</para>
 ///
 /// <para><b>Why a separate name rather than joining <c>app-alert-statics</c>.</b> Its five members touch
 /// <c>App</c>'s alert-settings statics and make no <c>AppLogger</c> calls at all, so joining them would

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -67,6 +67,14 @@ namespace PerformanceMonitorLite.Tests;
 /// nothing. Any further class that reads the log joins it too; a class that merely WRITES through the
 /// adapter still does not need to, and adding it would serialise the suite for no benefit.</para>
 ///
+/// <para><b>The name now covers two unrelated process-wide statics, which is a consequence of xUnit's
+/// model rather than a taxonomy choice.</b> <c>EntraCredentialSelectionTests</c> and
+/// <c>EntraCredentialSelectionModeGateTests</c> also share <c>Azure.Identity</c>'s process-wide event
+/// source — one raises events on it, the other attaches listeners to it. A class can belong to only one
+/// collection, so a second name for that hazard would have failed to serialise those two against each
+/// other. One name, two reasons, and the reasons are recorded at each member rather than inferred from
+/// the name.</para>
+///
 /// <para><b>Why a separate name rather than joining <c>app-alert-statics</c>.</b> Its five members touch
 /// <c>App</c>'s alert-settings statics and make no <c>AppLogger</c> calls at all, so joining them would
 /// serialise this class against classes that cannot race with it while still not serialising the five

--- a/Lite/Helpers/EntraCredentialSelection.cs
+++ b/Lite/Helpers/EntraCredentialSelection.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.Threading;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using PerformanceMonitorLite.Services;
@@ -206,7 +207,9 @@ internal static class EntraCredentialSelectionLog
     /// </summary>
     internal const int MaxCredentialTypeNameLength = 256;
 
-    private static volatile string? s_lastReported;
+    /* Not volatile: every read goes through Volatile.Read and every write through
+       Interlocked.Exchange, and a volatile field cannot be passed by ref to either. */
+    private static string? s_lastReported;
 
     /// <summary>
     /// A listener for a connection about to be opened with
@@ -313,6 +316,12 @@ internal static class EntraCredentialSelectionLog
     /// <summary>
     /// Reads the listener and writes the line. A no-op for a <c>null</c> listener, which is every
     /// mode but this one.
+    ///
+    /// <para><b>Called from a <c>finally</c> at both call sites, so it must not throw.</b> Nothing
+    /// here does I/O: <see cref="Decide"/> is pure string work and <see cref="AppLogger"/> enqueues
+    /// into a buffer. There is deliberately no blanket <c>catch</c> — a <c>finally</c> that swallows
+    /// everything would make this feature silently dead at exactly the moment it broke, and would
+    /// hide the defect rather than the symptom.</para>
     /// </summary>
     internal static void Report(EntraCredentialSelectionListener? listener)
     {
@@ -321,11 +330,25 @@ internal static class EntraCredentialSelectionLog
             return;
         }
 
-        var line = Decide(listener.SelectedCredentialType, listener.RejectedPayload, s_lastReported);
+        var captured = listener.SelectedCredentialType;
+        var line = Decide(captured, listener.RejectedPayload, Volatile.Read(ref s_lastReported));
 
         if (line.Reported is not null)
         {
-            s_lastReported = line.Reported;
+            /* Claimed atomically, because a read-then-write pair does not dedupe here.
+               CheckAllConnectionsAsync checks servers concurrently, and one raised event is delivered
+               to EVERY attached listener - so two concurrent first connections capture the SAME name
+               and, reading before either writes, both decide they are the first and both log at
+               Information. Interlocked.Exchange hands exactly one caller a previous value different
+               from what it is claiming; anyone else gets its own name back and re-decides against it.
+               The correctness of that rests on the exchange being atomic, not on a test: the race is
+               not reproducible on demand, and the sequential form of the same path is pinned. */
+            var previous = Interlocked.Exchange(ref s_lastReported, line.Reported);
+
+            if (string.Equals(previous, line.Reported, StringComparison.Ordinal))
+            {
+                line = Decide(captured, listener.RejectedPayload, previous);
+            }
         }
 
         if (line.Level == LogLevel.Information)

--- a/Lite/Helpers/EntraCredentialSelection.cs
+++ b/Lite/Helpers/EntraCredentialSelection.cs
@@ -164,8 +164,25 @@ internal sealed class EntraCredentialSelectionListener : EventListener
 /// process, forever, to learn a fact that can only be reported once. So <see cref="Begin"/> is
 /// called immediately before the open and the listener is disposed immediately after it; an
 /// undisposed <see cref="EventListener"/> keeps receiving events, so the disposal is the window.
-/// The cost of the narrow window is that an event raised outside it is missed, which is why BOTH of
-/// Lite's connection-open sites carry one rather than only the dialog a user is looking at.</para>
+/// The cost of the narrow window is that an event raised outside it is missed — so the two
+/// instrumented sites had to be the ones that get there FIRST, and they are, by construction rather
+/// than by luck: <c>CollectionBackgroundService.ExecuteAsync</c> runs
+/// <c>ServerManager.CheckAllConnectionsAsync</c> BEFORE
+/// <c>RemoteCollectorService.RunDueCollectorsAsync</c> on every cycle including the first, and that
+/// loop is the only thing that drives collection — so the connectivity check is the first code in
+/// the process to open a connection to a monitored server. The interactive first-touch paths are
+/// the connection dialog's Test button and <c>MainWindow</c>'s explicit retry, and both go through
+/// an instrumented open. <c>EntraCredentialSelectionOrderingTests</c> pins that ordering, because it
+/// lives in another file and a reorder there would silently blind this.</para>
+///
+/// <para><b>What that still does not cover, stated rather than implied.</b> Lite has other
+/// <c>SqlConnection</c> sites that reach a monitored server — the bulk-add dialog, the excluded-
+/// databases dialog, a server tab's ad-hoc reads, the plan fetcher. Each needs an already-configured
+/// server, so in practice the sweep has run first; but a user who drives one of them inside the
+/// background service's five-second startup delay could acquire the first token there. The
+/// consequence is a <see cref="LogLevel.Debug"/> "not observed" line rather than a wrong one, which
+/// is the direction to fail in — and it is why that line names the caching as the expected cause
+/// instead of asserting it.</para>
 ///
 /// <para><i>Only the last REPORTED name outlives the attempt.</i> Nothing else is retained: the
 /// listener is gone and the captured value is read once. <see cref="s_lastReported"/> exists so an

--- a/Lite/Helpers/EntraCredentialSelection.cs
+++ b/Lite/Helpers/EntraCredentialSelection.cs
@@ -34,10 +34,12 @@ namespace PerformanceMonitorLite.Helpers;
 /// <para><b>An ALLOWLIST on the event id, because the level cannot narrow this and keywords do not
 /// exist here.</b> Event 13 is itself <c>Informational</c>, so <c>Informational</c> is the LOWEST
 /// level that delivers it — and <see cref="EventListener.EnableEvents(EventSource, EventLevel)"/>
-/// admits every event at or above the requested severity, which in this source is <b>28 of its 29
-/// events</b>: 20 at <c>Informational</c> (19 besides this one), plus 4 <c>Warning</c>, 2
-/// <c>Error</c>, 1 <c>Critical</c> and 1 <c>LogAlways</c>. Only the single <c>Verbose</c> event is
-/// excluded. Several of the 28 carry exactly what an application log must never hold:
+/// admits every event at or above the requested severity — which at 1.18.0 is <b>28 of this
+/// source's 29 events</b>: 20 at <c>Informational</c> (19 besides this one), plus 4
+/// <c>Warning</c>, 2 <c>Error</c>, 1 <c>Critical</c> and 1 <c>LogAlways</c>. Only the single
+/// <c>Verbose</c> event is excluded. Counted twice, off two things that fail differently: the
+/// <c>[Event]</c> attributes in the source at tag <c>Azure.Identity_1.18.0</c>, and reflection over
+/// the shipped <c>Azure.Identity.dll</c>. Several of the 28 carry exactly what an application log must never hold:
 /// <c>TenantIdDiscoveredAndUsed</c> / <c>TenantIdDiscoveredAndNotUsed</c> carry tenant ids,
 /// <c>AuthenticatedAccountDetails</c> carries account details, <c>GetTokenFailed</c> carries a
 /// formatted <c>Exception</c>, the six <c>MsalLog*</c> events carry MSAL's own log lines, and
@@ -153,8 +155,10 @@ internal sealed class EntraCredentialSelectionListener : EventListener
 ///
 /// <para><i>The listener's window is one connection open, not the process.</i> While the source is
 /// enabled, <c>AzureIdentityEventSource.IsEnabled(EventLevel.Informational, …)</c> answers true
-/// inside <c>Azure.Identity</c> and it performs the formatting work its seven
-/// <c>if (IsEnabled(…))</c> guards otherwise skip — formatting scope arrays, rendering exceptions.
+/// inside <c>Azure.Identity</c> and it performs the formatting work that the
+/// <c>IsEnabled(…)</c> guard on almost every one of its event methods otherwise skips — formatting
+/// scope arrays, rendering exceptions. At 1.18.0 that is 21 such guards plus 10
+/// <c>when IsEnabled(…)</c> switch arms.
 /// A monitoring tool that left it on would pay that on every token operation for the life of the
 /// process, forever, to learn a fact that can only be reported once. So <see cref="Begin"/> is
 /// called immediately before the open and the listener is disposed immediately after it; an

--- a/Lite/Helpers/EntraCredentialSelection.cs
+++ b/Lite/Helpers/EntraCredentialSelection.cs
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Diagnostics.Tracing;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Helpers;
+
+/// <summary>
+/// Captures which credential <c>DefaultAzureCredential</c> actually selected, by listening to the
+/// one <c>Azure-Identity</c> event that says so.
+///
+/// <para><b>Observability only.</b> Nothing here participates in acquiring a token, building a
+/// connection string, or ordering the credential chain. Remove the type and the app connects
+/// identically; the only difference is that nobody can tell which identity it connected as.</para>
+///
+/// <para><b>The event.</b> <c>Azure.Identity</c> 1.18.0,
+/// <c>Credentials/DefaultAzureCredential.cs:178</c>, on the success path immediately after
+/// <c>GetTokenFromSourcesAsync</c> picks a source:
+/// <c>AzureIdentityEventSource.Singleton.DefaultAzureCredentialCredentialSelected(credential.GetType().FullName)</c>.
+/// Its declaration is <c>AzureIdentityEventSource.cs:307</c> — event id <b>13</b>
+/// (<c>AzureIdentityEventSource.cs:34</c>), <c>Level = EventLevel.Informational</c>, one
+/// <c>string credentialType</c> parameter — on the source named <b><c>Azure-Identity</c></b>
+/// (<c>AzureIdentityEventSource.cs:18</c>).</para>
+///
+/// <para><b>An ALLOWLIST on the event id, because the level cannot narrow this and keywords do not
+/// exist here.</b> Event 13 is itself <c>Informational</c>, so <c>Informational</c> is the LOWEST
+/// level that delivers it — and <see cref="EventListener.EnableEvents(EventSource, EventLevel)"/>
+/// admits every event at or above the requested severity, which in this source is <b>28 of its 29
+/// events</b>: 20 at <c>Informational</c> (19 besides this one), plus 4 <c>Warning</c>, 2
+/// <c>Error</c>, 1 <c>Critical</c> and 1 <c>LogAlways</c>. Only the single <c>Verbose</c> event is
+/// excluded. Several of the 28 carry exactly what an application log must never hold:
+/// <c>TenantIdDiscoveredAndUsed</c> / <c>TenantIdDiscoveredAndNotUsed</c> carry tenant ids,
+/// <c>AuthenticatedAccountDetails</c> carries account details, <c>GetTokenFailed</c> carries a
+/// formatted <c>Exception</c>, the six <c>MsalLog*</c> events carry MSAL's own log lines, and
+/// <c>GetToken</c> / <c>GetTokenSucceeded</c> carry scopes and parent request ids.</para>
+///
+/// <para><b>And keyword filtering cannot help</b>: not one of the 29 events in that file declares
+/// <c>Keywords</c>, so <c>EnableEvents</c> has no dimension to exclude the noisy siblings on. That
+/// makes <see cref="OnEventWritten"/>'s filter the only barrier between this app's log and a tenant
+/// id — which is why it is an allowlist on <see cref="CredentialSelectedEventId"/> rather than a
+/// denylist of the events known to be sensitive today. A denylist is the form that fails when a
+/// future <c>Azure.Identity</c> adds an event; an allowlist is the form that survives it, because
+/// the new event is not event 13.</para>
+///
+/// <para><b>What leaves this type is <see cref="EventWrittenEventArgs.Payload"/>[0] and nothing
+/// else</b>, and only when it has the shape of a CLR type name (see
+/// <see cref="EntraCredentialSelectionLog.IsCredentialTypeName"/>). Never
+/// <c>eventData.ToString()</c>, never the payload collection, never
+/// <see cref="EventWrittenEventArgs.Message"/> formatted with its arguments.</para>
+/// </summary>
+internal sealed class EntraCredentialSelectionListener : EventListener
+{
+    /// <summary>
+    /// <c>Azure.Identity</c> 1.18.0, <c>AzureIdentityEventSource.cs:18</c>. Matched
+    /// <see cref="StringComparison.Ordinal"/>: this is a wire identifier, not display text.
+    /// </summary>
+    internal const string AzureIdentitySourceName = "Azure-Identity";
+
+    /// <summary>
+    /// <c>Azure.Identity</c> 1.18.0, <c>AzureIdentityEventSource.cs:34</c>
+    /// (<c>DefaultAzureCredentialCredentialSelectedEvent</c>). The whole allowlist.
+    /// </summary>
+    internal const int CredentialSelectedEventId = 13;
+
+    /* Both values the OnEventSourceCreated callback needs are const, and that is the mitigation for
+       the classic EventListener bug rather than an accident of style. EventListener's BASE
+       CONSTRUCTOR calls OnEventSourceCreated for every EventSource that already exists in the
+       process - and a C# derived-class constructor BODY runs after the base constructor, so a source
+       name or event id assigned there is still null/0 when that callback fires. The symptom is not an
+       exception: the listener simply never enables the source and silently observes nothing forever.
+       Azure-Identity is a lazily-created singleton, so whether it pre-exists depends on whether
+       anything has touched Azure.Identity yet - which makes this a bug that appears and disappears
+       with unrelated ordering. Nothing on this type is assigned in a constructor, there is no
+       constructor, and EntraCredentialSelectionListenerTests constructs the listener AFTER forcing
+       the source to exist, which is the path that goes through the base constructor. */
+
+    private volatile string? _selected;
+    private volatile bool _rejectedPayload;
+
+    /// <summary>
+    /// The credential type name event 13 reported, or null if it has not arrived (or arrived in a
+    /// shape this type declines to forward — see <see cref="RejectedPayload"/>).
+    /// </summary>
+    internal string? SelectedCredentialType => _selected;
+
+    /// <summary>
+    /// True when event 13 arrived but its first payload slot was not something this type is willing
+    /// to log. Kept separate from "nothing arrived" so a future payload change is a legible signal
+    /// rather than silence — an absence and a refusal need different answers, and the refused value
+    /// itself is never retained.
+    /// </summary>
+    internal bool RejectedPayload => _rejectedPayload;
+
+    /// <inheritdoc/>
+    protected override void OnEventSourceCreated(EventSource eventSource)
+    {
+        if (eventSource is null ||
+            !string.Equals(eventSource.Name, AzureIdentitySourceName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        /* Informational is not a choice - it is the lowest level that delivers event 13, because
+           event 13 is itself Informational. See this type's remarks for what else that admits and
+           why OnEventWritten's allowlist, not this level, is the barrier. */
+        EnableEvents(eventSource, EventLevel.Informational);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        /* A conjunction, so neither half alone can admit an event. The id is the allowlist; the
+           source name means an id-13 collision from some other source this listener never enabled
+           still cannot reach the log. */
+        if (eventData is null ||
+            eventData.EventId != CredentialSelectedEventId ||
+            !string.Equals(eventData.EventSource?.Name, AzureIdentitySourceName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var payload = eventData.Payload;
+        var credentialType = payload is { Count: > 0 } ? payload[0] as string : null;
+
+        /* Payload[0] only, and only if it looks like a type name. Both halves are load-bearing: the
+           index is what keeps a future second parameter out of the log, and the shape check is what
+           keeps a REORDERED first parameter out of it. A tenant id, a UPN, a scope URL and an
+           exception message each fail the shape check on a character a type name cannot contain. */
+        if (EntraCredentialSelectionLog.IsCredentialTypeName(credentialType))
+        {
+            _selected = credentialType;
+        }
+        else
+        {
+            _rejectedPayload = true;
+        }
+    }
+}
+
+/// <summary>
+/// Decides whether a captured credential selection is worth a log line, and writes it.
+///
+/// <para><b>Two lifetimes, both deliberate.</b></para>
+///
+/// <para><i>The listener's window is one connection open, not the process.</i> While the source is
+/// enabled, <c>AzureIdentityEventSource.IsEnabled(EventLevel.Informational, …)</c> answers true
+/// inside <c>Azure.Identity</c> and it performs the formatting work its seven
+/// <c>if (IsEnabled(…))</c> guards otherwise skip — formatting scope arrays, rendering exceptions.
+/// A monitoring tool that left it on would pay that on every token operation for the life of the
+/// process, forever, to learn a fact that can only be reported once. So <see cref="Begin"/> is
+/// called immediately before the open and the listener is disposed immediately after it; an
+/// undisposed <see cref="EventListener"/> keeps receiving events, so the disposal is the window.
+/// The cost of the narrow window is that an event raised outside it is missed, which is why BOTH of
+/// Lite's connection-open sites carry one rather than only the dialog a user is looking at.</para>
+///
+/// <para><i>Only the last REPORTED name outlives the attempt.</i> Nothing else is retained: the
+/// listener is gone and the captured value is read once. <see cref="s_lastReported"/> exists so an
+/// unchanged repeat is a <see cref="LogLevel.Debug"/> line instead of an
+/// <see cref="LogLevel.Information"/> one, because the selection is a process fact and a monitoring
+/// tool restating it once per server per sweep would be noise. A CHANGED name still reports at
+/// <see cref="LogLevel.Information"/> — the driver clears its credential cache
+/// (<c>ActiveDirectoryAuthenticationProvider.cs:136-138</c>), so a different source genuinely can
+/// win later, and that is the one thing here worth interrupting someone with.</para>
+///
+/// <para><b>Why this reports at most once in practice, stated rather than discovered.</b> Two
+/// caches sit above the event and both are process-wide. <c>DefaultAzureCredential</c> raises event
+/// 13 only on the branch that has no cached credential yet
+/// (<c>DefaultAzureCredential.cs:168-179</c>): once <c>_credentialLock</c> holds a value, later
+/// token requests take the <c>HasValue</c> branch and raise nothing. And SqlClient caches the
+/// <c>DefaultAzureCredential</c> INSTANCE in a <c>static</c> map keyed by authority, scope, audience
+/// and client id (<c>Microsoft.Data.SqlClient.Extensions.Azure</c> 7.0.2,
+/// <c>ActiveDirectoryAuthenticationProvider.cs:29</c> and <c>:258-262</c>). So event 13 fires at most
+/// once per process per key, and a second connection to the same tenant reports nothing at all. That
+/// absence is a <see cref="LogLevel.Debug"/> line saying so, rather than silence: an empty result
+/// must not be mistakable for "nothing happened".</para>
+///
+/// <para><b>No server name on the line, and that is not squeamishness.</b> The selection is scoped
+/// to the process and to the driver's cache key, not to a server — the credential chain resolves
+/// from environment variables, an <c>az login</c> session and machine identity, none of which are
+/// per-server. Naming the server that happened to observe it would assert a per-server fact that is
+/// not true, and the next connection to a different server in the same tenant reports nothing while
+/// using the very same credential.</para>
+/// </summary>
+internal static class EntraCredentialSelectionLog
+{
+    /// <summary>The <c>AppLogger</c> source column for these lines.</summary>
+    internal const string LogSource = "EntraCredential";
+
+    /// <summary>
+    /// The longest value forwarded as a credential type name. <c>Azure.Identity</c>'s longest
+    /// credential type name is well under 60 characters; this is a bound on what an unexpected
+    /// payload could put in the log, not a measurement of anything.
+    /// </summary>
+    internal const int MaxCredentialTypeNameLength = 256;
+
+    private static volatile string? s_lastReported;
+
+    /// <summary>
+    /// A listener for a connection about to be opened with
+    /// <see cref="SqlAuthenticationMethod.ActiveDirectoryDefault"/> — which is what
+    /// <see cref="PerformanceMonitor.Common.AuthenticationTypes.EntraDefaultCredential"/> maps to,
+    /// and the only mode whose token comes from a <c>DefaultAzureCredential</c> — or <c>null</c> for
+    /// every other mode. A <c>null</c> is a <c>using</c> that disposes nothing and a
+    /// <see cref="Report"/> that does nothing, so no other mode enables the source or pays for it.
+    ///
+    /// <para>Keyed off the BUILDER rather than off the app's own mode string on purpose: this is the
+    /// keyword the driver will actually act on, so the gate cannot disagree with the connection
+    /// string, and it follows a credential profile into this mode for free if one is ever offered
+    /// there (today they offer SQL, service principal and managed identity only).</para>
+    /// </summary>
+    internal static EntraCredentialSelectionListener? Begin(SqlConnectionStringBuilder? builder) =>
+        builder?.Authentication == SqlAuthenticationMethod.ActiveDirectoryDefault
+            ? new EntraCredentialSelectionListener()
+            : null;
+
+    /// <summary>
+    /// Whether a captured payload has the shape of a CLR type name, and may therefore be logged.
+    ///
+    /// <para><b>The second barrier, and the one that survives a payload REORDER.</b> The allowlist
+    /// in <see cref="EntraCredentialSelectionListener.OnEventWritten"/> guarantees the event is
+    /// event 13; this guarantees the value taken from it is not something else. Every sensitive
+    /// sibling payload in that source fails on a character a namespace-qualified type name cannot
+    /// contain: a tenant id has <c>-</c>, an account UPN has <c>@</c>, a scope has <c>:</c> and
+    /// <c>/</c>, an exception message and an MSAL log line have spaces. A dot is required, so a bare
+    /// word is not a type name either.</para>
+    ///
+    /// <para>Generic type names (<c>`1[[…]]</c>) are rejected by the same rule. No credential type in
+    /// <c>Azure.Identity</c> is generic, and rejecting one costs a <see cref="LogLevel.Debug"/> line
+    /// saying the payload was declined — which is the direction to fail in.</para>
+    /// </summary>
+    internal static bool IsCredentialTypeName(string? value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length > MaxCredentialTypeNameLength)
+        {
+            return false;
+        }
+
+        foreach (var c in value)
+        {
+            if (!char.IsAsciiLetterOrDigit(c) && c != '.' && c != '_' && c != '+')
+            {
+                return false;
+            }
+        }
+
+        return value.Contains('.', StringComparison.Ordinal) && value[0] != '.' && value[^1] != '.';
+    }
+
+    /// <summary>
+    /// What a captured (or absent, or declined) selection should produce, given what was last
+    /// reported. Pure and static: no clock, no I/O, the caller passes the previous state and
+    /// persists the returned one, which is what makes the whole decision testable without a log
+    /// file. One return value carries the level, the text and the new state together so a caller
+    /// cannot write the line and drop the state.
+    /// </summary>
+    /// <param name="credentialTypeName">
+    /// <see cref="EntraCredentialSelectionListener.SelectedCredentialType"/>.
+    /// </param>
+    /// <param name="rejectedPayload">
+    /// <see cref="EntraCredentialSelectionListener.RejectedPayload"/>.
+    /// </param>
+    /// <param name="lastReported">The last name reported at <see cref="LogLevel.Information"/>.</param>
+    internal static EntraCredentialSelectionLine Decide(
+        string? credentialTypeName,
+        bool rejectedPayload,
+        string? lastReported)
+    {
+        if (!IsCredentialTypeName(credentialTypeName))
+        {
+            /* Re-checked here rather than trusted from the listener, so this function's answer does
+               not depend on which of two types applied the rule. The declined value is NOT in the
+               message - naming it would be the leak the check exists to prevent. */
+            return rejectedPayload
+                ? new EntraCredentialSelectionLine(
+                    LogLevel.Debug,
+                    "DefaultAzureCredential reported a credential selection whose payload was not a "
+                        + "type name, so it was not logged. Azure.Identity's event 13 payload may have "
+                        + "changed shape.",
+                    Reported: null)
+                : new EntraCredentialSelectionLine(
+                    LogLevel.Debug,
+                    "DefaultAzureCredential did not report which credential it selected on this "
+                        + "connection. Expected on any connection but the first: Azure.Identity "
+                        + "raises that event once per credential instance, and SqlClient caches the "
+                        + "instance for the process.",
+                    Reported: null);
+        }
+
+        return string.Equals(credentialTypeName, lastReported, StringComparison.Ordinal)
+            ? new EntraCredentialSelectionLine(
+                LogLevel.Debug,
+                $"DefaultAzureCredential selected {credentialTypeName} (unchanged).",
+                Reported: null)
+            : new EntraCredentialSelectionLine(
+                LogLevel.Information,
+                $"DefaultAzureCredential selected {credentialTypeName}.",
+                Reported: credentialTypeName);
+    }
+
+    /// <summary>
+    /// Reads the listener and writes the line. A no-op for a <c>null</c> listener, which is every
+    /// mode but this one.
+    /// </summary>
+    internal static void Report(EntraCredentialSelectionListener? listener)
+    {
+        if (listener is null)
+        {
+            return;
+        }
+
+        var line = Decide(listener.SelectedCredentialType, listener.RejectedPayload, s_lastReported);
+
+        if (line.Reported is not null)
+        {
+            s_lastReported = line.Reported;
+        }
+
+        if (line.Level == LogLevel.Information)
+        {
+            AppLogger.Info(LogSource, line.Message);
+        }
+        else
+        {
+            AppLogger.Debug(LogSource, line.Message);
+        }
+    }
+
+    /// <summary>
+    /// Forgets the last reported name, so a test can exercise the first-observation arm. Never
+    /// called by the app.
+    /// </summary>
+    internal static void ResetForTests() => s_lastReported = null;
+}
+
+/// <summary>
+/// One log line: the level it is written at, its text, and the name to remember as reported (null
+/// when nothing should be remembered). A record struct so the three cannot be returned separately
+/// and recombined wrongly.
+/// </summary>
+internal readonly record struct EntraCredentialSelectionLine(
+    LogLevel Level,
+    string Message,
+    string? Reported);

--- a/Lite/Helpers/EntraCredentialSelection.cs
+++ b/Lite/Helpers/EntraCredentialSelection.cs
@@ -187,8 +187,15 @@ internal sealed class EntraCredentialSelectionListener : EventListener
 /// <para><i>Only the last REPORTED name outlives the attempt.</i> Nothing else is retained: the
 /// listener is gone and the captured value is read once. <see cref="s_lastReported"/> exists so an
 /// unchanged repeat is a <see cref="LogLevel.Debug"/> line instead of an
-/// <see cref="LogLevel.Information"/> one, because the selection is a process fact and a monitoring
-/// tool restating it once per server per sweep would be noise. A CHANGED name still reports at
+/// <see cref="LogLevel.Information"/> one, because a monitoring tool restating it once per server per
+/// sweep would be noise. <b>Process-wide is the right granularity for what is logged, which is not
+/// quite the same as the selection being a process fact.</b> The chain it resolves from — environment
+/// variables, an <c>az login</c> session, machine identity — is genuinely process-wide, but the
+/// driver keys its credential cache on authority, scope, audience and client id, so two servers in
+/// different tenants get different <c>DefaultAzureCredential</c> instances and each raises its own
+/// event. Both are collapsed here when they select the same TYPE, deliberately: the type name is all
+/// that is recorded, so a second line would repeat it and add nothing. Telling those two apart would
+/// need the tenant or the server on the line, and neither belongs there. A CHANGED name still reports at
 /// <see cref="LogLevel.Information"/> — the driver clears its credential cache
 /// (<c>ActiveDirectoryAuthenticationProvider.cs:136-138</c>), so a different source genuinely can
 /// win later, and that is the one thing here worth interrupting someone with.</para>

--- a/Lite/Services/ServerManager.cs
+++ b/Lite/Services/ServerManager.cs
@@ -449,11 +449,24 @@ public class ServerManager
                mode disposes nothing and logs nothing, and the window is exactly this open rather than
                the life of the process - see EntraCredentialSelectionLog for both lifetime decisions.
                This is also the site that usually gets there first: the sweep runs on a timer, and the
-               driver's static credential cache means the event fires at most once per process. */
+               driver's static credential cache means the event fires at most once per process.
+
+               Reported in a FINALLY, so a failed open reports too. Azure.Identity raises the event
+               when it ACQUIRES a token, before SQL Server has accepted or rejected the identity that
+               token names - so "DefaultAzureCredential picked the wrong ambient identity" arrives as
+               a login failure with the selection already captured, and that is the case this whole
+               feature exists for. It is also the only chance to see it: the driver caches the
+               credential the moment a token is acquired, so a retry raises nothing. */
             using (var credentialSelection = EntraCredentialSelectionLog.Begin(builder))
             {
-                await connection.OpenAsync();
-                EntraCredentialSelectionLog.Report(credentialSelection);
+                try
+                {
+                    await connection.OpenAsync();
+                }
+                finally
+                {
+                    EntraCredentialSelectionLog.Report(credentialSelection);
+                }
             }
 
             // Connection succeeded — server is reachable regardless of DMV permissions below.

--- a/Lite/Services/ServerManager.cs
+++ b/Lite/Services/ServerManager.cs
@@ -443,7 +443,18 @@ public class ServerManager
             };
 
             using var connection = new SqlConnection(builder.ConnectionString);
-            await connection.OpenAsync();
+
+            /* Observability only: the listener reads one Azure-Identity event and writes the chosen
+               credential's type name. It is non-null for EntraDefaultCredential alone, so every other
+               mode disposes nothing and logs nothing, and the window is exactly this open rather than
+               the life of the process - see EntraCredentialSelectionLog for both lifetime decisions.
+               This is also the site that usually gets there first: the sweep runs on a timer, and the
+               driver's static credential cache means the event fires at most once per process. */
+            using (var credentialSelection = EntraCredentialSelectionLog.Begin(builder))
+            {
+                await connection.OpenAsync();
+                EntraCredentialSelectionLog.Report(credentialSelection);
+            }
 
             // Connection succeeded — server is reachable regardless of DMV permissions below.
             status.IsOnline = true;

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -380,11 +380,23 @@ public partial class AddServerDialog : Window
                - see EntraCredentialSelectionLog. Instrumented here AS WELL AS in ServerManager, not
                instead of it: the event fires at most once per process, so whichever site opens the
                first EntraDefaultCredential connection is the only one that can observe it, and which
-               one that is depends on whether a server was already saved when the sweep ran. */
+               one that is depends on whether a server was already saved when the sweep ran.
+
+               Reported in a FINALLY for the same reason as the sibling site: the token is acquired,
+               and the event raised, BEFORE SQL Server accepts or rejects the identity it names. A
+               user pressing Test because they suspect the wrong Azure identity is being used gets a
+               failed open, and the selection has to survive it - which is also the only chance,
+               since the driver caches the credential as soon as a token exists. */
             using (var credentialSelection = EntraCredentialSelectionLog.Begin(builder))
             {
-                await connection.OpenAsync();
-                EntraCredentialSelectionLog.Report(credentialSelection);
+                try
+                {
+                    await connection.OpenAsync();
+                }
+                finally
+                {
+                    EntraCredentialSelectionLog.Report(credentialSelection);
+                }
             }
 
             using var cmd = new SqlCommand("SELECT @@VERSION", connection);

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -373,8 +373,20 @@ public partial class AddServerDialog : Window
 
         try
         {
-            using var connection = new SqlConnection(BuildConnectionBuilder().ConnectionString);
-            await connection.OpenAsync();
+            var builder = BuildConnectionBuilder();
+            using var connection = new SqlConnection(builder.ConnectionString);
+
+            /* Observability only, window exactly this open, non-null for EntraDefaultCredential alone
+               - see EntraCredentialSelectionLog. Instrumented here AS WELL AS in ServerManager, not
+               instead of it: the event fires at most once per process, so whichever site opens the
+               first EntraDefaultCredential connection is the only one that can observe it, and which
+               one that is depends on whether a server was already saved when the sweep ran. */
+            using (var credentialSelection = EntraCredentialSelectionLog.Begin(builder))
+            {
+                await connection.OpenAsync();
+                EntraCredentialSelectionLog.Report(credentialSelection);
+            }
+
             using var cmd = new SqlCommand("SELECT @@VERSION", connection);
             var version = await cmd.ExecuteScalarAsync() as string;
             serverVersion = version?.Split('\n')[0]?.Trim();

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ It signs in as **whichever Azure identity is already established on the machine*
 
 - **With no Azure sign-in on the machine it fails rather than asking for one.** Run `az login` first. The connection dialog says which of the two failure modes happened — nothing found, or one found and broken — and the log names each source and why it declined.
 - **The order is the driver's, not yours.** There is no seam to narrow the list: the driver constructs the credential chain itself and this app cannot pass options into it. On a machine with several Azure identities set up, this connects as whichever comes first, which is not necessarily the one you signed into Windows with. When a specific identity matters, use **Service Principal**, which names it.
+- **The log says which one won.** Lite records the credential type `DefaultAzureCredential` actually selected — `AzureCliCredential`, `EnvironmentCredential`, `ManagedIdentityCredential` and so on — so "whichever comes first" is answerable after the fact rather than only a caveat. Expect exactly one such line per run of the app: `Azure.Identity` reports the selection once per credential instance and the driver caches that instance for the process, so later connections have nothing new to report and say so at `Debug`. The type name is the only thing recorded; no tenant id, account or scope.
 
 Darling does not offer this mode: the Darling service's connect path builds Windows-integrated or SQL-login connections only and acquires no tokens at all, so its viewer rejects every Azure mode at the credential step.
 


### PR DESCRIPTION
`EntraDefaultCredential` signs in as whichever Azure identity the machine already has, in an order the driver owns and this app cannot narrow. #3218 disclosed that in dialog text and in the README, and recommended instrumenting it as a follow-up. This is the follow-up: the credential type `DefaultAzureCredential` actually selected, in the log, and nothing else.

Observability only. No change to the connection string or the credential chain, and the only change to control flow is a `try`/`finally` around each open whose `finally` writes a log line.

## The upstream event, re-verified at the tag rather than at `main`

Read at tag **`Azure.Identity_1.18.0`** — the version the repository resolves, transitively, through `Microsoft.Data.SqlClient.Extensions.Azure` 7.0.2 (#3219). All four line citations I was handed check out exactly, which is worth saying because a `main`-vs-tag mismatch cost this queue three corrections in one day:

| claim | verified at `Azure.Identity_1.18.0` |
|---|---|
| `Credentials/DefaultAzureCredential.cs:178` raises `DefaultAzureCredentialCredentialSelected(credential.GetType().FullName)` on the success path | exact |
| `AzureIdentityEventSource.cs:18` — source name `Azure-Identity` | exact |
| `AzureIdentityEventSource.cs:34` — event id `13` | exact |
| `AzureIdentityEventSource.cs:307` — `Level = EventLevel.Informational`, one `string credentialType` | exact |

## An allowlist, because the level cannot narrow this and keywords do not exist here

The brief that reached me said event 13 shares `Informational` with 18 other events. The count is **19 others**, and the framing understates the problem in a way that matters: `EventListener.EnableEvents(source, level)` admits every event **at or above** the requested severity, so `Informational` delivers **28 of that source's 29 events** — 20 `Informational`, 4 `Warning`, 2 `Error`, 1 `Critical`, 1 `LogAlways`. Only the single `Verbose` event is excluded. So the level admits `MsalLogError`, `MsalLogCritical`, `MsalLogAlways` and `ProcessRunnerError` as well as the `Informational` siblings that carry tenant ids, account details, scopes, parent request ids and a formatted `Exception`.

And **no event in that file declares `Keywords`** — 0 of 29 — so `EnableEvents` has no dimension to exclude them on.

Every count above was taken **twice, off two things that fail differently**: parsing the `[Event]` attributes in the source at tag `Azure.Identity_1.18.0`, and reflecting over the shipped `Azure.Identity.dll` in the harness's own closure. They agree exactly — 29 events, 20 `Informational`, 28 delivered at `Informational`, 0 with `Keywords` — and the second instrument also confirms the assembly is `1.18.0+05d48fdf`, so the line numbers and the histogram are about the same build. The callback filter is the only barrier, which is why it is an allowlist on `EventId == 13` and not a denylist: a future `Azure.Identity` adding an event is precisely where a denylist fails and an allowlist survives.

**Two barriers, not one.** The allowlist guarantees the event; a shape check guarantees the value taken from it. `Payload[0]` is forwarded only if it looks like a namespace-qualified CLR type name — which rejects every sensitive sibling payload on a character a type name cannot contain: a tenant id has `-`, an account UPN has `@`, a scope has `:` and `/`, a message has spaces. That is the barrier that survives a payload **reorder**, which the id allowlist alone does not. Never `eventData.ToString()`, never the payload collection, never `Message` formatted with its arguments.

The sharpest evidence that the id is doing the work: `ManagedIdentityCredentialSelected` (event 26, `Informational`) has a first payload slot that is *also* called `credentialType` and *also* holds a real credential type name. It passes the level, the source name and the shape check. Only the id keeps it out, and a test raises it to prove that.

## Both lifetime decisions

**The listener's window is one connection open, not the process.** While the source is enabled, `AzureIdentityEventSource.IsEnabled(Informational, …)` answers true inside `Azure.Identity` and it performs the formatting work its seven `if (IsEnabled(…))` guards otherwise skip. A monitoring tool that left it on would pay that on every token operation for the life of the process, forever, to learn a fact that can only be reported once. `Begin` is called immediately before the open; the listener is disposed immediately after it, because an undisposed `EventListener` keeps receiving events. The cost of the narrow window is that an event raised outside it is missed — which is why **both** of Lite's connection-open sites carry one rather than only the dialog a user is looking at.

**Only the last reported name outlives the attempt.** The listener is gone and the captured value is read once. One static string exists so an unchanged repeat is `Debug` rather than `Information`: the selection is a process fact, and a monitoring tool restating it once per server per sweep would be noise. It is claimed with `Interlocked.Exchange` rather than read and then written — one raised event is delivered to *every* attached listener and `CheckAllConnectionsAsync` checks servers concurrently, so two concurrent first connections capture the same name and a read-then-write pair lets both decide they are first. A *changed* name still reports at `Information` — the driver clears its credential cache (`ActiveDirectoryAuthenticationProvider.cs:136-138`), so a different source genuinely can start winning, and that is a different identity connecting.

**Why it reports at most once, stated rather than discovered.** Two process-wide caches sit above the event. `DefaultAzureCredential` raises event 13 only on the branch with no cached credential (`DefaultAzureCredential.cs:168-179`); once `_credentialLock` holds a value, later requests take the `HasValue` branch and raise nothing. And SqlClient caches the `DefaultAzureCredential` **instance** in a `static` map keyed by authority, scope, audience and client id (`ActiveDirectoryAuthenticationProvider.cs:29`, `:258-262`). So the event fires at most once per process per key, and a second connection to the same tenant reports nothing at all. That absence is a `Debug` line saying why, not silence.

**Two sites out of about twenty, and that is sound for a reason rather than by hope.** Lite has roughly twenty `new SqlConnection` sites that reach a monitored server. Only two are instrumented, which only works because the connectivity check gets there first — and it does, by construction: `CollectionBackgroundService.ExecuteAsync` runs `ServerManager.CheckAllConnectionsAsync` **before** `RemoteCollectorService.RunDueCollectorsAsync` on every cycle including the first, and that loop is the only thing that drives collection. The interactive first-touch paths are the dialog's Test button and `MainWindow`'s explicit retry, and both go through an instrumented open. A reorder of that loop would break observability with **nothing to notice** — the app connects normally, the listener attaches normally, and the event has already been raised and discarded, permanently — so `EntraCredentialSelectionOrderingTests` pins it.

What that still does not cover, said rather than implied: the bulk-add dialog, the excluded-databases dialog, a server tab's ad-hoc reads and the plan fetcher all open connections too. Each needs an already-configured server, so in practice the sweep has run first; a user who drives one inside the background service's five-second startup delay could acquire the first token there. The consequence is the `Debug` "not observed" line rather than a wrong one, which is the direction to fail in, and it is why that line names the caching as the *expected* cause instead of asserting it.

**Reported on the failure path as well, and that is where it matters most.** `Azure.Identity` raises event 13 when it **acquires a token** — before SQL Server has accepted or rejected the identity that token names. So "`DefaultAzureCredential` picked the wrong ambient identity", which is the exact complaint this feature exists to answer, arrives as a *login failure* with the selection already captured. Reporting only after a successful open dropped precisely that case; both sites now report from a `finally`. It is also the only chance to see it: the driver caches the credential the moment a token exists, so a retry raises nothing at all. `Report` takes nothing but the listener — it has no success argument to get wrong — and it does no I/O, so a `finally` cannot mask the connection's own exception. There is deliberately no blanket `catch` in it: one would make the feature silently dead at the moment it broke.

## Which paths log, and which deliberately do not

"Logs on success and on failure" is true and is not the claim. The claim is **it logs whenever a selection occurred, on either path, and it never records a selection that did not occur.**

| Path | What is written |
|---|---|
| Selection observed, open **succeeded** | `Information`, naming the credential type — or `Debug` "(unchanged)" if it repeats a name already reported this process |
| Selection observed, open **failed** | identical. This is the primary case: the token is acquired, and the event raised, before SQL Server accepts or rejects the identity it names |
| No selection observed — a repeat connection on the driver's cached credential, a chain that found nothing so raised no event, or a pre-token failure (DNS, network, timeout) | one `Debug` line naming the caching as the *expected* cause, **carrying no credential name**. `Debug` is below the default minimum, so on a default install this path writes **nothing at all** |
| Event 13 raised but `Payload[0]` failed the type-name shape check | one `Debug` line saying the payload was not a type name, **not carrying the value** |
| Any mode other than `EntraDefaultCredential` | nothing, ever. `Begin` returns `null`, `Report` no-ops, and the event source is never enabled |
| Lite's other four `SqlConnection` sites (bulk-add dialog, excluded-databases dialog, server-tab ad-hoc reads, plan fetcher) | not instrumented. See the ordering section above for why that is sound and what it costs |

Three pins hold the "never records a selection that did not occur" half, each falsified: the not-observed line written at `Information` instead of `Debug` (Failed: 6), that line rewritten to claim a selection and name it `unknown` (Failed: 3), and the refused-payload line rewritten to name the refused value (which cannot leak, for a structural reason recorded in the file). The `Debug` explanation is deliberately not silence — an operator who lowers the level and goes looking should find "the event fires once per credential instance and the driver caches the instance" rather than an absence they have to explain.

**No server name on the line.** The selection is scoped to the process and the driver's cache key, not to a server: the chain resolves from environment variables, an `az login` session and machine identity, none of which are per-server. Naming the server that happened to observe it would assert a per-server fact that is not true.

**The gate keys off the builder, not the mode string.** `SqlAuthenticationMethod.ActiveDirectoryDefault` is the keyword the driver acts on, so the gate cannot disagree with the connection string — and it follows a credential profile into this mode for free if one is ever offered there (today profiles offer SQL, service principal and managed identity only). The one degree of indirection that buys is closed by a test that runs the real `ServerConnection.ApplyAuthentication` for every mode reflected off `AuthenticationTypes` and asserts exactly one attaches a listener.

## How the pin is falsified in both directions

Every pin raises the **real** event on the **real** event source: `Azure.Identity`'s `AzureIdentityEventSource` is `internal`, so it is reached by reflection and its actual methods are invoked. The id, the level, the payload shape and the source name are the ones that ship.

- **Positive** — event 13 raised, the type name must arrive. Raised with the source already created, so `OnEventSourceCreated` is reached from the `EventListener` **base constructor**: the path on which a derived field assigned in a constructor body is still null and the listener silently never enables. Both values that callback needs are `const` for exactly that reason.
- **Negative, on the same listener** — three siblings raised first (`ManagedIdentityCredentialSelected`, whose payload passes every check but the id; `TenantIdDiscoveredAndUsed`, which carries tenant ids; `UserAssignedManagedIdentityNotSupported`, at `Warning`), none forwarded — *then* event 13, which must be. A listener that simply received nothing fails the last assertion, so the first three are evidence of filtering rather than of silence.
- **An independent instrument for the level claim** — a recording listener enabling the same source at the same level records every id delivered, so "the sibling was not forwarded" can be told apart from "the level never delivered it". Without it the callback filter could be deleted with nothing noticing.
- **Enables `Azure-Identity` and nothing else** — a bystander `EventSource` must be *un*-enabled while `Azure-Identity` demonstrably is. A dropped name check would turn this into a listener that enables every source in the process, and every other pin here would stay green.
- **The upstream contract** — source name, method signature, `[Event]` id and level read off the shipped assembly; and that no event declares `Keywords`, with the event count as the control. This is the pin that makes #3219's unpinned transitive dependency loud instead of silent.
- **Payload slot 0 is `credentialType`, by NAME, on a real written event** — read off `EventWrittenEventArgs.PayloadNames` rather than the reflected signature, because the name the runtime attaches to that position is what the positional read actually gets. The runtime does report payload names for this event (measured). A parameter added or reordered ahead of `credentialType` is declined at runtime by the shape check; this is what makes it loud rather than merely survivable.
- **Both call sites, in order, and reporting on both paths** — asserted on `StripCommentsAndStrings`' output, because both sites carry a comment naming `EntraCredentialSelectionLog` and a raw substring search would be satisfied by the comment with every call deleted (#3201's defect). Three discriminating assertions: `Begin` before the open (a `Report` placed first captures nothing forever while reading as fully instrumented); `Report` after it; and a `try`/`finally` **in the window between them**, because `Begin`-before-open plus `Report`-after-open is satisfied by a `Report` on the success tail. Asserted on the window rather than the method body on purpose — `RunConnectionTestAsync` already had an unrelated `finally` for re-enabling its buttons, which would have satisfied a body-wide check.
- **Through the real `AppLogger`, at the default level** — the first observation must reach the log; the unchanged repeat must not. Nothing else would catch a `Report` that wrote every line at `Debug`: the messages would still be correct and the whole feature would be invisible on every shipped install.

## Mutation table

Baseline before every mutation, in a `net10.0` xunit.v3 harness compiling the real shipped `.cs` under `AssemblyName=Lite.Tests` (so `InternalsVisibleTo` applies) with versions from `Directory.Packages.props`:

**`Total: 57, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0`** for the table below, and **`Total: 58, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0`** after the payload-name pin was added, for the three rows that follow it.

Each mutation was applied by unique-anchor byte replacement, confirmed present by `git diff --numstat` **and** by content occurrence count, rebuilt, run, restored with `git checkout --`, and confirmed gone by content plus an empty `git status`.

| Mutation | Result |
|---|---|
| allowlist on `EventId` removed | Failed: 1 |
| allowlist replaced by a denylist of today's known-sensitive ids | Failed: 1 |
| payload shape check removed | Failed: 1 |
| shape check widened by ONE character, so a hyphen passes | Failed: 1 |
| source-name check dropped from `OnEventSourceCreated` | Failed: 1 |
| source name moved off `const` into a constructor-body field, read from the callback | Failed: 6 |
| `Report` writes every line at `Debug` | Failed: 1 |
| `Report` never persists the reported name | Failed: 2 |
| `Begin` returns a listener for every authentication method | Failed: 11 |
| `Decide` reports an unchanged repeat at `Information` | Failed: 3 |
| `Decide` trusts the listener's bool instead of re-reading the rule | Failed: 3 |
| the listener retains a refused payload anyway | Failed: 1 |
| `ServerManager` reports BEFORE the open | Failed: 1 |
| `AddServerDialog`'s whole scope deleted, its explaining comment kept | Failed: 1 |
| **instrument:** `Raise()` made a no-op, so no real event is written | Failed: 5 |
| **instrument:** the reflection target aimed at a type that does not exist | Failed: 9 |
| **instrument:** log reader filters on a source never written | Failed: 2 |
| **instrument:** call-site pin reads RAW source, dialog's calls deleted, comment kept | Failed: 1 |
| **instrument:** sibling pin loses its positive control AND the listener never enables | Failed: 5 |
| **instrument:** enabled-level pin's floor control `>= 3` → `>= 0` AND the listener never enables | Failed: 6 |
| **instrument:** keywords pin loses its count control AND enumerates nothing | **Failed: 0** |
| payload-name pin expects a different name (is the assertion live?) | Failed: 1 |
| payload-name pin's captured VALUE assertion expects the wrong credential | Failed: 1 |
| **instrument:** the capture listener discards payload names, count assertion deleted | Failed: 1 |
| `ServerManager` reverted to reporting on the success tail (the defect review found) | Failed: 1 |
| `AddServerDialog` reverted to reporting on the success tail | Failed: 1 |
| `Report` gains a success flag and gates on it | Failed: 1 |
| **instrument:** the `finally` assertion reads the whole method body instead of the `Begin`→`Report` window, and the dialog reverts | **Failed: 0** |
| dedupe claimed by read-then-write instead of `Interlocked.Exchange` | **Failed: 0** |
| the collection loop genuinely collects before it checks connections | Failed: 1 |
| the same inversion plus a comment naming the check, strip intact | Failed: 1 |
| `ServerManager` stops attaching the listener at all | Failed: 2 |
| **instrument:** ordering pin drops its strip, inverted loop carries a comment naming the check | **Failed: 0** |

Baseline: **`Total: 59`** for the `finally` rows, **`Total: 61`** for the ordering rows, `Errors: 0, Failed: 0, Skipped: 0, Not Run: 0` in both cases.

### Re-run in full against the head, after the `finally` move

Moving a call changes which paths the pins cover, so the whole table was regenerated against the current source and re-run rather than assumed to survive — **27 mutations, baseline `Total: 61, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0`**. 23 red. The four green are the same four disclosed above (`Interlocked.Exchange`, and the three instrument demonstrations); nothing went vacuous from the move, and in particular the success-tail revert, the whole-scope deletion and the success-flag mutation are all red at both sites.

Three more on the no-selection path, baseline `Total: 62`:

| Mutation | Result |
|---|---|
| the not-observed line written at `Information` instead of `Debug` | Failed: 6 |
| the not-observed arm claims a selection and names it `unknown` | Failed: 3 |
| **instrument:** the new default-level pin loses its positive control | **Failed: 0** |

The ordering rows are the clean three-way discrimination, and getting there took a correction worth recording: my first attempt at inverting the loop moved the collector call to just *after* the connection check and I read the resulting green as a vacuous pin. It was a vacuous **mutation**. The real inversion fails (Failed: 1); the same inversion with the strip removed and one comment added naming `CheckAllConnectionsAsync` passes (Failed: 0); and the same inversion *with* the strip and the comment fails again (Failed: 1) — so it is the strip, not the absence of the comment, doing the work. No comment in that file names either identifier today, so the strip is invisible until someone reordering the loop writes a one-line ordering note, which is exactly the case the pin exists for.

Three more rows are green and each is disclosed rather than explained away. The body-wide `finally` check is the demonstration that the window matters: `RunConnectionTestAsync`'s own button-re-enabling `finally` satisfies it while the selection is dropped on every failed open. And **the `Interlocked.Exchange` claim is not pinned by anything** — the race is two concurrent first connections capturing one delivered event, which is not reproducible on demand, so the argument is the exchange's atomicity and the sequential form of the same path is what the suite covers. Said here rather than left to look tested.

The keywords row is green on purpose and is the demonstration, not an escape: with the event-count control removed and the enumeration aimed at a type carrying no events, "no event declares `Keywords`" passes while asserting nothing. That control is why the real pin is not decoration.

### Two pins went green that should have been red, and mutation is what found them

**Every rejection case for the shape check was also missing a dot**, so the dot requirement alone rejected it and the character allowlist was never under test — widening it by a hyphen left all 44 tests green. Fixed by ten rows that are each a well-formed dotted name differing from an acceptable one by exactly one illegal character, so each character in the allowlist is load-bearing.

**`Decide` re-reads the shape rule rather than trusting the listener's verdict, and nothing exercised that re-read** — keying the refusal off the bool alone was green. Fixed by handing `Decide` a value that is not a type name with `rejectedPayload: false`, which is the shape a listener that stopped applying the rule would produce.

A third mutation — interpolating the refused value into `Decide`'s message — also went green, and that one is *not* a gap: the refused value never leaves `OnEventWritten` (the listener stores a bool, not the string), so `Decide` structurally cannot name it. The test's `DoesNotContain` there is a consequence of the design rather than an independent check of it, and now says so in the file.

Mutation also corrected a claim I had written *about* a test. I had called the payload-name pin's `names.Count > 0` assertion a control against a vacuous index check; discarding the names and deleting the assertion still failed, because `names[0]` on an empty list throws. It is not a control — it names the cause instead of leaving an index-out-of-range to diagnose — and the file now says that rather than the flattering version.

## Counts in comments

Every count in the new file names the version it was measured at, because a count in prose is a partial list with a numeral welded on. One was simply wrong on the first pass: the cost note said `Azure.Identity` has seven `if (IsEnabled(…))` guards, and at 1.18.0 it has 21, plus 10 `when IsEnabled(…)` switch arms. Corrected, and the event histogram now records that it was counted two ways.

## Review

**Third round.** `claude[bot]` found that `EntraCredentialSelectionTests` reads and mutates `AppLogger`'s process-wide statics — it drains the buffer and asserts on what came out, and one pin moves the minimum — without joining the `app-logger-statics` xUnit collection that `LiteLogLevelGateTests` created for exactly that. Verified: that class's own remarks state the invariant this PR falsified, in so many words — *"this class is the only reader of the sink anywhere in the suite"* — and name the trigger, *"the condition that would make it bite is any of those five reading the log, and then they join `app-logger-statics`"*.

Both mechanisms are real and neither is reproducible on demand: `DrainBufferedLines` is destructive, so a concurrent sweep dequeues the line this class is about to look for and tag-filtering on the log source cannot recover it; and those sweeps set the minimum as far as `None`, so the `Information` line this class expects to be admitted is never enqueued at all. Two green CI runs do not disprove a flake. Fixed by joining the collection — which means the name now serialises two classes rather than nothing — and by **correcting the invariant in `LiteLogLevelGateTests`' own remarks**, rather than leaving a false claim for the next person to reason from. **And the listener needed the same collection, for a second reason.** The `EventListener`/`EventSource` pair is process-wide too: enabling a source is a global effect, and a raised event is delivered to *every* listener attached to it anywhere in the process. `EntraCredentialSelectionModeGateTests` calls `Begin`, so it constructs real listeners on the same source that `EntraCredentialSelectionTests` raises real events on — so it joins, **not** for the `AppLogger` reason (it touches none) but because a class can belong to only one collection, and a separate name for the event-source hazard would have failed to serialise it against the class that matters. It changes no assertion there today, because those pins only ask whether `Begin` returned a listener and never read what one captured; the condition that would make it bite is reading `SelectedCredentialType`/`RejectedPayload` or calling `Report`. That widening is recorded in the collection's home file as well, so the name is not the only thing describing what it covers.

Measured rather than assumed: these are the **only** `EventListener` subclasses and the **only** `Azure-Identity` consumers anywhere in the repository, so no third party can observe the events raised here today.

`EntraCredentialSelectionOrderingTests` stays out, and is the case that shows the rule is about *reach* rather than subject matter: it is entirely about this feature and reads source files only — no `AppLogger`, no listener, no event source, nothing process-wide to share.

**First round.** `claude[bot]` found a real defect and it is fixed above: `Report` reached only the success path, which drops the selection in the one case the feature exists for. Both call sites now report from a `finally`, and the call-site pin was extended to require it — the previous pin passed with the defect restored, which is the part worth recording.

Its second finding — `s_lastReported` written with only `volatile` while `CheckAllConnectionsAsync` runs concurrently — is also fixed, though the analysis was slightly off in a way that makes it worse than "cosmetic": one raised event is delivered to *every* attached listener, so two concurrent first connections do not merely race on the write, they both legitimately capture the same name. `Interlocked.Exchange` now claims it.

## The one CI failure, and what it says about local verification

`build` went red on `c849c9f13` at `Darling.Tests.DocCommentHygieneTests.NoMemberCarriesTwoStackedSummaryBlocks` — pointing at `Lite.Tests/EntraCredentialSelectionTests.cs:792`. `Run Lite tests` in the same job passed; the failure was Darling's **whole-tree** doc guard reading Lite source.

The cause is worth naming because it is a mechanism, not a typo: two separate later insertions anchored on `private sealed class RecordingListener : EventListener` — the class *declaration* — rather than on the line above its doc comment. Each insertion therefore pushed that comment further up and left the class undocumented behind a stack of summaries. XML docs take the **last** summary, so tooling read correctly and only a human reading the file was misled. The guard's own message warns against deleting the first block for exactly this reason, so it was **moved back onto the member it documents**, not removed.

It also exposed a gap in my local verification, now closed: I had been running my own suite and not the whole-tree guards that read my files from the other app's suite. Fixed by compiling the real `DocCommentHygieneTests.cs` plus `CSharpSourceWalker.cs` into a throwaway `net10.0` console shim — the guard walks up from the test binary looking for `PerformanceMonitor.sln`, so the shim has to live inside the tree (`Darling/tools/pg-harnesses/`, which is gitignored). 76 of that class's 77 tests pass; the 77th, `TheDerivedProjectListCoversEveryProjectInTheTree`, fails naming the shim's own `.csproj`, because it enumerates every `.csproj` on disk. **The shim was deleted afterwards for that reason** — leaving it would fail an unrelated real guard on the next local run.

Verified red-first: restoring the displaced state fails with the same two line numbers CI reported (792, 801); the fix passes.

## What only CI can confirm, and what nobody here can

`Lite.Tests` targets `net10.0-windows` and cannot run on macOS. `EntraCredentialSelectionModeGateTests` is a separate file because it needs `ServerConnection`, whose closure reaches Windows-only credential storage — so the mode → `ApplyAuthentication` → gate link ran in `build` only, not locally. Everything else ran locally against the real `Azure.Identity` 1.18.0 assembly.

Execution in CI confirmed by test-count delta, since MTP prints no `Passed` lines: `Lite.Tests` reports **3568** on `dev` at `91c0a919a` (run 34371264224) and **3631** here, `Failed: 0, Not Run: 0`. The delta of 63 is exactly 19 `[Fact]` + 30 `[InlineData]` rows + 10 `[MemberData]` rows in `EntraCredentialSelectionTests`, 2 in `EntraCredentialSelectionOrderingTests` and 2 in `EntraCredentialSelectionModeGateTests`.

And a note on which check to read: `Darling Linux build` (11s) and `Darling PostgreSQL tests` (17s) both take build.yml's path fast path, because the diff touches no `Darling/**` and no shared project. Their green says nothing about this change. **`build` is the check that ran my content**, at ~8.5 minutes.

And the part no test reaches: that a live Entra tenant issues a token to a real `az login` session through this path, and that the type name which then lands in the log is the one a user would recognise. Still unverified against a live tenant — the limit #3196, #3214 and #3218 all had.

## CHANGELOG

Not edited, per lane convention. Entry text:

- **Lite now records which Azure credential `DefaultAzureCredential` selected for an Existing Sign-In (`az login`) connection** ([#3218] follow-up, and see [#3219]) - the mode signs in as whichever identity the machine already has, in an order the driver owns and the app cannot narrow, which the connection dialog and the README warned about and nothing recorded. A narrowly-scoped `EventListener` enables `Azure.Identity`'s `Azure-Identity` event source for exactly the duration of one connection open, forwards event 13 and nothing else, and writes the selected credential's type name - `AzureCliCredential`, `EnvironmentCredential`, `ManagedIdentityCredential` and so on - through `AppLogger`. The filter is an allowlist on the event id rather than a level or a keyword because neither can narrow this: event 13 is itself `Informational`, so that is the lowest level which delivers it, `EnableEvents` admits everything at or above the level requested (28 of that source's 29 events), and not one event in it declares `Keywords` - so the callback filter is the only barrier between the app's log and the siblings carrying tenant ids, account details and raw exceptions. `Payload[0]` is the only value read and only if it has the shape of a CLR type name, which is what survives a future payload reorder. Expect one line per run of the app: `Azure.Identity` reports the selection once per credential instance and the driver caches that instance in a process-wide static, so later connections have nothing new to report and say so at `Debug` rather than silently. Observability only - the connection path, the connection string and the credential chain are unchanged, and no other authentication mode enables the event source or pays anything for this
