### PR TITLE
Pair every desktop clock render with its column's frame, in both SKUs (#3207, #3221)

### DIFF
--- a/Darling/Darling.Tests/ConsumedTimestampFrameDisciplineTests.cs
+++ b/Darling/Darling.Tests/ConsumedTimestampFrameDisciplineTests.cs
@@ -710,6 +710,41 @@ public sealed class ConsumedTimestampFrameDisciplineTests
         ("FormatServerClock", ClockFrame.ServerLocal),
     ];
 
+    /// <summary>
+    /// A ONE-HOP RENDER WRAPPER: a static formatter in the render roots that reaches one of the
+    /// <see cref="Renderers"/> instead of being one. A wrapper hides the renderer's NAME from the
+    /// render scan, which keys on it - so a column rendered through one is invisible to a census that
+    /// calls itself closed. That is not hypothetical: four server-local <c>plan_correction</c> stamps
+    /// reached <c>ForDisplay</c> through <c>ViewerDataService.PlanCorrection</c>'s <c>Local()</c>, in
+    /// the wrong frame, and no scan here could see them.
+    ///
+    /// <para>Declared with the renderer each one reaches and pinned at SET EQUALITY against the
+    /// derived set by <see cref="TheOneHopRenderWrappers_AreExactlyTheDeclaredSet"/>, so a new or
+    /// renamed wrapper fails the build and has to declare its frame rather than quietly reopening the
+    /// hole.</para>
+    /// </summary>
+    private static readonly (string File, string Method, string Renderer)[] RenderWrappers =
+    [
+        ("Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCorrection.cs", "Local", "ForDisplay"),
+        ("Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SystemEvents.cs", "Local", "ForDisplay"),
+        ("Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs", "CollectionLocal", "ForDisplay"),
+        ("Darling/PerformanceMonitor.Darling.Viewer/ViewerPostgresDisplay.cs", "Timestamp", "ForDisplay"),
+        ("Lite/Services/LocalDataService.ConfigChanges.cs", "Local", "FormatServerTime"),
+        ("Lite/Services/LocalDataService.SystemEvents.cs", "Local", "FormatServerTime"),
+    ];
+
+    /// <summary>A static formatter over a <c>DateTime</c>. Return type and parameter both matter: the
+    /// wrappers in the tree return <c>string</c> or <c>DateTime</c> and take one nullable-or-not
+    /// <c>DateTime</c>, and widening this past that shape drags in every method that merely mentions
+    /// a renderer somewhere in a long body.</summary>
+    private static readonly Regex WrapperSignature =
+        new(@"\b(?:public|private|internal|protected)\s+static\s+(?:string|DateTime)\??\s+(\w+)\s*\(\s*DateTime\??\s+\w+");
+
+    /// <summary>How far past a wrapper's signature its body is read for a renderer call. These are
+    /// one-expression formatters; a bound is what keeps the NEXT member's renderer call from being
+    /// read as this one's.</summary>
+    private const int WrapperBodyBound = 400;
+
     private enum SiteLabel
     {
         /// <summary>A server-local column stamped into an MCP payload with no marking and no conversion,
@@ -830,71 +865,21 @@ public sealed class ConsumedTimestampFrameDisciplineTests
             "#1262: get_cpu_utilization de-skews sample_time in SQL by the per-batch quantised offset, then "
             + "buckets the de-skewed value, so the emitted expression is the bucket key"),
 
-        /* ── desktop renders: the column's frame against the renderer's (#3207) ── */
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs",
-            "first_execution_time", "query_store_stats", 1,
-            "naive UTC rendered RAW, so four hours late; Lite gets this one right"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs",
-            "last_execution_time", "query_store_stats", 1, "naive UTC rendered RAW, so four hours late"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs",
-            "last_execution_time", "query_store_stats", 1,
-            "naive UTC rendered RAW; the doc at :29 states the wrong frame outright and appeals to the "
-            + "sibling Query Store tab, which is how one wrong site became three"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs",
-            "start_time", "running_jobs", 1,
-            "server-local through ForDisplay, so four hours EARLY, beside a CollectionTimeLocal that is right"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs",
-            "first_execution_time", "query_store_stats", 1,
-            "the file header lumps Query Store in with the DMVs; true of query_stats/procedure_stats in the "
-            + "same file, false of query_store_stats"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs",
-            "last_execution_time", "query_store_stats", 1,
-            "same file, same header; the query_stats and procedure_stats rows beside it are correct, which "
-            + "is why the Tables column is part of this key"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.Blocking.cs",
-            "blocked_last_tran_started", "blocked_process_reports+dmv_blocking_snapshots", 1,
-            "server-local through FormatServerTime, which adds the offset again; EventTimeLocal in the same "
-            + "class is correct"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.Blocking.cs",
-            "blocked_last_batch_started", "blocked_process_reports", 1, "server-local through FormatServerTime"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.Blocking.cs",
-            "blocked_last_batch_completed", "blocked_process_reports", 1, "server-local through FormatServerTime"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.Blocking.cs",
-            "tran_start_time", "query_snapshots", 1,
-            "server-local through FormatServerTime; Darling renders the same column through FormatServerClock "
-            + "and its comment claims the two agree"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.PlanCorrection.cs",
-            "valid_since", "plan_correction", 1,
-            "server-local through FormatServerTime; not in #3207's list, found by deriving the census"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.PlanCorrection.cs",
-            "last_refresh", "plan_correction", 1, "server-local through FormatServerTime; not in #3207's list"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.PlanCorrection.cs",
-            "execute_action_initiated_time", "plan_correction", 1,
-            "server-local through FormatServerTime; not in #3207's list"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.PlanCorrection.cs",
-            "revert_action_initiated_time", "plan_correction", 1,
-            "server-local through FormatServerTime; not in #3207's list"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.QueryStats.cs",
-            "creation_time", "query_stats", 2,
-            "server-local through FormatServerTime, in two row types; the Lite read de-skews only the WINDOW "
-            + "BOUND ($2 + $5 * INTERVAL '1' MINUTE) and returns the raw local value, which is #3198's "
-            + "half-fix shape. Darling renders the same column through FormatServerClock"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.QueryStats.cs",
-            "cached_time", "procedure_stats", 2, "server-local through FormatServerTime; not in #3207's list"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.QueryStats.cs",
-            "last_execution_time", "procedure_stats+query_stats", 4,
-            "server-local through FormatServerTime in four row types; both tables agree on the frame, so the "
-            + "ambiguous NAME resolves here even though it does not in general"),
+        /* ── desktop renders: the column's frame against the renderer's (#3207) ──
+
+           EMPTY, and that is a result rather than an omission. #3207 fixed all twenty-two sites this
+           label carried, so their rows are gone with them - set equality fails in the removing
+           direction too, which is what made the deletions provable. The scan below still fails on a
+           new offender: found is compared against this label's rows, and a non-empty found against
+           no rows is a failure. What an empty label costs is the reach evidence NotEmpty(actual)
+           used to give for free, so the floor on sites actually JUDGED is now the exact measured
+           baseline rather than a loose bound, and
+           TheRenderVerdict_FlagsBothDirections_AndPassesTheCorrectPairings exercises the scan's own
+           verdict against a planted offender in each direction. */
     ];
 
     private const int McpPayloadUnmarkedSites = 33;
-    private const int DesktopRenderMismatchSites = 22;
+    private const int DesktopRenderMismatchSites = 0;
     private const int DeSkewedAtReadSites = 2;
 
     /* ═══════════════════════ 5. resolving which table a site's column came from ═══════════════════════ */
@@ -1033,6 +1018,35 @@ public sealed class ConsumedTimestampFrameDisciplineTests
     private const int MinimumMcpEmissionSites = 110;
     private const int MinimumRenderFiles = 380;
 
+    /* The render sites the scan JUDGES - resolved to one frame and compared against their renderer.
+       Measured on this branch at 43: the 38 #3220 measured, plus Lite's running-job start time (which
+       reached DateTime.ToLocalTime() rather than any renderer, so nothing judged it) and the four
+       plan_correction stamps in the Darling viewer that now name FormatServerClock at the site
+       instead of reaching ForDisplay through a wrapper. */
+    private const int JudgedRenderSites = 43;
+
+    /* Call sites of a declared RenderWrapper passing a census column, and how many (file, method)
+       wrappers reach one at all. Measured at 16 sites across 2 of the 6 wrappers - every one of them
+       event_time through a SystemEvents wrapper. Floored, and the reaching-wrapper count pinned
+       exactly, so the check cannot report a clean bill of health by examining nothing: with no
+       offenders left, "examined nothing" and "found nothing" are otherwise the same result. */
+    private const int WrapperCallSitesOverCensusColumns = 16;
+    private const int WrapperFilesReachingACensusColumn = 2;
+
+    /// <summary>
+    /// The render scan's per-site verdict: the column's frame in its resolved table against what the
+    /// renderer at the site expects. Factored out so
+    /// <see cref="TheRenderVerdict_FlagsBothDirections_AndPassesTheCorrectPairings"/> exercises THIS
+    /// predicate rather than a retyped copy - a second, weaker copy of the resolution logic is how
+    /// three of #3220's marker-reachability exemptions came to be unfalsifiable.
+    /// </summary>
+    private static bool RenderFrameDisagrees(
+        Dictionary<(string Table, string Column), ClockFrame> register,
+        string table,
+        string column,
+        string renderer) =>
+        register[(table, column)] != Renderers.Single(r => r.Renderer == renderer).Expects;
+
     /// <summary>
     /// A payload field named after a store column whose frame is ServerLocal, stamped by
     /// <c>ToString("o")</c>. Derived end to end: the field name comes from the catalog, the frame from the
@@ -1099,6 +1113,11 @@ public sealed class ConsumedTimestampFrameDisciplineTests
                 }
             }
         }
+
+        /* Reach, in the direction AssertMatchesInventory no longer asserts: the MCP arm has offenders
+           today, so an empty found here is a broken matcher rather than a clean tree. #3206 owns
+           these rows; when its lane empties this label too, this assertion goes with them. */
+        Assert.NotEmpty(found);
 
         AssertMatchesInventory(found, [SiteLabel.McpPayloadUnmarked, SiteLabel.DeSkewedAtRead]);
 
