### PR TITLE
Render every desktop timestamp through the renderer for its own clock frame (#3207)

### DIFF
--- a/Darling/Darling.Tests/ConsumedTimestampFrameDisciplineTests.cs
+++ b/Darling/Darling.Tests/ConsumedTimestampFrameDisciplineTests.cs
@@ -698,15 +698,26 @@ public sealed class ConsumedTimestampFrameDisciplineTests
     private static readonly Regex ProjectionAlias =
         new(@"([^\r\n]*?)\s+AS\s+([a-z][a-z0-9_]*)(?![\w])", RegexOptions.IgnoreCase);
 
-    /// <summary>The two WPF renderers that ADD the collected offset — i.e. that take naive UTC — and the
-    /// one that renders raw, i.e. that takes the server's own clock. <c>FormatServerTime</c> is Lite's
-    /// <c>ForDisplay</c>, not its <c>FormatServerClock</c>: it adds the offset and names its parameter
-    /// <c>utcTime</c>. Lite has no raw renderer at all, which is why a comment in the Darling viewer
-    /// claiming parity with it is wrong in the direction that hid this.</summary>
+    /// <summary>
+    /// Every WPF renderer, with the frame its input has to be in. <c>ForDisplay</c> and Lite's
+    /// <c>FormatServerTime</c> ADD the collected offset, so they take naive UTC — <c>FormatServerTime</c> is
+    /// Lite's <c>ForDisplay</c>, not its <c>FormatServerClock</c>, and it names its parameter
+    /// <c>utcTime</c>. <c>FormatServerClock</c> takes the server's own clock.
+    ///
+    /// <para>#3207 changed two things here. Lite had NO raw renderer, which is why sixteen of its sites
+    /// pushed a server-local value through <c>FormatServerTime</c> and why a comment in the Darling viewer
+    /// claiming parity with it was wrong in the direction that hid this; Lite now has
+    /// <c>ServerTimeHelper.FormatServerClock</c>, matching the name already listed here. And
+    /// <c>FormatStoredUtc</c> is new on the Darling side: the five <c>query_store_stats</c> sites had no
+    /// honest way to say "this column is UTC" and reached for the raw renderer instead. It is registered
+    /// rather than left out so those sites stay checkable — an unlisted renderer is invisible to this scan,
+    /// which would have silently dropped five sites out of the census as the price of fixing them.</para>
+    /// </summary>
     private static readonly (string Renderer, ClockFrame Expects)[] Renderers =
     [
         ("ForDisplay", ClockFrame.Utc),
         ("FormatServerTime", ClockFrame.Utc),
+        ("FormatStoredUtc", ClockFrame.Utc),
         ("FormatServerClock", ClockFrame.ServerLocal),
     ];
 
@@ -831,70 +842,10 @@ public sealed class ConsumedTimestampFrameDisciplineTests
             + "buckets the de-skewed value, so the emitted expression is the bucket key"),
 
         /* ── desktop renders: the column's frame against the renderer's (#3207) ── */
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs",
-            "first_execution_time", "query_store_stats", 1,
-            "naive UTC rendered RAW, so four hours late; Lite gets this one right"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs",
-            "last_execution_time", "query_store_stats", 1, "naive UTC rendered RAW, so four hours late"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs",
-            "last_execution_time", "query_store_stats", 1,
-            "naive UTC rendered RAW; the doc at :29 states the wrong frame outright and appeals to the "
-            + "sibling Query Store tab, which is how one wrong site became three"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs",
-            "start_time", "running_jobs", 1,
-            "server-local through ForDisplay, so four hours EARLY, beside a CollectionTimeLocal that is right"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs",
-            "first_execution_time", "query_store_stats", 1,
-            "the file header lumps Query Store in with the DMVs; true of query_stats/procedure_stats in the "
-            + "same file, false of query_store_stats"),
-        (SiteLabel.DesktopRenderFrameMismatch,
-            "Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs",
-            "last_execution_time", "query_store_stats", 1,
-            "same file, same header; the query_stats and procedure_stats rows beside it are correct, which "
-            + "is why the Tables column is part of this key"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.Blocking.cs",
-            "blocked_last_tran_started", "blocked_process_reports+dmv_blocking_snapshots", 1,
-            "server-local through FormatServerTime, which adds the offset again; EventTimeLocal in the same "
-            + "class is correct"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.Blocking.cs",
-            "blocked_last_batch_started", "blocked_process_reports", 1, "server-local through FormatServerTime"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.Blocking.cs",
-            "blocked_last_batch_completed", "blocked_process_reports", 1, "server-local through FormatServerTime"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.Blocking.cs",
-            "tran_start_time", "query_snapshots", 1,
-            "server-local through FormatServerTime; Darling renders the same column through FormatServerClock "
-            + "and its comment claims the two agree"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.PlanCorrection.cs",
-            "valid_since", "plan_correction", 1,
-            "server-local through FormatServerTime; not in #3207's list, found by deriving the census"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.PlanCorrection.cs",
-            "last_refresh", "plan_correction", 1, "server-local through FormatServerTime; not in #3207's list"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.PlanCorrection.cs",
-            "execute_action_initiated_time", "plan_correction", 1,
-            "server-local through FormatServerTime; not in #3207's list"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.PlanCorrection.cs",
-            "revert_action_initiated_time", "plan_correction", 1,
-            "server-local through FormatServerTime; not in #3207's list"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.QueryStats.cs",
-            "creation_time", "query_stats", 2,
-            "server-local through FormatServerTime, in two row types; the Lite read de-skews only the WINDOW "
-            + "BOUND ($2 + $5 * INTERVAL '1' MINUTE) and returns the raw local value, which is #3198's "
-            + "half-fix shape. Darling renders the same column through FormatServerClock"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.QueryStats.cs",
-            "cached_time", "procedure_stats", 2, "server-local through FormatServerTime; not in #3207's list"),
-        (SiteLabel.DesktopRenderFrameMismatch, "Lite/Services/LocalDataService.QueryStats.cs",
-            "last_execution_time", "procedure_stats+query_stats", 4,
-            "server-local through FormatServerTime in four row types; both tables agree on the frame, so the "
-            + "ambiguous NAME resolves here even though it does not in general"),
     ];
 
     private const int McpPayloadUnmarkedSites = 33;
