### PR TITLE
Declare the product version once, and pin every reader to it (#3222)

### DIFF
--- a/.claude/skills/release-checklist/SKILL.md
+++ b/.claude/skills/release-checklist/SKILL.md
@@ -9,7 +9,7 @@ disable-model-invocation: false
 
 Run through the full release prep checklist for PerformanceMonitor. `$ARGUMENTS` is the target version (e.g., `3.3.0`).
 
-> **Scope (since v3.3.0):** the Full Dashboard and the CLI Installer are DEPRECATED and OUT of this process — they ship no release artifacts and get no live install/upgrade testing here. They still build and their test suites still run in CI on the release event, and their csprojs still get version bumps (below). The release artifacts are: Lite (zip + Velopack Setup.exe), the Darling service zip, and the Darling Viewer Setup.exe.
+> **Scope (since v3.3.0):** the Full Dashboard and the CLI Installer are DEPRECATED and OUT of this process — they ship no release artifacts and get no live install/upgrade testing here. They still build and their test suites still run in CI on the release event, and they inherit the single `<Version>` with everything else in the tree (below). The release artifacts are: Lite (zip + Velopack Setup.exe), the Darling service zip, and the Darling Viewer Setup.exe.
 
 ## Checklist
 
@@ -17,15 +17,17 @@ Work through each step in order. Report status as you go. If a step fails, stop 
 
 ### 1. Version Bumps
 
-Bump `<Version>`, `<AssemblyVersion>`, `<FileVersion>`, and `<InformationalVersion>` in all 6 csproj files:
-- `Lite/PerformanceMonitorLite.csproj`
-- `Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj` (carries the Version/AssemblyVersion/FileVersion triplet, no InformationalVersion)
-- `Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj` (same triplet)
-- `deprecated/Dashboard/Dashboard.csproj` — still bumped even though deprecated: the `check-version-bump` workflow reads THIS file
-- `deprecated/Installer/PerformanceMonitorInstaller.csproj` — still bumped for consistency (CI builds it on release events)
-- `deprecated/Installer.Core/Installer.Core.csproj` — same
+Bump `<Version>` in **`Directory.Build.props`**. That is the whole step — one line, one file.
 
-The `check-version-bump` workflow only reads `Dashboard.csproj`, so the other five are on THIS checklist to catch — nothing in CI enforces them.
+Every project in the tree inherits it, and `AssemblyVersion` / `FileVersion` / `InformationalVersion` derive
+from it at build time. Do not add any of those four elements to a csproj: `ProductVersionDeclarationTests`
+fails the build on a second `<Version>` property anywhere in the tree, on a re-added derived property, and
+on a workflow or script that reads a version from any path but `Directory.Build.props`.
+
+This replaced six independently hand-bumped csproj files (#3222). Two of them had been sitting three
+releases behind, `deprecated/Dashboard/Dashboard.csproj` was declaring 3.6.0 while its binary stamped
+3.3.0.0, and the release gate took its judgement from that file — so nothing in CI compared the version it
+gated on against the version the artifacts were named with. Both now read the file above.
 
 Verify no other files contain hardcoded version strings that need updating.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,13 @@ jobs:
             # affect every product, so it forces a full build/test/publish.
             root:
               - 'PerformanceMonitor.sln'
+              # #3222: every project in the tree inherits the product version from here, so a
+              # release bump touches this file and NOTHING else. Absent this entry that bump
+              # matches no area filter at all and the job that stamps the artifacts never builds
+              # them: the enumerated-list failure this file's other comments keep describing.
+              # Spelled without the angle brackets on purpose. ProductVersionDeclarationTests
+              # treats that spelling as a version READ and would score this comment as one.
+              - 'Directory.Build.props'
               - 'global.json'
               - 'nuget.config'
               - 'NuGet.config'
@@ -391,7 +398,7 @@ jobs:
         id: version
         shell: pwsh
         run: |
-          $version = ([xml](Get-Content Lite/PerformanceMonitorLite.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          $version = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
 
       # #2501: -r win-x64 --self-contained, and it makes the portable ZIP SMALLER, not bigger.
@@ -981,7 +988,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version="$(grep -oPm1 '(?<=<Version>)[^<]+' Lite/PerformanceMonitorLite.csproj)"
+          version="$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)"
           echo "VERSION=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Package linux artifact + checksum

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,12 @@ jobs:
               # directories, for the same reason #2114 added the *.xaml catch-all above an
               # enumerated six: an enumerated list stops covering the next file added.
               - 'Lite/**/*.cs'
+              # #3222, same reason again and a project file this time: ProductVersionDeclarationTests
+              # enumerates every csproj/props/targets in the tree to assert that exactly one place
+              # declares a product version. Lite's project file is in that population, so adding a
+              # version property back to it must run the Darling guard that would catch it. Derived
+              # rather than the one path, for the reason the two entries above are derived.
+              - 'Lite/**/*.csproj'
             # The DOCUMENTATION allowlist: files that cannot affect a build under any
             # job in this workflow. Deliberately an allowlist of non-executable content,
             # not a "everything that isn't code" subtraction — a new file type defaults

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -399,7 +399,9 @@ jobs:
         shell: pwsh
         run: |
           $version = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }
+          if ([string]::IsNullOrWhiteSpace($version)) { throw "Read no version from Directory.Build.props." }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "Version: $version"
 
       # #2501: -r win-x64 --self-contained, and it makes the portable ZIP SMALLER, not bigger.
       # The RID-agnostic framework-dependent publish this replaced copied every platform its
@@ -989,6 +991,7 @@ jobs:
         run: |
           set -euo pipefail
           version="$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)"
+          [ -n "${version}" ] || { echo "::error::Read no version from Directory.Build.props."; exit 1; }
           echo "VERSION=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Package linux artifact + checksum

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -62,9 +62,9 @@ jobs:
         shell: pwsh
         run: |
           # main does not carry Directory.Build.props until the release that centralises the
-          # version (#3222) lands there, so fall back to the file this gate used to read --
-          # that release PR has to be able to pass on a main that predates the change.
-          # Removable once main has Directory.Build.props.
+          # version (#3222) lands there, so fall back to deprecated/Dashboard/Dashboard.csproj,
+          # which is where main declares its version. That release PR has to be able to pass
+          # against a main that predates the file. Removable once main has it.
           $path = 'main-branch/Directory.Build.props'
           if (-not (Test-Path $path)) { $path = 'main-branch/deprecated/Dashboard/Dashboard.csproj' }
           $version = ([xml](Get-Content $path)).Project.PropertyGroup.Version | Where-Object { $_ }

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -45,7 +45,7 @@ jobs:
         id: pr
         shell: pwsh
         run: |
-          $version = ([xml](Get-Content deprecated/Dashboard/Dashboard.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          $version = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
           Write-Host "PR version: $version"
 
@@ -61,11 +61,12 @@ jobs:
         id: main
         shell: pwsh
         run: |
-          # main still carries the pre-deprecation layout until the v3.3.0 promotion lands;
-          # fall back to the old path so the release PR itself can pass. Removable once
-          # main has deprecated/Dashboard/.
-          $path = 'main-branch/deprecated/Dashboard/Dashboard.csproj'
-          if (-not (Test-Path $path)) { $path = 'main-branch/Dashboard/Dashboard.csproj' }
+          # main does not carry Directory.Build.props until the release that centralises the
+          # version (#3222) lands there, so fall back to the file this gate used to read --
+          # that release PR has to be able to pass on a main that predates the change.
+          # Removable once main has Directory.Build.props.
+          $path = 'main-branch/Directory.Build.props'
+          if (-not (Test-Path $path)) { $path = 'main-branch/deprecated/Dashboard/Dashboard.csproj' }
           $version = ([xml](Get-Content $path)).Project.PropertyGroup.Version | Where-Object { $_ }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
           Write-Host "Main version: $version (from $path)"
@@ -79,7 +80,7 @@ jobs:
           echo "Main version: $MAIN_VERSION"
           echo "PR version:   $PR_VERSION"
           if [ "$PR_VERSION" == "$MAIN_VERSION" ]; then
-            echo "::error::Version in deprecated/Dashboard/Dashboard.csproj ($PR_VERSION) has not changed from main. Bump the version before merging to main."
+            echo "::error::Version in Directory.Build.props ($PR_VERSION) has not changed from main. Bump the version before merging to main."
             exit 1
           fi
           echo "✅ Version bumped: $MAIN_VERSION → $PR_VERSION"

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -46,6 +46,7 @@ jobs:
         shell: pwsh
         run: |
           $version = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }
+          if ([string]::IsNullOrWhiteSpace($version)) { throw "Read no version from Directory.Build.props." }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
           Write-Host "PR version: $version"
 
@@ -68,6 +69,9 @@ jobs:
           $path = 'main-branch/Directory.Build.props'
           if (-not (Test-Path $path)) { $path = 'main-branch/deprecated/Dashboard/Dashboard.csproj' }
           $version = ([xml](Get-Content $path)).Project.PropertyGroup.Version | Where-Object { $_ }
+          # Two empty reads compare EQUAL, so an unguarded pair fails this gate for the wrong reason
+          # while one empty side passes it for the wrong reason.
+          if ([string]::IsNullOrWhiteSpace($version)) { throw "Read no version from $path." }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
           Write-Host "Main version: $version (from $path)"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,6 +112,7 @@ jobs:
         shell: pwsh
         run: |
           $base = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }
+          if ([string]::IsNullOrWhiteSpace($base)) { throw "Read no version from Directory.Build.props." }
           $date = Get-Date -Format "yyyyMMdd"
           $nightly = "$base-nightly.$date"
           echo "VERSION=$nightly" >> $env:GITHUB_OUTPUT
@@ -471,6 +472,7 @@ jobs:
         run: |
           set -euo pipefail
           base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)
+          [ -n "${base}" ] || { echo "::error::Read no version from Directory.Build.props."; exit 1; }
           date=$(date +%Y%m%d)
           echo "VERSION=${base}-nightly.${date}" >> "$GITHUB_OUTPUT"
           echo "Nightly version: ${base}-nightly.${date}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -111,7 +111,7 @@ jobs:
         id: version
         shell: pwsh
         run: |
-          $base = ([xml](Get-Content Lite/PerformanceMonitorLite.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          $base = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }
           $date = Get-Date -Format "yyyyMMdd"
           $nightly = "$base-nightly.$date"
           echo "VERSION=$nightly" >> $env:GITHUB_OUTPUT
@@ -470,7 +470,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          base=$(grep -oPm1 '(?<=<Version>)[^<]+' Lite/PerformanceMonitorLite.csproj)
+          base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)
           date=$(date +%Y%m%d)
           echo "VERSION=${base}-nightly.${date}" >> "$GITHUB_OUTPUT"
           echo "Nightly version: ${base}-nightly.${date}"

--- a/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
+++ b/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
@@ -40,19 +40,23 @@ namespace Darling.Tests;
 /// or a second <c>Directory.Build.props</c> shadows it for a subtree, either of which leaves projects
 /// inheriting nothing (both in the first pin); a consumer reads a path that is not the declaration
 /// (<see cref="EveryVersionRead_NamesTheDeclarationFile"/>); the detector that judges those consumers stops
-/// detecting (<see cref="TheReadDetector_SeesEachShippedShapeAndReportsAWrongPath"/>); and the declaration
+/// detecting (<see cref="TheReadDetector_SeesEachShippedShapeAndReportsAWrongPath"/>); the declaration
 /// file resolves for one reader shape but not another
-/// (<see cref="EveryShippedTextReadPattern_AgreesWithTheXmlRead"/>).</para>
+/// (<see cref="EveryShippedTextReadPattern_AgreesWithTheXmlRead"/>); and a reader aimed at the right
+/// file reads nothing out of it anyway and carries on
+/// (<see cref="EveryVersionRead_FailsItsStepOnAnEmptyResult"/>, with
+/// <see cref="TheGuardDetector_CreditsOnlyAGuardThatFailsTheStep"/> holding its detector).</para>
 ///
 /// <para><b>The reader pins are the half that would have caught this.</b> The gate and the nightly
-/// disagreeing was the actual bug and no test had ever looked at a workflow file. They matter more after the
-/// fix than before it: an INHERITED property is not present in the inheriting project's XML, so a read left
-/// pointing at a csproj returns EMPTY rather than failing. Every one of these nine reads only names an
-/// artifact, so an empty result produces <c>PerformanceMonitorLite-.zip</c> and a green build. That is not a
-/// hypothetical either — <c>nightly.yml</c>'s own header records the 2026-07-26 nightly dying on a version
-/// read whose path had moved (#1550/#1551 before it), and that variant at least had the decency to be loud,
-/// because <c>Get-Content</c> on a MISSING file throws while <c>Get-Content</c> on a present file with no
-/// such element returns nothing.</para>
+/// disagreeing was the actual bug and no test had ever looked at a workflow file. They matter more with the
+/// version inherited than they would have before: an INHERITED property is not present in the inheriting
+/// project's XML, so a read left pointing at a csproj returns EMPTY. Every one of the nine reads only names
+/// something, so on its own an empty result is <c>PerformanceMonitorLite-.zip</c> and a green build; each
+/// read therefore also fails its own step on an empty value, which is the arrangement the guard pin holds.
+/// The distinction that makes the silent case the dangerous one: <c>Get-Content</c> on a MISSING file
+/// throws, while <c>Get-Content</c> on a present file with no such element returns nothing. Both variants
+/// are real — <c>nightly.yml</c>'s own header records the 2026-07-26 nightly dying on a version read
+/// whose path had moved (#1550/#1551 before it), and that one at least had the decency to be loud.</para>
 /// </summary>
 public class ProductVersionDeclarationTests
 {
@@ -543,7 +547,7 @@ public class ProductVersionDeclarationTests
     /// <c>exit /b 1</c> in a cmd script.</para>
     ///
     /// <para>The bash arm requires the exit as well as the test. <c>[ -n "</c> on its own is not a
-    /// guard &#8212; the workflows already use that spelling for unrelated conditions, and one sitting
+    /// guard — the workflows already use that spelling for unrelated conditions, and one sitting
     /// near a read would otherwise be credited as protecting it.</para>
     /// </summary>
     private static bool IsGuardLine(string line) =>

--- a/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
+++ b/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
@@ -63,7 +63,7 @@ public class ProductVersionDeclarationTests
     /// The version-source paths a reader may name. Two entries are checkouts of <c>main</c> rather than
     /// paths in this tree: <c>check-version-bump.yml</c> compares the PR's version against main's, and
     /// main does not carry <see cref="DeclarationFile"/> until the release that introduces it lands there,
-    /// so the gate falls back to the file it used to read. A path under <c>main-branch/</c> cannot be
+    /// so the gate falls back to where main does declare it. A path under <c>main-branch/</c> cannot be
     /// validated against this tree at all, which is why the allowance is three named literals and not a
     /// prefix: a fourth arriving fails, and the fallback is meant to be deleted once main has the file.
     /// </summary>

--- a/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
+++ b/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
@@ -407,9 +407,74 @@ public class ProductVersionDeclarationTests
         }
     }
 
-    /// <summary>One detected version read: the line it sits on, and the version-source paths it resolves
-    /// to. Plural because a read through a variable resolves to every literal assigned to it.</summary>
-    private sealed record VersionRead(string Line, IReadOnlyList<string> Sources);
+    /// <summary>
+    /// Every version read fails its own step when it reads nothing.
+    ///
+    /// <para><b>No test of the readers' PATHS can cover this.</b> A read pointed at the right file still
+    /// yields an empty string if the property is renamed, the file is malformed, or a comment gets in
+    /// front of the element for the text scrapers. Every one of these nine reads only NAMES something,
+    /// so an empty result is a green run and an artifact called <c>PerformanceMonitorLite-.zip</c>.</para>
+    ///
+    /// <para>Why the guards are not self-evidently unnecessary: on a pull request <c>build.yml</c>'s read
+    /// EXECUTES, and every consumer of its value is gated on <c>github.event_name == 'release'</c>. So a
+    /// pull request demonstrates only that the read does not throw; the VALUE first matters on a release,
+    /// which is the worst place to discover it. The release gate's pair is worse than silent: two empty
+    /// reads compare EQUAL, so an unguarded pair fails the gate for the wrong reason while one empty side
+    /// passes it for the wrong reason.</para>
+    /// </summary>
+    [Fact]
+    public void EveryVersionRead_FailsItsStepOnAnEmptyResult()
+    {
+        var reads = 0;
+        var unguarded = new List<string>();
+
+        foreach (var file in VersionReadingSources())
+        {
+            var text = File.ReadAllText(file).Replace("\r\n", "\n", StringComparison.Ordinal);
+            var name = RepoRelative(file);
+
+            foreach (var read in VersionReads(text))
+            {
+                reads++;
+
+                if (!read.Guarded)
+                {
+                    unguarded.Add($"{name}: {read.Line.Trim()}");
+                }
+            }
+        }
+
+        Assert.True(reads >= 9, $"only {reads} version reads were detected; the detector is not detecting");
+
+        Assert.True(
+            unguarded.Count == 0,
+            "A version read that does not fail its step when it reads nothing. These reads only name "
+            + "artifacts, so an empty value ships a wrongly-named build rather than going red:\n  "
+            + string.Join("\n  ", unguarded));
+    }
+
+    /// <summary>
+    /// The guard detector recognises each language's guard, does not credit an unguarded read, and does
+    /// not credit a bash emptiness TEST that fails nothing.
+    ///
+    /// <para>The last three rows are the point: a detector returning true for everything satisfies the
+    /// pin above by never having anything to report.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("$v = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version\nif ([string]::IsNullOrWhiteSpace($v)) { throw \"no\" }", true)]
+    [InlineData("base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)\n[ -n \"${base}\" ] || { echo x; exit 1; }", true)]
+    [InlineData("for /f \"tokens=2 delims=<>\" %%a in ('findstr \"<Version>\" Directory.Build.props') do set VERSION=%%a\nif \"%VERSION%\"==\"\" (\n    exit /b 1\n)", true)]
+    [InlineData("$v = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version\necho \"VERSION=$v\"", false)]
+    [InlineData("base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)", false)]
+    // An emptiness test that fails nothing is not a guard, and this spelling is already in the workflows.
+    [InlineData("base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)\nif [ -n \"$base\" ]; then echo found; fi", false)]
+    public void TheGuardDetector_CreditsOnlyAGuardThatFailsTheStep(string snippet, bool expected) =>
+        Assert.Equal(expected, Assert.Single(VersionReads(snippet)).Guarded);
+
+    /// <summary>One detected version read: the line it sits on, the version-source paths it resolves to,
+    /// and whether an emptiness guard follows it. Sources is plural because a read through a variable
+    /// resolves to every literal assigned to it.</summary>
+    private sealed record VersionRead(string Line, IReadOnlyList<string> Sources, bool Guarded);
 
     /// <summary>
     /// The version reads in a block of text.
@@ -426,8 +491,9 @@ public class ProductVersionDeclarationTests
         var lines = normalised.Split('\n');
         var found = new List<VersionRead>();
 
-        foreach (var line in lines)
+        for (var index = 0; index < lines.Length; index++)
         {
+            var line = lines[index];
             var selectsProperty = line.Contains("PropertyGroup.Version", StringComparison.Ordinal);
             var scrapesSource = line.Contains("<Version>", StringComparison.Ordinal);
 
@@ -456,11 +522,34 @@ public class ProductVersionDeclarationTests
 
             /* A line that reads a version and resolves to no path at all is reported as a read with no
                source, which fails the caller's membership check rather than vanishing from the count. */
-            found.Add(new VersionRead(line, sources.Count == 0 ? new[] { "(unresolved)" } : sources));
+            found.Add(new VersionRead(
+                line,
+                sources.Count == 0 ? new[] { "(unresolved)" } : sources,
+                lines.Skip(index + 1).Take(GuardWindowLines).Any(IsGuardLine)));
         }
 
         return found;
     }