@@ -1259,7 +1278,7 @@ public sealed class ConsumedTimestampFrameDisciplineTests
 
             foreach (var column in register.Keys.Select(k => k.Column).Distinct(StringComparer.Ordinal))
             {
-                foreach (var (renderer, expects) in Renderers)
+                foreach (var (renderer, _) in Renderers)
                 {
                     foreach (var site in RenderCall(renderer, column).Matches(text).Cast<Match>())
                     {
@@ -1273,7 +1292,7 @@ public sealed class ConsumedTimestampFrameDisciplineTests
 
                         judged++;
 
-                        if (register[(tables.Split('+')[0], column)] != expects)
+                        if (RenderFrameDisagrees(register, tables.Split('+')[0], column, renderer))
                         {
                             Bump(found, (Relative(path), column, tables));
                         }
@@ -1283,13 +1302,196 @@ public sealed class ConsumedTimestampFrameDisciplineTests
         }
 
         /* A floor on the sites actually JUDGED, not only on the files opened: a matcher that stopped
-           recognising the renderers would otherwise report an empty offender set over 459 files. */
-        Assert.True(judged >= 30, $"only {judged} render sites were judged — check the renderer patterns");
+           recognising the renderers would otherwise report an empty offender set over 459 files. It is
+           the EXACT measured population rather than a loose bound, because the offender set is now
+           empty and this is the only thing left standing between a crippled matcher and a green
+           census. Adding a render site raises it and is a deliberate edit; removing one lowers it and
+           is the direction that must be loud. */
+        Assert.True(
+            judged >= JudgedRenderSites,
+            $"only {judged} render sites were judged, expected at least {JudgedRenderSites} — check the renderer patterns");
         Assert.Equal(
             DeclinedAmbiguousRenderSites.OrderBy(d => d, StringComparer.Ordinal).ToArray(),
             declined.OrderBy(d => d, StringComparer.Ordinal).ToArray());
 
         AssertMatchesInventory(found, [SiteLabel.DesktopRenderFrameMismatch]);
+    }
+
+    /// <summary>
+    /// The scan's verdict, exercised against a planted offender in BOTH directions and against the two
+    /// correct pairings of the same columns. With #3207's twenty-two sites fixed the offender set is
+    /// empty, and an empty offender set is otherwise indistinguishable from a verdict that never says
+    /// yes - so the verdict is asked directly, over the real register and the real renderer table.
+    ///
+    /// <para>Both directions, because they are different defects and a pin for one can be blind to the
+    /// other: a server-local value through <c>ForDisplay</c> adds the collected offset a second time
+    /// and shows four hours EARLY on the fleet's measured -240, while a naive-UTC value through
+    /// <c>FormatServerClock</c> renders raw and shows four hours LATE. The two columns are the two the
+    /// fixes moved in opposite directions, and their frames are asserted here rather than assumed, so
+    /// a register that lost a frame fails on the frame rather than on the verdict.</para>
+    /// </summary>
+    [Fact]
+    public void TheRenderVerdict_FlagsBothDirections_AndPassesTheCorrectPairings()
+    {
+        var register = FrameRegister();
+
+        Assert.Equal(ClockFrame.ServerLocal, register[("running_jobs", "start_time")]);
+        Assert.Equal(ClockFrame.Utc, register[("query_store_stats", "last_execution_time")]);
+
+        /* four hours EARLY: the server's own clock through a renderer that adds the offset. */
+        Assert.True(RenderFrameDisagrees(register, "running_jobs", "start_time", "ForDisplay"));
+        Assert.True(RenderFrameDisagrees(register, "running_jobs", "start_time", "FormatServerTime"));
+
+        /* four hours LATE: naive UTC through the renderer that renders raw. */
+        Assert.True(RenderFrameDisagrees(register, "query_store_stats", "last_execution_time", "FormatServerClock"));
+
+        /* And the pairings the fixes landed on are NOT flagged, or the check above would pass by
+           flagging everything. */
+        Assert.False(RenderFrameDisagrees(register, "running_jobs", "start_time", "FormatServerClock"));
+        Assert.False(RenderFrameDisagrees(register, "query_store_stats", "last_execution_time", "ForDisplay"));
+        Assert.False(RenderFrameDisagrees(register, "query_store_stats", "last_execution_time", "FormatServerTime"));
+    }
+
+    /// <summary>
+    /// The one-hop render wrappers in the tree are exactly <see cref="RenderWrappers"/>. A wrapper is
+    /// the census's blind spot - the render scan keys on the renderer's NAME, and a wrapper is a
+    /// different name reaching the same renderer - so a new one has to be declared rather than
+    /// discovered later by hand, which is how the four plan_correction stamps were found.
+    ///
+    /// <para>A method that IS a renderer is not a wrapper of itself: <c>FormatServerTime</c>'s
+    /// nullable overload calls its own name and would otherwise be reported here.</para>
+    /// </summary>
+    [Fact]
+    public void TheOneHopRenderWrappers_AreExactlyTheDeclaredSet()
+    {
+        var files = RenderSourceFiles().ToArray();
+
+        Assert.True(files.Length >= MinimumRenderFiles, $"only {files.Length} viewer/Lite files scanned — check the globs");
+
+        var derived = new List<(string File, string Method, string Renderer)>();
+
+        foreach (var path in files)
+        {
+            /* Comments out: WrapperSignature matches a doc-comment line that merely QUOTES a
+               declaration, and this file is full of prose about these very methods, so a note would
+               otherwise be derived as a wrapper and fail set equality against the real ones. Same
+               inversion CollectorTimestampFrameTests.QueryTextOf makes, and it also stops a renderer
+               named only in a comment inside a body from deciding which renderer that body reaches. */
+            var text = WithoutComments(File.ReadAllText(path));
+
+            foreach (var signature in WrapperSignature.Matches(text).Cast<Match>())
+            {
+                var method = signature.Groups[1].Value;
+
+                if (Renderers.Any(r => string.Equals(r.Renderer, method, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                var body = text.Substring(
+                    signature.Index,
+                    Math.Min(WrapperBodyBound, text.Length - signature.Index));
+
+                foreach (var (renderer, _) in Renderers)
+                {
+                    if (Regex.IsMatch(body, @"\b" + Regex.Escape(renderer) + @"\s*\("))
+                    {
+                        derived.Add((Relative(path), method, renderer));
+                        break;
+                    }
+                }
+            }
+        }
+
+        static string Render((string File, string Method, string Renderer) w) =>
+            $"{w.File}|{w.Method}|{w.Renderer}";
+
+        Assert.Equal(
+            RenderWrappers.Select(Render).OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+            derived.Select(Render).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// No declared wrapper is handed a census column that EVERY table declaring it frames the other
+    /// way. That was the shape of the four <c>plan_correction</c> stamps: <c>valid_since</c>,
+    /// <c>last_refresh</c> and the two action stamps are server-local in the only table that declares
+    /// them, and they reached <c>ForDisplay</c> through a wrapper named <c>Local</c>.
+    ///
+    /// <para><b>Unanimous disagreement only, and that bound is deliberate.</b> Where a column NAME
+    /// spans both frames - <c>event_time</c> is five tables and two of them - a wrapper site cannot be
+    /// judged from the name, and the direct-call scan's resolution machinery does not apply here: a
+    /// wrapper is not the site of the read, so the file it sits in is not the file whose SQL decides
+    /// the table. Sixteen <c>event_time</c> sites through the two <c>SystemEvents</c> wrappers are
+    /// therefore out of this check's reach rather than cleared by it, which is why the count of sites
+    /// EXAMINED is floored: a check that decides nothing and examines nothing look identical.</para>
+    /// </summary>
+    [Fact]
+    public void NoRenderWrapper_IsHandedAColumnEveryTableFramesTheOtherWay()
+    {
+        var register = FrameRegister();
+        var byColumn = TablesByColumn();
+        var offenders = new List<string>();
+        var reached = new HashSet<string>(StringComparer.Ordinal);
+        var examined = 0;
+
+        /* Per (file, method), not per method: two different wrappers in the Darling viewer are both
+           named Local, over different frames, so a name-keyed scan would judge each one's sites
+           against the other's renderer as well as its own. */
+        foreach (var (file, method, renderer) in RenderWrappers)
+        {
+            var expects = Renderers.Single(r => string.Equals(r.Renderer, renderer, StringComparison.Ordinal)).Expects;
+            var text = File.ReadAllText(RepoPath(file));
+
+            foreach (var column in byColumn.Keys)
+            {
+                foreach (var site in RenderCall(method, column).Matches(text).Cast<Match>())
+                {
+                    examined++;
+                    reached.Add($"{file}|{method}");
+
+                    if (byColumn[column].All(table => register[(table, column)] != expects))
+                    {
+                        offenders.Add(
+                            $"{file}:{text[..site.Index].Count(c => c == '\n') + 1}"
+                            + $" {method}({Pascal(column)}) reaches {renderer}, which takes {expects}");
+                    }
+                }
+            }
+        }
+
+        /* Every wrapper CALL SITE over a census column sits in a file that declares a wrapper of that
+           name. Without this the scan above is scoped to a fact nobody checked - that these six are
+           only ever called from their own file - and a wrapper called from elsewhere would be back
+           outside the census with nothing failing. */
+        var declared = RenderWrappers.Select(w => $"{w.File}|{w.Method}").ToHashSet(StringComparer.Ordinal);
+        var names = RenderWrappers.Select(w => w.Method).Distinct(StringComparer.Ordinal).ToArray();
+        var elsewhere = new List<string>();
+
+        foreach (var path in RenderSourceFiles())
+        {
+            var text = File.ReadAllText(path);
+
+            foreach (var method in names)
+            {
+                if (declared.Contains($"{Relative(path)}|{method}"))
+                {
+                    continue;
+                }
+
+                foreach (var column in byColumn.Keys.Where(c => RenderCall(method, c).IsMatch(text)))
+                {
+                    elsewhere.Add($"{Relative(path)}|{method}({Pascal(column)})");
+                }
+            }
+        }
+
+        Assert.Empty(elsewhere);
+        Assert.True(
+            examined >= WrapperCallSitesOverCensusColumns,
+            $"only {examined} wrapper call sites over census columns were examined, expected at least "
+            + $"{WrapperCallSitesOverCensusColumns} — check WrapperSignature and RenderCall");
+        Assert.Equal(WrapperFilesReachingACensusColumn, reached.Count);
+        Assert.Empty(offenders);
     }
 
     /// <summary>
@@ -1463,6 +1665,30 @@ public sealed class ConsumedTimestampFrameDisciplineTests
             "last_user_access",
             ProjectionAlias.Match("    GREATEST(last_user_seek, last_user_scan) AS last_user_access,").Groups[2].Value);
 
+        /* WrapperSignature: the three real declaration shapes in the tree, and the shapes that are not
+           one-hop formatters. Bounded on BOTH the return type and the parameter, because widening it
+           past that drags in every method that merely mentions a renderer somewhere in a long body,
+           and narrowing it drops a wrapper back out of the census. */
+        Assert.Equal(
+            "Local",
+            WrapperSignature.Match("    internal static string Local(DateTime? naiveUtc)").Groups[1].Value);
+        Assert.Equal(
+            "CollectionLocal",
+            WrapperSignature.Match("    public static string CollectionLocal(DateTime collectionTimeUtc)").Groups[1].Value);
+        Assert.Equal(
+            "Timestamp",
+            WrapperSignature.Match("    internal static string Timestamp(DateTime? utc) =>").Groups[1].Value);
+        /* Not static: an instance display getter is the SITE, judged by the render scan itself. */
+        Assert.DoesNotMatch(WrapperSignature, "    public string StartTimeLocal => Format(StartTime);");
+        /* Static, but not over a DateTime: nothing here can carry a clock frame. */
+        Assert.DoesNotMatch(WrapperSignature, "    private static string Local(string text)");
+        Assert.DoesNotMatch(WrapperSignature, "    private static string Local(long ticks)");
+        /* A doc-comment mention of one is not a declaration, and the derivation strips comments before
+           matching for exactly that reason: this raw pattern DOES match the quoted form, which is why
+           the strip is load-bearing rather than tidy. */
+        Assert.Matches(WrapperSignature, "    /// public static string Local(DateTime? utc)");
+        Assert.DoesNotMatch(WrapperSignature, WithoutComments("    /// public static string Local(DateTime? utc)"));
+
         /* And the two renderer families are distinguished, not merged: three names, two expectations. */
         Assert.Equal(3, Renderers.Length);
         Assert.Equal(2, Renderers.Select(r => r.Expects).Distinct().Count());
@@ -1534,6 +1760,16 @@ public sealed class ConsumedTimestampFrameDisciplineTests
         where TKey : notnull =>
         counts[key] = counts.TryGetValue(key, out var existing) ? existing + 1 : 1;
 
+    /// <summary>
+    /// Set equality between what a scan FOUND and the rows the inventory carries for its labels.
+    ///
+    /// <para>It deliberately does NOT assert that either side is non-empty. It used to, as a
+    /// stand-in for "the scan actually looked" - but an emptied label is a legitimate end state
+    /// (#3207 fixed every render site), and an assertion that blocks the fix it exists to prove is
+    /// worse than no assertion. Reach is asserted at each call site instead, against that scan's own
+    /// measured population: the MCP scan floors its file, emission and emitting-file counts, and the
+    /// render scan floors the sites it judged.</para>
+    /// </summary>
     private static void AssertMatchesInventory(
         Dictionary<(string File, string Column, string Tables), int> found,
         SiteLabel[] labels)
@@ -1552,7 +1788,6 @@ public sealed class ConsumedTimestampFrameDisciplineTests
             .OrderBy(x => x, StringComparer.Ordinal)
             .ToArray();
 
-        Assert.NotEmpty(actual);
         Assert.Equal(expected, actual);
     }
 

--- a/Darling/Darling.Tests/ConsumedTimestampFrameDisciplineTests.cs
+++ b/Darling/Darling.Tests/ConsumedTimestampFrameDisciplineTests.cs
@@ -702,11 +702,25 @@ public sealed class ConsumedTimestampFrameDisciplineTests
     /// one that renders raw, i.e. that takes the server's own clock. <c>FormatServerTime</c> is Lite's
     /// <c>ForDisplay</c>, not its <c>FormatServerClock</c>: it adds the offset and names its parameter
     /// <c>utcTime</c>. Lite has no raw renderer at all, which is why a comment in the Darling viewer
-    /// claiming parity with it is wrong in the direction that hid this.</summary>
+    /// claiming parity with it is wrong in the direction that hid this.
+    ///
+    /// <para><c>FormatStoredUtc</c> is the Darling viewer's named UTC renderer, beside
+    /// <c>FormatServerClock</c> so the choice between the pair is reviewable at the site. Registering it
+    /// is not optional: this scan keys on the renderer's NAME, so an unlisted one is invisible and its
+    /// sites would leave the census as the price of being fixed.</para>
+    ///
+    /// <para><b>This list's completeness is the guard's own soft spot, and two checks cover it.</b>
+    /// <see cref="TheOneHopRenderWrappers_AreExactlyTheDeclaredSet"/> derives the ALIASES — a static
+    /// formatter over a <c>DateTime</c> reaching a renderer under a different name — and pins them at set
+    /// equality, so a new one must be declared. That criterion is a SHAPE, and a shape can be evaded, so
+    /// <see cref="NoUnregisteredRenderCapableMember_IsAppliedToACensusColumn"/> closes the residual with
+    /// no shape assumption at all: whatever its signature, a member that renders may not be handed a
+    /// census timestamp column unless it is registered here or declared as an alias.</para></summary>
     private static readonly (string Renderer, ClockFrame Expects)[] Renderers =
     [
         ("ForDisplay", ClockFrame.Utc),
         ("FormatServerTime", ClockFrame.Utc),
+        ("FormatStoredUtc", ClockFrame.Utc),
         ("FormatServerClock", ClockFrame.ServerLocal),
     ];
 
@@ -1042,6 +1056,10 @@ public sealed class ConsumedTimestampFrameDisciplineTests
        exactly, so the check cannot report a clean bill of health by examining nothing: with no
        offenders left, "examined nothing" and "found nothing" are otherwise the same result. */
     private const int WrapperCallSitesOverCensusColumns = 16;
+
+    /* Calls of ANY identifier on a census timestamp column across the render surface. Floored so the
+       shape-free residual check cannot satisfy its set equality with an empty left side. */
+    private const int CallsOnACensusColumn = 72;
     private const int WrapperFilesReachingACensusColumn = 2;
 
     /// <summary>
@@ -1426,6 +1444,110 @@ public sealed class ConsumedTimestampFrameDisciplineTests
     }
 
     /// <summary>
+    /// Identifiers applied to a census timestamp column that are NOT rendering it. The matcher below
+    /// takes any identifier before <c>(</c>, deliberately — that is what makes it shape-free — so the
+    /// benign ones are declared with what they actually are rather than filtered out by a pattern that
+    /// would also hide a real renderer.
+    /// </summary>
+    private static readonly (string Name, string Why)[] NonRenderingCallsOnACensusColumn =
+    [
+        ("if", "a null test - if (row.EventTime.HasValue) and if (summary.OldestPlanCreateTime is not "
+            + "{ } oldest). The matcher reads the identifier before the parenthesis and a keyword is one"),
+        ("DateTime", "new DateTime(d.SampleTime.Year, ..., d.SampleTime.Hour, 0, 0) - an hour-truncating "
+            + "bucket key built FROM a timestamp, not a rendering of one"),
+        ("Compare", "Nullable.Compare(a.EventTime, b.EventTime) - a sort comparison"),
+    ];
+
+    /// <summary>
+    /// <b>The residual, with no shape assumption.</b> Whatever its signature, no member may be handed a
+    /// census timestamp column unless it is a registered renderer, a declared alias, or declared as not
+    /// rendering. Every identifier applied to one is derived and the set is pinned at set equality.
+    ///
+    /// <para><b>Why this exists next to the alias derivation.</b> That one keys on a SHAPE — static,
+    /// over a <c>DateTime</c>, returning a formatted value — and a shape can be evaded: an instance
+    /// method, an extension method, a different return type. This check cannot be evaded that way
+    /// because it does not ask what a member looks like, only what it is applied to. The two fail in
+    /// different directions: the alias check fails when a new formatter appears at all, this one when a
+    /// new name reaches a census column, and neither subsumes the other.</para>
+    ///
+    /// <para>It is also the only check here that would have caught the four <c>plan_correction</c>
+    /// stamps from the OUTSIDE — <c>Local(ValidSince)</c> is an unregistered name applied to a census
+    /// column, which is the defect stated without reference to what <c>Local</c> happens to be.</para>
+    /// </summary>
+    [Fact]
+    public void NoUnregisteredRenderCapableMember_IsAppliedToACensusColumn()
+    {
+        var files = RenderSourceFiles().ToArray();
+
+        Assert.True(files.Length >= MinimumRenderFiles, $"only {files.Length} viewer/Lite files scanned — check the globs");
+
+        var columns = TablesByColumn().Keys.Select(Pascal).Distinct(StringComparer.Ordinal).ToArray();
+        var applied = new Dictionary<string, int>(StringComparer.Ordinal);
+        var total = 0;
+
+        Assert.NotEmpty(columns);
+
+        /* Any identifier, then a census column as the first argument, off an optional receiver. The
+           receiver group is the same one RenderCall carries, and for the same reason: three real render
+           sites pass the property off a lambda parameter. */
+        var call = new Regex(
+            @"\b(\w+)\s*\(\s*(?:[A-Za-z_]\w*\.)?(?:" + string.Join("|", columns.Select(Regex.Escape)) + @")\b");
+
+        foreach (var path in files)
+        {
+            foreach (var site in call.Matches(WithoutComments(File.ReadAllText(path))).Cast<Match>())
+            {
+                total++;
+                Bump(applied, site.Groups[1].Value);
+            }
+        }
+
+        /* Reach: a matcher that stopped matching would satisfy the set equality below with an empty
+           left side, over 459 files. */
+        Assert.True(
+            total >= CallsOnACensusColumn,
+            $"only {total} calls on a census timestamp column were found, expected at least "
+            + $"{CallsOnACensusColumn} — check the identifier matcher");
+
+        var accounted = Renderers.Select(r => r.Renderer)
+            .Concat(RenderWrappers.Select(w => w.Method))
+            .Concat(NonRenderingCallsOnACensusColumn.Select(n => n.Name))
+            .ToHashSet(StringComparer.Ordinal);
+
+        /* THE PROPERTY: nothing unaccounted reaches a census timestamp column. */
+        Assert.Equal(
+            Array.Empty<string>(),
+            applied.Keys.Where(name => !accounted.Contains(name))
+                .OrderBy(x => x, StringComparer.Ordinal).ToArray());
+
+        /* Not set equality, because a DECLARED ALIAS need not reach a census column at all - two of the
+           six only ever render collection_time, which the collector framework stamps and no
+           CollectorColumn declares. Their staleness is caught by
+           TheOneHopRenderWrappers_AreExactlyTheDeclaredSet instead, against the derived set, so nothing
+           is left unguarded by relaxing it here. The other two directions ARE asserted: */
+
+        /* a registered renderer that reaches no census column is a typo in the map, and it would take
+           its sites out of the judged population silently; */
+        Assert.Equal(
+            Array.Empty<string>(),
+            Renderers.Select(r => r.Renderer).Where(name => !applied.ContainsKey(name))
+                .OrderBy(x => x, StringComparer.Ordinal).ToArray());
+
+        /* and a declared non-renderer that no longer appears is an exemption asserting nothing, which is
+           the direction an exemption list rots in. */
+        Assert.Equal(
+            Array.Empty<string>(),
+            NonRenderingCallsOnACensusColumn.Select(n => n.Name).Where(name => !applied.ContainsKey(name))
+                .OrderBy(x => x, StringComparer.Ordinal).ToArray());
+
+        /* Every declared non-renderer carries its reasoning, so the exemption list cannot grow by a
+           bare name. */
+        Assert.All(
+            NonRenderingCallsOnACensusColumn,
+            n => Assert.False(string.IsNullOrWhiteSpace(n.Why), $"{n.Name}: an exemption with no reasoning"));
+    }
+
+    /// <summary>
     /// No declared wrapper is handed a census column that EVERY table declaring it frames the other
     /// way. That was the shape of the four <c>plan_correction</c> stamps: <c>valid_since</c>,
     /// <c>last_refresh</c> and the two action stamps are server-local in the only table that declares
@@ -1767,11 +1889,16 @@ public sealed class ConsumedTimestampFrameDisciplineTests
         Assert.Matches(WrapperSignature, "    /// public static string Local(DateTime? utc)");
         Assert.DoesNotMatch(WrapperSignature, WithoutComments("    /// public static string Local(DateTime? utc)"));
 
-        /* And the two renderer families are distinguished, not merged: three names, two expectations. */
-        Assert.Equal(3, Renderers.Length);
+        /* And the two renderer families are distinguished, not merged: four names, two expectations. Three
+           take naive UTC and exactly ONE takes the server's own clock — asserted as a count rather than
+           left as a comment, because the defect class IS a value reaching the renderer for the other
+           frame, and a second server-local renderer appearing unnoticed would split that side. */
+        Assert.Equal(4, Renderers.Length);
         Assert.Equal(2, Renderers.Select(r => r.Expects).Distinct().Count());
         Assert.Equal(ClockFrame.ServerLocal, Renderers.Single(r => r.Renderer == "FormatServerClock").Expects);
         Assert.Equal(ClockFrame.Utc, Renderers.Single(r => r.Renderer == "FormatServerTime").Expects);
+        Assert.Equal(ClockFrame.Utc, Renderers.Single(r => r.Renderer == "FormatStoredUtc").Expects);
+        Assert.Single(Renderers.Where(r => r.Expects == ClockFrame.ServerLocal));
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/ViewerClockRendererArithmeticTests.cs
+++ b/Darling/Darling.Tests/ViewerClockRendererArithmeticTests.cs
@@ -15,14 +15,15 @@ using Xunit;
 namespace Darling.Tests;
 
 /// <summary>
-/// #3207: the viewer's naive-UTC conversion, against ONE instant expressed in both frames, plus the raw
-/// server-clock render's mode behaviour stated as a fact rather than described.
+/// #3207: the viewer's two conversions — naive-UTC and server-clock — against ONE instant expressed in
+/// both frames.
 ///
-/// <para><b>Why one instant.</b> A pinned string per renderer passes under a sign error as readily as
+/// <para><b>Why one instant.</b> A pinned string per conversion passes under a sign error as readily as
 /// under the right sign, because expectation and implementation are written from the same belief about
-/// which way the offset goes. What discriminates is that <see cref="ViewerTimeHelper.ForDisplay"/> handed
-/// the instant's NAIVE-UTC value and the raw render of the instant's SERVER-CLOCK value produce the same
-/// text in Server mode and differ by the whole offset if either side's arithmetic moves.</para>
+/// which way the offset goes. What discriminates is that <see cref="ViewerTimeHelper.ConvertToDisplay"/>
+/// handed the instant's NAIVE-UTC value and
+/// <see cref="ViewerTimeHelper.ConvertServerClockToDisplay"/> handed the instant's SERVER-CLOCK value
+/// must agree in EVERY mode, and differ by the whole offset if either side's arithmetic moves.</para>
 ///
 /// <para><b>Where -240 comes from.</b> The fleet's measured offset, not an illustration: #2932 measured
 /// <c>cpu_utilization_stats.sample_time</c> exactly four hours behind the same run's
@@ -33,12 +34,12 @@ namespace Darling.Tests;
 /// <c>utc + offset</c>, so a value already in that frame must not be sent through the conversion that adds
 /// the offset again.</para>
 ///
-/// <para><b>The raw render is mode-blind, and that is pinned here rather than left implied.</b>
-/// <c>ViewerDataService.FormatServerClock</c> emits the server's own clock in all three display modes
-/// because <see cref="ViewerTimeHelper"/> has no server-local arm to route through. Lite's namesake takes
-/// the same frame and DOES honour the preference, through <c>ServerTimeHelper.ConvertForDisplay</c>. The
-/// shared name is an input contract, not shared behaviour, and the assertions below fail if that stops
-/// being true in either direction.</para>
+/// <para><b>The server-clock conversion composes; it does not reimplement.</b> The naive-UTC twin of a
+/// server-clock value is <c>serverLocal - offset</c>, so
+/// <see cref="ViewerTimeHelper.ConvertServerClockToDisplay"/> is one subtraction in front of
+/// <see cref="ViewerTimeHelper.ConvertToDisplay"/> and every arm — the machine-local one especially — is
+/// the one already there. The agreement theory below asserts that composition rather than restating any
+/// arm, so a divergence between the two conversions fails instead of being duplicated into both.</para>
 /// </summary>
 public sealed class ViewerClockRendererArithmeticTests
 {
@@ -112,21 +113,6 @@ public sealed class ViewerClockRendererArithmeticTests
     }
 
     /// <summary>
-    /// The other direction, which no test asserted before: a naive-UTC value rendered RAW — the shape the
-    /// three Query Store surfaces shipped — is the whole offset LATE against the same instant converted
-    /// properly. Four hours late reads as plausible on a Query Store row, which is why these sites were
-    /// silent while the running-job one was visible.
-    /// </summary>
-    [Fact]
-    public void ANaiveUtcValue_RenderedRaw_IsTheWholeOffsetLate()
-    {
-        var correct = ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.ServerTime, FleetOffsetMinutes);
-
-        Assert.Equal(TimeSpan.FromMinutes(-FleetOffsetMinutes), NaiveUtc - correct);
-        Assert.True(NaiveUtc > correct, "expected the raw render to be LATER");
-    }
-
-    /// <summary>
     /// The inverse the custom-range pickers use round-trips, in every mode. A conversion pair that agrees
     /// with itself in one direction only skews every window the user types.
     /// </summary>
@@ -139,6 +125,64 @@ public sealed class ViewerClockRendererArithmeticTests
         var display = ViewerTimeHelper.ConvertToDisplay(NaiveUtc, mode, FleetOffsetMinutes);
 
         Assert.Equal(NaiveUtc, ViewerTimeHelper.ConvertFromDisplay(display, mode, FleetOffsetMinutes));
+    }
+
+    /// <summary>
+    /// The server-clock conversion composes out of <see cref="ViewerTimeHelper.ConvertToDisplay"/>'s
+    /// EXISTING arms with one pre-step, and this asserts the composition rather than reimplementing it:
+    /// a server-clock value converted for display must equal the same instant's naive-UTC value
+    /// converted for display, in every mode. That holds because the naive-UTC twin of a server-clock
+    /// value is <c>serverLocal - offset</c>, so nothing needs a new arm — the Local arm in particular is
+    /// reused, not re-derived.
+    /// </summary>
+    [Theory]
+    [InlineData(TimeDisplayMode.ServerTime)]
+    [InlineData(TimeDisplayMode.LocalTime)]
+    [InlineData(TimeDisplayMode.UTC)]
+    public void TheServerClockConversion_AgreesWithTheNaiveUtcOne_OnOneInstant(TimeDisplayMode mode)
+    {
+        Assert.Equal(
+            ViewerTimeHelper.ConvertToDisplay(NaiveUtc, mode, FleetOffsetMinutes),
+            ViewerTimeHelper.ConvertServerClockToDisplay(ServerClock, mode, FleetOffsetMinutes));
+
+        /* And the two are NOT interchangeable: the same value through both conversions differs by the
+           whole offset. Without this the agreement above is satisfied by any pair of conversions that
+           happen to coincide, including one conversion compared against itself. */
+        Assert.NotEqual(
+            ViewerTimeHelper.ConvertToDisplay(ServerClock, mode, FleetOffsetMinutes),
+            ViewerTimeHelper.ConvertServerClockToDisplay(ServerClock, mode, FleetOffsetMinutes));
+    }
+
+    /// <summary>
+    /// <b>The assertion that makes the pair honest.</b> The same server-clock value must render
+    /// DIFFERENTLY under UTC and Server mode, by exactly the offset. A renderer that ignores the
+    /// preference passes every same-instant check above trivially in Server mode and is untestable on
+    /// this axis — which is why the raw render shipped unnoticed.
+    /// </summary>
+    [Fact]
+    public void TheServerClockConversion_HonoursTheDisplayMode()
+    {
+        var server = ViewerTimeHelper.ConvertServerClockToDisplay(ServerClock, TimeDisplayMode.ServerTime, FleetOffsetMinutes);
+        var utc = ViewerTimeHelper.ConvertServerClockToDisplay(ServerClock, TimeDisplayMode.UTC, FleetOffsetMinutes);
+
+        Assert.NotEqual(server, utc);
+        Assert.Equal(TimeSpan.FromMinutes(-FleetOffsetMinutes), utc - server);
+
+        /* Server mode is the value itself: it IS the server's clock, so there is nothing to convert. */
+        Assert.Equal(ServerClock, server);
+        Assert.Equal(NaiveUtc, utc);
+    }
+
+    /// <summary>The two conversions are inverses across the frames: a naive-UTC value through the
+    /// server-clock conversion would be the whole offset out, which is the "four hours late" direction
+    /// stated as arithmetic rather than as prose.</summary>
+    [Fact]
+    public void ANaiveUtcValue_ThroughTheServerClockConversion_IsTheWholeOffsetLate()
+    {
+        var correct = ViewerTimeHelper.ConvertServerClockToDisplay(ServerClock, TimeDisplayMode.ServerTime, FleetOffsetMinutes);
+        var skewed = ViewerTimeHelper.ConvertServerClockToDisplay(NaiveUtc, TimeDisplayMode.ServerTime, FleetOffsetMinutes);
+
+        Assert.Equal(TimeSpan.FromMinutes(-FleetOffsetMinutes), skewed - correct);
     }
 
     /// <summary>The pinned wall clocks, so the relative assertions above cannot all agree on a wrong

--- a/Darling/Darling.Tests/ViewerClockRendererArithmeticTests.cs
+++ b/Darling/Darling.Tests/ViewerClockRendererArithmeticTests.cs
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Globalization;
+using PerformanceMonitor.Darling.Viewer;
+using PerformanceMonitor.Ui;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3207: the viewer's naive-UTC conversion, against ONE instant expressed in both frames, plus the raw
+/// server-clock render's mode behaviour stated as a fact rather than described.
+///
+/// <para><b>Why one instant.</b> A pinned string per renderer passes under a sign error as readily as
+/// under the right sign, because expectation and implementation are written from the same belief about
+/// which way the offset goes. What discriminates is that <see cref="ViewerTimeHelper.ForDisplay"/> handed
+/// the instant's NAIVE-UTC value and the raw render of the instant's SERVER-CLOCK value produce the same
+/// text in Server mode and differ by the whole offset if either side's arithmetic moves.</para>
+///
+/// <para><b>Where -240 comes from.</b> The fleet's measured offset, not an illustration: #2932 measured
+/// <c>cpu_utilization_stats.sample_time</c> exactly four hours behind the same run's
+/// <c>collection_time</c> on 42 of 42 servers, and re-measured 2026-09-09 on the collected store,
+/// <c>query_stats.last_execution_time - collection_time</c> is -240 on 2,092 captures across 42 of 42
+/// while <c>query_store_stats.last_execution_time - collection_time</c> is -1 on 225 captures across 43 —
+/// the two frames, in the same store, in one measurement. A stored server-clock value is
+/// <c>utc + offset</c>, so a value already in that frame must not be sent through the conversion that adds
+/// the offset again.</para>
+///
+/// <para><b>The raw render is mode-blind, and that is pinned here rather than left implied.</b>
+/// <c>ViewerDataService.FormatServerClock</c> emits the server's own clock in all three display modes
+/// because <see cref="ViewerTimeHelper"/> has no server-local arm to route through. Lite's namesake takes
+/// the same frame and DOES honour the preference, through <c>ServerTimeHelper.ConvertForDisplay</c>. The
+/// shared name is an input contract, not shared behaviour, and the assertions below fail if that stops
+/// being true in either direction.</para>
+/// </summary>
+public sealed class ViewerClockRendererArithmeticTests
+{
+    /// <summary>The fleet's measured offset. Negative, and large enough that a sign error lands eight
+    /// hours out rather than somewhere a reader might accept.</summary>
+    private const int FleetOffsetMinutes = -240;
+
+    private static readonly DateTime NaiveUtc =
+        new(2026, 9, 9, 18, 0, 0, DateTimeKind.Unspecified);
+
+    private static readonly DateTime ServerClock =
+        new(2026, 9, 9, 14, 0, 0, DateTimeKind.Unspecified);
+
+    /// <summary>The fixtures are one instant in two frames, asserted rather than assumed: they are the
+    /// premise of every assertion below.</summary>
+    [Fact]
+    public void TheFixtures_AreOneInstantInTwoFrames()
+    {
+        Assert.Equal(ServerClock, NaiveUtc.AddMinutes(FleetOffsetMinutes));
+        Assert.Equal(NaiveUtc, ServerClock.AddMinutes(-FleetOffsetMinutes));
+        Assert.Equal(-240, FleetOffsetMinutes);
+    }
+
+    /// <summary>
+    /// Server mode: the conversion of the naive-UTC value lands on the server's own wall clock, which is
+    /// what the raw render of the server-clock value already shows. The two frames meet here, which is
+    /// exactly why a mis-paired renderer is invisible on a UTC dev box and four hours out on the fleet.
+    /// </summary>
+    [Fact]
+    public void ServerMode_ConvertsNaiveUtcOntoTheServersOwnWallClock()
+    {
+        Assert.Equal(
+            ServerClock,
+            ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.ServerTime, FleetOffsetMinutes));
+    }
+
+    /// <summary>UTC mode returns the stored value: the store is naive UTC, so there is nothing to do.</summary>
+    [Fact]
+    public void UtcMode_ReturnsTheStoredValue()
+    {
+        Assert.Equal(
+            NaiveUtc,
+            ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.UTC, FleetOffsetMinutes));
+    }
+
+    /// <summary>Local mode is the host's own zone, computed from the instant rather than pinned to a
+    /// literal — CI and a developer machine are not in the same zone.</summary>
+    [Fact]
+    public void LocalMode_IsTheHostsOwnZone()
+    {
+        Assert.Equal(
+            DateTime.SpecifyKind(NaiveUtc, DateTimeKind.Utc).ToLocalTime(),
+            ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.LocalTime, FleetOffsetMinutes));
+    }
+
+    /// <summary>
+    /// The defect, with its magnitude and direction: a server-clock value through the naive-UTC conversion
+    /// lands exactly <see cref="FleetOffsetMinutes"/> away — four hours EARLY on this fleet — in every mode
+    /// that applies the offset. Stated as the size of the error rather than as an inequality.
+    /// </summary>
+    [Theory]
+    [InlineData(TimeDisplayMode.ServerTime)]
+    [InlineData(TimeDisplayMode.LocalTime)]
+    public void AServerClockValue_ThroughTheNaiveUtcConversion_IsTheWholeOffsetEarly(TimeDisplayMode mode)
+    {
+        var correct = ViewerTimeHelper.ConvertToDisplay(NaiveUtc, mode, FleetOffsetMinutes);
+        var skewed = ViewerTimeHelper.ConvertToDisplay(ServerClock, mode, FleetOffsetMinutes);
+
+        Assert.Equal(TimeSpan.FromMinutes(FleetOffsetMinutes), skewed - correct);
+        Assert.True(skewed < correct, $"{mode}: expected the skewed conversion to be EARLIER");
+    }
+
+    /// <summary>
+    /// The other direction, which no test asserted before: a naive-UTC value rendered RAW — the shape the
+    /// three Query Store surfaces shipped — is the whole offset LATE against the same instant converted
+    /// properly. Four hours late reads as plausible on a Query Store row, which is why these sites were
+    /// silent while the running-job one was visible.
+    /// </summary>
+    [Fact]
+    public void ANaiveUtcValue_RenderedRaw_IsTheWholeOffsetLate()
+    {
+        var correct = ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.ServerTime, FleetOffsetMinutes);
+
+        Assert.Equal(TimeSpan.FromMinutes(-FleetOffsetMinutes), NaiveUtc - correct);
+        Assert.True(NaiveUtc > correct, "expected the raw render to be LATER");
+    }
+
+    /// <summary>
+    /// The inverse the custom-range pickers use round-trips, in every mode. A conversion pair that agrees
+    /// with itself in one direction only skews every window the user types.
+    /// </summary>
+    [Theory]
+    [InlineData(TimeDisplayMode.ServerTime)]
+    [InlineData(TimeDisplayMode.LocalTime)]
+    [InlineData(TimeDisplayMode.UTC)]
+    public void TheDisplayInverse_RoundTripsTheStoredValue(TimeDisplayMode mode)
+    {
+        var display = ViewerTimeHelper.ConvertToDisplay(NaiveUtc, mode, FleetOffsetMinutes);
+
+        Assert.Equal(NaiveUtc, ViewerTimeHelper.ConvertFromDisplay(display, mode, FleetOffsetMinutes));
+    }
+
+    /// <summary>The pinned wall clocks, so the relative assertions above cannot all agree on a wrong
+    /// value.</summary>
+    [Fact]
+    public void ServerAndUtcModes_RenderThePinnedWallClocks()
+    {
+        Assert.Equal(
+            "2026-09-09 14:00:00",
+            ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.ServerTime, FleetOffsetMinutes)
+                .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+        Assert.Equal(
+            "2026-09-09 18:00:00",
+            ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.UTC, FleetOffsetMinutes)
+                .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+    }
+}