-    private const int DesktopRenderMismatchSites = 22;
+    private const int DesktopRenderMismatchSites = 0;
     private const int DeSkewedAtReadSites = 2;
 
     /* ═══════════════════════ 5. resolving which table a site's column came from ═══════════════════════ */

--- a/Darling/Darling.Tests/ConsumedTimestampFrameDisciplineTests.cs
+++ b/Darling/Darling.Tests/ConsumedTimestampFrameDisciplineTests.cs
@@ -1240,7 +1240,19 @@ public sealed class ConsumedTimestampFrameDisciplineTests
             DeclinedAmbiguousRenderSites.OrderBy(d => d, StringComparer.Ordinal).ToArray(),
             declined.OrderBy(d => d, StringComparer.Ordinal).ToArray());
 
-        AssertMatchesInventory(found, [SiteLabel.DesktopRenderFrameMismatch]);
+        /* Set equality against the inventory, spelled out here rather than through AssertMatchesInventory,
+           because that helper asserts the found set is NOT empty and #3207 fixed every render site — the
+           inventory carries no DesktopRenderFrameMismatch rows now, so the correct found set IS empty.
+           Vacuity is already excluded, and more strongly than NotEmpty manages: `judged` above counts the
+           sites this scan LOOKED AT, so a matcher that stopped recognising the renderers fails on the floor
+           instead of reporting a clean bill. The ratchet survives intact in the direction that matters — a
+           reintroduced mismatch lands in `found`, is absent from the inventory, and reds here. */
+        Assert.Equal(
+            Inventory.Where(i => i.Label == SiteLabel.DesktopRenderFrameMismatch)
+                .Select(i => $"{i.File} | {i.Column} | {i.Tables} | {i.Sites}")
+                .OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+            found.Select(x => $"{x.Key.File} | {x.Key.Column} | {x.Key.Tables} | {x.Value}")
+                .OrderBy(x => x, StringComparer.Ordinal).ToArray());
     }
 
     /// <summary>
@@ -1414,11 +1426,16 @@ public sealed class ConsumedTimestampFrameDisciplineTests
             "last_user_access",
             ProjectionAlias.Match("    GREATEST(last_user_seek, last_user_scan) AS last_user_access,").Groups[2].Value);
 
-        /* And the two renderer families are distinguished, not merged: three names, two expectations. */
-        Assert.Equal(3, Renderers.Length);
+        /* And the two renderer families are distinguished, not merged: four names, two expectations. Three
+           take naive UTC and one takes the server's own clock; #3207 added FormatStoredUtc to the UTC side,
+           and registering it is what keeps its five sites visible to this scan rather than dropping them out
+           of the census as the price of fixing them. */
+        Assert.Equal(4, Renderers.Length);
         Assert.Equal(2, Renderers.Select(r => r.Expects).Distinct().Count());
         Assert.Equal(ClockFrame.ServerLocal, Renderers.Single(r => r.Renderer == "FormatServerClock").Expects);
         Assert.Equal(ClockFrame.Utc, Renderers.Single(r => r.Renderer == "FormatServerTime").Expects);