+
+    /// <summary>How far after a read an emptiness guard may sit. Small on purpose: a guard further away
+    /// than this is not visibly attached to the read it protects.</summary>
+    private const int GuardWindowLines = 6;
+
+    /// <summary>
+    /// Whether one line is an emptiness guard that fails its own step.
+    ///
+    /// <para>Three spellings, because the reads live in three languages and each needs the form that
+    /// actually fails there: <c>throw</c> in a pwsh step, a <c>||</c> exit in a bash step,
+    /// <c>exit /b 1</c> in a cmd script.</para>
+    ///
+    /// <para>The bash arm requires the exit as well as the test. <c>[ -n "</c> on its own is not a
+    /// guard &#8212; the workflows already use that spelling for unrelated conditions, and one sitting
+    /// near a read would otherwise be credited as protecting it.</para>
+    /// </summary>
+    private static bool IsGuardLine(string line) =>
+        line.Contains("IsNullOrWhiteSpace", StringComparison.Ordinal)
+        || (line.Contains("[ -n \"", StringComparison.Ordinal) && line.Contains("exit 1", StringComparison.Ordinal))
+        || line.Contains("==\"\" (", StringComparison.Ordinal);
 
     /// <summary>The MSBuild file paths named on one line, separators normalised to forward slashes.</summary>
     private static List<string> MsBuildPathsIn(string line) =>