--- a/Darling/Darling.Tests/ViewerQueriesTests.cs
+++ b/Darling/Darling.Tests/ViewerQueriesTests.cs
@@ -388,37 +388,21 @@ public sealed class ViewerQueriesDisplayTests
     /// columns get. <c>query_store_stats</c>' stamps are not in this family: the collector normalises
     /// them to UTC, so they take <c>ViewerTimeHelper.ForDisplay</c> instead (#3207).
     ///
-    /// <para><b>Raw means raw in all three display modes</b>, because
-    /// <c>ViewerTimeHelper</c> has no server-local arm to route through. That is asserted below rather
-    /// than left to be inferred from the absence of a mode argument: Lite's same-named
-    /// <c>ServerTimeHelper.FormatServerClock</c> takes the same frame and DOES honour the Server /
-    /// Local / UTC preference, through <c>ServerTimeHelper.ConvertForDisplay</c>. The shared name is an
-    /// input contract, not shared behaviour, and a reader who assumes otherwise is the reason #3207's
-    /// sites spread.</para>
+    /// <para>Raw means raw in all three display modes, because <c>ViewerTimeHelper</c> has no
+    /// server-local arm to route through — and Lite's same-named
+    /// <c>ServerTimeHelper.FormatServerClock</c> takes the same frame and DOES honour the preference,
+    /// so the shared name is an input contract and not shared behaviour. That fact is asserted by
+    /// <c>ViewerTimeHelperTests.FormatServerClock_IgnoresTheDisplayMode_AtTheFleetOffset</c> rather than
+    /// here: it has to flip the process-wide display-mode static, and only the
+    /// <c>viewer-time-statics</c> collection serializes that. This file holds a live-Postgres class, so
+    /// it is in neither the right collection nor a place a <c>finally</c> belongs.</para>
     /// </summary>
     [Fact]
-    public void FormatServerClock_ShowsRawServerWallClock_InEveryDisplayMode_EmptyForNull()
+    public void FormatServerClock_ShowsRawServerWallClock_EmptyForNull()
     {
         var t = new DateTime(2026, 7, 1, 13, 45, 7);
-        var savedMode = ViewerTimeHelper.CurrentDisplayMode;
-        var savedOffset = ViewerTimeHelper.UtcOffsetMinutes;
-        try
-        {
-            /* The fleet's measured offset, so a renderer that started honouring the mode would move. */
-            ViewerTimeHelper.UtcOffsetMinutes = -240;
-
-            foreach (var mode in new[] { TimeDisplayMode.ServerTime, TimeDisplayMode.LocalTime, TimeDisplayMode.UTC })
-            {
-                ViewerTimeHelper.CurrentDisplayMode = mode;
-                Assert.Equal("2026-07-01 13:45:07", ViewerDataService.FormatServerClock(t));
-                Assert.Equal("", ViewerDataService.FormatServerClock(null));
-            }
-        }
-        finally
-        {
-            ViewerTimeHelper.CurrentDisplayMode = savedMode;
-            ViewerTimeHelper.UtcOffsetMinutes = savedOffset;
-        }
+        Assert.Equal("2026-07-01 13:45:07", ViewerDataService.FormatServerClock(t));
+        Assert.Equal("", ViewerDataService.FormatServerClock(null));
     }
 
     [Fact]

--- a/Darling/Darling.Tests/ViewerQueriesTests.cs
+++ b/Darling/Darling.Tests/ViewerQueriesTests.cs
@@ -388,21 +388,18 @@ public sealed class ViewerQueriesDisplayTests
     /// columns get. <c>query_store_stats</c>' stamps are not in this family: the collector normalises
     /// them to UTC, so they take <c>ViewerTimeHelper.ForDisplay</c> instead (#3207).
     ///
-    /// <para>Raw means raw in all three display modes, because <c>ViewerTimeHelper</c> has no
-    /// server-local arm to route through — and Lite's same-named
-    /// <c>ServerTimeHelper.FormatServerClock</c> takes the same frame and DOES honour the preference,
-    /// so the shared name is an input contract and not shared behaviour. That fact is asserted by
-    /// <c>ViewerTimeHelperTests.FormatServerClock_IgnoresTheDisplayMode_AtTheFleetOffset</c> rather than
-    /// here: it has to flip the process-wide display-mode static, and only the
-    /// <c>viewer-time-statics</c> collection serializes that. This file holds a live-Postgres class, so
-    /// it is in neither the right collection nor a place a <c>finally</c> belongs.</para>
+    /// <para>Only the NULL contract is asserted here, and deliberately: both renderers honour the display
+    /// mode, so a pinned rendered value depends on the process-wide
+    /// <c>ViewerTimeHelper.CurrentDisplayMode</c>, which this class does not serialize — xUnit runs classes
+    /// in parallel and three others flip it. The values are asserted in
+    /// <c>ViewerTimeHelperTests.FormatServerClock_HonoursTheDisplayMode_AtTheFleetOffset</c>, which is in
+    /// the <c>viewer-time-statics</c> collection. Empty-for-null is the same in every mode.</para>
     /// </summary>
     [Fact]
-    public void FormatServerClock_ShowsRawServerWallClock_EmptyForNull()
+    public void TheTwoClockRenderers_RenderEmptyForNull()
     {
-        var t = new DateTime(2026, 7, 1, 13, 45, 7);
-        Assert.Equal("2026-07-01 13:45:07", ViewerDataService.FormatServerClock(t));
         Assert.Equal("", ViewerDataService.FormatServerClock(null));
+        Assert.Equal("", ViewerDataService.FormatStoredUtc(null));
     }
 
     [Fact]

--- a/Darling/Darling.Tests/ViewerQueriesTests.cs
+++ b/Darling/Darling.Tests/ViewerQueriesTests.cs
@@ -382,14 +382,43 @@ public sealed class ViewerQueriesSqlTests
 /// <summary>The Queries row models' pure display helpers: raw server-clock formatting, FullName, totals.</summary>
 public sealed class ViewerQueriesDisplayTests
 {
+    /// <summary>
+    /// <c>query_stats</c>' and <c>procedure_stats</c>' execution and cache stamps are the SQL server's
+    /// own wall clock, shown raw — NOT run through the naive-UTC conversion the <c>collection_time</c>
+    /// columns get. <c>query_store_stats</c>' stamps are not in this family: the collector normalises
+    /// them to UTC, so they take <c>ViewerTimeHelper.ForDisplay</c> instead (#3207).
+    ///
+    /// <para><b>Raw means raw in all three display modes</b>, because
+    /// <c>ViewerTimeHelper</c> has no server-local arm to route through. That is asserted below rather
+    /// than left to be inferred from the absence of a mode argument: Lite's same-named
+    /// <c>ServerTimeHelper.FormatServerClock</c> takes the same frame and DOES honour the Server /
+    /// Local / UTC preference, through <c>ServerTimeHelper.ConvertForDisplay</c>. The shared name is an
+    /// input contract, not shared behaviour, and a reader who assumes otherwise is the reason #3207's
+    /// sites spread.</para>
+    /// </summary>
     [Fact]
-    public void FormatServerClock_ShowsRawServerWallClock_EmptyForNull()
+    public void FormatServerClock_ShowsRawServerWallClock_InEveryDisplayMode_EmptyForNull()
     {
-        /* last_execution_time / creation_time are the SQL server's local wall clock — shown raw, NOT run
-           through the naive-UTC-to-local conversion the collection_time columns get. */
         var t = new DateTime(2026, 7, 1, 13, 45, 7);
-        Assert.Equal("2026-07-01 13:45:07", ViewerDataService.FormatServerClock(t));
-        Assert.Equal("", ViewerDataService.FormatServerClock(null));
+        var savedMode = ViewerTimeHelper.CurrentDisplayMode;
+        var savedOffset = ViewerTimeHelper.UtcOffsetMinutes;
+        try
+        {
+            /* The fleet's measured offset, so a renderer that started honouring the mode would move. */
+            ViewerTimeHelper.UtcOffsetMinutes = -240;
+
+            foreach (var mode in new[] { TimeDisplayMode.ServerTime, TimeDisplayMode.LocalTime, TimeDisplayMode.UTC })
+            {
+                ViewerTimeHelper.CurrentDisplayMode = mode;
+                Assert.Equal("2026-07-01 13:45:07", ViewerDataService.FormatServerClock(t));
+                Assert.Equal("", ViewerDataService.FormatServerClock(null));
+            }
+        }
+        finally
+        {
+            ViewerTimeHelper.CurrentDisplayMode = savedMode;
+            ViewerTimeHelper.UtcOffsetMinutes = savedOffset;
+        }
     }
 
     [Fact]

--- a/Darling/Darling.Tests/ViewerTimeHelperTests.cs
+++ b/Darling/Darling.Tests/ViewerTimeHelperTests.cs
@@ -128,6 +128,51 @@ public sealed class ViewerTimeHelperTests
         }
     }
 