+        Assert.Equal(ClockFrame.Utc, Renderers.Single(r => r.Renderer == "FormatStoredUtc").Expects);
+        Assert.Single(Renderers.Where(r => r.Expects == ClockFrame.ServerLocal));
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
@@ -63,8 +63,11 @@ public sealed class DeadlockProcessDetail : DeadlockProcessInfo
         => DeadlockTime is { } t ? ViewerTimeHelper.ForDisplay(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
     public string VictimDisplay => IsVictim ? "Victim" : "";
     public string WaitTimeFormatted => WaitTime > 0 ? $"{WaitTime:N0} ms" : "";
-    public string LastTranStartedLocal
-        => LastTranStarted is { } t ? ViewerTimeHelper.ForDisplay(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
+    /// <summary>The transaction start parsed out of the deadlock graph's <c>lasttranstarted</c> attribute,
+    /// which SQL Server writes in the monitored server's LOCAL clock — so it renders raw, unlike
+    /// <see cref="DeadlockTimeLocal"/> above, whose <c>deadlock_time</c> is the XE <c>@timestamp</c> and is
+    /// naive UTC. Two frames, two renderers, one class (#3207).</summary>
+    public string LastTranStartedLocal => ViewerDataService.FormatServerClock(LastTranStarted);
 
     /// <summary>
     /// Parses a list of <see cref="ViewerDeadlockRow"/> into per-process detail rows via the shared

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
@@ -80,11 +80,18 @@ public sealed class ViewerQuerySnapshotRow
     public string CollectionTimeLocal =>
         CollectionTime == DateTime.MinValue ? "" : ViewerTimeHelper.ForDisplay(CollectionTime).ToString("yyyy-MM-dd HH:mm:ss");
 
-    /// <summary>The transaction begin time, empty when the request has no open transaction. Mirrors Lite's
-    /// <c>QuerySnapshotRow.TranStartTimeLocal</c> (raw server-clock <c>FormatServerTime</c>):
-    /// transaction_begin_time from sys.dm_tran_active_transactions is a SQL-server-local wall-clock time (NOT
-    /// naive UTC), so it renders raw via <see cref="ViewerDataService.FormatServerClock"/> like the other
-    /// dm_exec_* times (last_execution_time / cached_time), NOT through the UTC-converting ForDisplay.</summary>
+    /// <summary>The transaction begin time, empty when the request has no open transaction.
+    /// <c>transaction_begin_time</c> from <c>sys.dm_tran_active_transactions</c> is a SQL-server-local
+    /// wall-clock time (NOT naive UTC), so it renders raw via
+    /// <see cref="ViewerDataService.FormatServerClock"/> like the other <c>dm_exec_*</c> times
+    /// (last_execution_time / cached_time), NOT through the UTC-converting <c>ForDisplay</c>.
+    ///
+    /// <para>This used to claim parity with Lite's <c>QuerySnapshotRow.TranStartTimeLocal</c>, calling its
+    /// <c>FormatServerTime</c> a "raw server-clock" renderer. It is not — it ADDS the collected offset and
+    /// names its parameter <c>utcTime</c> — so Lite's site was double-skewing while this comment asserted
+    /// the two agreed, which is the direction that hid it. #3207 gave Lite a real raw renderer
+    /// (<c>ServerTimeHelper.FormatServerClock</c>) and moved its site onto it, so the two SKUs now do
+    /// agree.</para></summary>
     public string TranStartTimeLocal => ViewerDataService.FormatServerClock(TranStartTime);
 }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
@@ -602,6 +602,25 @@ public sealed partial class ViewerDataService
         => serverLocal.HasValue ? serverLocal.Value.ToString("yyyy-MM-dd HH:mm:ss") : "";
 
     /// <summary>
+    /// Renders a STORED naive-UTC timestamp in the current display mode — the counterpart to
+    /// <see cref="FormatServerClock"/>, which renders a value that is already the monitored server's own
+    /// clock. Named for the frame it takes rather than for what it does, because picking the wrong one of
+    /// the pair is silent: both return a plausible timestamp and they differ by the server's whole offset,
+    /// four hours on the production fleet's measured -240.
+    ///
+    /// <para>#3207 added this because five sites had no honest way to say "this column is UTC" and reached
+    /// for <see cref="FormatServerClock"/> instead — <c>query_store_stats</c>' first- and last-execution
+    /// times, which Query Store returns as <c>datetimeoffset</c> and <c>QueryStoreCollector</c> normalises
+    /// through <c>DateTimeOffset.UtcDateTime</c>. Inlining
+    /// <c>ViewerTimeHelper.ForDisplay(x).ToString(...)</c> would work identically; a named method beside its
+    /// opposite is what makes the choice reviewable.</para>
+    /// </summary>
+    public static string FormatStoredUtc(DateTime? naiveUtc)
+        => naiveUtc.HasValue
+            ? ViewerTimeHelper.ForDisplay(naiveUtc.Value).ToString("yyyy-MM-dd HH:mm:ss")
+            : "";
+
+    /// <summary>
     /// Collapses whitespace runs (query text arrives with its original formatting) to a single
     /// space and caps at <see cref="CellTextCap"/> with an ellipsis — the one-line grid preview.
     /// </summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
@@ -91,8 +91,8 @@ public sealed class ViewerQueryStoreRow
     public double AvgNumPhysicalIoReads { get; set; }
     public double MinNumPhysicalIoReads { get; set; }
     public double MaxNumPhysicalIoReads { get; set; }
-    public string FirstExecutionTimeLocal => ViewerDataService.FormatServerClock(FirstExecutionTime);
-    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+    public string FirstExecutionTimeLocal => ViewerDataService.FormatStoredUtc(FirstExecutionTime);
+    public string LastExecutionTimeLocal => ViewerDataService.FormatStoredUtc(LastExecutionTime);
     public double TotalCpuMs => TotalExecutions * AvgCpuTimeMs;
     public double TotalDurationMs => TotalExecutions * AvgDurationMs;
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
@@ -25,9 +25,12 @@ namespace PerformanceMonitor.Darling.Viewer;
 ///
 /// <para>Metric values are ms (duration/CPU, converted from µs in SQL) and raw pages (reads); the percents
 /// are plain deltas the grid formats to N2%. <see cref="LastExecutionTime"/> is the Query Store row's
-/// last-exec column (the SQL server's local wall clock in Darling's store), shown RAW via
-/// <see cref="ViewerDataService.FormatServerClock"/> exactly like the sibling Query Store tab — NOT run
-/// through the naive-UTC→local conversion the collection_time columns get. The regression read carries no
+/// last-exec column, and it is naive UTC in Darling's store — Query Store returns
+/// <c>datetimeoffset</c> and <c>QueryStoreCollector</c> normalises through
+/// <c>DateTimeOffset.UtcDateTime</c> before storing — so it converts through
+/// <see cref="ViewerDataService.FormatStoredUtc"/> like the collection_time columns, NOT raw. #3207: it was
+/// rendered raw here and on the sibling Query Store tab, four hours LATE on the fleet's measured -240, and
+/// the appeal to that sibling is how one wrong site became three. The regression read carries no
 /// plan XML (the Dashboard TVF selects none either), so — like the sibling Query Store tab (View-Plan
 /// deferred) — there is no plan surface; double-clicking a row opens that query's history window instead
 /// (mirroring the Dashboard grid's double-click).</para>
@@ -60,8 +63,8 @@ public sealed class ViewerQueryStoreRegressionRow
     public bool CanGetActualPlan => QueryId != 0;
     public DateTime? LastExecutionTime { get; set; }
 
-    /// <summary>The last-execution wall clock shown raw (the sibling Query Store tab's convention).</summary>
-    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+    /// <summary>The last-execution time, converted from the store's naive UTC to the display mode.</summary>
+    public string LastExecutionTimeLocal => ViewerDataService.FormatStoredUtc(LastExecutionTime);
 }
 
 public sealed partial class ViewerDataService

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
@@ -113,10 +113,12 @@ public sealed partial class ViewerDataService
 /// <summary>
 /// One row of the Running Jobs grid — a currently-running SQL Agent job with its historical duration
 /// comparison. Copied VERBATIM from Lite's <c>RunningJobRow</c> (LocalDataService.RunningJobs.cs): the