--- a/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
+++ b/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
@@ -1,0 +1,545 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+using static Darling.Tests.RepoFile;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// One place in this repository declares a product version, and every consumer of a version reads a value
+/// that resolves to it (#3222).
+///
+/// <para><b>The defect was not that the numbers differed, it was that nothing noticed.</b> Six csproj files
+/// each declared their own version property: four at 3.6.0 and the two deprecated Installer projects at
+/// 3.3.0, three releases behind. <c>check-version-bump.yml</c> gated the release on
+/// <c>deprecated/Dashboard/Dashboard.csproj</c>; <c>nightly.yml</c> named every artifact from
+/// <c>Lite/PerformanceMonitorLite.csproj</c>; the two Darling projects were read by neither; and no test
+/// compared any of them. Bumping the file the gate read let a release merge with every artifact still
+/// carrying the old version, and bumping the file the nightly read failed the gate on a correctly-versioned
+/// build.</para>
+///
+/// <para><b>So these pins hold the invariant that survives the fix, not the six literals the fix
+/// deleted.</b> A pin asserting the six agreed would have been deleted along with them. The routes by which
+/// "one declaration, and every reader resolves to it" can be violated are enumerated rather than sampled,
+/// because reading the assertions finds a wrong one and only enumerating the routes finds a missing one:
+/// a second version property appears (<see cref="ExactlyOneMsBuildProperty_DeclaresTheProductVersion"/>); a
+/// project hand-sets a property that DERIVES from it and so wins the stamp
+/// (<see cref="NoProjectHandSetsADerivedVersionProperty"/>); the declaration moves off the repository root,
+/// or a second <c>Directory.Build.props</c> shadows it for a subtree, either of which leaves projects
+/// inheriting nothing (both in the first pin); a consumer reads a path that is not the declaration
+/// (<see cref="EveryVersionRead_NamesTheDeclarationFile"/>); the detector that judges those consumers stops
+/// detecting (<see cref="TheReadDetector_SeesEachShippedShapeAndReportsAWrongPath"/>); and the declaration
+/// file resolves for one reader shape but not another
+/// (<see cref="EveryShippedTextReadPattern_AgreesWithTheXmlRead"/>).</para>
+///
+/// <para><b>The reader pins are the half that would have caught this.</b> The gate and the nightly
+/// disagreeing was the actual bug and no test had ever looked at a workflow file. They matter more after the
+/// fix than before it: an INHERITED property is not present in the inheriting project's XML, so a read left
+/// pointing at a csproj returns EMPTY rather than failing. Every one of these nine reads only names an
+/// artifact, so an empty result produces <c>PerformanceMonitorLite-.zip</c> and a green build. That is not a
+/// hypothetical either — <c>nightly.yml</c>'s own header records the 2026-07-26 nightly dying on a version
+/// read whose path had moved (#1550/#1551 before it), and that variant at least had the decency to be loud,
+/// because <c>Get-Content</c> on a MISSING file throws while <c>Get-Content</c> on a present file with no
+/// such element returns nothing.</para>
+/// </summary>
+public class ProductVersionDeclarationTests
+{
+    /// <summary>The one file that declares a product version, repo-relative with forward slashes.</summary>
+    private const string DeclarationFile = "Directory.Build.props";
+
+    /// <summary>
+    /// The version-source paths a reader may name. Two entries are checkouts of <c>main</c> rather than
+    /// paths in this tree: <c>check-version-bump.yml</c> compares the PR's version against main's, and
+    /// main does not carry <see cref="DeclarationFile"/> until the release that introduces it lands there,
+    /// so the gate falls back to the file it used to read. A path under <c>main-branch/</c> cannot be
+    /// validated against this tree at all, which is why the allowance is three named literals and not a
+    /// prefix: a fourth arriving fails, and the fallback is meant to be deleted once main has the file.
+    /// </summary>
+    private static readonly string[] s_permittedVersionSources =
+    {
+        DeclarationFile,
+        "main-branch/" + DeclarationFile,
+        "main-branch/deprecated/Dashboard/Dashboard.csproj",
+    };
+
+    /// <summary>The MSBuild properties the SDK DERIVES from the declared version.</summary>
+    private static readonly string[] s_derivedVersionProperties =
+    {
+        "AssemblyVersion",
+        "FileVersion",
+        "InformationalVersion",
+    };
+
+    /// <summary>
+    /// Exactly one MSBuild property element in the tree declares a product version, it lives in
+    /// <see cref="DeclarationFile"/> at the repository root, and its value is a version.
+    ///
+    /// <para><b>Counted by parsing XML, not by matching text.</b> The issue this closes was itself
+    /// mis-counted by a grep: searching for <c>3.6.0</c> found four of six declarations, because a search
+    /// shaped like the expected answer returns a confident partial count and no error. Text matching fails
+    /// the other way here too — the three shipped csprojs each carried a COMMENT quoting the property name,
+    /// so a substring count reported three per file where there was one. An element walk cannot see a
+    /// comment, and scoping to elements whose parent is a <c>PropertyGroup</c> keeps a
+    /// <c>PackageReference</c>'s nested version spelling out of the count.</para>
+    ///
+    /// <para><b>Root placement and shadowing are part of the same property.</b> A declaration that moved to
+    /// a subdirectory would still be the only one, and every project outside that subdirectory would stamp
+    /// the SDK's 1.0.0 default. A second <c>Directory.Build.props</c> below the root is worse, because
+    /// MSBuild imports only the NEAREST one: a shadowing file that declares nothing takes the version away
+    /// from its whole subtree while adding no declaration for the count to catch.</para>
+    /// </summary>
+    [Fact]
+    public void ExactlyOneMsBuildProperty_DeclaresTheProductVersion()
+    {
+        var scanned = 0;
+        var declarations = new List<string>();
+
+        foreach (var file in MsBuildFiles())
+        {
+            scanned++;
+
+            foreach (var value in PropertyValues(file, "Version"))
+            {
+                declarations.Add($"{RepoRelative(file)} = {value}");
+            }
+        }
+
+        /* Non-vacuity: the walk read the tree's MSBuild files. A glob matching nothing would report zero
+           declarations, which fails the count below rather than passing it — but it would fail for the wrong
+           reason and send the next reader to the wrong file, so the floor says which one it was. */
+        Assert.True(scanned >= 20, $"only {scanned} MSBuild files were scanned; the walk is not reading the tree");
+
+        Assert.True(
+            declarations.Count == 1,
+            $"Exactly one MSBuild property may declare a product version, and it belongs in {DeclarationFile}. "
+            + $"Found {declarations.Count}:\n  " + string.Join("\n  ", declarations));
+
+        Assert.StartsWith(DeclarationFile + " = ", declarations[0], StringComparison.Ordinal);
+
+        var declared = declarations[0][(DeclarationFile.Length + 3)..];
+        Assert.True(
+            Version.TryParse(declared, out _),
+            $"The declared product version does not parse as a version: '{declared}'");
+
+        /* The shadowing route. Path.GetRelativePath is used rather than a name comparison so a file called
+           Directory.Build.props in a subdirectory is reported by the path that makes the problem obvious. */
+        var shadowing = Directory
+            .GetFiles(Root, "Directory.Build.props", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .Select(RepoRelative)
+            .Where(relative => !relative.Equals(DeclarationFile, StringComparison.Ordinal))
+            .OrderBy(relative => relative, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            shadowing.Count == 0,
+            "MSBuild imports only the NEAREST Directory.Build.props, so one below the root takes the "
+            + $"product version away from its whole subtree even when it declares nothing:\n  {string.Join("\n  ", shadowing)}");
+    }
+
+    /// <summary>
+    /// No project hand-sets <c>AssemblyVersion</c>, <c>FileVersion</c> or <c>InformationalVersion</c>.
+    ///
+    /// <para>These three DERIVE from the declared version at build time, and a hand-set copy silently wins
+    /// the stamp. #2113 established that and deleted them from the three shipped projects, having proved it
+    /// from an artifact: the 3.4.0 release bumped the version and shipped binaries still stamped 3.3.0.0.
+    /// The three deprecated projects were never included, so the trap stayed live in exactly the place it
+    /// did the most damage — <c>deprecated/Dashboard/Dashboard.csproj</c> declared 3.6.0 while its binary
+    /// stamped 3.3.0.0, and that file was what the release gate took its judgement from. Measured on the
+    /// change that added this pin, deleting those pins moved the Dashboard binary 3.3.0.0 to 3.6.0.0 with
+    /// no other edit to it.</para>
+    ///
+    /// <para>Held separately from the declaration count because it is a different violation route with the
+    /// same outcome: the count can be exactly one and the artifact still stamp something else.</para>
+    /// </summary>
+    [Fact]
+    public void NoProjectHandSetsADerivedVersionProperty()
+    {
+        var scanned = 0;
+        var offending = new List<string>();
+
+        foreach (var file in MsBuildFiles())
+        {
+            scanned++;
+
+            foreach (var property in s_derivedVersionProperties)
+            {
+                foreach (var value in PropertyValues(file, property))
+                {
+                    offending.Add($"{RepoRelative(file)}: <{property}>{value}</{property}>");
+                }
+            }
+        }
+
+        Assert.True(scanned >= 20, $"only {scanned} MSBuild files were scanned; the walk is not reading the tree");
+
+        Assert.True(
+            offending.Count == 0,
+            "AssemblyVersion / FileVersion / InformationalVersion derive from the declared version at build "
+            + "time. A hand-set copy wins the stamp, which is how a release bump ships binaries carrying the "
+            + $"previous version (#2113):\n  {string.Join("\n  ", offending)}");
+    }
+
+    /// <summary>
+    /// Every version read in the CI workflows and the repository's build scripts names
+    /// <see cref="DeclarationFile"/>.
+    ///
+    /// <para><b>This is the pin that would have caught the reported defect</b>, and nothing had ever looked
+    /// at a workflow file. It is also the pin the fix makes load-bearing rather than tidy: with the version
+    /// inherited, a read still pointing at a csproj finds no such element and yields an EMPTY string, and
+    /// since every one of these reads only names an artifact, the run stays green and the artifact is named
+    /// wrongly.</para>
+    ///
+    /// <para>Scanned across workflows AND the root <c>.cmd</c> scripts, because narrowing to the workflows
+    /// would have left three reads of the same fact unexamined next door — and two of those three were
+    /// pointing at a path that had not existed since #1612 moved it, which is the live proof that this class
+    /// of read rots silently.</para>
+    /// </summary>
+    [Fact]
+    public void EveryVersionRead_NamesTheDeclarationFile()
+    {
+        var scanned = 0;
+        var reads = 0;
+        var offending = new List<string>();
+
+        foreach (var file in VersionReadingSources())
+        {
+            scanned++;
+            var text = File.ReadAllText(file).Replace("\r\n", "\n", StringComparison.Ordinal);
+            var name = RepoRelative(file);
+
+            foreach (var read in VersionReads(text))
+            {
+                reads++;
+
+                foreach (var source in read.Sources)
+                {
+                    if (!s_permittedVersionSources.Contains(source, StringComparer.Ordinal))
+                    {
+                        offending.Add($"{name}: reads a version from '{source}' — {read.Line.Trim()}");
+                    }
+                }
+            }
+        }
+
+        /* Non-vacuity, and the reason both floors are here rather than one. A crippled GLOB scans no files
+           and finds no reads; a crippled DETECTOR scans every file and finds no reads. Either leaves the
+           emptiness assertion below satisfied by having nothing to judge, and the two floors fail
+           differently, so the message names which happened. The read count is the number this tree holds,
+           not a token positive number: six XML selects and three text scrapes. */
+        Assert.True(scanned >= 5, $"only {scanned} candidate files were scanned; the glob is not reading the tree");
+        Assert.True(reads >= 9, $"only {reads} version reads were detected across {scanned} files; the detector is not detecting");
+
+        Assert.True(
+            offending.Count == 0,
+            "A version read naming anything but the one file that declares one. An inherited property is "
+            + "not in the inheriting project's XML, so such a read returns EMPTY and names the artifact "
+            + $"with nothing rather than going red:\n  {string.Join("\n  ", offending)}");
+    }
+
+    /// <summary>
+    /// The detector sees each shape this repository actually uses, reports a read whose path is wrong, and
+    /// does not score a line that merely names a project file.
+    ///
+    /// <para><b>Without this, the repository scan above is decoration.</b> A detector narrowed until it
+    /// matches nothing passes the emptiness assertion, and one widened until it accepts every path passes it
+    /// too; the floors catch the first and only a case with a KNOWN-BAD path catches the second. That exact
+    /// vacuity has shipped in this repository more than once, so the wrong-path row is the point of this
+    /// theory and the rest is coverage of the shapes it has to survive.</para>
+    /// </summary>
+    [Theory]
+    // The pwsh XML select, as four workflow steps and two .cmd scripts spell it.
+    [InlineData(
+        "          $version = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }",
+        "Directory.Build.props")]
+    // The same shape pointing at a project file: the defect, which must be REPORTED and not excused.
+    [InlineData(
+        "          $base = ([xml](Get-Content Lite/PerformanceMonitorLite.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }",
+        "Lite/PerformanceMonitorLite.csproj")]
+    [InlineData(
+        "          $version = ([xml](Get-Content deprecated/Dashboard/Dashboard.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }",
+        "deprecated/Dashboard/Dashboard.csproj")]
+    // The bash lookbehind scrape, both quotings build.yml and nightly.yml use.
+    [InlineData(
+        "          base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)",
+        "Directory.Build.props")]
+    [InlineData(
+        "          version=\"$(grep -oPm1 '(?<=<Version>)[^<]+' Lite/PerformanceMonitorLite.csproj)\"",
+        "Lite/PerformanceMonitorLite.csproj")]
+    // The cmd findstr scrape, with its backslash separator normalised.
+    [InlineData(
+        "for /f \"tokens=2 delims=<>\" %%a in ('findstr \"<Version>\" Directory.Build.props') do set VERSION=%%a",
+        "Directory.Build.props")]
+    [InlineData(
+        "for /f \"tokens=2 delims=<>\" %%a in ('findstr \"<Version>\" Dashboard\\Dashboard.csproj') do set VERSION=%%a",
+        "Dashboard/Dashboard.csproj")]
+    // The cmd wrapper around the pwsh select.
+    [InlineData(
+        "for /f %%a in ('powershell -Command \"([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }\"') do set VERSION=%%a",
+        "Directory.Build.props")]
+    public void TheReadDetector_SeesEachShippedShapeAndReportsAWrongPath(string line, string expected)
+    {
+        var reads = VersionReads(line);
+
+        var read = Assert.Single(reads);
+        Assert.Equal(new[] { expected }, read.Sources);
+    }
+
+    /// <summary>
+    /// A line that names a project file without reading a version out of it is not a version read, and a
+    /// variable-indirect read resolves to the literals assigned to that variable.
+    ///
+    /// <para>The negative cases are what stop the detector degenerating into "any line mentioning a
+    /// csproj": <c>build.yml</c> alone names project files on dozens of restore and publish lines, and a
+    /// detector that scored those would report the whole workflow as offending and be turned off.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("        run: dotnet publish Lite/PerformanceMonitorLite.csproj -c Release -o publish/Lite", 0)]
+    [InlineData("          dotnet restore Lite.Tests/Lite.Tests.csproj --locked-mode", 0)]
+    [InlineData("              - 'Darling/**/!(*.md)'", 0)]
+    [InlineData("          $version = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version", 1)]
+    public void TheReadDetector_DoesNotScoreALineThatMerelyNamesAProject(string line, int expected) =>
+        Assert.Equal(expected, VersionReads(line).Count);
+
+    /// <summary>
+    /// A read through a variable resolves to every literal that variable is assigned in the same file, so
+    /// the gate's fallback chain is judged rather than skipped.
+    /// </summary>
+    [Fact]
+    public void TheReadDetector_ResolvesAVariableToItsAssignedLiterals()
+    {
+        const string Snippet =
+            "          $path = 'main-branch/Directory.Build.props'\n"
+          + "          if (-not (Test-Path $path)) { $path = 'main-branch/deprecated/Dashboard/Dashboard.csproj' }\n"
+          + "          $version = ([xml](Get-Content $path)).Project.PropertyGroup.Version | Where-Object { $_ }\n";
+
+        var read = Assert.Single(VersionReads(Snippet));
+
+        Assert.Equal(
+            new[] { "main-branch/Directory.Build.props", "main-branch/deprecated/Dashboard/Dashboard.csproj" },
+            read.Sources);
+    }
+
+    /// <summary>
+    /// Every text-scraping read in the tree, run as its OWN shipped pattern against the declaration file,
+    /// returns the same value the XML selects return.
+    ///
+    /// <para><b>This holds the ordering inside the declaration file, which nothing else can.</b> The XML
+    /// readers select an element and are indifferent to comments; the text readers take the FIRST match in
+    /// the file, so a comment spelling the property name ahead of the property itself is what they return.
+    /// That is not a hypothesis: the declaration file was written comment-first, and all three text reads
+    /// came back with the word <c>from</c> out of the prose while the six XML selects still returned the
+    /// version. Nothing would have gone red — naming an artifact is all those reads do.</para>
+    ///
+    /// <para>The pattern is extracted from the workflow and script source rather than retyped here. A
+    /// retyped copy proves the transcription works and keeps passing while the shipped one drifts.</para>
+    /// </summary>
+    [Fact]
+    public void EveryShippedTextReadPattern_AgreesWithTheXmlRead()
+    {
+        var declaration = PathTo(DeclarationFile);
+        var text = File.ReadAllText(declaration);
+
+        var expected = PropertyValues(declaration, "Version").Single();
+        Assert.False(string.IsNullOrWhiteSpace(expected));
+
+        var patterns = new List<(string Source, string Pattern)>();
+
+        foreach (var file in VersionReadingSources())
+        {
+            var name = RepoRelative(file);
+            var lines = File.ReadAllText(file).Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                /* The lookbehind scrape, lifted verbatim out of the single-quoted grep argument. */
+                var lookbehind = Regex.Match(lines[i], @"grep\s+-oPm1\s+'([^']+)'");
+                if (lookbehind.Success)
+                {
+                    patterns.Add(($"{name}:{i + 1}", lookbehind.Groups[1].Value));
+                }
+
+                /* findstr takes a literal, not a pattern: the value is the third <>-delimited token of the
+                   first matching line, which is what `tokens=2 delims=<>` extracts. Modelled as the
+                   equivalent pattern so both shapes are judged by one comparison. */
+                var findstr = Regex.Match(lines[i], @"findstr\s+""(<[A-Za-z]+>)""");
+                if (findstr.Success)
+                {
+                    patterns.Add(($"{name}:{i + 1}", $"(?<={Regex.Escape(findstr.Groups[1].Value)})[^<]+"));
+                }
+            }
+        }
+
+        /* Non-vacuity: three text reads exist in this tree — build.yml's and nightly.yml's linux jobs, and
+           package-release.cmd. Extracting none would leave the loop below asserting nothing at all. */
+        Assert.True(
+            patterns.Count >= 3,
+            $"only {patterns.Count} text-scraping version-read patterns were extracted; the extraction is not reading the source");
+
+        foreach (var (source, pattern) in patterns)
+        {
+            var match = Regex.Match(text, pattern);
+
+            Assert.True(
+                match.Success,
+                $"{source}'s own pattern /{pattern}/ matches nothing in {DeclarationFile}, so that read yields "
+                + "an empty version and names its artifact with nothing.");
+
+            Assert.True(
+                match.Value.Trim().Equals(expected, StringComparison.Ordinal),
+                $"{source}'s own pattern /{pattern}/ reads '{match.Value}' from {DeclarationFile} where the "
+                + $"XML select reads '{expected}'. The text readers take the FIRST match in the file, so a "
+                + "comment naming the property ahead of the property itself is what they return.");
+        }
+    }
+
+    /// <summary>One detected version read: the line it sits on, and the version-source paths it resolves
+    /// to. Plural because a read through a variable resolves to every literal assigned to it.</summary>
+    private sealed record VersionRead(string Line, IReadOnlyList<string> Sources);
+
+    /// <summary>
+    /// The version reads in a block of text.
+    ///
+    /// <para>A line is a read when it selects the version property out of parsed MSBuild XML, or scrapes
+    /// the property's angle-bracket spelling out of MSBuild source as text. Both spellings are load-bearing
+    /// and neither implies the other: four workflow steps and two scripts use the first, and three use the
+    /// second. Naming a project file is deliberately NOT sufficient — see
+    /// <see cref="TheReadDetector_DoesNotScoreALineThatMerelyNamesAProject"/>.</para>
+    /// </summary>
+    private static List<VersionRead> VersionReads(string text)
+    {
+        var normalised = text.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalised.Split('\n');
+        var found = new List<VersionRead>();
+
+        foreach (var line in lines)
+        {
+            var selectsProperty = line.Contains("PropertyGroup.Version", StringComparison.Ordinal);
+            var scrapesSource = line.Contains("<Version>", StringComparison.Ordinal);
+
+            if (!selectsProperty && !scrapesSource)
+            {
+                continue;
+            }
+
+            var sources = MsBuildPathsIn(line);
+
+            if (sources.Count == 0)
+            {
+                /* A read through a variable. Resolve it to the literals that variable is assigned in this
+                   same text, so the gate's transitional fallback is judged rather than waved through. */
+                var variable = Regex.Match(line, @"Get-Content\s+\$(\w+)");
+                if (variable.Success)
+                {
+                    sources = Regex
+                        .Matches(normalised, @"\$" + Regex.Escape(variable.Groups[1].Value) + @"\s*=\s*['""]([^'""]+)['""]")
+                        .Select(match => Normalise(match.Groups[1].Value))
+                        .Where(candidate => candidate.Length > 0)
+                        .Distinct(StringComparer.Ordinal)
+                        .ToList();
+                }
+            }
+
+            /* A line that reads a version and resolves to no path at all is reported as a read with no
+               source, which fails the caller's membership check rather than vanishing from the count. */
+            found.Add(new VersionRead(line, sources.Count == 0 ? new[] { "(unresolved)" } : sources));
+        }
+
+        return found;
+    }
+
+    /// <summary>The MSBuild file paths named on one line, separators normalised to forward slashes.</summary>
+    private static List<string> MsBuildPathsIn(string line) =>
+        Regex
+            .Matches(line, @"[A-Za-z0-9_./\\-]+\.(?:csproj|props|targets)\b")
+            .Select(match => Normalise(match.Value))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+    private static string Normalise(string path) => path.Replace('\\', '/').Trim();
+
+    /// <summary>
+    /// The files that may perform a version read: the CI workflows, and the build and packaging scripts at
+    /// the repository root. Ordered so a failure message reads the same on every host.
+    /// </summary>
+    private static List<string> VersionReadingSources()
+    {
+        var found = Directory
+            .GetFiles(Path.Combine(Root, ".github", "workflows"), "*.yml")
+            .ToList();
+
+        found.AddRange(Directory.GetFiles(Root, "*.cmd", SearchOption.TopDirectoryOnly));
+
+        return found.OrderBy(path => path, StringComparer.Ordinal).ToList();
+    }
+
+    /// <summary>
+    /// Every MSBuild file in the tree, build output excluded.
+    ///
+    /// <para>The exclusion changes no answer today — 32 generated props and targets sit under <c>obj</c>
+    /// after a build and not one declares a version property — and that is measured rather than left
+    /// looking like a measurement. It is here because the walk is a recursive glob: a generated copy
+    /// declaring one would be reported as a second declaration, failing for whoever had built the tree and
+    /// passing for whoever had not.</para>
+    /// </summary>
+    private static List<string> MsBuildFiles()
+    {
+        var found = new List<string>();
+
+        foreach (var pattern in new[] { "*.csproj", "*.props", "*.targets" })
+        {
+            found.AddRange(Directory.GetFiles(Root, pattern, SearchOption.AllDirectories));
+        }
+
+        return found
+            .Where(path => !IsBuildOutput(path))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// The values of one MSBuild PROPERTY in a file: elements of that name whose parent is a
+    /// <c>PropertyGroup</c>.
+    ///
+    /// <para>Parsed, not matched. A comment quoting the property name is invisible to an element walk and
+    /// indistinguishable from a declaration to a substring count, which is how the three shipped csprojs
+    /// each looked like three declarations. Scoping to a <c>PropertyGroup</c> parent keeps
+    /// <c>PackageReference</c>'s nested version spelling out of the answer, and keeps the count on the
+    /// question actually being asked: which places declare a version PROPERTY.</para>
+    /// </summary>
+    private static List<string> PropertyValues(string file, string property) =>
+        XDocument
+            .Load(file)
+            .Descendants()
+            .Where(element => element.Name.LocalName.Equals(property, StringComparison.Ordinal)
+                           && element.Parent is not null
+                           && element.Parent.Name.LocalName.Equals("PropertyGroup", StringComparison.Ordinal))
+            .Select(element => element.Value.Trim())
+            .ToList();
+
+    /// <summary>An absolute path as a repo-relative one with forward slashes, so failure messages spell a
+    /// path the same way on every host.</summary>
+    private static string RepoRelative(string absolute) =>
+        Path.GetRelativePath(Root, absolute).Replace(Path.DirectorySeparatorChar, '/');
+
+    /// <summary>Whether a path sits under a <c>bin</c> or <c>obj</c> directory below the repository
+    /// root.</summary>
+    private static bool IsBuildOutput(string absolute) =>
+        Path.GetRelativePath(Root, absolute)
+            .Split(Path.DirectorySeparatorChar, '/')
+            .Any(segment => segment.Equals("bin", StringComparison.OrdinalIgnoreCase)
+                         || segment.Equals("obj", StringComparison.OrdinalIgnoreCase));
+}

--- a/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
+++ b/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
@@ -88,11 +88,13 @@ public class ProductVersionDeclarationTests
     ///
     /// <para><b>Counted by parsing XML, not by matching text.</b> The issue this closes was itself
     /// mis-counted by a grep: searching for <c>3.6.0</c> found four of six declarations, because a search
-    /// shaped like the expected answer returns a confident partial count and no error. Text matching fails
-    /// the other way here too — the three shipped csprojs each carried a COMMENT quoting the property name,
-    /// so a substring count reported three per file where there was one. An element walk cannot see a
-    /// comment, and scoping to elements whose parent is a <c>PropertyGroup</c> keeps a
-    /// <c>PackageReference</c>'s nested version spelling out of the count.</para>
+    /// shaped like the expected answer returns a confident partial count and no error. A substring count
+    /// fails the other way, and by more: the three shipped csprojs each carried a COMMENT quoting the
+    /// property name, so counting the angle-bracket spelling over the six files returned 12 where the
+    /// element walk returned 6. Three methods, three answers, on one tree. On the tree AFTER this change
+    /// the two agree at 1, so the walk changes no answer today and is here for the reason it disagreed
+    /// before. An element walk cannot see a comment, and scoping to elements whose parent is a
+    /// <c>PropertyGroup</c> keeps a <c>PackageReference</c>'s nested version spelling out of the count.</para>
     ///
     /// <para><b>Root placement and shadowing are part of the same property.</b> A declaration that moved to
     /// a subdirectory would still be the only one, and every project outside that subdirectory would stamp

--- a/Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj
+++ b/Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj
@@ -5,13 +5,6 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <RootNamespace>PerformanceMonitor.Darling.Service</RootNamespace>
     <AssemblyName>PerformanceMonitor.Darling.Service</AssemblyName>
-    <Version>3.6.0</Version>
-    <!-- #2113: <Version> is the ONE hand-set version. AssemblyVersion / FileVersion /
-         InformationalVersion derive from it at build time - the 3.4.0 release bumped only
-         <Version> and shipped binaries still STAMPED 3.3.0.0, because four hand-maintained
-         copies of one fact is a release-day trap. The suffix suppression keeps
-         InformationalVersion a clean semver instead of gaining a +sha under CI SourceLink. -->
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj
+++ b/Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj
@@ -15,13 +15,6 @@
          hooks go unhandled. It is a harmless no-op for the co-located (non-Velopack) viewer that
          ships inside the service zip. -->
     <StartupObject>PerformanceMonitor.Darling.Viewer.Program</StartupObject>
-    <Version>3.6.0</Version>
-    <!-- #2113: <Version> is the ONE hand-set version. AssemblyVersion / FileVersion /
-         InformationalVersion derive from it at build time - the 3.4.0 release bumped only
-         <Version> and shipped binaries still STAMPED 3.3.0.0, because four hand-maintained
-         copies of one fact is a release-day trap. The suffix suppression keeps
-         InformationalVersion a clean semver instead of gaining a +sha under CI SourceLink. -->
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <ApplicationIcon>EDD.ico</ApplicationIcon>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,8 +49,8 @@
     this change: the three shipped apps stamp 3.6.0.0 before and after, Dashboard and the two Installer
     projects move 3.3.0.0 to 3.6.0.0, and the shared libraries and test assemblies move 1.0.0.0 to 3.6.0.0.
     Nothing reads a library's or test assembly's own version to make a decision. UpdateCheckService reads the
-    ENTRY assembly, and DarlingCliCommands.ProductVersion reads the service assembly, which declared a
-    version before this change and inherits the same one now.
+    ENTRY assembly, and DarlingCliCommands.ProductVersion reads the service assembly, which is a shipped
+    app and carries the product version either way.
   -->
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,56 @@
+<Project>
+
+  <!--
+    #3222: the ONE place a product version is declared. Every project in the tree inherits it by MSBuild's
+    automatic Directory.Build.props import, and AssemblyVersion / FileVersion / InformationalVersion derive
+    from it at build time. A release bump is the one line below.
+
+    The PropertyGroup comes FIRST, ahead of the rationale, and no prose above it may spell the property name
+    in its angle-bracket form. Three consumers read this file as TEXT and take the first match: the linux jobs
+    in build.yml and nightly.yml, with a grep lookbehind, and package-release.cmd, with findstr. A mention of
+    the property ahead of the property itself is what those reads return. Not hypothetical, it was written
+    that way first, and all three came back with the word "from" out of this comment while the four XML reads
+    still returned 3.6.0. Naming artifacts is all those reads do, so nothing goes red, the release tarball is
+    just named wrongly. ProductVersionDeclarationTests runs each shipped read's own pattern against this file
+    and requires it to agree with the XML read, so the ordering is enforced rather than remembered.
+  -->
+  <PropertyGroup>
+    <Version>3.6.0</Version>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+  </PropertyGroup>
+
+  <!--
+    Why one declaration, and why here.
+
+    #2113 established the rule one level down and inside a single project: four hand-maintained copies of one
+    fact is a release-day trap. It proved that from a shipped artifact. The 3.4.0 release bumped the version
+    property and the binaries still STAMPED 3.3.0.0, because AssemblyVersion / FileVersion /
+    InformationalVersion were pinned by hand beside it. The remedy was to delete the derived properties and
+    let derivation happen.
+
+    The same trap had reassembled itself one level UP, across projects. Six csproj files each declared their
+    own version: four at 3.6.0, and the two deprecated Installer projects at 3.3.0, three releases behind.
+    Two consumers read two DIFFERENT files. check-version-bump.yml gated the release on
+    deprecated/Dashboard/Dashboard.csproj while nightly.yml named every artifact from
+    Lite/PerformanceMonitorLite.csproj, and nothing compared them, so bumping the file the gate read let a
+    release merge with every artifact still carrying the old version. The deprecated projects also still
+    hand-set the three derived properties #2113 deleted, which is why Dashboard's binary stamped 3.3.0.0
+    while its csproj said 3.6.0: the file the release gate took its judgement from produced an artifact three
+    releases behind.
+
+    The suffix suppression is the second half of the same fact. It keeps InformationalVersion a clean semver
+    rather than gaining a source-revision suffix under CI SourceLink; without it the deprecated projects'
+    binaries stamped 3.3.0 plus a sha even where the version was hand-pinned.
+
+    Directory.Build.props rather than a file the projects import by hand: an explicit Import is a convention a
+    new project can forget, which is the shape of the defect this replaces. The automatic import reaches the
+    test projects and the deprecated subtree as well, so all 22 projects in the tree now stamp the product
+    version instead of the SDK's 1.0.0 default. That is the blast radius and it is deliberate. Measured on
+    this change: the three shipped apps stamp 3.6.0.0 before and after, Dashboard and the two Installer
+    projects move 3.3.0.0 to 3.6.0.0, and the shared libraries and test assemblies move 1.0.0.0 to 3.6.0.0.
+    Nothing reads a library's or test assembly's own version to make a decision. UpdateCheckService reads the
+    ENTRY assembly, and DarlingCliCommands.ProductVersion reads the service assembly, which declared a
+    version before this change and inherits the same one now.
+  -->
+
+</Project>

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -1204,14 +1204,15 @@ public class CrossAppGuardCiGateTests
     /// project that compiles and references its own SKU, so those two carry the count floor and
     /// <see cref="TheEvaluatedRead_SurvivesEveryFormThatDefeatsAnXmlParse"/> carries the other four.</para>
     ///
-    /// <para><see cref="ImportedBuildFileProperties"/> is reported and not floored on the first two names:
-    /// there is no <c>Directory.Build.props</c> or <c>Directory.Build.targets</c> in this repository and
-    /// asserting one exists would be asserting a fiction. What IS floored is that the property set came back
-    /// populated at all, through <c>MSBuildProjectFullPath</c> naming the project that was asked — so
-    /// "MSBuild says there are none" is distinguishable from "no properties were returned".
-    /// <c>Directory.Packages.props</c> is asserted because it is imported into every project here, and
-    /// because a two-name upward probe of <c>Directory.Build.*</c> is exactly the answer that misses
-    /// it.</para>
+    /// <para><see cref="ImportedBuildFileProperties"/> is asserted by VALUE on all three names.
+    /// <c>Directory.Build.props</c> carries the repository's one product-version declaration (#3222) and
+    /// <c>Directory.Packages.props</c> the central package versions, so both are imported into every
+    /// project here; there is no <c>Directory.Build.targets</c>, and that name reading empty is itself the
+    /// assertion. A two-name upward probe of <c>Directory.Build.*</c> is exactly the answer that misses the
+    /// packages file. What ALSO stays floored is that the property set came back populated at all, through
+    /// <c>MSBuildProjectFullPath</c> naming the project that was asked — so "MSBuild says there are
+    /// none" is distinguishable from "no properties were returned", which three empty strings would
+    /// read as either.</para>
     /// </summary>
     [Fact]
     public void ThePopulationReachesTheProjectItems_AndNotOnlyTheCSharp()
@@ -1276,11 +1277,19 @@ public class CrossAppGuardCiGateTests
                 Path.GetFullPath(Path.Combine(repo, manifest.Replace('/', Path.DirectorySeparatorChar))),
                 evaluated.Properties.TryGetValue("MSBuildProjectFullPath", out var self) ? self : null);
 