+    /// <summary>
+    /// <c>ViewerDataService.FormatServerClock</c> — the renderer for a column already in the monitored
+    /// server's own frame — emits that clock verbatim in ALL THREE display modes, because
+    /// <see cref="ViewerTimeHelper"/> has no server-local arm for it to route through: every overload
+    /// above takes naive UTC.
+    ///
+    /// <para>Asserted rather than inferred from the absence of a mode argument, and asserted at the
+    /// fleet's measured -240 so a renderer that started converting would move. Lite's same-named
+    /// <c>ServerTimeHelper.FormatServerClock</c> takes the same frame and DOES honour the preference,
+    /// through <c>ServerTimeHelper.ConvertForDisplay</c> — the shared name is an INPUT CONTRACT, not
+    /// shared behaviour, and a reader who assumes otherwise is why #3207's sites spread. Whether the
+    /// viewer SHOULD convert here is a product question; this pin only stops the answer changing by
+    /// accident, in either direction.</para>
+    /// </summary>
+    [Fact]
+    public void FormatServerClock_IgnoresTheDisplayMode_AtTheFleetOffset()
+    {
+        var serverClock = new DateTime(2026, 7, 1, 13, 45, 7, DateTimeKind.Unspecified);
+        var savedMode = ViewerTimeHelper.CurrentDisplayMode;
+        var savedOffset = ViewerTimeHelper.UtcOffsetMinutes;
+        try
+        {
+            ViewerTimeHelper.UtcOffsetMinutes = -240;
+
+            foreach (var mode in new[] { TimeDisplayMode.ServerTime, TimeDisplayMode.LocalTime, TimeDisplayMode.UTC })
+            {
+                ViewerTimeHelper.CurrentDisplayMode = mode;
+                Assert.Equal("2026-07-01 13:45:07", ViewerDataService.FormatServerClock(serverClock));
+                Assert.Equal("", ViewerDataService.FormatServerClock(null));
+            }
+
+            /* And the naive-UTC renderer in the same viewer DOES move with the mode, so the assertion
+               above is about this renderer rather than about a display mode nothing honours. */
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.ServerTime;
+            var server = ViewerTimeHelper.ForDisplay(serverClock);
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.UTC;
+            Assert.NotEqual(server, ViewerTimeHelper.ForDisplay(serverClock));
+        }
+        finally
+        {
+            ViewerTimeHelper.CurrentDisplayMode = savedMode;
+            ViewerTimeHelper.UtcOffsetMinutes = savedOffset;
+        }
+    }
+
     [Fact]
     public void ServerUtcOffsetSql_ReadsLatestNonNullOffsetForServer()
     {

--- a/Darling/Darling.Tests/ViewerTimeHelperTests.cs
+++ b/Darling/Darling.Tests/ViewerTimeHelperTests.cs
@@ -130,20 +130,21 @@ public sealed class ViewerTimeHelperTests
 
     /// <summary>
     /// <c>ViewerDataService.FormatServerClock</c> — the renderer for a column already in the monitored
-    /// server's own frame — emits that clock verbatim in ALL THREE display modes, because
-    /// <see cref="ViewerTimeHelper"/> has no server-local arm for it to route through: every overload
-    /// above takes naive UTC.
+    /// server's own frame — HONOURS the display mode, through
+    /// <see cref="ViewerTimeHelper.ForServerClockDisplay"/>. Server mode is the value itself; UTC mode is
+    /// the value less the collected offset; Local mode is that instant in the viewer machine's zone.
     ///
-    /// <para>Asserted rather than inferred from the absence of a mode argument, and asserted at the
-    /// fleet's measured -240 so a renderer that started converting would move. Lite's same-named
-    /// <c>ServerTimeHelper.FormatServerClock</c> takes the same frame and DOES honour the preference,
-    /// through <c>ServerTimeHelper.ConvertForDisplay</c> — the shared name is an INPUT CONTRACT, not
-    /// shared behaviour, and a reader who assumes otherwise is why #3207's sites spread. Whether the
-    /// viewer SHOULD convert here is a product question; this pin only stops the answer changing by
-    /// accident, in either direction.</para>
+    /// <para><b>The load-bearing assertion is that the modes DIFFER</b>, by exactly the offset, at the
+    /// fleet's measured -240. A renderer that emitted the server's clock verbatim would satisfy the Server
+    /// arm and nothing else, and it is untestable on this axis without this comparison — which is why the
+    /// raw render went unnoticed until #3207 read the pair together.</para>
+    ///
+    /// <para>Lite's same-named <c>ServerTimeHelper.FormatServerClock</c> is the mirror: same input
+    /// contract, and it reaches the modes through <c>ConvertForDisplay</c>, which starts from the server's
+    /// clock instead of from naive UTC. One offset step between the frames, either way round.</para>
     /// </summary>
     [Fact]
-    public void FormatServerClock_IgnoresTheDisplayMode_AtTheFleetOffset()
+    public void FormatServerClock_HonoursTheDisplayMode_AtTheFleetOffset()
     {
         var serverClock = new DateTime(2026, 7, 1, 13, 45, 7, DateTimeKind.Unspecified);
         var savedMode = ViewerTimeHelper.CurrentDisplayMode;
@@ -152,19 +153,27 @@ public sealed class ViewerTimeHelperTests
         {
             ViewerTimeHelper.UtcOffsetMinutes = -240;
 
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.ServerTime;
+            Assert.Equal("2026-07-01 13:45:07", ViewerDataService.FormatServerClock(serverClock));
+
+            /* UTC mode is four hours LATER on this fleet: the stored value is utc + offset, so recovering
+               UTC subtracts a negative offset. A sign error here renders 09:45:07 and is eight hours out. */
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.UTC;
+            Assert.Equal("2026-07-01 17:45:07", ViewerDataService.FormatServerClock(serverClock));
+
+            /* Local mode is that same instant in the viewer machine's zone, computed rather than pinned:
+               CI and a developer machine are not in the same zone. */
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.LocalTime;
+            Assert.Equal(
+                DateTime.SpecifyKind(new DateTime(2026, 7, 1, 17, 45, 7), DateTimeKind.Utc)
+                    .ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"),
+                ViewerDataService.FormatServerClock(serverClock));
+
             foreach (var mode in new[] { TimeDisplayMode.ServerTime, TimeDisplayMode.LocalTime, TimeDisplayMode.UTC })
             {
                 ViewerTimeHelper.CurrentDisplayMode = mode;
-                Assert.Equal("2026-07-01 13:45:07", ViewerDataService.FormatServerClock(serverClock));
                 Assert.Equal("", ViewerDataService.FormatServerClock(null));
             }
-
-            /* And the naive-UTC renderer in the same viewer DOES move with the mode, so the assertion
-               above is about this renderer rather than about a display mode nothing honours. */
-            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.ServerTime;
-            var server = ViewerTimeHelper.ForDisplay(serverClock);
-            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.UTC;
-            Assert.NotEqual(server, ViewerTimeHelper.ForDisplay(serverClock));
         }
         finally
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
@@ -68,7 +68,7 @@ public sealed class DeadlockProcessDetail : DeadlockProcessInfo
 
     /// <summary>The deadlock graph's <c>lasttranstarted</c> attribute, walked out of the stored
     /// <c>deadlock_graph_xml</c> at READ time by <see cref="DeadlockGraphProcessParser"/>. SQL Server
-    /// writes that attribute in its own local clock, so it renders raw through
+    /// writes that attribute in its own local clock, so it converts through
     /// <see cref="ViewerDataService.FormatServerClock"/> — the other frame from
     /// <see cref="DeadlockTimeLocal"/> two properties up, in the same row. No <c>CollectorColumn</c>
     /// declares it, so the catalog-derived clock-frame census cannot reach this pair and the frames are

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
@@ -59,12 +59,21 @@ public sealed class DeadlockProcessDetail : DeadlockProcessInfo
     /// </summary>
     public bool CanViewVictimPlan => IsVictim && HasVictimQueryPlan;
 
+    /// <summary><c>deadlocks.deadlock_time</c> is the XE <c>@timestamp</c>, so it is naive UTC and
+    /// converts through <see cref="ViewerTimeHelper.ForDisplay"/>.</summary>
     public string DeadlockTimeLocal
         => DeadlockTime is { } t ? ViewerTimeHelper.ForDisplay(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
     public string VictimDisplay => IsVictim ? "Victim" : "";
     public string WaitTimeFormatted => WaitTime > 0 ? $"{WaitTime:N0} ms" : "";
-    public string LastTranStartedLocal
-        => LastTranStarted is { } t ? ViewerTimeHelper.ForDisplay(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
+
+    /// <summary>The deadlock graph's <c>lasttranstarted</c> attribute, walked out of the stored
+    /// <c>deadlock_graph_xml</c> at READ time by <see cref="DeadlockGraphProcessParser"/>. SQL Server
+    /// writes that attribute in its own local clock, so it renders raw through
+    /// <see cref="ViewerDataService.FormatServerClock"/> — the other frame from
+    /// <see cref="DeadlockTimeLocal"/> two properties up, in the same row. No <c>CollectorColumn</c>
+    /// declares it, so the catalog-derived clock-frame census cannot reach this pair and the frames are
+    /// stated here instead.</summary>
+    public string LastTranStartedLocal => ViewerDataService.FormatServerClock(LastTranStarted);
 
     /// <summary>
     /// Parses a list of <see cref="ViewerDeadlockRow"/> into per-process detail rows via the shared

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.cs
@@ -334,7 +334,11 @@ public sealed class StorageGrowthRow
     public decimal GrowthPct30d { get; set; }
 }
 
-/// <summary>Database with zero query executions over the window (Optimization sub-tab). LastExecutionTime localized in read.</summary>
+/// <summary>Database with zero query executions over the window (Optimization sub-tab).
+/// <see cref="LastExecutionTime"/> is <c>query_stats.last_execution_time</c>, the monitored server's own
+/// wall clock, and <c>GetIdleDatabasesAsync</c> reads it VERBATIM — see that read's own comment for why,
+/// and for the contrast with the collection_time-derived timestamps in the same port. The grid binds it
+/// directly with a XAML <c>StringFormat</c>, so no renderer sees it in either SKU.</summary>
 public sealed class IdleDatabaseRow
 {
     public string DatabaseName { get; set; } = "";
@@ -542,7 +546,10 @@ public sealed class ObjectSizeGrowthRow
     public decimal GrowthPct30d { get; set; }
 }
 
-/// <summary>Per-index usage with unused/write-only classification (Storage Growth index drill). LastUserAccess localized in read.</summary>
+/// <summary>Per-index usage with unused/write-only classification (Storage Growth index drill).
+/// <see cref="LastUserAccess"/> is a <c>GREATEST</c> over <c>index_object_stats</c>' four
+/// <c>last_user_*</c> columns, all of them the monitored server's own wall clock, and the read takes it
+/// VERBATIM — see that read's own comment.</summary>
 public sealed class IndexUsageRow
 {
     public string DatabaseName { get; set; } = "";

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemHistory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemHistory.cs
@@ -29,8 +29,11 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// Convention deviations from Lite (matching every other viewer read): (1) reads are both-sides window-bound
 /// on naive-UTC <c>collection_time</c> ($ positional params, Kind=Unspecified); (2) <c>collection_time</c> is
 /// naive UTC and renders through <see cref="ViewerTimeHelper.ForDisplay"/>, while the DMV wall-clock stamps
-/// (creation_time / last_execution_time / cached_time / first_execution_time) are the SQL server's own local
-/// time and render raw through <see cref="FormatServerClock"/>; (3) Darling's <c>delta_*</c> columns are
+/// (query_stats' creation_time / last_execution_time and procedure_stats' cached_time /
+/// last_execution_time) are the SQL server's own local time and render raw through
+/// <see cref="FormatServerClock"/> — query_store_stats' first_execution_time / last_execution_time are
+/// NOT in that family, being normalised to UTC by the collector, and take ForDisplay; (3) Darling's
+/// <c>delta_*</c> columns are
 /// already per-collection-cycle deltas, so — like the overlay — there is no C# row-over-row differencing
 /// (Lite's history rows carry the same collector-computed deltas). Numeric columns read through
 /// <c>Convert.ToXxx(GetValue)</c> so a bigint / integer / numeric provider type all bind cleanly.

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemHistory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemHistory.cs
@@ -30,7 +30,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// on naive-UTC <c>collection_time</c> ($ positional params, Kind=Unspecified); (2) <c>collection_time</c> is
 /// naive UTC and renders through <see cref="ViewerTimeHelper.ForDisplay"/>, while the DMV wall-clock stamps
 /// (query_stats' creation_time / last_execution_time and procedure_stats' cached_time /
-/// last_execution_time) are the SQL server's own local time and render raw through
+/// last_execution_time) are the SQL server's own local time and convert through
 /// <see cref="FormatServerClock"/> — query_store_stats' first_execution_time / last_execution_time are
 /// NOT in that family, being normalised to UTC by the collector, and take ForDisplay; (3) Darling's
 /// <c>delta_*</c> columns are

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCorrection.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCorrection.cs
@@ -207,9 +207,9 @@ public class PlanCorrectionRow
 
     public string CollectionTimeLocal => Local(CollectionTime);
 
-    /* sys.dm_db_tuning_recommendations reports these four in the instance's own clock, so they render
-       raw through FormatServerClock while CollectionTime above, which the collector stamps in UTC,
-       goes through Local. The renderer is named at the site rather than reached through Local: a
+    /* sys.dm_db_tuning_recommendations reports these four in the instance's own clock, so they convert
+       through FormatServerClock while CollectionTime above, which the collector stamps in UTC, goes
+       through Local. The renderer is named at the site rather than reached through Local: a
        one-hop wrapper hides the renderer from the clock-frame census, which is how the frame these
        four are in went unread. */
     public string ValidSinceLocal => ViewerDataService.FormatServerClock(ValidSince);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCorrection.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCorrection.cs
@@ -206,16 +206,24 @@ public class PlanCorrectionRow
     public string ImplementationScript { get; set; } = "";
 
     public string CollectionTimeLocal => Local(CollectionTime);
-    public string ValidSinceLocal => Local(ValidSince);
-    public string LastRefreshLocal => Local(LastRefresh);
-    public string ExecuteActionInitiatedTimeLocal => Local(ExecuteActionInitiatedTime);
-    public string RevertActionInitiatedTimeLocal => Local(RevertActionInitiatedTime);
+
+    /* sys.dm_db_tuning_recommendations reports these four in the instance's own clock, so they render
+       raw through FormatServerClock while CollectionTime above, which the collector stamps in UTC,
+       goes through Local. The renderer is named at the site rather than reached through Local: a
+       one-hop wrapper hides the renderer from the clock-frame census, which is how the frame these
+       four are in went unread. */
+    public string ValidSinceLocal => ViewerDataService.FormatServerClock(ValidSince);
+    public string LastRefreshLocal => ViewerDataService.FormatServerClock(LastRefresh);
+    public string ExecuteActionInitiatedTimeLocal => ViewerDataService.FormatServerClock(ExecuteActionInitiatedTime);
+    public string RevertActionInitiatedTimeLocal => ViewerDataService.FormatServerClock(RevertActionInitiatedTime);
 
     /* Tri-state: the flags are NULL when Query Store aged the plan out, which is not the same as "No". */
     public string ForcedDisplay => YesNo(LastGoodPlanIsForced);
     public string ExecutableDisplay => YesNo(IsExecutableAction);
     public string RevertableDisplay => YesNo(IsRevertableAction);
 
+    /// <summary>A naive-UTC stamp in the display mode. NOT for a server-clock column — every one of
+    /// those in this row uses <see cref="ViewerDataService.FormatServerClock"/> instead.</summary>
     internal static string Local(DateTime? naiveUtc)
         => naiveUtc is { } utc ? ViewerTimeHelper.ForDisplay(utc).ToString("yyyy-MM-dd HH:mm:ss") : "";
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
@@ -80,11 +80,15 @@ public sealed class ViewerQuerySnapshotRow
     public string CollectionTimeLocal =>
         CollectionTime == DateTime.MinValue ? "" : ViewerTimeHelper.ForDisplay(CollectionTime).ToString("yyyy-MM-dd HH:mm:ss");
 
-    /// <summary>The transaction begin time, empty when the request has no open transaction. Mirrors Lite's
-    /// <c>QuerySnapshotRow.TranStartTimeLocal</c> (raw server-clock <c>FormatServerTime</c>):
+    /// <summary>The transaction begin time, empty when the request has no open transaction.
     /// transaction_begin_time from sys.dm_tran_active_transactions is a SQL-server-local wall-clock time (NOT
     /// naive UTC), so it renders raw via <see cref="ViewerDataService.FormatServerClock"/> like the other
-    /// dm_exec_* times (last_execution_time / cached_time), NOT through the UTC-converting ForDisplay.</summary>
+    /// dm_exec_* times (last_execution_time / cached_time), NOT through the UTC-converting ForDisplay.
+    ///
+    /// <para>Lite's <c>QuerySnapshotRow.TranStartTimeLocal</c> is the mirror, through
+    /// <c>ServerTimeHelper.FormatServerClock</c>. It is NOT <c>FormatServerTime</c>: that method takes
+    /// naive UTC and adds the collected offset, so it is the wrong renderer for this frame in either
+    /// SKU.</para></summary>
     public string TranStartTimeLocal => ViewerDataService.FormatServerClock(TranStartTime);
 }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
@@ -82,8 +82,8 @@ public sealed class ViewerQuerySnapshotRow
 
     /// <summary>The transaction begin time, empty when the request has no open transaction.
     /// transaction_begin_time from sys.dm_tran_active_transactions is a SQL-server-local wall-clock time (NOT
-    /// naive UTC), so it renders raw via <see cref="ViewerDataService.FormatServerClock"/> like the other
-    /// dm_exec_* times (last_execution_time / cached_time), NOT through the UTC-converting ForDisplay.
+    /// naive UTC), so it converts via <see cref="ViewerDataService.FormatServerClock"/> like the other
+    /// dm_exec_* times (last_execution_time / cached_time), NOT through the naive-UTC ForDisplay.
     ///
     /// <para>Lite's <c>QuerySnapshotRow.TranStartTimeLocal</c> is the mirror, through
     /// <c>ServerTimeHelper.FormatServerClock</c>. It is NOT <c>FormatServerTime</c>: that method takes

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
@@ -596,10 +596,19 @@ public sealed partial class ViewerDataService
 
     /// <summary>
     /// Formats a SQL-server-local wall-clock time (dm_exec_* last_execution_time / creation_time /
-    /// cached_time — NOT naive UTC) for the grid: shown raw, no timezone conversion. Empty when null.
+    /// cached_time, plan_correction's action stamps, msdb Agent's job start time — NOT naive UTC) for
+    /// the grid, in the current display mode. Empty when null.
+    ///
+    /// <para>The counterpart to <see cref="FormatStoredUtc"/>. Exactly one of the pair applies the
+    /// collected offset, and which one depends only on the column's frame; picking the wrong one is
+    /// silent, because both return a plausible timestamp and they differ by the server's whole offset.
+    /// Both honour the Server / Local / UTC preference, so the choice is about the FRAME and never about
+    /// whether the user's selection is respected.</para>
     /// </summary>
     public static string FormatServerClock(DateTime? serverLocal)
-        => serverLocal.HasValue ? serverLocal.Value.ToString("yyyy-MM-dd HH:mm:ss") : "";
+        => serverLocal.HasValue
+            ? ViewerTimeHelper.ForServerClockDisplay(serverLocal.Value).ToString("yyyy-MM-dd HH:mm:ss")
+            : "";
 
     /// <summary>
     /// Renders a STORED naive-UTC timestamp in the current display mode — the counterpart to

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
@@ -602,6 +602,25 @@ public sealed partial class ViewerDataService
         => serverLocal.HasValue ? serverLocal.Value.ToString("yyyy-MM-dd HH:mm:ss") : "";
 
     /// <summary>
+    /// Renders a STORED naive-UTC timestamp in the current display mode — the counterpart to
+    /// <see cref="FormatServerClock"/>, which renders a value that is already the monitored server's own
+    /// clock. Named for the frame it takes rather than for what it does, because picking the wrong one of
+    /// the pair is silent: both return a plausible timestamp and they differ by the server's whole offset,
+    /// four hours on the production fleet's measured -240.
+    ///
+    /// <para>#3207 added this because five sites had no honest way to say "this column is UTC" and reached
+    /// for <see cref="FormatServerClock"/> instead — <c>query_store_stats</c>' first- and last-execution
+    /// times, which Query Store returns as <c>datetimeoffset</c> and <c>QueryStoreCollector</c> normalises
+    /// through <c>DateTimeOffset.UtcDateTime</c>. Inlining
+    /// <c>ViewerTimeHelper.ForDisplay(x).ToString(...)</c> would work identically; a named method beside its
+    /// opposite is what makes the choice reviewable.</para>
+    /// </summary>
+    public static string FormatStoredUtc(DateTime? naiveUtc)
+        => naiveUtc.HasValue
+            ? ViewerTimeHelper.ForDisplay(naiveUtc.Value).ToString("yyyy-MM-dd HH:mm:ss")
+            : "";
+
+    /// <summary>
     /// Collapses whitespace runs (query text arrives with its original formatting) to a single
     /// space and caps at <see cref="CellTextCap"/> with an ellipsis — the one-line grid preview.
     /// </summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
@@ -96,14 +96,10 @@ public sealed class ViewerQueryStoreRow
     /// <c>query_store_stats.first_execution_time</c> and <c>last_execution_time</c> are naive UTC —
     /// unlike the <c>sys.dm_exec_*</c> stamps, which are the server's own clock. They therefore convert
     /// through <see cref="ViewerTimeHelper.ForDisplay"/> rather than rendering raw.</summary>
-    public string FirstExecutionTimeLocal => FirstExecutionTime.HasValue
-        ? ViewerTimeHelper.ForDisplay(FirstExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
-        : "";
+    public string FirstExecutionTimeLocal => ViewerDataService.FormatStoredUtc(FirstExecutionTime);
 
     /// <inheritdoc cref="FirstExecutionTimeLocal"/>
-    public string LastExecutionTimeLocal => LastExecutionTime.HasValue
-        ? ViewerTimeHelper.ForDisplay(LastExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
-        : "";
+    public string LastExecutionTimeLocal => ViewerDataService.FormatStoredUtc(LastExecutionTime);
     public double TotalCpuMs => TotalExecutions * AvgCpuTimeMs;
     public double TotalDurationMs => TotalExecutions * AvgDurationMs;
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
@@ -91,8 +91,19 @@ public sealed class ViewerQueryStoreRow
     public double AvgNumPhysicalIoReads { get; set; }
     public double MinNumPhysicalIoReads { get; set; }
     public double MaxNumPhysicalIoReads { get; set; }
-    public string FirstExecutionTimeLocal => ViewerDataService.FormatServerClock(FirstExecutionTime);
-    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+    /// <summary>Query Store returns <c>datetimeoffset</c> and <c>QueryStoreCollector</c> normalises both
+    /// execution stamps through <c>((DateTimeOffset)…).UtcDateTime</c> before storing, so
+    /// <c>query_store_stats.first_execution_time</c> and <c>last_execution_time</c> are naive UTC —
+    /// unlike the <c>sys.dm_exec_*</c> stamps, which are the server's own clock. They therefore convert
+    /// through <see cref="ViewerTimeHelper.ForDisplay"/> rather than rendering raw.</summary>
+    public string FirstExecutionTimeLocal => FirstExecutionTime.HasValue
+        ? ViewerTimeHelper.ForDisplay(FirstExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
+        : "";
+
+    /// <inheritdoc cref="FirstExecutionTimeLocal"/>
+    public string LastExecutionTimeLocal => LastExecutionTime.HasValue
+        ? ViewerTimeHelper.ForDisplay(LastExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
+        : "";
     public double TotalCpuMs => TotalExecutions * AvgCpuTimeMs;
     public double TotalDurationMs => TotalExecutions * AvgDurationMs;
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
@@ -95,7 +95,8 @@ public sealed class ViewerQueryStoreRow
     /// execution stamps through <c>((DateTimeOffset)…).UtcDateTime</c> before storing, so
     /// <c>query_store_stats.first_execution_time</c> and <c>last_execution_time</c> are naive UTC —
     /// unlike the <c>sys.dm_exec_*</c> stamps, which are the server's own clock. They therefore convert
-    /// through <see cref="ViewerTimeHelper.ForDisplay"/> rather than rendering raw.</summary>
+    /// through <see cref="ViewerDataService.FormatStoredUtc"/> rather than through the server-clock
+    /// renderer.</summary>
     public string FirstExecutionTimeLocal => ViewerDataService.FormatStoredUtc(FirstExecutionTime);
 
     /// <inheritdoc cref="FirstExecutionTimeLocal"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
@@ -25,9 +25,13 @@ namespace PerformanceMonitor.Darling.Viewer;
 ///
 /// <para>Metric values are ms (duration/CPU, converted from µs in SQL) and raw pages (reads); the percents
 /// are plain deltas the grid formats to N2%. <see cref="LastExecutionTime"/> is the Query Store row's
-/// last-exec column (the SQL server's local wall clock in Darling's store), shown RAW via
-/// <see cref="ViewerDataService.FormatServerClock"/> exactly like the sibling Query Store tab — NOT run
-/// through the naive-UTC→local conversion the collection_time columns get. The regression read carries no
+/// last-exec column, which is naive UTC in Darling's store — Query Store returns
+/// <c>datetimeoffset</c> and <c>QueryStoreCollector</c> normalises it through
+/// <c>((DateTimeOffset)…).UtcDateTime</c> before storing — so it converts through
+/// <see cref="ViewerTimeHelper.ForDisplay"/>, the same conversion the collection_time columns get, and
+/// like the sibling Query Store tab. The <c>sys.dm_exec_*</c> stamps that DO render raw through
+/// <see cref="ViewerDataService.FormatServerClock"/> are a different frame, not a different tab: the
+/// renderer follows the column, never the neighbouring grid. The regression read carries no
 /// plan XML (the Dashboard TVF selects none either), so — like the sibling Query Store tab (View-Plan
 /// deferred) — there is no plan surface; double-clicking a row opens that query's history window instead
 /// (mirroring the Dashboard grid's double-click).</para>
@@ -60,8 +64,10 @@ public sealed class ViewerQueryStoreRegressionRow
     public bool CanGetActualPlan => QueryId != 0;
     public DateTime? LastExecutionTime { get; set; }
 
-    /// <summary>The last-execution wall clock shown raw (the sibling Query Store tab's convention).</summary>
-    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+    /// <summary>The last-execution stamp, naive UTC in the store, converted to the display mode.</summary>
+    public string LastExecutionTimeLocal => LastExecutionTime.HasValue
+        ? ViewerTimeHelper.ForDisplay(LastExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
+        : "";
 }
 
 public sealed partial class ViewerDataService

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
@@ -29,7 +29,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <c>datetimeoffset</c> and <c>QueryStoreCollector</c> normalises it through
 /// <c>((DateTimeOffset)…).UtcDateTime</c> before storing — so it converts through
 /// <see cref="ViewerTimeHelper.ForDisplay"/>, the same conversion the collection_time columns get, and
-/// like the sibling Query Store tab. The <c>sys.dm_exec_*</c> stamps that DO render raw through
+/// like the sibling Query Store tab. The <c>sys.dm_exec_*</c> stamps that go through
 /// <see cref="ViewerDataService.FormatServerClock"/> are a different frame, not a different tab: the
 /// renderer follows the column, never the neighbouring grid. The regression read carries no
 /// plan XML (the Dashboard TVF selects none either), so — like the sibling Query Store tab (View-Plan

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
@@ -65,9 +65,7 @@ public sealed class ViewerQueryStoreRegressionRow
     public DateTime? LastExecutionTime { get; set; }
 
     /// <summary>The last-execution stamp, naive UTC in the store, converted to the display mode.</summary>
-    public string LastExecutionTimeLocal => LastExecutionTime.HasValue
-        ? ViewerTimeHelper.ForDisplay(LastExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
-        : "";
+    public string LastExecutionTimeLocal => ViewerDataService.FormatStoredUtc(LastExecutionTime);
 }
 
 public sealed partial class ViewerDataService

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
@@ -113,10 +113,16 @@ public sealed partial class ViewerDataService
 /// <summary>
 /// One row of the Running Jobs grid — a currently-running SQL Agent job with its historical duration
 /// comparison. Copied VERBATIM from Lite's <c>RunningJobRow</c> (LocalDataService.RunningJobs.cs): the
-/// duration/percent/running-long display columns are all collector-side computations, and
-/// <see cref="StartTimeLocal"/> routes the store's naive-UTC start_time through
-/// <see cref="ViewerTimeHelper.ForDisplay"/> — the viewer's mode-aware Server/Local/UTC conversion every
-/// other Darling timestamp also uses.
+/// duration/percent/running-long display columns are all collector-side computations.
+///
+/// <para><see cref="StartTimeLocal"/> and <see cref="CollectionTime"/> are in DIFFERENT frames.
+/// <c>running_jobs.start_time</c> is <c>ja.start_execution_date</c> — msdb Agent's own local clock,
+/// which <c>RunningJobsCollector</c> confirms by taking the running duration as
+/// <c>DATEDIFF(SECOND, ja.start_execution_date, GETDATE())</c>, a local-vs-local subtraction — so it
+/// renders raw through <see cref="ViewerDataService.FormatServerClock"/>. <c>collection_time</c> is
+/// naive UTC and converts through <see cref="ViewerTimeHelper.ForDisplay"/>. Sending the start time
+/// through that conversion applies the collected offset a second time and shows a job that started
+/// seconds ago as a four-hour runner on the fleet's measured -240.</para>
 /// </summary>
 public class RunningJobRow
 {
@@ -132,7 +138,7 @@ public class RunningJobRow
     public bool IsRunningLong { get; set; }
     public decimal? PercentOfAverage { get; set; }
 
-    public string StartTimeLocal => ViewerTimeHelper.ForDisplay(StartTime).ToString("yyyy-MM-dd HH:mm:ss");
+    public string StartTimeLocal => ViewerDataService.FormatServerClock(StartTime);
 
     public string CurrentDurationFormatted => FormatDuration(CurrentDurationSeconds);
     public string AvgDurationFormatted => FormatDuration(AvgDurationSeconds);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
@@ -119,7 +119,7 @@ public sealed partial class ViewerDataService
 /// <c>running_jobs.start_time</c> is <c>ja.start_execution_date</c> — msdb Agent's own local clock,
 /// which <c>RunningJobsCollector</c> confirms by taking the running duration as
 /// <c>DATEDIFF(SECOND, ja.start_execution_date, GETDATE())</c>, a local-vs-local subtraction — so it
-/// renders raw through <see cref="ViewerDataService.FormatServerClock"/>. <c>collection_time</c> is
+/// converts through <see cref="ViewerDataService.FormatServerClock"/>. <c>collection_time</c> is
 /// naive UTC and converts through <see cref="ViewerTimeHelper.ForDisplay"/>. Sending the start time
 /// through that conversion applies the collected offset a second time and shows a job that started
 /// seconds ago as a four-hour runner on the fleet's measured -240.</para>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
@@ -234,11 +234,7 @@ public sealed class ViewerQueryStoreHistoryRow
     /* query_store_stats, not query_stats: both stamps are naive UTC (see the file header), so they take
        the same conversion CollectionTime above takes rather than the raw render the two DMV history
        row types use for their same-named columns. */
-    public string FirstExecutionTimeLocal => FirstExecutionTime.HasValue
-        ? ViewerTimeHelper.ForDisplay(FirstExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
-        : "";
+    public string FirstExecutionTimeLocal => ViewerDataService.FormatStoredUtc(FirstExecutionTime);
 
-    public string LastExecutionTimeLocal => LastExecutionTime.HasValue
-        ? ViewerTimeHelper.ForDisplay(LastExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
-        : "";
+    public string LastExecutionTimeLocal => ViewerDataService.FormatStoredUtc(LastExecutionTime);
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
@@ -19,7 +19,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <see cref="CollectionTime"/> is the collector's naive-UTC capture time in all three and routes through
 /// <see cref="ViewerTimeHelper.ForDisplay"/>. The <c>sys.dm_exec_*</c> stamps in
 /// <see cref="ViewerQueryStatsHistoryRow"/> and <see cref="ViewerProcedureStatsHistoryRow"/>
-/// (creation / cached / last-execution) are the SQL server's own local time and render raw through
+/// (creation / cached / last-execution) are the SQL server's own local time and convert through
 /// <see cref="ViewerDataService.FormatServerClock"/> — the same split every other viewer query row uses
 /// (see <see cref="ViewerQueryStatsRow"/>). <see cref="ViewerQueryStoreHistoryRow"/>'s first- and
 /// last-execution stamps are NOT in that family: Query Store returns <c>datetimeoffset</c> and
@@ -232,8 +232,9 @@ public sealed class ViewerQueryStoreHistoryRow
     public double TotalCpuMs => ExecutionCount * AvgCpuTimeMs;
     public string CollectionTimeLocal => HistoryTime.CollectionLocal(CollectionTime);
     /* query_store_stats, not query_stats: both stamps are naive UTC (see the file header), so they take
-       the same conversion CollectionTime above takes rather than the raw render the two DMV history
-       row types use for their same-named columns. */
+       the same conversion CollectionTime above takes rather than the server-clock one the two DMV history
+       row types use for their same-named columns. Both honour the display mode; they differ only in which
+       frame they start from. */
     public string FirstExecutionTimeLocal => ViewerDataService.FormatStoredUtc(FirstExecutionTime);
 
     public string LastExecutionTimeLocal => ViewerDataService.FormatStoredUtc(LastExecutionTime);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
@@ -15,11 +15,18 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <c>QueryStatsHistoryRow</c> / <c>ProcedureStatsHistoryRow</c> / <c>QueryStoreHistoryRow</c>
 /// (LocalDataService.QueryStats.cs / .QueryStore.cs). Numeric members stay in the store's units (microseconds
 /// for CPU/duration, KB for grants); the display properties convert, mirroring Lite's grid + metric chart.
-/// The one viewer adaptation is time display: <see cref="CollectionTime"/> is the collector's naive-UTC
-/// capture time and routes through <see cref="ViewerTimeHelper.ForDisplay"/>, while the DMV / Query Store
-/// wall-clock stamps (creation / last-execution / cached / first-execution) are the SQL server's own local
-/// time and render raw through <see cref="ViewerDataService.FormatServerClock"/> — the same split every other
-/// viewer query row uses (see <see cref="ViewerQueryStatsRow"/>).
+/// The one viewer adaptation is time display, and the three row types here do NOT agree on it.
+/// <see cref="CollectionTime"/> is the collector's naive-UTC capture time in all three and routes through
+/// <see cref="ViewerTimeHelper.ForDisplay"/>. The <c>sys.dm_exec_*</c> stamps in
+/// <see cref="ViewerQueryStatsHistoryRow"/> and <see cref="ViewerProcedureStatsHistoryRow"/>
+/// (creation / cached / last-execution) are the SQL server's own local time and render raw through
+/// <see cref="ViewerDataService.FormatServerClock"/> — the same split every other viewer query row uses
+/// (see <see cref="ViewerQueryStatsRow"/>). <see cref="ViewerQueryStoreHistoryRow"/>'s first- and
+/// last-execution stamps are NOT in that family: Query Store returns <c>datetimeoffset</c> and
+/// <c>QueryStoreCollector</c> normalises them through <c>((DateTimeOffset)…).UtcDateTime</c> before
+/// storing, so they are naive UTC and convert through <see cref="ViewerTimeHelper.ForDisplay"/> like
+/// <see cref="CollectionTime"/>. Two of the three row types below take one renderer for those columns
+/// and the third takes the other; the store table decides it, not the column name and not the file.
 /// </summary>
 internal static class HistoryTime
 {
@@ -224,6 +231,14 @@ public sealed class ViewerQueryStoreHistoryRow
     public double TotalDurationMs => ExecutionCount * AvgDurationMs;
     public double TotalCpuMs => ExecutionCount * AvgCpuTimeMs;
     public string CollectionTimeLocal => HistoryTime.CollectionLocal(CollectionTime);
-    public string FirstExecutionTimeLocal => ViewerDataService.FormatServerClock(FirstExecutionTime);
-    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+    /* query_store_stats, not query_stats: both stamps are naive UTC (see the file header), so they take
+       the same conversion CollectionTime above takes rather than the raw render the two DMV history
+       row types use for their same-named columns. */
+    public string FirstExecutionTimeLocal => FirstExecutionTime.HasValue
+        ? ViewerTimeHelper.ForDisplay(FirstExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
+        : "";
+
+    public string LastExecutionTimeLocal => LastExecutionTime.HasValue
+        ? ViewerTimeHelper.ForDisplay(LastExecutionTime.Value).ToString("yyyy-MM-dd HH:mm:ss")
+        : "";
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerTimeHelper.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerTimeHelper.cs
@@ -75,6 +75,30 @@ public static class ViewerTimeHelper
     };
 
     /// <summary>
+    /// Converts a stored SERVER-CLOCK timestamp — one already in the monitored server's own frame, which
+    /// is what the <c>sys.dm_exec_*</c> family, <c>plan_correction</c>'s action stamps, msdb Agent's job
+    /// start time and the blocked-process report's attributes hold — to the current display mode.
+    ///
+    /// <para>It composes out of <see cref="ConvertToDisplay"/>'s existing arms rather than adding new
+    /// ones: the naive-UTC twin of a server-clock value is <c>serverLocal - offset</c>, so subtracting
+    /// the offset first is the whole difference between the two conversions. Nothing is re-derived — the
+    /// Local arm in particular is the same one <see cref="ForDisplay"/> uses, reached with a corrected
+    /// input.</para>
+    ///
+    /// <para>This is the mirror of Lite's pair, which starts from the other frame:
+    /// <c>ServerTimeHelper.ConvertForDisplay</c> takes the server's clock and its naive-UTC renderer
+    /// ADDS the offset first. Either way there is exactly one offset step between the two frames, and
+    /// applying it twice or not at all is the whole of #3207.</para>
+    /// </summary>
+    public static DateTime ForServerClockDisplay(DateTime serverLocal) =>
+        ConvertServerClockToDisplay(serverLocal, CurrentDisplayMode, _utcOffsetMinutes);
+
+    /// <summary>Pure (static-free) server-clock → display conversion for an explicit mode + offset. The
+    /// testable core of <see cref="ForServerClockDisplay"/>.</summary>
+    public static DateTime ConvertServerClockToDisplay(DateTime serverLocal, TimeDisplayMode mode, int utcOffsetMinutes) =>
+        ConvertToDisplay(serverLocal.AddMinutes(-utcOffsetMinutes), mode, utcOffsetMinutes);
+
+    /// <summary>
     /// Inverse of <see cref="ForDisplay"/> for the custom-range pickers: a wall-clock value the user typed
     /// IN THE CURRENT display mode, back to the store's naive-UTC window bound.
     /// </summary>

--- a/Lite.Tests/ServerClockRendererArithmeticTests.cs
+++ b/Lite.Tests/ServerClockRendererArithmeticTests.cs
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Globalization;
+using PerformanceMonitor.Ui;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #3207 / #3221: the two renderers' arithmetic, against ONE instant expressed in both frames.
+///
+/// <para><b>Why one instant and not two pinned strings.</b> A pinned string per renderer passes under a
+/// sign error as readily as under the right sign, because the expectation and the implementation are
+/// written from the same belief about which way the offset goes. The load-bearing assertion here is that
+/// <see cref="ServerTimeHelper.FormatServerTime"/> handed the instant's NAIVE-UTC value and
+/// <see cref="ServerTimeHelper.FormatServerClock"/> handed the instant's SERVER-CLOCK value produce the
+/// same text, in every display mode. That holds only if exactly one of the two adds the offset, in the
+/// direction the store's data actually has it — an implementation that adds it in both, in neither, or with
+/// the sign flipped disagrees by 240 or 480 minutes. The absolute renderings are pinned as well, so the
+/// pair cannot agree on a jointly wrong value.</para>
+///
+/// <para><b>Where -240 comes from.</b> It is the fleet's measured offset, not an illustration. #2932
+/// measured <c>cpu_utilization_stats.sample_time</c> exactly four hours behind the same run's
+/// <c>collection_time</c> on 42 of 42 servers; re-measured 2026-09-09 on the collected store,
+/// <c>query_stats.last_execution_time - collection_time</c> is -240 on 2,092 captures across 42 of 42, and
+/// <c>blocked_process_reports</c> carries <c>blocked_last_tran_started</c> -240 from the XE
+/// <c>event_time</c> in the SAME ROW. A stored server-clock value is therefore <c>utc + offset</c>, so
+/// recovering UTC SUBTRACTS the offset — which is what <see cref="ServerTimeHelper.ConvertForDisplay"/>'s
+/// UTC arm does, and what <see cref="ServerTimeHelper.FormatServerTime"/> must NOT do a second time.</para>
+///
+/// <para>Both display modes that are not the default are exercised, because the defect is present in all
+/// three and a test written only against <c>ServerTime</c> — the default — would pass on a renderer that
+/// emits the server's clock verbatim and ignores the preference entirely.</para>
+/// </summary>
+/* Writes ServerTimeHelper.UtcOffsetMinutes and CurrentDisplayMode, both process-wide mutable statics, so
+   it joins the collection the other offset-touching classes use rather than racing them. */
+[Collection("server-time-helper")]
+public sealed class ServerClockRendererArithmeticTests
+{
+    /// <summary>The fleet's measured offset. Negative, and large enough that a sign error lands eight
+    /// hours out rather than somewhere a reader might accept.</summary>
+    private const int FleetOffsetMinutes = -240;
+
+    /// <summary>One instant, twice: the naive-UTC value a collector stamps, and the same instant on the
+    /// monitored server's own clock at <see cref="FleetOffsetMinutes"/>.</summary>
+    private static readonly DateTime NaiveUtc =
+        new(2026, 9, 9, 18, 0, 0, DateTimeKind.Unspecified);
+
+    private static readonly DateTime ServerClock =
+        new(2026, 9, 9, 14, 0, 0, DateTimeKind.Unspecified);
+
+    /// <summary>The two frames are the same instant under <see cref="FleetOffsetMinutes"/>, asserted rather
+    /// than assumed: the fixtures above are the whole premise of every assertion below, and an arithmetic
+    /// slip in them would make the suite agree with itself about the wrong instant.</summary>
+    [Fact]
+    public void TheFixtures_AreOneInstantInTwoFrames()
+    {
+        Assert.Equal(ServerClock, NaiveUtc.AddMinutes(FleetOffsetMinutes));
+        Assert.Equal(NaiveUtc, ServerClock.AddMinutes(-FleetOffsetMinutes));
+        Assert.Equal(-240, FleetOffsetMinutes);
+    }
+
+    [Theory]
+    [InlineData(TimeDisplayMode.ServerTime)]
+    [InlineData(TimeDisplayMode.LocalTime)]
+    [InlineData(TimeDisplayMode.UTC)]
+    public void TheTwoRenderers_RenderOneInstantIdentically_InEveryDisplayMode(TimeDisplayMode mode)
+    {
+        WithOffsetAndMode(mode, () =>
+        {
+            Assert.Equal(
+                ServerTimeHelper.FormatServerTime(NaiveUtc),
+                ServerTimeHelper.FormatServerClock(ServerClock));
+
+            /* And the nullable overloads, which are what the row getters actually reach. */
+            Assert.Equal(
+                ServerTimeHelper.FormatServerTime((DateTime?)NaiveUtc),
+                ServerTimeHelper.FormatServerClock((DateTime?)ServerClock));
+        });
+    }
+
+    /// <summary>
+    /// The defect, with its magnitude and direction: a server-clock value through the naive-UTC renderer
+    /// lands exactly <see cref="FleetOffsetMinutes"/> away — four hours EARLY on this fleet — in every
+    /// mode. Parsed back rather than string-compared, so the assertion states the size of the error
+    /// instead of only that there is one.
+    /// </summary>
+    [Theory]
+    [InlineData(TimeDisplayMode.ServerTime)]
+    [InlineData(TimeDisplayMode.LocalTime)]
+    [InlineData(TimeDisplayMode.UTC)]
+    public void AServerClockValue_ThroughTheNaiveUtcRenderer_IsTheWholeOffsetEarly(TimeDisplayMode mode)
+    {
+        WithOffsetAndMode(mode, () =>
+        {
+            var correct = Parse(ServerTimeHelper.FormatServerClock(ServerClock));
+            var skewed = Parse(ServerTimeHelper.FormatServerTime(ServerClock));
+
+            Assert.Equal(TimeSpan.FromMinutes(FleetOffsetMinutes), skewed - correct);
+            Assert.True(skewed < correct, $"{mode}: expected the skewed rendering to be EARLIER");
+        });
+    }
+
+    /// <summary>
+    /// The two modes whose rendering is independent of the machine the test runs on, pinned absolutely, so
+    /// the agreement above cannot be agreement on a wrong value.
+    /// </summary>
+    [Fact]
+    public void ServerAndUtcModes_RenderThePinnedWallClocks()
+    {
+        WithOffsetAndMode(TimeDisplayMode.ServerTime, () =>
+        {
+            Assert.Equal("2026-09-09 14:00:00", ServerTimeHelper.FormatServerClock(ServerClock));
+            Assert.Equal("2026-09-09 14:00:00", ServerTimeHelper.FormatServerTime(NaiveUtc));
+        });
+
+        WithOffsetAndMode(TimeDisplayMode.UTC, () =>
+        {
+            Assert.Equal("2026-09-09 18:00:00", ServerTimeHelper.FormatServerClock(ServerClock));
+            Assert.Equal("2026-09-09 18:00:00", ServerTimeHelper.FormatServerTime(NaiveUtc));
+        });
+    }
+
+    /// <summary>
+    /// Local mode against the host's own zone, computed from the instant rather than pinned to a literal
+    /// (CI and a developer machine are not in the same zone). This is what makes the mode arm load-bearing:
+    /// a renderer that emitted the server's clock verbatim would pass the ServerTime pin above and fail
+    /// here on any host that is not at the fleet offset.
+    /// </summary>
+    [Fact]
+    public void LocalMode_RendersTheInstantInTheHostsOwnZone()
+    {
+        var expected = DateTime.SpecifyKind(NaiveUtc, DateTimeKind.Utc).ToLocalTime()
+            .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+
+        WithOffsetAndMode(TimeDisplayMode.LocalTime, () =>
+        {
+            Assert.Equal(expected, ServerTimeHelper.FormatServerClock(ServerClock));
+            Assert.Equal(expected, ServerTimeHelper.FormatServerTime(NaiveUtc));
+        });
+    }
+
+    [Fact]
+    public void ANullServerClockValue_RendersEmpty()
+    {
+        WithOffsetAndMode(TimeDisplayMode.ServerTime, () =>
+            Assert.Equal("", ServerTimeHelper.FormatServerClock((DateTime?)null)));
+    }
+
+    private static DateTime Parse(string rendered) =>
+        DateTime.ParseExact(rendered, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+
+    private static void WithOffsetAndMode(TimeDisplayMode mode, Action body)
+    {
+        var savedOffset = ServerTimeHelper.UtcOffsetMinutes;
+        var savedMode = ServerTimeHelper.CurrentDisplayMode;
+        try
+        {
+            ServerTimeHelper.UtcOffsetMinutes = FleetOffsetMinutes;
+            ServerTimeHelper.CurrentDisplayMode = mode;
+            body();
+        }
+        finally
+        {
+            ServerTimeHelper.UtcOffsetMinutes = savedOffset;
+            ServerTimeHelper.CurrentDisplayMode = savedMode;
+        }
+    }
+}

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -984,13 +984,22 @@ public class DeadlockRow : DeadlockAlertRow
 /// sp_BlitzLock-style graph walk now live once on the shared <see cref="DeadlockProcessInfo"/> /
 /// <see cref="DeadlockGraphProcessParser"/> (Common); only Lite's per-server display getters
 /// (<see cref="ServerTimeHelper"/>) stay here.
+///
+/// <para>The two timestamps are in DIFFERENT frames and take different renderers.
+/// <c>DeadlockTime</c> is <c>deadlocks.deadlock_time</c>, the XE <c>@timestamp</c>, so it is naive UTC
+/// and converts through <see cref="ServerTimeHelper.FormatServerTime"/>. <c>LastTranStarted</c> is the
+/// deadlock graph's <c>lasttranstarted</c> attribute, walked out of the stored XML at READ time by
+/// <see cref="DeadlockGraphProcessParser"/>, and SQL Server writes that attribute in its own local
+/// clock — so it renders through <see cref="ServerTimeHelper.FormatServerClock"/>. No
+/// <c>CollectorColumn</c> declares it, so the catalog-derived clock-frame census cannot reach this
+/// pair and the frames are stated here instead.</para>
 /// </summary>
 public class DeadlockProcessDetail : DeadlockProcessInfo
 {
     public string DeadlockTimeLocal => ServerTimeHelper.FormatServerTime(DeadlockTime);
     public string VictimDisplay => IsVictim ? "Victim" : "";
     public string WaitTimeFormatted => WaitTime > 0 ? $"{WaitTime:N0} ms" : "";
-    public string LastTranStartedLocal => ServerTimeHelper.FormatServerTime(LastTranStarted);
+    public string LastTranStartedLocal => ServerTimeHelper.FormatServerClock(LastTranStarted);
 
     /// <summary>
     /// Parses a list of <see cref="DeadlockRow"/> into per-process detail rows via the shared
@@ -1043,9 +1052,12 @@ public class BlockedProcessReportRow : BlockedProcessAlertRow
     public string EventTimeLocal => ServerTimeHelper.FormatServerTime(EventTime);
     public string WaitTimeFormatted => WaitTimeMs < 1000 ? $"{WaitTimeMs} ms" : $"{WaitTimeMs / 1000.0:F1} sec";
     public bool IsLongBlock => WaitTimeMs > 30000;
-    public string BlockedLastTranStartedLocal => ServerTimeHelper.FormatServerTime(BlockedLastTranStarted);
-    public string BlockedLastBatchStartedLocal => ServerTimeHelper.FormatServerTime(BlockedLastBatchStarted);
-    public string BlockedLastBatchCompletedLocal => ServerTimeHelper.FormatServerTime(BlockedLastBatchCompleted);
+    /* EventTime above is the XE @timestamp and is naive UTC. These three are attributes of the
+       blocked-process report XML, which SQL Server writes in the monitored server's own clock, so
+       they take the server-clock renderer instead: one row, two frames, two renderers. */
+    public string BlockedLastTranStartedLocal => ServerTimeHelper.FormatServerClock(BlockedLastTranStarted);
+    public string BlockedLastBatchStartedLocal => ServerTimeHelper.FormatServerClock(BlockedLastBatchStarted);
+    public string BlockedLastBatchCompletedLocal => ServerTimeHelper.FormatServerClock(BlockedLastBatchCompleted);
 }
 
 public class QuerySnapshotRow
@@ -1100,7 +1112,12 @@ public class QuerySnapshotRow
     public double TranLogUsedMb { get; set; }
     public DateTime? TranStartTime { get; set; }
     public int RequestId { get; set; }
-    public string TranStartTimeLocal => ServerTimeHelper.FormatServerTime(TranStartTime);
+    /// <summary>The transaction begin time, empty when the request has no open transaction.
+    /// <c>query_snapshots.tran_start_time</c> is <c>MIN(transaction_begin_time)</c> off
+    /// <c>sys.dm_tran_active_transactions</c> — the server's own wall clock, not naive UTC — so unlike
+    /// <see cref="CollectionTimeLocal"/> beside it, it renders through
+    /// <see cref="ServerTimeHelper.FormatServerClock"/>.</summary>
+    public string TranStartTimeLocal => ServerTimeHelper.FormatServerClock(TranStartTime);
 
     // Chain mode — set by WaitDrillDownWindow when showing head blockers
     public string ChainBlockingPath { get; set; } = "";

--- a/Lite/Services/LocalDataService.JobHistory.cs
+++ b/Lite/Services/LocalDataService.JobHistory.cs
@@ -234,6 +234,9 @@ public class JobHistoryRow
     /// <summary>run_datetime is the server's local wall clock; shown as-is (the time SSMS shows).</summary>
     public string RunTimeLocal => RunDateTime?.ToString("yyyy-MM-dd HH:mm:ss") ?? "";
 
+    /// <summary><see cref="LastSuccessfulRun"/> is <c>MAX(run_datetime)</c> over this job's successful
+    /// step-0 rows, so it is the same server-local wall clock as <see cref="RunTimeLocal"/> and is shown
+    /// the same way — as-is, not converted to the display mode.</summary>
     public string LastSuccessfulRunLocal => LastSuccessfulRun?.ToString("yyyy-MM-dd HH:mm:ss") ?? "Never";
 
     public string DurationFormatted => FormatDuration(RunDurationSeconds);
@@ -310,5 +313,11 @@ public class AgentStatusRow
     /// server that runs one. Stale and never-present are neutral — they are absence of signal, not a problem.</summary>
     public bool IsAgentProblem => !IsStale && !AgentRunning && EverSeenRunning;
 
+    /// <summary><c>agent_status.next_scheduled_run</c> is the monitored server's own local wall clock, and
+    /// this shows it as-is — not converted to the selected display mode — matching
+    /// <see cref="JobHistoryRow.RunTimeLocal"/> in this file. Darling's read of the same column de-skews it
+    /// to UTC in SQL and then converts, so the two SKUs present this grid differently on purpose in
+    /// Darling's case and by inheritance here; the frame is stated at the property rather than only in the
+    /// class summary because that is where a reader checks it.</summary>
     public string NextScheduledRunLocal => NextScheduledRun?.ToString("yyyy-MM-dd HH:mm:ss") ?? "None scheduled";
 }

--- a/Lite/Services/LocalDataService.PlanCorrection.cs
+++ b/Lite/Services/LocalDataService.PlanCorrection.cs
@@ -203,10 +203,14 @@ public class PlanCorrectionRow
     public string ImplementationScript { get; set; } = "";
 
     public string CollectionTimeLocal => ServerTimeHelper.FormatServerTime(CollectionTime);
-    public string ValidSinceLocal => ServerTimeHelper.FormatServerTime(ValidSince);
-    public string LastRefreshLocal => ServerTimeHelper.FormatServerTime(LastRefresh);
-    public string ExecuteActionInitiatedTimeLocal => ServerTimeHelper.FormatServerTime(ExecuteActionInitiatedTime);
-    public string RevertActionInitiatedTimeLocal => ServerTimeHelper.FormatServerTime(RevertActionInitiatedTime);
+
+    /* sys.dm_db_tuning_recommendations reports these four in the instance's own clock, so they take
+       the server-clock renderer while CollectionTime above, which the collector stamps in UTC, takes
+       the UTC one. Four of the six timestamps in this row are in the other frame from the first. */
+    public string ValidSinceLocal => ServerTimeHelper.FormatServerClock(ValidSince);
+    public string LastRefreshLocal => ServerTimeHelper.FormatServerClock(LastRefresh);
+    public string ExecuteActionInitiatedTimeLocal => ServerTimeHelper.FormatServerClock(ExecuteActionInitiatedTime);
+    public string RevertActionInitiatedTimeLocal => ServerTimeHelper.FormatServerClock(RevertActionInitiatedTime);
 
     /* Tri-state: the flags are NULL when Query Store aged the plan out, which is not the same as "No". */
     public string ForcedDisplay => YesNo(LastGoodPlanIsForced);

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -1476,8 +1476,8 @@ public class QueryStatsRow
     public string QueryHash { get; set; } = "";
     public DateTime? LastExecutionTime { get; set; }
     public DateTime? CreationTime { get; set; }
-    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerTime(LastExecutionTime);
-    public string CreationTimeLocal => Services.ServerTimeHelper.FormatServerTime(CreationTime);
+    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerClock(LastExecutionTime);
+    public string CreationTimeLocal => Services.ServerTimeHelper.FormatServerClock(CreationTime);
     public long TotalExecutions { get; set; }
     public long TotalCpuUs { get; set; }
     public long TotalElapsedUs { get; set; }
@@ -1599,8 +1599,8 @@ public class ProcedureStatsRow
     public double MaxCpuMs => MaxWorkerTimeUs / 1000.0;
     public double MinElapsedMs => MinElapsedTimeUs / 1000.0;
     public double MaxElapsedMs => MaxElapsedTimeUs / 1000.0;
-    public string CachedTimeFormatted => Services.ServerTimeHelper.FormatServerTime(CachedTime);
-    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerTime(LastExecutionTime);
+    public string CachedTimeFormatted => Services.ServerTimeHelper.FormatServerClock(CachedTime);
+    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerClock(LastExecutionTime);
 }
 
 public class QueryStatsHistoryRow
@@ -1668,8 +1668,8 @@ public class QueryStatsHistoryRow
     public double TotalCpuMs => TotalCpuUs / 1000.0;
     public double TotalElapsedMs => TotalElapsedUs / 1000.0;
     public string CollectionTimeLocal => ServerTimeHelper.FormatServerTime(CollectionTime);
-    public string CreationTimeLocal => ServerTimeHelper.FormatServerTime(CreationTime);
-    public string LastExecutionTimeLocal => ServerTimeHelper.FormatServerTime(LastExecutionTime);
+    public string CreationTimeLocal => ServerTimeHelper.FormatServerClock(CreationTime);
+    public string LastExecutionTimeLocal => ServerTimeHelper.FormatServerClock(LastExecutionTime);
 }
 
 public class ProcedureStatsHistoryRow
@@ -1722,6 +1722,6 @@ public class ProcedureStatsHistoryRow
     public double TotalCpuMs => TotalCpuUs / 1000.0;
     public double TotalElapsedMs => TotalElapsedUs / 1000.0;
     public string CollectionTimeLocal => ServerTimeHelper.FormatServerTime(CollectionTime);
-    public string CachedTimeLocal => ServerTimeHelper.FormatServerTime(CachedTime);
-    public string LastExecutionTimeLocal => ServerTimeHelper.FormatServerTime(LastExecutionTime);
+    public string CachedTimeLocal => ServerTimeHelper.FormatServerClock(CachedTime);
+    public string LastExecutionTimeLocal => ServerTimeHelper.FormatServerClock(LastExecutionTime);
 }

--- a/Lite/Services/LocalDataService.RunningJobs.cs
+++ b/Lite/Services/LocalDataService.RunningJobs.cs
@@ -155,7 +155,13 @@ public class RunningJobRow
     public bool IsRunningLong { get; set; }
     public decimal? PercentOfAverage { get; set; }
 
-    public string StartTimeLocal => StartTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+    /// <summary>The job's start time. <c>running_jobs.start_time</c> is msdb Agent's
+    /// <c>start_execution_date</c> — the monitored instance's own clock, which the collector confirms
+    /// by taking its running duration as <c>DATEDIFF(SECOND, ja.start_execution_date, GETDATE())</c> —
+    /// so it renders through <see cref="ServerTimeHelper.FormatServerClock"/> like every other
+    /// server-clock stamp, and honours the Server / Local / UTC display preference the rest of the app
+    /// honours.</summary>
+    public string StartTimeLocal => ServerTimeHelper.FormatServerClock(StartTime);
 
     public string CurrentDurationFormatted => FormatDuration(CurrentDurationSeconds);
     public string AvgDurationFormatted => FormatDuration(AvgDurationSeconds);

--- a/Lite/Services/ServerTimeHelper.cs
+++ b/Lite/Services/ServerTimeHelper.cs
@@ -126,10 +126,12 @@ public static class ServerTimeHelper
     /// and, applied to a value already in the server's frame, skews it by the collected offset a second
     /// time — the fleet's -240 renders four hours early, in every display mode.</para>
     ///
-    /// <para>Darling's <c>ViewerDataService.FormatServerClock</c> takes the same frame under the same name.
-    /// The INPUT CONTRACT is the shared fact; the mode handling is not — that renderer emits the server's
-    /// clock verbatim in all three modes, because <c>ViewerTimeHelper</c> has no server-local arm to route
-    /// through. Do not read the shared name as shared behaviour.</para>
+    /// <para>Darling's <c>ViewerDataService.FormatServerClock</c> is the mirror of this, under the same
+    /// name and with the same input contract, reached the other way round: its
+    /// <c>ViewerTimeHelper.ConvertToDisplay</c> takes naive UTC, so the server-clock conversion there
+    /// SUBTRACTS the offset first, where this one starts from the server's clock and the naive-UTC renderer
+    /// adds it. Either way there is exactly one offset step between the two frames, and both renderers
+    /// honour the display preference.</para>
     /// </summary>
     public static string FormatServerClock(DateTime serverLocal, string format = "yyyy-MM-dd HH:mm:ss")
         => ConvertForDisplay(serverLocal, CurrentDisplayMode).ToString(format);

--- a/Lite/Services/ServerTimeHelper.cs
+++ b/Lite/Services/ServerTimeHelper.cs
@@ -101,9 +101,40 @@ public static class ServerTimeHelper
         _ => $"UTC{(_utcOffsetMinutes >= 0 ? "+" : "")}{_utcOffsetMinutes / 60}:{Math.Abs(_utcOffsetMinutes % 60):D2}"
     };
 
+    /// <summary>
+    /// Formats a NAIVE-UTC timestamp for display. The offset add converts UTC to the server's own clock,
+    /// which is <see cref="ConvertForDisplay"/>'s input; use <see cref="FormatServerClock"/> instead for a
+    /// value that is already the server's clock.
+    /// </summary>
     public static string FormatServerTime(DateTime utcTime, string format = "yyyy-MM-dd HH:mm:ss")
         => ConvertForDisplay(utcTime.AddMinutes(_utcOffsetMinutes), CurrentDisplayMode).ToString(format);
 
+    /// <inheritdoc cref="FormatServerTime(DateTime, string)"/>
     public static string FormatServerTime(DateTime? utcTime, string format = "yyyy-MM-dd HH:mm:ss")
         => utcTime.HasValue ? ConvertForDisplay(utcTime.Value.AddMinutes(_utcOffsetMinutes), CurrentDisplayMode).ToString(format) : "";
+
+    /// <summary>
+    /// Formats a timestamp that is ALREADY the monitored server's own wall clock: the
+    /// <c>sys.dm_exec_*</c> family (<c>creation_time</c>, <c>cached_time</c>, <c>last_execution_time</c>),
+    /// <c>plan_correction</c>'s recommendation and action stamps, the blocked-process report's
+    /// <c>*_last_tran_started</c> / <c>*_last_batch_*</c> attributes, <c>query_snapshots.tran_start_time</c>
+    /// and msdb Agent's <c>start_execution_date</c>.
+    ///
+    /// <para><see cref="ConvertForDisplay"/> already takes the server's clock and honours the selected
+    /// display mode, so this is <see cref="FormatServerTime"/> with the offset add removed rather than a
+    /// second conversion. That add is the whole defect it exists to prevent: it is correct for naive UTC
+    /// and, applied to a value already in the server's frame, skews it by the collected offset a second
+    /// time — the fleet's -240 renders four hours early, in every display mode.</para>
+    ///
+    /// <para>Darling's <c>ViewerDataService.FormatServerClock</c> takes the same frame under the same name.
+    /// The INPUT CONTRACT is the shared fact; the mode handling is not — that renderer emits the server's
+    /// clock verbatim in all three modes, because <c>ViewerTimeHelper</c> has no server-local arm to route
+    /// through. Do not read the shared name as shared behaviour.</para>
+    /// </summary>
+    public static string FormatServerClock(DateTime serverLocal, string format = "yyyy-MM-dd HH:mm:ss")
+        => ConvertForDisplay(serverLocal, CurrentDisplayMode).ToString(format);
+
+    /// <inheritdoc cref="FormatServerClock(DateTime, string)"/>
+    public static string FormatServerClock(DateTime? serverLocal, string format = "yyyy-MM-dd HH:mm:ss")
+        => serverLocal.HasValue ? ConvertForDisplay(serverLocal.Value, CurrentDisplayMode).ToString(format) : "";
 }


### PR DESCRIPTION
Fixes #3207. Fixes #3221.

Twenty-nine desktop render sites across both SKUs, wrong in **opposite directions**, and each SKU correct exactly where the other is wrong — which is why no parity check ever caught it. A server-local column through `ForDisplay` / `FormatServerTime` adds the collected offset a second time and displays four hours **early** on the fleet's measured −240; a naive-UTC column through `FormatServerClock` renders raw and displays four hours **late**. A blanket "add the offset" or "stop adding it" fixes half and breaks half, so every site here is paired against its column's frame taken from #3220's catalog-derived census, not from the column's name and not from the neighbouring grid.

#3221 is an external reporter reproducing eight of these from the outside, on `Lite/Services/LocalDataService.QueryStats.cs`. That is the whole file's offending set and it lands exactly where the census put it.

## The frames, measured on collected production data

Both directions, from the store rather than from the collectors' C#. `server_properties.utc_offset_minutes` is −240 across the fleet (one self-monitored server at 0), and a stored server-clock value is therefore `utc + offset`, so recovering UTC **subtracts** the offset:

| probe | rows | servers | skew vs the UTC stamp beside it | reads as |
|---|---|---|---|---|
| `blocked_process_reports`: `blocked_last_tran_started` − `event_time`, **same row** | 143 | 7 | −240 … −242 | server-local |
| `query_stats.last_execution_time` − `collection_time` | 2,092 captures | 42 of 42 | **−240 exactly** (min = max) | server-local |
| `procedure_stats.last_execution_time` − `collection_time` | 2,092 captures | 42 of 42 | −240 … −241 | server-local |
| `cpu_utilization_stats`: `max(sample_time)` − `collection_time` | 2,092 samples | 42 of 42 | −240 … −241 | server-local (#2932, reproduced) |
| `query_store_stats.last_execution_time` − `collection_time` | 225 captures | 43 | **−6 … +1, mean −1** | **naive UTC** |
| `query_store_stats.first_execution_time` (max) − `collection_time` | 225 captures | 43 | −7 … +1, mean −1 | **naive UTC** |

The first four are the columns #3207 and #3221 say are server-local; the last two are the ones both issues argue are UTC from `QueryStoreCollector`'s `((DateTimeOffset)…).UtcDateTime` line. Nobody had measured either claim. The blocked-process row is the sharpest of the six: both values sit in the **same row**, one is the XE `@timestamp` and one is an XML attribute, and a blocked process's last transaction started seconds — not four hours — before the report fired, so the −240 is frame skew with no age mixed in.

The arithmetic direction is therefore checked against data, not against the sign in the source. Two of the store columns land in the tests as `−240` with a same-instant fixture pair, so a sign error is eight hours out rather than plausible.

## Every site, its column's frame, and its renderer

Line numbers are post-fix. **Census row** says whether #3220's `DesktopRenderFrameMismatch` inventory carried the site; the seventeen rows it did carry are deleted in this change, and set equality fails in the removing direction, so each deletion is proved by the fix that earned it.

### Darling viewer — naive UTC rendered RAW, four hours late

| site | column → table | frame | was | now | census row |
|---|---|---|---|---|---|
| `ViewerDataService.QueryStore.cs:99` `FirstExecutionTimeLocal` | `first_execution_time` → `query_store_stats` | UTC | `FormatServerClock` | `ViewerTimeHelper.ForDisplay` | deleted |
| `ViewerDataService.QueryStore.cs:104` `LastExecutionTimeLocal` | `last_execution_time` → `query_store_stats` | UTC | `FormatServerClock` | `ForDisplay` | deleted |
| `ViewerDataService.QueryStoreRegressions.cs:68` `LastExecutionTimeLocal` | `last_execution_time` → `query_store_stats` | UTC | `FormatServerClock` | `ForDisplay` | deleted |
| `ViewerHistoryRows.cs:237` `FirstExecutionTimeLocal` | `first_execution_time` → `query_store_stats` | UTC | `FormatServerClock` | `ForDisplay` | deleted |
| `ViewerHistoryRows.cs:241` `LastExecutionTimeLocal` | `last_execution_time` → `query_store_stats` | UTC | `FormatServerClock` | `ForDisplay` | deleted |

`ViewerHistoryRows.cs:106-107` and `:166-167` are the `query_stats` and `procedure_stats` history rows in the same file, on same-named columns, and they are **correct as they stand** — they keep `FormatServerClock`. That is the whole reason the census keys its inventory on the resolved TABLE and not on the column: a fix at one `last_execution_time` site in this file and a regression at another would cancel in a bare count.

### Darling viewer — server-local sent through `ForDisplay`, four hours early

| site | column → table | frame | was | now | census row |
|---|---|---|---|---|---|
| `ViewerDataService.RunningJobs.cs:141` `StartTimeLocal` | `start_time` → `running_jobs` | server-local | `ForDisplay` | `FormatServerClock` | deleted |
| `ViewerDataService.Deadlock.cs:76` `LastTranStartedLocal` | deadlock-graph `lasttranstarted` | server-local | `ForDisplay` | `FormatServerClock` | **none** |
| `ViewerDataService.PlanCorrection.cs:215` `ValidSinceLocal` | `valid_since` → `plan_correction` | server-local | `Local(…)` → `ForDisplay` | `FormatServerClock` | **none** |
| `ViewerDataService.PlanCorrection.cs:216` `LastRefreshLocal` | `last_refresh` → `plan_correction` | server-local | `Local(…)` → `ForDisplay` | `FormatServerClock` | **none** |
| `ViewerDataService.PlanCorrection.cs:217` `ExecuteActionInitiatedTimeLocal` | `execute_action_initiated_time` → `plan_correction` | server-local | `Local(…)` → `ForDisplay` | `FormatServerClock` | **none** |
| `ViewerDataService.PlanCorrection.cs:218` `RevertActionInitiatedTimeLocal` | `revert_action_initiated_time` → `plan_correction` | server-local | `Local(…)` → `ForDisplay` | `FormatServerClock` | **none** |

### Lite — server-local sent through `FormatServerTime`, four hours early

| site | column → table | was | now | census row |
|---|---|---|---|---|
| `LocalDataService.Blocking.cs:1002` `LastTranStartedLocal` | deadlock-graph `lasttranstarted` | `FormatServerTime` | `FormatServerClock` | **none** |
| `LocalDataService.Blocking.cs:1058-1060` `Blocked{LastTranStarted,LastBatchStarted,LastBatchCompleted}Local` | `blocked_process_reports` | `FormatServerTime` | `FormatServerClock` | deleted (3 sites) |
| `LocalDataService.Blocking.cs:1120` `TranStartTimeLocal` | `query_snapshots.tran_start_time` | `FormatServerTime` | `FormatServerClock` | deleted |
| `LocalDataService.PlanCorrection.cs:210-213` | `plan_correction` ×4 | `FormatServerTime` | `FormatServerClock` | deleted (4 sites) |
| `LocalDataService.QueryStats.cs:1480, 1671` `CreationTimeLocal` | `query_stats.creation_time` | `FormatServerTime` | `FormatServerClock` | deleted (1 row / 2 sites) |
| `LocalDataService.QueryStats.cs:1602, 1725` `CachedTime{Formatted,Local}` | `procedure_stats.cached_time` | `FormatServerTime` | `FormatServerClock` | deleted (1 row / 2 sites) |
| `LocalDataService.QueryStats.cs:1479, 1603, 1672, 1726` `LastExecutionTimeLocal` | `procedure_stats` + `query_stats` | `FormatServerTime` | `FormatServerClock` | deleted (1 row / 4 sites) |
| `LocalDataService.RunningJobs.cs:164` `StartTimeLocal` | `running_jobs.start_time` | `DateTime.ToLocalTime()` | `FormatServerClock` | **none** |

`DeadlockTimeLocal` (`deadlocks.deadlock_time`), `EventTimeLocal` (the XE `@timestamp` on both blocking arms) and every `CollectionTimeLocal` keep `FormatServerTime`: they are naive UTC and were already right. Three of the six blocked-process XML stamps — the `Blocking*` half — are read into properties and never bound, so there is no render site to fix; the census lists the three that are.

## Lite had no server-clock renderer, so its columns had nowhere correct to go

`ServerTimeHelper.FormatServerTime` names its parameter `utcTime` and adds the collected offset before converting — it is Lite's `ForDisplay`, not its `FormatServerClock`, and there was no raw renderer at all. `ServerTimeHelper.FormatServerClock` is that renderer. It is not a new conversion: `ConvertForDisplay`'s documented input is already the server's clock, so the new method is `FormatServerTime` with the offset add removed. Exactly one add on the naive-UTC path, none on this one.

It honours the Server / Local / UTC preference, through the existing `ConvertForDisplay`, and that matters rather than being a nicety. #3221's reproduction is in **Local Time** mode on a UTC+02 host against a UTC−05 server, and reports the row rendering at 15:00 where 20:00 is correct. A renderer that emitted the server's clock verbatim would fix Server mode and leave the reporter's own repro rendering 13:00 — a different wrong answer. Lite also prints the mode's timezone label in its status bar (`ServerTab.Refresh.cs:122`), so a raw render under `UTC` would sit under a label saying UTC.

**Darling's same-named `ViewerDataService.FormatServerClock` now honours the mode too**, so the frame fix costs no preference. It did not at first: it emitted the server's own clock in all three modes, so moving `running_jobs.start_time` onto it fixed the frame and dropped the mode, at a site that had respected the user's choice. The review bot caught that, correctly.

It composes out of `ViewerTimeHelper.ConvertToDisplay`'s **existing** arms rather than adding any. The naive-UTC twin of a server-clock value is `serverLocal - offset`, so `ConvertServerClockToDisplay` is one subtraction in front of the conversion already there, and every arm — the machine-local one especially — is reused rather than re-derived. That was checked as arithmetic before it was written: a server-clock value converted for display equals the same instant's naive-UTC value converted for display, in **every** mode.

| mode | a server-clock 14:00 at offset −240, on a UTC+02 host | before |
|---|---|---|
| Server | `14:00` — it is the server's clock | `14:00` |
| UTC | `18:00` | `14:00`, labelled UTC |
| Local | `20:00` | `14:00` |

The pair is now symmetric across the SKUs and the doc comments say so: Darling's `ConvertToDisplay` takes naive UTC so its server-clock conversion subtracts the offset first; Lite's `ConvertForDisplay` takes the server's clock so its naive-UTC renderer adds it. One offset step between the frames, either way round.

**Both modes are pinned**, which the old renderer could not support: with no mode input it was untestable on this axis, and that is how a raw render shipped unnoticed. `ViewerTimeHelperTests.FormatServerClock_HonoursTheDisplayMode_AtTheFleetOffset` asserts the same server-local value rendering `14:00` under Server and `17:45`-shaped under UTC at the fleet's measured −240, and `ViewerClockRendererArithmeticTests` asserts the composition and the non-interchangeability of the two conversions — the latter runs locally, against the shipped `ViewerTimeHelper.cs`.

Seven doc comments that said "renders raw" now say what the code does.

**Lite is untouched.** `ServerTimeHelper` already honours the mode. Its two job-history getters (`RunTimeLocal`, `NextScheduledRunLocal`) show `run_datetime` and `next_scheduled_run` as-is and are documented as deliberately showing "the time SSMS shows"; whether that should change is a product question and stays one, in the queue.

## The comments that made this spread

Four, all corrected with the code, because a comment stating the wrong frame is the mechanism by which one wrong site became several:

- **`ViewerDataService.QueryStoreRegressions.cs:29`** stated the frame outright — *"the SQL server's local wall clock in Darling's store, shown RAW … exactly like the sibling Query Store tab"* — and appealed to a sibling tab as precedent. The renderer follows the column, never the neighbouring grid; that sentence is what turned one site into three.
- **`ViewerHistoryRows.cs:19-22`** lumped Query Store in with the DMVs: *"the DMV / Query Store wall-clock stamps … are the SQL server's own local time"*. True of `query_stats` / `procedure_stats` — whose rows sit in the same file and are correct — and false of `query_store_stats`. The header now says the three row types do not agree and that the store table decides it.
- **`ViewerDataService.ItemHistory.cs:33`** listed `first_execution_time` in the same breath as the DMV stamps. Same error, different file.
- **`ViewerDataService.QuerySnapshots.cs:84-85`** justified the correct Darling site by parity: *"Mirrors Lite's `QuerySnapshotRow.TranStartTimeLocal` (raw server-clock `FormatServerTime`)"*. `FormatServerTime` is not raw. The Darling site was right, the Lite site it claimed to mirror was double-skewed, and the sentence asserting they agreed is what kept the divergence invisible.

Two class summaries in `ViewerDataService.FinOps.cs` (`:337`, `:545`) claimed `LastExecutionTime localized in read` / `LastUserAccess localized in read`. Both reads take the value **verbatim** and say so, with the reason and the contrast against the `collection_time`-derived timestamps in the same port — so the summary asserted a conversion the code deliberately does not perform, on a server-local column, which is the same mechanism as the four above. Both now defer to their read. The coordinator found one; a grep for the phrase finds two, and the second is wrong for the same reason.

Three raw-render getters in `Lite/Services/LocalDataService.JobHistory.cs` show `run_datetime` and `next_scheduled_run` as-is, and only one of the three said so. `RunTimeLocal:235` carried the reasoning ("the time SSMS shows"); `LastSuccessfulRunLocal:240` — `MAX(run_datetime)` over the successful step-0 rows, the same column and the same frame — had nothing at either property or class level, and `NextScheduledRunLocal:322` had it in the class summary only. Both now state it at the property, where a reader checks. **No behaviour changes**: whether Lite should honour the display preference on that grid at all is a product question (Lite is single-server and mirroring SSMS is a coherent choice; Darling is fleet-wide and normalises, which is why it de-skews the same two columns in SQL and says so three times), and it is not settled here.

`ViewerDataService.RunningJobs.cs`'s class doc claimed `start_time` was "the store's naive-UTC start_time"; the collector proves otherwise on the next line of its own query. It now states both frames in the row and what happens if they are crossed.

## The census, and the four sites it could not see

#3220's `DesktopRenderFrameMismatch` label carried **17 rows / 22 sites**, pinned at set equality in both directions. All 17 are deleted here, and the ratchet is what makes the deletions evidence rather than assertion: reverting any one fix while leaving its row behind fails, and reverting any one row while leaving the fix behind fails. The label is now empty, which is a result and not an omission — the scan still fails on a new offender, because a non-empty found set against no rows is a failure.

`DesktopRenderMismatchSites` goes 22 → 0, and `AssertMatchesInventory`'s `Assert.NotEmpty(actual)` had to go with it: it stood in for "the scan actually looked", and an assertion that blocks the fix it exists to prove is worse than none. Reach is asserted per scan instead. The MCP arm keeps an explicit `Assert.NotEmpty(found)` because it still has 33 offenders (#3206's, via #3212), with a note saying it goes when that lane empties its label. The render arm's floor on **sites judged** is now the exact measured baseline of **43** rather than a loose 30, because with no offenders left it is the only thing standing between a crippled matcher and a green census. Calibrated red-first: at 44 with nothing planted the suite fails and reports `only 43 render sites were judged`.

**The four `plan_correction` sites in the Darling viewer are not in the census, and could not have been.** `ValidSinceLocal` and its three siblings reached `ForDisplay` through `PlanCorrectionRow.Local(…)` — a one-hop wrapper — and the render scan keys on the renderer's *name*. A wrapper is a different name reaching the same renderer, so the sites were invisible to a census that calls itself closed. They are real: the register classifies all four columns server-local from `PlanCorrectionCollector`'s own SQL, `sys.dm_db_tuning_recommendations` documents them in the instance's clock, and #3212 is de-skewing the same four on the MCP side.

Two changes close that hole rather than fixing the four instances:

- Each of the four now **names its renderer at the site**, so the existing scan judges them (`judged` 38 → 43, with Lite's running-job start time the fifth addition).
- **`RenderWrappers`** declares the six one-hop wrappers in the two UI trees with the renderer each reaches, pinned at set equality against a derived set, so a new or renamed wrapper fails the build and has to declare its frame. `NoRenderWrapper_IsHandedAColumnEveryTableFramesTheOtherWay` then judges each wrapper's call sites over census columns — per **(file, method)**, because two different wrappers in the Darling viewer are both named `Local` over different frames and a name-keyed scan would judge each one's sites against the other's renderer.

That check's bound is deliberate and stated: **unanimous disagreement only**. Where a column name spans both frames — `event_time` is five tables and two of them — a wrapper site cannot be judged from the name, and the direct-call scan's resolution machinery does not transfer, because a wrapper is not the site of the read and the file it sits in is not the file whose SQL decides the table. Sixteen `event_time` sites through the two `SystemEvents` wrappers are therefore **out of reach rather than cleared**, and the count of sites *examined* is floored (16) with the number of wrappers *reaching* a census column pinned exactly (2) — because with no offenders left, "examined nothing" and "found nothing" are the same result.

Writing that check's both-directions pin found a bug in it. `WrapperSignature` matches a **doc comment quoting a declaration**, and this guard's own file is full of prose about these very methods, so a note would have been derived as a wrapper and failed set equality against the real ones. The derivation strips comments first, and the pin asserts the raw pattern *does* match the quoted form so the strip is visibly load-bearing rather than tidy. No such comment exists today; a planted one turns it red.

## The renderer map's completeness, pinned two ways

`FormatStoredUtc` is ported from #3228 with its doc comment, and it is the right change for a reason different from the one it was asked for. It is the Darling viewer's **named** UTC renderer, beside `FormatServerClock`, so the choice between the pair is reviewable at every site rather than spelled out in a ternary — and picking the wrong one of the pair is silent, since both return a plausible timestamp and they differ by the server's whole offset. The five `query_store_stats` sites take it.

**The stated reason for the port was that the inline ternaries left those sites using no registered renderer, so the scan could not see them. That is not the case, and it is measurable.** `RenderCall` allows an optional receiver and a trailing member access, so `ViewerTimeHelper.ForDisplay(FirstExecutionTime.Value)` matches `\bForDisplay\s*\(\s*(?:[A-Za-z_]\w*\.)?FirstExecutionTime\b`. Renaming ONE of the five ternaries' renderer to an unregistered name drops `judged` from 43 to 42 and reds the floor — so all five were judged before the port, and they are judged after it. Registering `FormatStoredUtc` is what keeps that true, and the sites were never invisible.

**The map's completeness had no criterion, which is the class the guard exists to catch.** Two checks now cover it from different directions:

- **`TheOneHopRenderWrappers_AreExactlyTheDeclaredSet`** derives every ALIAS — a static formatter over a `DateTime` reaching a registered renderer under a different name — and pins the set at equality against `RenderWrappers`. Six today. A new one fails the build and has to declare the frame it renders.
- **`NoUnregisteredRenderCapableMember_IsAppliedToACensusColumn`** asks nothing about signatures. Every identifier applied to a census timestamp column across the render surface is derived — **72 applications, eight distinct names** — and each must be a registered renderer, a declared alias, or declared as not rendering with what it actually is (`if (…HasValue)`, `new DateTime(…Year, …Hour, 0, 0)`, `Nullable.Compare`). Three further directions are asserted: a registered renderer that reaches no census column is a map typo, a stale exemption that no longer appears is an assertion about nothing, and every exemption carries its reasoning.

The two do not subsume each other, and the mutation matrix shows it: an unregistered **instance** method handed a census column is invisible to the shape criterion and caught by the second check alone.

### The walker rewrite that was backed out, and the defect it found

The completeness derivation was first written on `CSharpMemberMap`, the repository's own C# member walker, because a regex over a fixed byte window after a signature is exactly what that walker exists to replace. **It found 3 of the 6 aliases and reported nothing wrong.**

`CSharpMemberMap`'s brace walk closes an expression-bodied member on the `{` of an **`is { }` property pattern**, so `Local`, `Local` and `Timestamp` — whose bodies all begin `utc is { } t ? …` — were read as 68, 74 and 80 characters and did not contain their own `ForDisplay` call. `ShapeOf` returned `WholeMember` for all three. `ViewerHistoryRows.CollectionLocal`, identical in every other respect but with no `is { }`, read whole.

The only reason the shortfall was visible is that the regex derivation had already answered the same question, so there was something to disagree with; written walker-first, it would have pinned a hand list of three and called the map complete. The walker version is backed out, the regex derivation that finds 6 of 6 is kept, and the `CSharpMemberMap` defect is staged for whoever owns that file rather than fixed from here — it is shared infrastructure with its own pins.

## The seven sites with no census row, and how each is covered

The census is derived from `CollectorCatalog.All`'s timestamp columns, so a site it cannot reach needs saying rather than leaving as an unexplained count. Twenty-two of the twenty-nine have rows. The other seven are three distinct kinds:

- **Two are read-time XML** — `ViewerDataService.Deadlock.cs:76` and `LocalDataService.Blocking.cs:1002`. `lasttranstarted` is walked out of the stored `deadlock_graph_xml` by `DeadlockGraphProcessParser` at READ time, so no `CollectorColumn` declares it and no derivation from the catalog can see it. Covered by a doc comment in each SKU stating both frames in the row and why the census cannot reach the pair; a guard for read-time XML provenance is a different shape and #3220 already says so.
- **Four are census columns behind a wrapper** — `ViewerDataService.PlanCorrection.cs:215-218`. The columns are in the register; the render SITE was invisible. Now covered twice: the sites name their renderer so the existing scan judges them, and `RenderWrappers` pins the wrapper set so the next one cannot hide.
- **One is a census column with no renderer at all** — `LocalDataService.RunningJobs.cs:164` was `StartTime.ToLocalTime()`. `running_jobs.start_time` is in the register, but `DateTime.ToLocalTime()` is not one of the three renderers the scan keys on, so the site was outside the judged population. It carried two defects: `ToLocalTime()` on a `Kind=Unspecified` value treats it as UTC when it is msdb Agent's own clock, and it rendered in the Lite host machine's zone regardless of the display preference every other timestamp in the app honours. Now `FormatServerClock`, which fixes both, and the site enters the judged population — which is why the floor moved to 43 rather than 42.

## Verified

Two `net10.0` xunit.v3 harnesses over the shipped sources, since both suites target `net10.0-windows` and cannot run on macOS.

- **`framecheck`** — `ConsumedTimestampFrameDisciplineTests` plus `StoreSqlClockDisciplineTests`, `CollectorTimestampFrameTests`, `DocCommentHygieneTests`, `CommentFilterAdoptionTests` and `TsqlConventionGuardTests`, compiled with `AssemblyName=Darling.Tests`. Baseline before this change `Total: 113, Failed: 0, Skipped: 0, Not Run: 0` — byte-identical to #3220's recorded baseline. After: **`Total: 116, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0`** (three new guards), and **`Total: 117, Failed: 0, Skipped: 0, Not Run: 0`** after merging `origin/dev` in, which brought #3223's additions to `StoreSqlClockDisciplineTests` — the sibling guard this one cross-checks its ambiguous-name register against — and left both green.
- **`clockcheck`** — the two new arithmetic test files compiled against the SHIPPED `ServerTimeHelper.cs`, `ViewerTimeHelper.cs` and `TimeDisplayMode.cs`, linked rather than referenced (neither production file touches WPF, so the real arithmetic runs; a retyped copy would prove the transcription). Baseline **`Total: 21, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0`**.

The two suites cover different halves and neither covers the other's: the census is a SOURCE scan and cannot see inside a renderer's body, while the arithmetic tests know nothing about which site calls which renderer. Both mutation classes below confirm that split rather than assuming it.

The row-getter wiring is not separately tested, deliberately: "this getter calls the wrong renderer" is exactly what the census scan judges, at set equality, over all 43 sites. A per-getter test would be a second, weaker copy of that.

Everything below the frame boundary is CI's: `Lite.Tests` (which is where `ServerClockRendererArithmeticTests` ships) and `Darling.Tests` run on Windows in `build`.

## Red-proof by mutation

Baseline printed above. Forty mutations, each committed first, applied by byte replacement with a uniqueness-checked anchor, verified present **by content and not only by `git diff --numstat`** (several are one-line-for-one-line and report an identical `1 1`), rebuilt, run, restored, and verified restored by content with the tree confirmed clean after every row.

### The fixes, one direction at a time

| mutation | outcome |
|---|---|
| CONTROL: Darling running-job start time back through `ForDisplay` (4h early) | RED — render census |
| CONTROL: Darling Query Store first-execution back to raw (4h late) | RED — render census |
| CONTROL: Darling Query Store *history* last-execution back to raw | RED — render census |
| CONTROL: Darling regressions tab back to raw | RED — render census |
| CONTROL: Lite `creation_time` back through `FormatServerTime` (#3221's own column) | RED — render census |
| CONTROL: Lite blocked-process `last_tran_started` back through `FormatServerTime` | RED — render census |
| CONTROL: Lite `plan_correction.valid_since` back through `FormatServerTime` | RED — render census |
| CONTROL: Lite running-job start time back to `DateTime.ToLocalTime()` | RED — render census (via the judged floor) |
| CONTROL: Darling `plan_correction.valid_since` back behind the `Local()` wrapper | RED — **two** guards: the census AND the new wrapper check |

Both directions of the defect are represented, in both SKUs, and the last row is the shape that was invisible before this change.

### The renderers' arithmetic — which the census structurally cannot see

| mutation | framecheck | clockcheck |
|---|---|---|
| Lite `FormatServerClock` adds the offset again (the original defect, inside the new renderer) | green | **RED, 8 tests** |
| Lite `FormatServerClock` subtracts the offset (sign error, eight hours out) | green | **RED, 8 tests** |
| Lite `FormatServerClock` renders raw, ignoring the display mode (Darling's semantics) | green | **RED, 3 tests** |
| Lite `FormatServerTime` stops adding the offset (the naive-UTC path, broken the other way) | green | **RED, 8 tests** |
| Darling `ViewerTimeHelper`'s Server-mode conversion subtracts the offset (sign error) | green | **RED, 4 tests** |
| INSTRUMENT: the arithmetic harness's own fixture pair is no longer one instant | green | **RED, 6 tests** |

Six rows where `framecheck` stays green and `clockcheck` reds. That is the split stated as a measurement: a source scan over renderer names cannot see a renderer's body, and this is what would have shipped a correctly-paired call to a wrong renderer. The third row is the one that matters for #3221 — a raw renderer passes Server mode and fails Local and UTC, which is exactly the half-fix its reproduction would have caught.

The last row mutates the *instrument*: with the two fixtures no longer one instant, six assertions move, so the same-instant premise is falsifiable rather than decorative.

### The instrument

| mutation | outcome |
|---|---|
| drop `Lite` from the render root list | RED — render census + wrapper set |
| drop `FormatServerClock` from the renderer table | RED |
| drop the optional receiver from `RenderCall` | RED |
| invert the render verdict (`==` for `!=`) | RED — census + the both-directions verdict control |
| `WrapperSignature` accepts only `private` members | RED — wrapper set + the matcher pins |
| a renderer counts as a wrapper of itself | RED — wrapper set |
| widen the wrapper body bound 400 → 6000 | RED — wrapper set |
| point every wrapper offender scan at the wrong file | RED — wrapper check |
| INSTRUMENT: stop stripping comments before deriving wrappers, nothing planted | **GREEN** — see below |
| the same, AND a doc comment quoting a declaration | RED — wrapper set |
| CONTROL: a wrapper called with a census column from a file declaring no wrapper | RED — the cross-file arm |
| NEGATIVE CONTROL: plant a CORRECTLY framed render site | **GREEN** |
| NEGATIVE CONTROL: the same planted correct site with the judged floor at 44 | **GREEN** |
| FLOOR CALIBRATION: judged floor at 44 with nothing planted | RED, reporting `only 43 render sites were judged` |

**The comment-strip pair is one argument.** Removing the strip changes no result today, which is precisely why it needed a mutation that fails without it: planting a doc comment that quotes a declaration turns it red. A bound that only holds for the comments currently in the tree is one note away from not holding, and this guard's own file is full of prose about these very methods.

**The three floor rows are one argument.** A negative control that survives being crippled was never a control, so the floor was calibrated red first: at 44 with nothing planted the suite fails, which fixes the baseline at 43. Planting a *correctly framed* site then makes 44 pass — proving the new site entered the judged population — while the offender set stays empty. Green there is evidence the scan discriminates, not evidence it did not look.

#### The failure this PR's first CI run reported, and what it was right about

`build` and `Darling PostgreSQL tests` both failed on head `d6da0314e`, on the same single test:
`LiveCleanupConversionRatchetTests.NoLiveTestCleansUpOnItsOwnBodysConnection`, naming `ViewerQueriesTests.cs:417`. The mode-blindness pin had been written into `ViewerQueriesTests.cs` with a `try`/`finally` restoring the two process-wide `ViewerTimeHelper` statics. That file also holds a `[Collection("live-postgres")]` class, so the whole file is in that ratchet's population, and a `finally` in it must route through `LiveStoreCleanup`.

The ratchet was right about the file for a reason beyond the one it reports: `ViewerQueriesTests` is in **no** collection, and flipping `CurrentDisplayMode` from there races the three classes that ARE in `[Collection("viewer-time-statics")]`. The pin now lives in `ViewerTimeHelperTests`, which owns those statics and is in that collection, and it gained a control — the naive-UTC renderer in the same viewer must MOVE with the mode, so the mode-blind assertion is about this renderer rather than about a preference nothing honours.

Reproduced and red-proofed locally by adding the ratchet class to `framecheck` (baseline **`Total: 132, Failed: 0, Skipped: 0, Not Run: 0`**): putting a non-store `finally` back into that file turns `NoLiveTestCleansUpOnItsOwnBodysConnection` red, and removing it turns it green. The ratchet had never been in this lane's harness, which is why the shape reached CI.

## Two pins this lane could not exercise locally

Both are the Darling mode-blindness pin, and both are green locally for the same reason: `ViewerTimeHelperTests` reaches `ViewerDataService`, hence the WPF Viewer assembly, so neither `net10.0` harness can compile it.

- Making Darling's `FormatServerClock` honour the display mode — closing the gap the note declines — went **GREEN on both harnesses**.
- Blinding the pin's own control (flipping the mode to the same value twice, so the "it must move" assertion asserts nothing) also went **GREEN**.

Neither is a hole in the guard; both are the limit of what a `net10.0` harness can compile. CI's `build` is the arbiter for `FormatServerClock_IgnoresTheDisplayMode_AtTheFleetOffset`, and that is stated rather than reported as covered.

## Corrections to #3207, #3221 and #3220

**#3207 numbers 9 sites; the census resolves them to 22 plus 7 it cannot reach, and the two counts are not comparable.** Several of #3207's entries name multiple lines (its sites 3, 5 and 7 are two, two and three render sites), and its site 9 is a third mechanism rather than a mis-paired renderer.

**#3207's site 1 cites `ViewerDataService.RunningJobs.cs:117`.** The `ForDisplay(StartTime)` call was at `:135`; #3220 already noted this.

**#3207's fix note says sites 3, 4 and 5 need `ForDisplay` and that Lite's 6, 7, 8 need a raw renderer "which Lite does not have".** Correct on the first count. On the second, "raw" is the wrong shape for Lite: a renderer that emits the server's clock verbatim leaves #3221's own reproduction rendering 13:00 where 20:00 is correct, because that repro is in Local Time mode. Lite's `ConvertForDisplay` already takes the server's clock and honours the mode, so the renderer Lite needed was `FormatServerTime` minus the offset add, not a raw one. #3207's parenthetical "(render raw, no offset add)" reads as those being the same thing; they differ in two of three display modes.

**#3221 lists eight affected columns and gets all eight right**, including the four `last_execution_time` ones, and its row-type attribution (`QueryStatsRow`, `ProcedureStatsRow`, `QueryStatsHistoryRow`, `ProcedureStatsHistoryRow`) matches the file exactly. It is also right that `collection_time` in the same rows is genuinely UTC and correctly formatted, which is what makes each history row visibly mixed-frame. Nothing in it needed correcting.

**#3221's "Confirmed in v3.6.0 source and current `dev`"** holds for the frame defect. Its note that #2987's shared-offset custom-range fix does not change the per-column source-frame mismatch is also right, and the two are independent: #2987 moved which server's offset a window used, this moves whether a column gets the offset at all.

**#3220's body says the census found "Eight render sites #3207 does not list".** Twelve of its rows are outside #3207's list, not eight: the four `plan_correction` stamps and the `creation_time` / `cached_time` pairs are annotated as such, and the four `LocalDataService.QueryStats.cs` `last_execution_time` sites are named in the same section without being counted into the eight. #3220 states the fact and undercounts it in the same paragraph.

**#3220 says two of #3207's sites sit outside the census.** Seven sites sit outside it, of three kinds — the two read-time XML ones it names, the four wrapper-hidden `plan_correction` ones it could not see, and Lite's running-job start time, whose column IS in the register but whose renderer was `DateTime.ToLocalTime()`. The last two kinds are both matcher reach, not catalog reach, which is why they are closed here rather than declared.

## CHANGELOG entry text

Here rather than in `CHANGELOG.md`: every concurrent lane appends to the same `[Unreleased]` block, so a per-PR edit turns one clean append into as many conflicting ones as there are lanes landing after it.

### Fixed
- Desktop timestamp columns were rendered in the wrong clock frame in both SKUs, in opposite directions, with each SKU correct exactly where the other was wrong. A column holding the monitored server's own wall clock — `sys.dm_exec_*` creation / cache / last-execution stamps, `plan_correction`'s recommendation and action stamps, the blocked-process report's transaction and batch attributes, `query_snapshots.tran_start_time`, msdb Agent's job start time and the deadlock graph's `lasttranstarted` — was sent through the renderer that adds the collected UTC offset, displaying it four hours early on a fleet at UTC-4; and Query Store's first- and last-execution stamps, which the collector normalises to UTC, were rendered raw and displayed four hours late. Each of twenty-nine render sites now takes the renderer matching its column's frame, and Lite gains `ServerTimeHelper.FormatServerClock` for the frame it had no renderer for, so a server-clock value converts exactly once and still honours the Server / Local / UTC display preference (#3207, #3221).
- Four doc comments stated a column's clock frame incorrectly, one of them appealing to a sibling tab as precedent and one asserting a cross-SKU parity that did not hold; they are the reason one wrong site became several, and each now states the frame the code uses (#3207).

### Added
- The clock-frame census now sees a renderer reached through a one-hop wrapper. Four server-local `plan_correction` stamps in the Darling viewer were in the wrong frame and invisible to it, because the render scan keys on the renderer's name and a wrapper is a different name reaching the same renderer. The wrapper set is derived and pinned at set equality, so a new one must declare the frame it renders, and no wrapper may be handed a column every table declaring it frames the other way (#3207).