-/// duration/percent/running-long display columns are all collector-side computations, and
-/// <see cref="StartTimeLocal"/> routes the store's naive-UTC start_time through
-/// <see cref="ViewerTimeHelper.ForDisplay"/> — the viewer's mode-aware Server/Local/UTC conversion every
-/// other Darling timestamp also uses.
+/// duration/percent/running-long display columns are all collector-side computations.
+/// <see cref="StartTimeLocal"/> renders <c>start_time</c> raw through
+/// <see cref="ViewerDataService.FormatServerClock"/>: it is the msdb Agent's LOCAL wall clock, not naive
+/// UTC — <c>RunningJobsCollector</c> ships <c>ja.start_execution_date</c> verbatim and measures duration
+/// against <c>GETDATE()</c> — so #3207 stopped it going through <c>ForDisplay</c>, which subtracts the
+/// offset a second time and showed a job four hours before it started on the fleet's measured -240.
 /// </summary>
 public class RunningJobRow
 {
@@ -132,7 +134,7 @@ public class RunningJobRow
     public bool IsRunningLong { get; set; }
     public decimal? PercentOfAverage { get; set; }
 
-    public string StartTimeLocal => ViewerTimeHelper.ForDisplay(StartTime).ToString("yyyy-MM-dd HH:mm:ss");
+    public string StartTimeLocal => ViewerDataService.FormatServerClock(StartTime);
 
     public string CurrentDurationFormatted => FormatDuration(CurrentDurationSeconds);
     public string AvgDurationFormatted => FormatDuration(AvgDurationSeconds);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
@@ -16,10 +16,12 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// (LocalDataService.QueryStats.cs / .QueryStore.cs). Numeric members stay in the store's units (microseconds
 /// for CPU/duration, KB for grants); the display properties convert, mirroring Lite's grid + metric chart.
 /// The one viewer adaptation is time display: <see cref="CollectionTime"/> is the collector's naive-UTC
-/// capture time and routes through <see cref="ViewerTimeHelper.ForDisplay"/>, while the DMV / Query Store
-/// wall-clock stamps (creation / last-execution / cached / first-execution) are the SQL server's own local
-/// time and render raw through <see cref="ViewerDataService.FormatServerClock"/> — the same split every other
-/// viewer query row uses (see <see cref="ViewerQueryStatsRow"/>).
+/// capture time and routes through <see cref="ViewerTimeHelper.ForDisplay"/>. The DMV wall-clock stamps
+/// (creation / cached / last-execution on <c>query_stats</c> and <c>procedure_stats</c>) are the SQL
+/// server's own local time and render raw through <see cref="ViewerDataService.FormatServerClock"/>.
+/// <c>query_store_stats</c>' first- and last-execution times are NOT in that group, which is what #3207
+/// corrected here: Query Store returns <c>datetimeoffset</c> and the collector normalises it to UTC, so
+/// those two convert through <see cref="ViewerDataService.FormatStoredUtc"/>.
 /// </summary>
 internal static class HistoryTime
 {
@@ -224,6 +226,6 @@ public sealed class ViewerQueryStoreHistoryRow
     public double TotalDurationMs => ExecutionCount * AvgDurationMs;
     public double TotalCpuMs => ExecutionCount * AvgCpuTimeMs;
     public string CollectionTimeLocal => HistoryTime.CollectionLocal(CollectionTime);
-    public string FirstExecutionTimeLocal => ViewerDataService.FormatServerClock(FirstExecutionTime);
-    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+    public string FirstExecutionTimeLocal => ViewerDataService.FormatStoredUtc(FirstExecutionTime);
+    public string LastExecutionTimeLocal => ViewerDataService.FormatStoredUtc(LastExecutionTime);
 }

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -990,7 +990,7 @@ public class DeadlockProcessDetail : DeadlockProcessInfo
     public string DeadlockTimeLocal => ServerTimeHelper.FormatServerTime(DeadlockTime);
     public string VictimDisplay => IsVictim ? "Victim" : "";
     public string WaitTimeFormatted => WaitTime > 0 ? $"{WaitTime:N0} ms" : "";
-    public string LastTranStartedLocal => ServerTimeHelper.FormatServerTime(LastTranStarted);
+    public string LastTranStartedLocal => ServerTimeHelper.FormatServerClock(LastTranStarted);
 
     /// <summary>
     /// Parses a list of <see cref="DeadlockRow"/> into per-process detail rows via the shared
@@ -1043,9 +1043,9 @@ public class BlockedProcessReportRow : BlockedProcessAlertRow
     public string EventTimeLocal => ServerTimeHelper.FormatServerTime(EventTime);
     public string WaitTimeFormatted => WaitTimeMs < 1000 ? $"{WaitTimeMs} ms" : $"{WaitTimeMs / 1000.0:F1} sec";
     public bool IsLongBlock => WaitTimeMs > 30000;
-    public string BlockedLastTranStartedLocal => ServerTimeHelper.FormatServerTime(BlockedLastTranStarted);
-    public string BlockedLastBatchStartedLocal => ServerTimeHelper.FormatServerTime(BlockedLastBatchStarted);
-    public string BlockedLastBatchCompletedLocal => ServerTimeHelper.FormatServerTime(BlockedLastBatchCompleted);
+    public string BlockedLastTranStartedLocal => ServerTimeHelper.FormatServerClock(BlockedLastTranStarted);
+    public string BlockedLastBatchStartedLocal => ServerTimeHelper.FormatServerClock(BlockedLastBatchStarted);
+    public string BlockedLastBatchCompletedLocal => ServerTimeHelper.FormatServerClock(BlockedLastBatchCompleted);
 }
 
 public class QuerySnapshotRow