-            /* MSBuild's own answer for the build files it imports unnamed. The two Directory.Build names
-               are absent from this tree, and Directory.Packages.props is not — which is the half a
-               two-name upward probe of the Directory.Build names cannot see. */
+            /* MSBuild's own answer for the build files it imports unnamed. Directory.Build.props carries
+               the one product-version declaration (#3222) and Directory.Packages.props the central
+               package versions; there is no Directory.Build.targets, which is why the middle name reads
+               empty. Asserting all three by VALUE is what a two-name upward probe of the
+               Directory.Build names cannot do — it never looks for the packages file at all, and it
+               cannot tell "MSBuild imported none" from "MSBuild answered nothing". */
             Assert.Equal(
-                new[] { string.Empty, string.Empty, Path.Combine(repo, "Directory.Packages.props") },
+                new[]
+                {
+                    Path.Combine(repo, "Directory.Build.props"),
+                    string.Empty,
+                    Path.Combine(repo, "Directory.Packages.props"),
+                },
                 ImportedBuildFileProperties
                     .Select(p => evaluated.Properties.TryGetValue(p, out var v) ? v : "<absent>")
                     .ToArray());

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -18,13 +18,6 @@
     <AssemblyName>PerformanceMonitorLite</AssemblyName>
     <RootNamespace>PerformanceMonitorLite</RootNamespace>
     <Product>SQL Server Performance Monitor Lite</Product>