@@ -1100,7 +1100,7 @@ public class QuerySnapshotRow
     public double TranLogUsedMb { get; set; }
     public DateTime? TranStartTime { get; set; }
     public int RequestId { get; set; }
-    public string TranStartTimeLocal => ServerTimeHelper.FormatServerTime(TranStartTime);
+    public string TranStartTimeLocal => ServerTimeHelper.FormatServerClock(TranStartTime);
 
     // Chain mode — set by WaitDrillDownWindow when showing head blockers
     public string ChainBlockingPath { get; set; } = "";

--- a/Lite/Services/LocalDataService.PlanCorrection.cs
+++ b/Lite/Services/LocalDataService.PlanCorrection.cs
@@ -203,10 +203,10 @@ public class PlanCorrectionRow
     public string ImplementationScript { get; set; } = "";
 
     public string CollectionTimeLocal => ServerTimeHelper.FormatServerTime(CollectionTime);
-    public string ValidSinceLocal => ServerTimeHelper.FormatServerTime(ValidSince);
-    public string LastRefreshLocal => ServerTimeHelper.FormatServerTime(LastRefresh);
-    public string ExecuteActionInitiatedTimeLocal => ServerTimeHelper.FormatServerTime(ExecuteActionInitiatedTime);
-    public string RevertActionInitiatedTimeLocal => ServerTimeHelper.FormatServerTime(RevertActionInitiatedTime);
+    public string ValidSinceLocal => ServerTimeHelper.FormatServerClock(ValidSince);
+    public string LastRefreshLocal => ServerTimeHelper.FormatServerClock(LastRefresh);
+    public string ExecuteActionInitiatedTimeLocal => ServerTimeHelper.FormatServerClock(ExecuteActionInitiatedTime);
+    public string RevertActionInitiatedTimeLocal => ServerTimeHelper.FormatServerClock(RevertActionInitiatedTime);
 
     /* Tri-state: the flags are NULL when Query Store aged the plan out, which is not the same as "No". */
     public string ForcedDisplay => YesNo(LastGoodPlanIsForced);

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -1476,8 +1476,8 @@ public class QueryStatsRow
     public string QueryHash { get; set; } = "";
     public DateTime? LastExecutionTime { get; set; }
     public DateTime? CreationTime { get; set; }
-    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerTime(LastExecutionTime);
-    public string CreationTimeLocal => Services.ServerTimeHelper.FormatServerTime(CreationTime);
+    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerClock(LastExecutionTime);
+    public string CreationTimeLocal => Services.ServerTimeHelper.FormatServerClock(CreationTime);
     public long TotalExecutions { get; set; }
     public long TotalCpuUs { get; set; }
     public long TotalElapsedUs { get; set; }
@@ -1599,8 +1599,8 @@ public class ProcedureStatsRow
     public double MaxCpuMs => MaxWorkerTimeUs / 1000.0;
     public double MinElapsedMs => MinElapsedTimeUs / 1000.0;
     public double MaxElapsedMs => MaxElapsedTimeUs / 1000.0;
-    public string CachedTimeFormatted => Services.ServerTimeHelper.FormatServerTime(CachedTime);
-    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerTime(LastExecutionTime);
+    public string CachedTimeFormatted => Services.ServerTimeHelper.FormatServerClock(CachedTime);
+    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerClock(LastExecutionTime);
 }
 
 public class QueryStatsHistoryRow
@@ -1668,8 +1668,8 @@ public class QueryStatsHistoryRow
     public double TotalCpuMs => TotalCpuUs / 1000.0;
     public double TotalElapsedMs => TotalElapsedUs / 1000.0;
     public string CollectionTimeLocal => ServerTimeHelper.FormatServerTime(CollectionTime);
-    public string CreationTimeLocal => ServerTimeHelper.FormatServerTime(CreationTime);
-    public string LastExecutionTimeLocal => ServerTimeHelper.FormatServerTime(LastExecutionTime);
+    public string CreationTimeLocal => ServerTimeHelper.FormatServerClock(CreationTime);
+    public string LastExecutionTimeLocal => ServerTimeHelper.FormatServerClock(LastExecutionTime);
 }
 
 public class ProcedureStatsHistoryRow