-    <Version>3.6.0</Version>
-    <!-- #2113: <Version> is the ONE hand-set version. AssemblyVersion / FileVersion /
-         InformationalVersion derive from it at build time - the 3.4.0 release bumped only
-         <Version> and shipped binaries still STAMPED 3.3.0.0, because four hand-maintained
-         copies of one fact is a release-day trap. The suffix suppression keeps
-         InformationalVersion a clean semver instead of gaining a +sha under CI SourceLink. -->
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Lightweight SQL Server performance monitoring - no installation required on target servers</Description>

--- a/PerformanceMonitor.Common/Services/UpdateCheckService.cs
+++ b/PerformanceMonitor.Common/Services/UpdateCheckService.cs
@@ -86,10 +86,12 @@ public static class UpdateCheckService
     private static Version? GetCurrentVersion()
     {
         // Use the entry assembly (the app .exe) rather than the executing assembly.
-        // This service lives in PerformanceMonitor.Common.dll, which carries no
-        // <Version> and defaults to 1.0.0.0. GetExecutingAssembly() would therefore
-        // report 1.0.0.0 and make every real release look like an available update.
-        // GetEntryAssembly() returns the host app's real version (e.g. 2.11.0.0).
+        // The comparison is against the latest release tag, so the version that answers
+        // it is the one the user is RUNNING - the host app's. This service lives in
+        // PerformanceMonitor.Common.dll, which inherits the same <Version> from
+        // Directory.Build.props (#3222) and so agrees today; it agrees by inheritance
+        // rather than by definition, and a library whose version diverged would make
+        // every real release look like an available update forever.
         return Assembly.GetEntryAssembly()?.GetName().Version;
     }
 