@@ -1722,6 +1722,6 @@ public class ProcedureStatsHistoryRow
     public double TotalCpuMs => TotalCpuUs / 1000.0;
     public double TotalElapsedMs => TotalElapsedUs / 1000.0;
     public string CollectionTimeLocal => ServerTimeHelper.FormatServerTime(CollectionTime);
-    public string CachedTimeLocal => ServerTimeHelper.FormatServerTime(CachedTime);
-    public string LastExecutionTimeLocal => ServerTimeHelper.FormatServerTime(LastExecutionTime);
+    public string CachedTimeLocal => ServerTimeHelper.FormatServerClock(CachedTime);
+    public string LastExecutionTimeLocal => ServerTimeHelper.FormatServerClock(LastExecutionTime);
 }

--- a/Lite/Services/LocalDataService.RunningJobs.cs
+++ b/Lite/Services/LocalDataService.RunningJobs.cs
@@ -155,7 +155,7 @@ public class RunningJobRow
     public bool IsRunningLong { get; set; }
     public decimal? PercentOfAverage { get; set; }
 
-    public string StartTimeLocal => StartTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+    public string StartTimeLocal => ServerTimeHelper.FormatServerClock(StartTime);
 
     public string CurrentDurationFormatted => FormatDuration(CurrentDurationSeconds);
     public string AvgDurationFormatted => FormatDuration(AvgDurationSeconds);

--- a/Lite/Services/ServerTimeHelper.cs
+++ b/Lite/Services/ServerTimeHelper.cs
@@ -106,4 +106,32 @@ public static class ServerTimeHelper
 
     public static string FormatServerTime(DateTime? utcTime, string format = "yyyy-MM-dd HH:mm:ss")
         => utcTime.HasValue ? ConvertForDisplay(utcTime.Value.AddMinutes(_utcOffsetMinutes), CurrentDisplayMode).ToString(format) : "";
+
+    /// <summary>
+    /// Renders a value that is ALREADY the monitored server's local wall clock — a DMV or XML timestamp the
+    /// collector shipped verbatim — in the current display mode. The counterpart to
+    /// <see cref="FormatServerTime(DateTime, string)"/>, which takes naive UTC and adds the offset to reach
+    /// the server's clock; this one is already there, so it only converts OUT.
+    ///
+    /// <para><b>Why Lite needed a second renderer.</b> <c>FormatServerTime</c> names its parameter
+    /// <c>utcTime</c> and adds the offset unconditionally, so handing it a server-local value adds the
+    /// offset a second time and displays one whole offset EARLY — four hours on the production fleet's
+    /// measured -240. Sixteen render sites did exactly that (#3207), because Lite had no way to say "this
+    /// value is already on the server's clock". The Darling viewer has had that distinction since it split
+    /// <c>ViewerTimeHelper.ForDisplay</c> from <c>ViewerDataService.FormatServerClock</c>; this closes the
+    /// gap, and a doc comment in <c>ViewerDataService.QuerySnapshots</c> that claimed the two SKUs already
+    /// agreed is corrected with it.</para>
+    ///
+    /// <para><b>It is mode-aware, unlike Darling's namesake.</b> Darling's <c>FormatServerClock</c> renders
+    /// literally raw and so shows the server's clock even under UTC display mode. Routing through
+    /// <see cref="ConvertForDisplay"/> instead honours the user's Server/Local/UTC choice for these columns
+    /// the way every other Lite timestamp does, which is the behaviour the setting promises.</para>
+    /// </summary>
+    public static string FormatServerClock(DateTime serverLocalTime, string format = "yyyy-MM-dd HH:mm:ss")
+        => ConvertForDisplay(serverLocalTime, CurrentDisplayMode).ToString(format);
+
+    /// <summary>As <see cref="FormatServerClock(DateTime, string)"/>, empty for a value the collector did
+    /// not capture.</summary>
+    public static string FormatServerClock(DateTime? serverLocalTime, string format = "yyyy-MM-dd HH:mm:ss")
+        => serverLocalTime.HasValue ? FormatServerClock(serverLocalTime.Value, format) : "";
 }


### PR DESCRIPTION
Fixes #3207.

Twenty-four desktop render sites across both SKUs rendered a timestamp through the renderer built for the **other** clock frame. Both directions were live and both are silent — the wrong renderer returns a plausible timestamp, off by the server's whole offset:

- a **server-local** value through `ForDisplay` / `FormatServerTime` subtracts the offset a second time and displays **4 hours early** on the fleet's measured −240;
- a **naive-UTC** value through `FormatServerClock` displays **4 hours late**.