--- a/build-dashboard.cmd
+++ b/build-dashboard.cmd
@@ -8,8 +8,8 @@ echo  Building Full Edition (Dashboard + Installers)
 echo ========================================
 echo.
 
-:: Get version from csproj
-for /f %%a in ('powershell -Command "([xml](Get-Content Dashboard\Dashboard.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }"') do set VERSION=%%a
+:: Get version from the one file that declares it (#3222)
+for /f %%a in ('powershell -Command "([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }"') do set VERSION=%%a
 echo Version: %VERSION%
 echo.
 

--- a/build-dashboard.cmd
+++ b/build-dashboard.cmd
@@ -10,6 +10,10 @@ echo.
 
 :: Get version from the one file that declares it (#3222)
 for /f %%a in ('powershell -Command "([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }"') do set VERSION=%%a
+if "%VERSION%"=="" (
+    echo ERROR: Could not determine version from Directory.Build.props.
+    exit /b 1
+)
 echo Version: %VERSION%
 echo.
 

--- a/build-lite.cmd
+++ b/build-lite.cmd
@@ -8,8 +8,8 @@ echo  Building Performance Monitor Lite
 echo ========================================
 echo.
 
-:: Get version from csproj
-for /f %%a in ('powershell -Command "([xml](Get-Content Lite\PerformanceMonitorLite.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }"') do set VERSION=%%a
+:: Get version from the one file that declares it (#3222)
+for /f %%a in ('powershell -Command "([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }"') do set VERSION=%%a
 echo Version: %VERSION%
 echo.
 

--- a/build-lite.cmd
+++ b/build-lite.cmd
@@ -10,6 +10,10 @@ echo.
 
 :: Get version from the one file that declares it (#3222)
 for /f %%a in ('powershell -Command "([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }"') do set VERSION=%%a
+if "%VERSION%"=="" (
+    echo ERROR: Could not determine version from Directory.Build.props.
+    exit /b 1
+)
 echo Version: %VERSION%
 echo.
 

--- a/deprecated/Dashboard/Dashboard.csproj
+++ b/deprecated/Dashboard/Dashboard.csproj
@@ -7,10 +7,6 @@
     <StartupObject>PerformanceMonitorDashboard.Program</StartupObject>
     <AssemblyName>PerformanceMonitorDashboard</AssemblyName>
     <Product>SQL Server Performance Monitor Dashboard</Product>
-    <Version>3.6.0</Version>
-    <AssemblyVersion>3.3.0.0</AssemblyVersion>
-    <FileVersion>3.3.0.0</FileVersion>
-    <InformationalVersion>3.3.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <ApplicationIcon>EDD.ico</ApplicationIcon>

--- a/deprecated/Installer.Core/Installer.Core.csproj
+++ b/deprecated/Installer.Core/Installer.Core.csproj
@@ -7,10 +7,6 @@
     <RootNamespace>Installer.Core</RootNamespace>
     <AssemblyName>Installer.Core</AssemblyName>
     <Product>SQL Server Performance Monitor Installer Core</Product>
-    <Version>3.3.0</Version>
-    <AssemblyVersion>3.3.0.0</AssemblyVersion>
-    <FileVersion>3.3.0.0</FileVersion>
-    <InformationalVersion>3.3.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright (c) 2026 Darling Data, LLC</Copyright>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/deprecated/Installer/PerformanceMonitorInstaller.csproj
+++ b/deprecated/Installer/PerformanceMonitorInstaller.csproj
@@ -20,10 +20,6 @@
     <!-- Application metadata -->
     <AssemblyName>PerformanceMonitorInstaller</AssemblyName>
     <Product>SQL Server Performance Monitor Installer</Product>
-    <Version>3.3.0</Version>
-    <AssemblyVersion>3.3.0.0</AssemblyVersion>
-    <FileVersion>3.3.0.0</FileVersion>
-    <InformationalVersion>3.3.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Installation utility for SQL Server Performance Monitor - Supports SQL Server 2016-2025</Description>

--- a/package-release.cmd
+++ b/package-release.cmd
@@ -8,11 +8,11 @@ echo  Packaging Performance Monitor Release
 echo ========================================
 echo.
 
-:: Get version from Dashboard csproj
-for /f "tokens=2 delims=<>" %%a in ('findstr "<Version>" Dashboard\Dashboard.csproj') do set VERSION=%%a
+:: Get version from the one file that declares it (#3222)
+for /f "tokens=2 delims=<>" %%a in ('findstr "<Version>" Directory.Build.props') do set VERSION=%%a
 
 if "%VERSION%"=="" (
-    echo ERROR: Could not determine version from Dashboard.csproj.
+    echo ERROR: Could not determine version from Directory.Build.props.
     exit /b 1
 )
 


### PR DESCRIPTION
Fixes #3222. (The repo's default branch is `main`, so a closing keyword does not fire on a merge to `dev` — #3222 needs closing explicitly.)

## What changed

`Directory.Build.props` at the repository root now holds the one `<Version>` (and the `InformationalVersion` suffix suppression that is the other half of the same fact). All 22 projects inherit it — measured with `dotnet msbuild -getProperty:Version`, not assumed.

The six per-project `<Version>` elements are gone. So are the nine hand-set `AssemblyVersion` / `FileVersion` / `InformationalVersion` elements in the three `deprecated/` projects, which #2113 deleted from the shipped three and never reached.

All nine version reads now name the declaring file: `check-version-bump.yml` (PR side and main side), `nightly.yml` ×2, `build.yml` ×2, `build-lite.cmd`, `build-dashboard.cmd`, `package-release.cmd`.

`Directory.Build.props` is added to `build.yml`'s `root:` path filter. Without it a release bump would touch one repo-root file matching no area filter, and nothing would build.

Each of those nine reads now **fails its own step when it reads nothing**. `ProductVersionDeclarationTests` holds the invariant: one declaration, no hand-set derived property, every reader naming the declaring file, every reader guarded, and every text reader's own pattern agreeing with the XML read.

`UpdateCheckService`'s comment and the release-checklist skill both asserted things this change makes false, and are corrected.

## The issue undercounted the consumers: two named, nine present

The issue named `check-version-bump.yml` and `nightly.yml:114`. Grepping for the literal `<Version>` finds only the text-scraping readers and misses every XML one, so sweeping by *path* instead turns up nine reads across five files — including `build.yml:394`/`:984`, which the issue does not mention, and three root `.cmd` scripts.

Two of those `.cmd` reads pointed at `Dashboard\Dashboard.csproj`, **a path that has not existed since #1612**. `build-dashboard.cmd` has no guard on the result, so it was already producing an empty version silently. That is this defect class already fired and sitting in the tree, and it is why the pin scans the scripts and not just the workflows.

## The gate was certifying a version its own file did not stamp

Read out of built binaries, on the base commit:

| assembly | AssemblyVersion | InformationalVersion |
|---|---|---|
| `PerformanceMonitorDashboard.dll` | **3.3.0.0** | **3.3.0**+sha |
| `Installer.Core.dll` | 3.3.0.0 | 3.3.0+sha |
| `PerformanceMonitorInstaller.dll` | 3.3.0.0 | 3.3.0+sha |

`deprecated/Dashboard/Dashboard.csproj` declared `<Version>3.6.0</Version>` while its binary stamped `3.3.0.0`, because the hand-set derived properties beside it won the stamp. That file is what `check-version-bump.yml` took its judgement from — so the release gate's "version bumped to 3.6.0" was certified from a project whose artifact was three releases behind. #2113's exact defect, live, in the gate's own source of truth.

## Stamped versions, before and after

Read out of the binaries with a metadata reader, not inferred from the props file:

| assembly | before | after |
|---|---|---|
| `PerformanceMonitor.Darling.Service.dll` | 3.6.0.0 / 3.6.0 | **unchanged** |
| `PerformanceMonitor.Darling.Viewer.dll` | 3.6.0.0 / 3.6.0 | **unchanged** |
| `PerformanceMonitorLite.dll` | 3.6.0.0 / 3.6.0 | **unchanged** |
| `PerformanceMonitorDashboard.dll` | 3.3.0.0 / 3.3.0+sha | 3.6.0.0 / 3.6.0 |
| `Installer.Core.dll` | 3.3.0.0 / 3.3.0+sha | 3.6.0.0 / 3.6.0 |
| `PerformanceMonitorInstaller.dll` | 3.3.0.0 / 3.3.0+sha | 3.6.0.0 / 3.6.0 |
| `PerformanceMonitor.Common.dll` | 1.0.0.0 / 1.0.0+sha | 3.6.0.0 / 3.6.0 |
| `Darling.Tests.dll` | 1.0.0.0 / 1.0.0+sha | 3.6.0.0 / 3.6.0 |

**The three shipped apps stamp exactly what they stamped before.** Everything else moves onto the product version, and every `InformationalVersion` loses its source-revision suffix because the suppression is now tree-wide.

## Blast radius of the root props file

MSBuild auto-imports it into every project below it, so the reach is all 22 — the four test projects and the whole `deprecated/` subtree included. That is the trade taken deliberately: an explicit `<Import>` is a convention a new project can forget, which is the shape of the defect being replaced.

Nothing reads a library's or a test assembly's own version to decide anything. `UpdateCheckService` reads the **entry** assembly (its comment claiming `PerformanceMonitor.Common.dll` "carries no `<Version>` and defaults to 1.0.0.0" is now false and is rewritten). `DarlingCliCommands.ProductVersion()` reads the service assembly, which declared a version before and inherits the same one now. The Velopack packs and every artifact name come from the workflow variable, which is unchanged in value — `vpk pack -v $env:VERSION`, where `VERSION` is the workflow output. The channel names (`lite`, `darlingviewer`) are literals and no project property reaches them, so the issue body's question about Velopack channel naming is answered: it is not affected.

## The bug I introduced writing this, and the pin that now holds it

The first draft put the rationale comment above the `PropertyGroup`. The four XML readers select an element and were fine; the three **text** readers take the first match in the file, so all three came back with the word `from` out of the comment prose. Every one of those reads only names an artifact, so nothing goes red — the release tarball is just named `PerformanceMonitorDarling-linux-x64- from.tar.gz`.

The `PropertyGroup` now precedes all prose, and `EveryShippedTextReadPattern_AgreesWithTheXmlRead` extracts each shipped read's **own** pattern from the workflow and script source and requires it to agree with the XML read. Reverting the ordering fails it.

## An empty read was invisible on a pull request

Worth stating because it makes the guards non-obvious. `build.yml`'s version read **executes** on a pull request — its only guard is the docs fast path, which this diff cannot engage. But every consumer of the value is `if: github.event_name == 'release'`, and the step never printed it. So a green PR proved the read did not *throw*; whether it returned anything first mattered on a release, which is the worst place to find out.

The release gate is worse than silent rather than merely silent: two empty reads compare **equal**, so an unguarded pair fails the gate for the wrong reason, while one empty side passes it for the wrong reason.

So each read now fails its step on an empty value — `throw` in the pwsh steps, a `||` exit in the bash steps, `exit /b 1` in the scripts. This covers what no test of the readers' *paths* can: a read aimed at the right file still yields empty if the property is renamed, the file is malformed, or a comment gets in front of the element. The bash guard was verified by executing the shipped lines against the real file (resolves `3.6.0`) and against a props file with no version (exits 1).

Guarding without an instrument would repeat the exact error this issue is about, so `EveryVersionRead_FailsItsStepOnAnEmptyResult` holds it.

## Pins, and the mutation table

Baseline: **24 tests, Failed: 0, Errors: 0, Not Run: 0.** Run by compiling the actual `ProductVersionDeclarationTests.cs` and `RepoFile.cs` into a `net10.0` console harness against real xunit.v3 3.2.2, because `Darling.Tests` is `net10.0-windows` and cannot execute on macOS. CI is the arbiter for the real run.

The violation routes were enumerated rather than sampled — reading assertions finds a wrong one, only enumerating routes finds a missing one. That is how the shadowing route (M5) got an assertion: a second `Directory.Build.props` in a subdirectory declaring *nothing* takes the version from its whole subtree while adding no declaration for a count to catch.

| # | mutation | expected red | result |
|---|---|---|---|
| M1 | a second `<Version>` reappears in Lite's csproj | `ExactlyOneMsBuildProperty…` | RED (1 failed) |
| M2 | a hand-set `<AssemblyVersion>` reappears in the gate's file | `NoProjectHandSetsADerived…` | RED (1 failed) |
| M3 | `nightly.yml`'s read points back at a project file | `EveryVersionRead_Names…` | RED (1 failed) |
| M4 | prose naming the property moves above the element | `EveryShippedTextReadPattern…` | RED (1 failed) |
| M5 | a shadowing `Directory.Build.props`, declaring nothing | `ExactlyOneMsBuildProperty…` | RED (1 failed) |
| M6 | the declared value stops being a version | `ExactlyOneMsBuildProperty…` | RED (1 failed) |
| I1 | the workflow **glob** is crippled to match nothing | the non-vacuity floors | RED (2 failed) |
| I2 | the detector's line **predicate** recognises no read | the non-vacuity floors | RED (11 failed) |
| I3 | the path **matcher** accepts everything | the detector theory | RED (5 failed) — and the repo scan **passed** |
| I4 | the detector loses its text-scrape half | `reads >= 9` floor | RED (1 failed) |
| I5 | crippled glob + one test's floors deleted | — | RED — a *second* test floors the same glob |
| I5b | crippled glob + **all three** floors deleted | — | **GREEN, 17/17** |
| I6 | element walk becomes a substring count | — | GREEN (see below) |
| G1 | a guard is deleted from `nightly.yml`'s artifact-naming read | `EveryVersionRead_FailsItsStep…` | RED (1 failed) |
| G2 | a guard is deleted from `build.yml`'s release-tarball read | `EveryVersionRead_FailsItsStep…` | RED (1 failed) |
| G3 | the guard detector credits **everything** | the guard theory | RED (2 failed) — and the guard scan **passed** |
| G4 | the guard look-ahead window shrinks to nothing | `EveryVersionRead_FailsItsStep…` | RED (4 failed) |
| G5 | the bash arm drops its `exit` requirement | the guard theory | RED (1 failed) |

**I3 and G3 are the rows that matter, and they are the same shape.** With the matcher accepting every path, the repository scan passes; with the guard detector crediting every line, the guard scan passes. Both scans are vacuous on their own. Only the theories' known-bad rows discriminate, which is why they exist.

**G5 is why the bash guard arm is narrow.** `[ -n "` on its own is not a guard — the workflows already spell that test for unrelated conditions, so one sitting near a read would be credited as protecting it. Dropping the `exit` requirement reds the theory.

**I5b is the honest bound.** Crippled glob plus all three floors deleted is 17/17 green having examined nothing. The floors are the only thing between a crippled glob and a green suite; I predicted I5 would show that with one test's floors and was wrong, because `EveryShippedTextReadPattern…` independently floors the same glob.

**I6 changes no answer today, and that is stated rather than dressed up.** Over the six declarations this replaced, a grep for the value found 4 (the issue's original count), a substring count of the angle-bracket spelling found 12, and the element walk found 6 — three methods, three answers. After the change the substring count and the walk both return 1. The walk is kept for the disagreement it had, not one it has.

## An existing guard caught two things this broke

`CrossAppGuardCiGateTests` (in `Lite.Tests`) failed the first full CI run, and both failures were real.

**The `darling` filter did not reach Lite's project file.** `ProductVersionDeclarationTests` enumerates every csproj in the tree, so adding a version property back to `Lite/PerformanceMonitorLite.csproj` has to run the Darling guard that would catch it — and the filter reached `Lite/**/*.cs` and `Lite/**/*.xaml` but no project file. Fixed with `Lite/**/*.csproj`, derived rather than the single path, matching the two entries above it. The guard has a sanctioned exemption list for this situation, and it is deliberately *not* used here: its own stated rationale is "nothing narrower than `Lite.Tests/**` would reach the sweep anyway", which does not apply to a path a filter can name precisely.

**The absence of `Directory.Build.props` was itself a pin.** `ThePopulationReachesTheProjectItems_AndNotOnlyTheCSharp` asserted MSBuild's `DirectoryBuildPropsPath` / `DirectoryBuildTargetsPath` / `DirectoryPackagesPropsPath` as `["", "", <packages>]`, with a comment explaining that asserting a `Directory.Build.props` existed "would be asserting a fiction". It is not a fiction any more. All three are now asserted by value, and the empty middle entry is the assertion that there is still no `Directory.Build.targets`. Verified against the instrument the test itself uses — `dotnet msbuild -getProperty:DirectoryBuildPropsPath` on both test projects returns exactly the three values now asserted.

Both fixes were proven red-first individually, by compiling the **real** `CrossAppGuardCiGateTests.cs` into a `net10.0` harness (13 tests): reverting the filter entry alone reds `EveryCrossAppSourceRead_IsReachableByTheFilterThatGatesItsSuite`; reverting the assertion alone reds `ThePopulationReachesTheProjectItems_AndNotOnlyTheCSharp`; with both in place, 13/13.

This is the same failure class as the issue, one level out: a pin whose population grew past the filter that runs it. Worth noting the first CI run also showed the ordering hazard — `Run Lite tests` failing aborted the job before `Run Darling tests`, so the new pins did not execute at all on that run.

## Run against the base tree

The strongest check available, and stronger than any single mutation: dropping the pin file alone onto an otherwise unmodified `91c0a919a` fails **4 of 17**, and the failure text is the issue's own finding, independently derived —

- `ExactlyOneMsBuildProperty…` lists all **six** declarations with values, 4 at 3.6.0 and 2 at 3.3.0. It reproduces the corrected count, not the issue body's four.
- `NoProjectHandSetsADerivedVersionProperty` lists all nine hand-set derived properties.
- `EveryVersionRead_NamesTheDeclarationFile` lists all **nine** reads across five files, resolving the gate's `$path` indirection to the literal it falls back to.
- `EveryShippedTextReadPattern…` fails on the absent declaration file.

## Open questions from #3222, and the arm taken

**Do the deprecated projects join? Yes.** `<Version>` describes the binary being built, not a historical release. A binary built from today's tree stamped 3.3.0 is the lie, not the fix — its shared dependencies moved across three releases. CI builds these on release events, and the release gate read one of them, so their version was never inert.

**Does `check-version-bump.yml` read the central file? Yes, and it is forced.** After centralising, no project's XML contains a `<Version>` element, so an XML read of one returns nothing. The main-side read keeps a fallback to `deprecated/Dashboard/Dashboard.csproj`, because `main` does not carry `Directory.Build.props` until the release that introduces it lands there — verified against `main`, which also **does not** have the `Dashboard/Dashboard.csproj` the old chain's second fallback named, so that dead arm is removed as its own comment said to. The docs-only skip logic is untouched and still mirrors `build.yml`'s filter.

**Does `nightly.yml` change? Yes, both of its reads** — `:114` (pwsh, Windows artifacts) and `:473` (bash, the linux job the issue does not mention). Both resolve; the bash one is covered by the pattern-agreement pin above.

## Not verifiable on this PR

`check-version-bump.yml` is `on: pull_request: branches: [main]`, so it does not execute on a PR to `dev`. Its change is validated by the pins and by reading, not by a live run. It fires on the next release PR.

There is no PowerShell on the machine this was written on, so the four pwsh reads are verified by the equivalent .NET XML select inside the pin, not by executing PowerShell. CI executes them; `build.yml`'s now prints its value, so the resolved version is visible in the log from this PR onward.

The `.cmd` scripts are not exercised by CI at all. `build-lite.cmd`'s change is a path swap plus a guard, read but not run.

## CHANGELOG entry text

Not applied here, per lane convention — for the coordinator to append to `[Unreleased]`:

```
- **The product version is declared in exactly one place** ([#3222]) - six csproj files each carried their own `<Version>`, two of them three releases behind, and the release gate read a different file from the one the nightly named artifacts with, so bumping the gate's file shipped artifacts carrying the old version while bumping the nightly's file failed the gate on a correct build. Nothing compared them, and no test had ever read a workflow file. One `<Version>` now lives in `Directory.Build.props` and all 22 projects inherit it. The three deprecated projects were also still hand-setting `AssemblyVersion` / `FileVersion` / `InformationalVersion`, which #2113 deleted from the shipped three because a hand-set copy wins the stamp - that is why `deprecated/Dashboard/Dashboard.csproj` declared 3.6.0 while its binary stamped 3.3.0.0, in the very file the release gate took its judgement from. All nine version reads across the workflows and the root build scripts now name the one declaring file, two of which had been pointing at a path that stopped existing in #1612. Each of those reads now fails its own step when it reads nothing, which a pull request could not previously reveal because every consumer of the value was gated on the release event. Two existing guards needed following: the `darling` path filter now reaches Lite's project file, since the new pin enumerates it, and `CrossAppGuardCiGateTests` had pinned the ABSENCE of `Directory.Build.props` and now asserts all three imported build files by value. A release bump is now one line, and `ProductVersionDeclarationTests` fails the build on a second declaration, a re-added derived property, a reader naming another path, an unguarded reader, or a comment that pushes the text-scraping readers off the element.
```