## Root cause: each SKU was missing one half of the pair

**Lite had no raw renderer at all.** `ServerTimeHelper.FormatServerTime` *is* Lite's `ForDisplay` — it adds the offset unconditionally and names its parameter `utcTime` — so there was no way to say "this value is already on the server's clock". Sixteen sites therefore pushed server-local DMV and XML values through it. `ServerTimeHelper.FormatServerClock` supplies the missing half, and unlike Darling's namesake it routes through `ConvertForDisplay`, so these columns now honour the user's Server/Local/UTC choice like every other Lite timestamp rather than ignoring it.

**Darling had no way to say "this column is UTC" in a display property.** Five `query_store_stats` sites reached for the raw renderer instead. `ViewerDataService.FormatStoredUtc` is now the named counterpart to `FormatServerClock` — Query Store returns `datetimeoffset` and `QueryStoreCollector` normalises through `DateTimeOffset.UtcDateTime`, so those five are UTC. The sixth Darling site goes the other way: `running_jobs.start_time` is the msdb Agent's clock (`RunningJobsCollector` ships `ja.start_execution_date` verbatim and measures duration against `GETDATE()`), so it moves off `ForDisplay` onto `FormatServerClock`.

Inlining `ViewerTimeHelper.ForDisplay(x).ToString(...)` would behave identically; a named method beside its opposite is what makes the choice reviewable, which is the whole failure mode here.

## Two sites #3220's census structurally cannot see

Found by hand, and worth naming because they show the guard's reach rather than a gap in its care:

- **the deadlock graph's `lasttranstarted`** (`ViewerDataService.Deadlock.cs`) — parsed from XML into `DeadlockProcessInfo`, with no store column of that name for the frame register to resolve. `DeadlockTimeLocal` two lines above is the XE `@timestamp` and correctly stays on `ForDisplay`: two frames, two renderers, one class.
- **Lite's `RunningJobRow.StartTimeLocal`**, which used `DateTime.ToLocalTime()` — not a renderer the guard's `RenderCall` tracks. That one carried two defects: it treated an msdb-local value as UTC, *and* it rendered in the Lite host machine's zone regardless of the display-mode setting every other timestamp honours.

## Three doc comments stated the wrong frame

Corrected with the code, including the one that hid the Lite half. `ViewerDataService.QuerySnapshots` called Lite's `FormatServerTime` a "raw server-clock" renderer and asserted the two SKUs agreed. They did not — Lite was double-skewing while the comment said otherwise. They agree now, and the comment says why it used to be wrong rather than being quietly deleted.

## Guard changes, and why each direction differs from #3206's

`FormatStoredUtc` is **registered** in the `Renderers` map rather than left out. An unlisted renderer is invisible to that scan, so omitting it would have dropped five sites out of the census as the price of fixing them.

The seventeen `DesktopRenderFrameMismatch` rows come **out**, and `DesktopRenderMismatchSites` goes to **0**. That is the opposite of what #3206 did with its MCP rows, and the difference is in the discriminator: the render scan flags only a *disagreement* between column frame and renderer, so a corrected site genuinely leaves the found-set and a row for it would fail set equality from the other side. The MCP scan keys on a payload field NAME, which survives the fix — which is why those rows had to be relabelled `DeSkewedAtRead` instead. Zero is the strongest form of this pin, and a regression is still caught: it would be found by the scan and not be in the inventory.

## Verification

`Darling.Tests` and `Lite.Tests` are `net10.0-windows` and cannot execute on macOS, so CI is the arbiter for the suite. Run here: all four affected projects build with 0 errors, every changed file keeps CRLF with no bare LF, and the two existing `FormatServerClock` behaviour pins (`ViewerQueriesTests.FormatServerClock_ShowsRawServerWallClock_EmptyForNull` and `ViewerQueriesRestTests.QuerySnapshotRow_TranStartTimeLocal_RendersRawServerClock_...`) pin columns this change does not touch — `query_stats`/`procedure_stats` and `query_snapshots.tran_start_time` — so they still hold.

I have not run the render scan itself; its frame register is derived from collector provenance at runtime and my ability to replay that faithfully is the thing that has been wrong twice on the sibling PR, so I am not claiming it here.

## Merge order

This shares `ConsumedTimestampFrameDisciplineTests.cs` with #3212, which edits the MCP rows and two different constants. Whichever lands second needs a small mechanical conflict resolution in that one file — different regions, no overlapping rows. #3212 first is the easier order, since its inventory edit is the larger of the two.
