### PR TITLE
Report the member ranges that stop short of their own content

### DIFF
--- a/Darling/Darling.Tests/CSharpMemberMap.cs
+++ b/Darling/Darling.Tests/CSharpMemberMap.cs
@@ -327,7 +327,8 @@ internal static class CSharpMemberMap
     ///
     /// <para><c>Auto</c> in <c>TsqlConventionGuardTests.TheResolver_AttributesByScope_NotByTheNearestNameAbove</c> pins the
     /// accessor-list case; found in review of #3097, where it resolved to <see cref="Unknown"/> in silence.
-    /// <c>TheWalkerRangesAreSound</c> pins the other three over the whole scanned tree, by set.</para>
+    /// <c>TsqlConventionGuardTests.TheMemberScan_ReadsEveryDeclarationWhole</c> pins the other three over
+    /// the whole scanned tree, by set, against its <c>KnownTruncatedRanges</c>.</para>
     /// </summary>
     private static int DeclarationEnd(string code, int from)
     {

--- a/Darling/Darling.Tests/CSharpMemberMap.cs
+++ b/Darling/Darling.Tests/CSharpMemberMap.cs
@@ -425,12 +425,12 @@ internal static class CSharpMemberMap
     /// <para><b>Trailing <c>;</c> and whitespace are trimmed, which is what makes the disagreement mean
     /// something.</b> <c>=&gt; new T { … };</c> ends the range at the initialiser's brace and leaves the
     /// <c>;</c> outside it — true of 510 members on the tree, and harmless, because no literal lives in a
-    /// semicolon. Reporting those would bury the 34 members tree-wide — 31 of them in the trees
-    /// <c>TsqlConventionGuardTests</c> sweeps — where real content falls outside the range. So what is
-    /// compared is the end of the declaration's CONTENT, and the shape reds only when something a scan
-    /// could look for is stranded. Those 510 are the same defect one character short of mattering: append
-    /// <c>.Normalize()</c> after the initialiser and the member joins the reported set with nothing else
-    /// changing, which is why the arm is a derivation rather than a list.</para>
+    /// semicolon — and they outnumber the members where real content falls outside the range by more than
+    /// ten to one, so reporting them would bury the set that matters. What is compared is therefore the end
+    /// of the declaration's CONTENT, and the shape reds only when something a scan could look for is
+    /// stranded. Those semicolon-only members are the same defect one character short of mattering: append
+    /// <c>.Normalize()</c> after the initialiser and one joins the reported set with nothing else changing,
+    /// which is why the arm is a derivation rather than a list.</para>
     /// </summary>
     private static int StatementEnd(string code, int from)
     {

--- a/Darling/Darling.Tests/CSharpMemberMap.cs
+++ b/Darling/Darling.Tests/CSharpMemberMap.cs
@@ -122,13 +122,21 @@ internal static class CSharpMemberMap
     /// same text and repeats the same walk is a tautology, not a check.</para>
     ///
     /// <para><c>End</c> is <c>-1</c> when the brace walk never closed the body.</para>
+    ///
+    /// <para><c>ContentEnd</c> is the same boundary derived a SECOND way — by
+    /// <see cref="StatementEnd"/>, which asks where the declaration's own <c>;</c> or body brace falls
+    /// rather than stopping at the first braced group. It exists so <see cref="ShapeOf"/> has something to
+    /// disagree with: <c>End</c> alone cannot report a range that stopped short, because a short range is
+    /// closed, is under <c>NextStart</c>, and overlaps nothing. Two derivations that fail on different
+    /// shapes, which is the only reason either is worth checking.</para>
     /// </summary>
     internal readonly record struct DeclaredRange(
         string Name,
         DeclarationKind Kind,
         int Start,
         int End,
-        int NextStart);
+        int NextStart,
+        int ContentEnd);
 
     /// <summary>Every declaration in one file, beside the walked source they are offsets into.</summary>
     internal sealed record MemberMap(string Code, IReadOnlyList<DeclaredRange> Declarations);
@@ -156,7 +164,8 @@ internal static class CSharpMemberMap
                 kind,
                 head.Index,
                 DeclarationEnd(code, after),
-                i + 1 < heads.Count ? heads[i + 1].Index : code.Length));
+                i + 1 < heads.Count ? heads[i + 1].Index : code.Length,
+                StatementEnd(code, after)));
         }
 
         return new MemberMap(code, declarations);
@@ -300,14 +309,25 @@ internal static class CSharpMemberMap
     /// declaration, so <see cref="DeclaredRange.NextStart"/> stays an independent bound that a runaway
     /// count can be caught by. Clamping here would make the two agree by construction.</para>
     ///
-    /// <para><b>A braced group does not always end the declaration.</b> An accessor list can be followed
-    /// by <c>= initialiser;</c>, and on an auto-property that initialiser is where a literal lives. This
-    /// is the one truncation <see cref="ShapeOf"/> is structurally unable to report — a range that stops
-    /// short of its own member is still closed and still well under
-    /// <see cref="DeclaredRange.NextStart"/>, so it reads as
-    /// <see cref="RangeShape.WholeMember"/> — which is why it is handled here rather than described as a
-    /// bound. <c>Auto</c> in <c>TsqlConventionGuardTests.TheResolver_AttributesByScope_NotByTheNearestNameAbove</c> is the
-    /// pin; found in review of #3097, where it resolved to <see cref="Unknown"/> in silence.</para>
+    /// <para><b>A braced group does not always end the declaration.</b> Returning at the first depth-0
+    /// <c>{</c> is right only when that brace opens the member's BODY. Four shapes put a braced group in
+    /// front of the body instead, and each one ends the range early:</para>
+    /// <list type="bullet">
+    /// <item>an accessor list followed by <c>= initialiser;</c> — <c>public string Q { get; set; } = "SELECT …";</c></item>
+    /// <item>a property or type pattern — <c>utc is { } t ? … : …</c>, <c>ex is PostgresException { SqlState: "57014" }</c></item>
+    /// <item>an object initialiser — <c>=&gt; new NpgsqlConnectionStringBuilder(cs) { Database = db }.ConnectionString</c></item>
+    /// <item>a collection expression — <c>=&gt; new[] { A, B }.SelectMany(…).Where(…)</c></item>
+    /// </list>
+    /// <para>Only the first is handled here, by the <c>=</c> look-ahead below, because on an auto-property
+    /// the initialiser is where a literal lives. The other three are REPORTED rather than avoided:
+    /// <see cref="RangeShape.Truncated"/> compares this walk against
+    /// <see cref="StatementEnd"/> and reds when they disagree. Reporting is the arm that generalises — all
+    /// four shapes arrived as cases nobody had enumerated, so the fifth will too, and a detector covers a
+    /// shape this method has never been taught.</para>
+    ///
+    /// <para><c>Auto</c> in <c>TsqlConventionGuardTests.TheResolver_AttributesByScope_NotByTheNearestNameAbove</c> pins the
+    /// accessor-list case; found in review of #3097, where it resolved to <see cref="Unknown"/> in silence.
+    /// <c>TheWalkerRangesAreSound</c> pins the other three over the whole scanned tree, by set.</para>
     /// </summary>
     private static int DeclarationEnd(string code, int from)
     {
@@ -387,6 +407,107 @@ internal static class CSharpMemberMap
 
     /// <summary>One past the <c>}</c> that closes the brace group opening at <paramref name="open"/>, or
     /// <c>-1</c> if it never closes.</summary>
+    /// <summary>
+    /// One past the declaration's last character, derived by asking which braced group is the BODY rather
+    /// than by stopping at the first one.
+    ///
+    /// <para>A member is expression-bodied when <c>=&gt;</c> is reached at depth 0 before any depth-0
+    /// <c>{</c>. Every braced group after that arrow is INSIDE the body — a property pattern, an object
+    /// initialiser, a collection expression — so this steps over it and keeps looking for the <c>;</c> that
+    /// actually ends the declaration. With no arrow, the first depth-0 <c>{</c> IS the body and closes it.</para>
+    ///
+    /// <para>This is deliberately not a corrected copy of <see cref="DeclarationEnd"/>, and it does not
+    /// replace it. It is a SECOND derivation of the same boundary, kept so the two can disagree; a checker
+    /// built by re-running the walk it is checking agrees with itself by construction, which is the
+    /// tautology <see cref="DeclaredRange.NextStart"/> already exists to avoid. Where the two disagree,
+    /// <see cref="ShapeOf"/> reports <see cref="RangeShape.Truncated"/> and a human adjudicates — neither
+    /// derivation is privileged as correct.</para>
+    ///
+    /// <para><b>Trailing <c>;</c> and whitespace are trimmed, which is what makes the disagreement mean
+    /// something.</b> <c>=&gt; new T { … };</c> ends the range at the initialiser's brace and leaves the
+    /// <c>;</c> outside it — true of 510 members on the tree, and harmless, because no literal lives in a
+    /// semicolon. Reporting those would bury the 34 where real content falls outside the range. So what is
+    /// compared is the end of the declaration's CONTENT, and the shape reds only when something a scan
+    /// could look for is stranded. Those 510 are the same defect one character short of mattering: append
+    /// <c>.Normalize()</c> after the initialiser and the member joins the 34 with nothing else changing,
+    /// which is why the arm is a derivation rather than a list.</para>
+    /// </summary>
+    private static int StatementEnd(string code, int from)
+    {
+        var paren = 0;
+        var bracket = 0;
+        var arrow = false;
+
+        for (var i = from; i < code.Length; i++)
+        {
+            var c = code[i];
+
+            if (c == '(')
+            {
+                paren++;
+            }
+            else if (c == ')')
+            {
+                paren--;
+            }
+            else if (c == '[')
+            {
+                bracket++;
+            }
+            else if (c == ']')
+            {
+                bracket--;
+            }
+            else if (paren != 0 || bracket != 0)
+            {
+                continue;
+            }
+            else if (c == '=' && i + 1 < code.Length && code[i + 1] == '>')
+            {
+                arrow = true;
+                i++;
+            }
+            else if (c == ';')
+            {
+                return ContentBefore(code, from, i + 1);
+            }
+            else if (c == '{')
+            {
+                var close = BraceGroupEnd(code, i);
+
+                if (close < 0)
+                {
+                    return -1;
+                }
+
+                if (!arrow)
+                {
+                    return close;
+                }
+
+                i = close - 1;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// <paramref name="end"/> walked back over trailing <c>;</c> and whitespace, so what it points past is
+    /// the declaration's last character of CONTENT. Never walks below <paramref name="from"/>.
+    /// </summary>
+    private static int ContentBefore(string code, int from, int end)
+    {
+        var i = end;
+
+        while (i > from && (code[i - 1] == ';' || char.IsWhiteSpace(code[i - 1])))
+        {
+            i--;
+        }
+
+        return i;
+    }
+
     private static int BraceGroupEnd(string code, int open)
     {
         var depth = 0;
@@ -481,21 +602,35 @@ internal static class CSharpMemberMap
         /// <summary>The walk ran past the next declaration, so that member's literals are attributed
         /// here.</summary>
         OverExtended,
+
+        /// <summary>The walk stopped short of the member's own end, so literals BELOW the stopping point
+        /// and still inside the member are attributed to nothing.</summary>
+        Truncated,
     }
 
     /// <summary>
     /// Which of three shapes a declaration's range is.
     ///
-    /// <para><b>The two failing shapes are complementary, not redundant.</b>
+    /// <para><b>The three failing shapes are complementary, not redundant.</b>
     /// <see cref="RangeShape.OverExtended"/> compares the brace walk against a regex offset, so it can
     /// disagree with the walk — but it is structurally blind at the END of the file, where the last
     /// declaration has no successor to run past. That tail is what
     /// <see cref="RangeShape.Unterminated"/> still covers, because a runaway there simply never closes.
     /// #3089 measured the same pair on the same kind of scan and both arms are pinned here.</para>
+    ///
+    /// <para><b>Both of those are over-reads, and that was the gap.</b> A range that stops SHORT is closed,
+    /// is under <c>NextStart</c>, and — ending early — cannot overlap its successor, so it satisfied every
+    /// arm above and read as <see cref="RangeShape.WholeMember"/>. Measured on the tree at the commit that
+    /// added this: 544 member ranges stop short, 34 of them by more than one character, and 13 strand a
+    /// string literal that <see cref="EnclosingMember"/> then answers <c>&lt;unknown&gt;</c> for.
+    /// <see cref="RangeShape.Truncated"/> is that arm, and it is the reason
+    /// <see cref="DeclaredRange.ContentEnd"/> is carried: it comes from
+    /// <see cref="StatementEnd"/> rather than from a second run of the walk being checked.</para>
     /// </summary>
     internal static RangeShape ShapeOf(DeclaredRange declaration) =>
         declaration.End < 0 ? RangeShape.Unterminated
         : declaration.End > declaration.NextStart ? RangeShape.OverExtended
+        : declaration.ContentEnd > declaration.End ? RangeShape.Truncated
         : RangeShape.WholeMember;
 
     /// <summary>
@@ -532,7 +667,8 @@ internal static class CSharpMemberMap
                 kind,
                 head.Index,
                 DeclarationEnd(text, after),
-                i + 1 < heads.Count ? heads[i + 1].Index : text.Length));
+                i + 1 < heads.Count ? heads[i + 1].Index : text.Length,
+                StatementEnd(text, after)));
         }
 
         return new MemberMap(text, declarations);

--- a/Darling/Darling.Tests/CSharpMemberMap.cs
+++ b/Darling/Darling.Tests/CSharpMemberMap.cs
@@ -405,8 +405,6 @@ internal static class CSharpMemberMap
         return -1;
     }
 
-    /// <summary>One past the <c>}</c> that closes the brace group opening at <paramref name="open"/>, or
-    /// <c>-1</c> if it never closes.</summary>
     /// <summary>
     /// One past the declaration's last character, derived by asking which braced group is the BODY rather
     /// than by stopping at the first one.
@@ -426,11 +424,12 @@ internal static class CSharpMemberMap
     /// <para><b>Trailing <c>;</c> and whitespace are trimmed, which is what makes the disagreement mean
     /// something.</b> <c>=&gt; new T { … };</c> ends the range at the initialiser's brace and leaves the
     /// <c>;</c> outside it — true of 510 members on the tree, and harmless, because no literal lives in a
-    /// semicolon. Reporting those would bury the 34 where real content falls outside the range. So what is
+    /// semicolon. Reporting those would bury the 34 members tree-wide — 31 of them in the trees
+    /// <c>TsqlConventionGuardTests</c> sweeps — where real content falls outside the range. So what is
     /// compared is the end of the declaration's CONTENT, and the shape reds only when something a scan
     /// could look for is stranded. Those 510 are the same defect one character short of mattering: append
-    /// <c>.Normalize()</c> after the initialiser and the member joins the 34 with nothing else changing,
-    /// which is why the arm is a derivation rather than a list.</para>
+    /// <c>.Normalize()</c> after the initialiser and the member joins the reported set with nothing else
+    /// changing, which is why the arm is a derivation rather than a list.</para>
     /// </summary>
     private static int StatementEnd(string code, int from)
     {
@@ -508,6 +507,8 @@ internal static class CSharpMemberMap
         return i;
     }
 
+    /// <summary>One past the <c>}</c> that closes the brace group opening at <paramref name="open"/>, or
+    /// <c>-1</c> if it never closes.</summary>
     private static int BraceGroupEnd(string code, int open)
     {
         var depth = 0;

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1369,9 +1369,23 @@ public sealed class TsqlConventionGuardTests
            no edit to any member — and it cannot tell an addition from a removal, which is the whole
            question here: one member leaving is progress, one arriving is a scan that has quietly stopped
            reading a member whole. Set equality fails on both, and names which. */
-        Assert.Equal(
-            KnownTruncatedRanges.OrderBy(s => s, StringComparer.Ordinal),
-            stoppedShort.OrderBy(s => s, StringComparer.Ordinal));
+        var arrived = stoppedShort.Except(KnownTruncatedRanges, StringComparer.Ordinal).OrderBy(s => s, StringComparer.Ordinal).ToList();
+        var left = KnownTruncatedRanges.Except(stoppedShort, StringComparer.Ordinal).OrderBy(s => s, StringComparer.Ordinal).ToList();
+
+        Assert.True(
+            arrived.Count == 0 && left.Count == 0,
+            "the set of members whose range stops short of its own content has moved, and this list is how "
+            + "a new one becomes visible before a census is written against it. Neither direction is a "
+            + "failure of your change — edit KnownTruncatedRanges to match and say which in the PR body."
+            + Environment.NewLine
+            + (arrived.Count == 0 ? "" : Environment.NewLine
+                + "ARRIVED — these now stop short. Add each line to KnownTruncatedRanges. If a census reads "
+                + "the file, check first that what falls outside the range is not a site it counts:"
+                + Environment.NewLine + string.Join(Environment.NewLine, arrived) + Environment.NewLine)
+            + (left.Count == 0 ? "" : Environment.NewLine
+                + "LEFT — these no longer stop short, usually because the member was rewritten into a shape "
+                + "the walk reads whole. That is progress. Delete each line from KnownTruncatedRanges:"
+                + Environment.NewLine + string.Join(Environment.NewLine, left)));
     }
 
     /// <summary>
@@ -1421,7 +1435,6 @@ public sealed class TsqlConventionGuardTests
         "Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs BuildViewerPreferences",
         "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs EventTimeLocal",
         "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs DeadlockTimeLocal",
-        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs LastTranStartedLocal",
         "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.JobHistory.cs RunTimeLocal",
         "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.JobHistory.cs LastSuccessfulRunLocal",
         "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.JobHistory.cs NextScheduledRunLocal",

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1240,11 +1240,13 @@ public sealed class TsqlConventionGuardTests
     /// <summary>
     /// Every member declaration's range is one whole member.
     ///
-    /// <para><b>Attribution is silent when this fails, which is why it is asserted separately.</b> A
-    /// truncated body stops containing the literals below the cut, and a literal contained by nothing is
-    /// labelled <see cref="Unknown"/> — loud. But an OVER-EXTENDED body keeps containing them, and it
-    /// contains the next member's literals too, so it hands out a name that is confidently wrong and
-    /// nothing above notices. That is the direction that needs its own check.</para>
+    /// <para><b>Attribution is silent in both failing directions, which is why each is asserted
+    /// separately.</b> An OVER-EXTENDED body keeps containing the literals below it AND the next member's,
+    /// so it hands out a name that is confidently wrong. An UNDER-READ body stops containing the literals
+    /// below the cut, and a literal contained by nothing is labelled <see cref="Unknown"/> — which is only
+    /// loud if some census is looking for a site of that kind. Thirteen members strand a literal today and
+    /// no census looks for those, so the whole class read as healthy until the ranges themselves were
+    /// checked against a second derivation.</para>
     ///
     /// <para>The two arms are complementary rather than redundant, and both are pinned by
     /// <see cref="TheMemberScan_IsBoundedByTheNextDeclaration_AndByTheBraceWalkAtTheEndOfTheFile"/>:
@@ -1266,6 +1268,7 @@ public sealed class TsqlConventionGuardTests
         var truncated = new List<string>();
         var overExtended = new List<string>();
         var overlapping = new List<string>();
+        var stoppedShort = new List<string>();
 
         foreach (var (tree, roots, anchor) in ScannedTrees)
         {
@@ -1308,6 +1311,10 @@ public sealed class TsqlConventionGuardTests
                             overExtended.Add(
                                 $"{where} runs to line {LineOf(map.Code, declaration.End - 1)}, past the "
                                 + $"declaration at line {LineOf(map.Code, declaration.NextStart)}");
+                            continue;
+
+                        case RangeShape.Truncated:
+                            stoppedShort.Add($"{relative} {declaration.Name}");
                             continue;
 
                         case RangeShape.WholeMember:
@@ -1357,7 +1364,73 @@ public sealed class TsqlConventionGuardTests
             "these member ranges overlap. Members do not nest, so one range has swallowed another and the "
             + "literals in the inner one are attributed by whichever starts later:"
             + Environment.NewLine + string.Join(Environment.NewLine, overlapping));
+
+        /* Asserted as a SET, not a count. A count restates the size of the inventory and goes stale with
+           no edit to any member — and it cannot tell an addition from a removal, which is the whole
+           question here: one member leaving is progress, one arriving is a scan that has quietly stopped
+           reading a member whole. Set equality fails on both, and names which. */
+        Assert.Equal(
+            KnownTruncatedRanges.OrderBy(s => s, StringComparer.Ordinal),
+            stoppedShort.OrderBy(s => s, StringComparer.Ordinal));
     }
+
+    /// <summary>
+    /// Every member whose range stops short of its own content — carried, labelled, and deliberately NOT
+    /// fixed.
+    ///
+    /// <para><b>Why an inventory rather than a repair.</b> No consumer of the map under-reads because of
+    /// these. The four that exist — <c>DarlingPgReadSqlParsesLiveTests</c>,
+    /// <c>StoreSqlClockDisciplineTests</c>, <c>TempDbReservedLabelProvenanceTests</c> and this file — either
+    /// scan a corpus none of these members are in (the first two read only
+    /// <c>PerformanceMonitor.Darling.Storage</c>) or look for a kind of site none of them strand: what
+    /// falls outside these ranges is date formats and UI fallbacks — <c>"yyyy-MM-dd HH:mm:ss"</c>,
+    /// <c>"Never"</c>, <c>"None scheduled"</c>, <c>"N0"</c> — never T-SQL and never a tempdb label. Editing
+    /// 31 member bodies to satisfy a walker would be changing the subject to suit the instrument.</para>
+    ///
+    /// <para><b>What the inventory is for is the day that stops being true.</b> Thirteen of these strand a
+    /// string literal, and <see cref="EnclosingMember"/> answers <c>&lt;unknown&gt;</c> for every one of
+    /// them today. A census that starts looking for a site of that kind — a format string, a renderer name —
+    /// would silently miss it here, and the miss reads as absence rather than as error. This list is what
+    /// makes such a member visible before a census is written against it, which is the opposite order from
+    /// how the current 31 were found.</para>
+    ///
+    /// <para>Scope: the trees <see cref="ScannedTrees"/> sweeps, so <c>Darling.Tests</c> and
+    /// <c>Lite.Tests</c> are outside it. Three further truncated members live there and are not listed.</para>
+    /// </summary>
+    private static readonly string[] KnownTruncatedRanges =
+    [
+        "PerformanceMonitor.Collectors/CollectorRuntimePrecondition.cs DescribeObserved",
+        "PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs Figure",
+        "PerformanceMonitor.Collectors/StallWaitProbe.cs TriggerElapsedFor",
+        "PerformanceMonitor.Collectors/StallWaitProbe.cs FitsUnderBudget",
+        "PerformanceMonitor.Common/SystemHealthParser.cs GbFromBytes",
+        "PerformanceMonitor.Common/SystemHealthParser.cs GbFromKb",
+        "PerformanceMonitor.Notifications/WebhookAlertService.cs DeriveResourceDatabase",
+        "Darling/PerformanceMonitor.Darling.Analysis/PgBaselineProvider.cs IsCommandTimeout",
+        "Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs ToSettings",
+        "Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs IsConfigured",
+        "Darling/PerformanceMonitor.Darling.Service/HypotheticalIndexRequest.cs IsComplete",
+        "Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingDataReader.cs OutputFinding",
+        "Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingStallProbeReader.cs TriggerMbPerSecond",
+        "Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingStallProbeReader.cs TerminalSilenceMs",
+        "Darling/PerformanceMonitor.Darling.Service/Targets/PostgresTargetProvider.cs WithDatabase",
+        "Darling/PerformanceMonitor.Darling.Service/Targets/SqlServerTargetProvider.cs WithDatabase",
+        "Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs SelectedTabCollectorScope",
+        "Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs LastCollectedDisplay",
+        "Darling/PerformanceMonitor.Darling.Viewer/RecommendationsViewModel.cs HasStructuredFixAction",
+        "Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs BuildViewerPreferences",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs EventTimeLocal",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs DeadlockTimeLocal",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs LastTranStartedLocal",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.JobHistory.cs RunTimeLocal",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.JobHistory.cs LastSuccessfulRunLocal",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.JobHistory.cs NextScheduledRunLocal",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.LongQueries.cs EventTimeLocal",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCorrection.cs Local",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SystemEvents.cs Local",
+        "Darling/PerformanceMonitor.Darling.Viewer/ViewerPostgresDisplay.cs Timestamp",
+        "Lite/Services/LocalDataService.CollectionHealth.cs OutputFinding",
+    ];
 
     /* ───────────────────────── the resolver, pinned on arranged source ───────────────────────── */
 


### PR DESCRIPTION
`ShapeOf` named two failing shapes for a declaration range, and both of them are over-reads. A range that stops SHORT satisfied every arm it had: it is closed, so not `Unterminated`; it is under `NextStart`, so not `OverExtended`; and ending early it cannot overlap its successor, so the companion overlap check (`Start < previousEnd`) cannot fire either. It read as `WholeMember`. The doc on `DeclarationEnd` described this exact failure and called it *"the one truncation `ShapeOf` is structurally unable to report"* — a reporter that cannot express the failure its own comment describes, whose green is then read as coverage.

## What was measured

Whole tree, 2,238 files, 42,927 declarations, read through the real `CSharpMemberMap.Of`, measured at `c9f04f3fe` — the commit this branch was cut from:

- **544** member ranges stop short of their own content
- **510** of those lose only the trailing `;` after `=> new T { … };` — no literal lives in a semicolon
- **31** in the trees this guard sweeps strand real content
- **13** strand a string literal, and `EnclosingMember` answers `<unknown>` for every one

The 13 are mostly the viewer's timestamp renderers, where what falls outside the range is `ViewerTimeHelper.ForDisplay(t).ToString("yyyy-MM-dd HH:mm:ss")`.

**It has already changed a guard's answer, on a guard that was being built rather than one already merged.** While this was being measured, the #3207 lane derived an alias-completeness set through the walker and got **3 of 6** — and it looked healthy, green with `WholeMember` on every declaration, because a short range is exactly what this change teaches `ShapeOf` to report. Four of those six aliases are named `Local`, in four different files across both SKUs, and two of them are in the inventory below. Reported by that lane rather than measured here; what makes it worth stating is that it is the failure arriving in the ordinary way — someone writing a new census against a map that under-reads and cannot say so.

**No merged consumer of the map under-reads because of this**, and *merged* is doing real work in that sentence — the guard above was under construction. The map has exactly four merged consumers — `DarlingPgReadSqlParsesLiveTests`, `StoreSqlClockDisciplineTests`, `TempDbReservedLabelProvenanceTests` and this guard. The first two read only `PerformanceMonitor.Darling.Storage`, which contains none of them. The other two do reach them, but every stranded literal is a date format or a UI fallback — `"yyyy-MM-dd HH:mm:ss"`, `"Never"`, `"None scheduled"`, `"N0"` — so no T-SQL for the convention guard and no tempdb vocabulary for the label provenance test. `ServerLocalReadFrameDisciplineTests` keys on `ViewerTimeHelper.ForDisplay` and carries hard-coded per-file counts, which makes it look like a fifth consumer; it does its own text scan and never touches the map.

## The change

`DeclaredRange` carries `ContentEnd`, derived by a new `StatementEnd`. `RangeShape.Truncated` is the disagreement between the two.

`StatementEnd` is deliberately **not** a corrected copy of `DeclarationEnd`. It asks a different question — which braced group is the *body* — by tracking whether `=>` was reached at depth 0 before the first depth-0 `{`. A checker built by re-running the walk it checks agrees with itself by construction, which is the tautology `NextStart` already exists to avoid.

Trailing `;` and whitespace are trimmed, so what is compared is the end of the declaration's **content**. That is what keeps the 510 quiet without a suppression list; they are the same defect one character short of mattering, and appending anything after the initialiser moves a member into the reported set with nothing else changing — which is what `DarlingConfig.ToSettings` and `SettingsWindow.BuildViewerPreferences` already are, at 13 characters each.

## Reported, not repaired

Four shapes put a braced group in front of the body. `DeclarationEnd` handles the first, because on an auto-property the initialiser is where a literal lives:

| shape | example |
|---|---|
| accessor list + initialiser | `public string Q { get; set; } = "SELECT …";` |
| property or type pattern | `utc is { } t ? … : …`, `ex is PostgresException { SqlState: "57014" }` |
| object initialiser | `=> new NpgsqlConnectionStringBuilder(cs) { Database = db }.ConnectionString` |
| collection expression | `=> new[] { A, B }.SelectMany(…).Where(…)` |

The other three are reported rather than avoided, and they are carried as an inventory rather than fixed. All four shapes arrived as cases nobody had enumerated, so the fifth will too, and a detector covers a shape `DeclarationEnd` has never been taught. Editing member bodies to satisfy a walker would be changing the subject to suit the instrument.

**The inventory shipped at 30, not the 31 measured above** — rebasing onto #3227 removed `ViewerDataService.Deadlock.cs LastTranStartedLocal`, which that PR rewrote onto `FormatServerClock` into a shape the walk reads whole. It decayed from an unrelated merge within an hour of being written, which is the standing cost of an enumerated set: it will red on any PR that edits one of these members. The failure message separates what arrived from what left, says which direction is progress, and tells the reader to edit the list — without that, the rote fix is to delete whichever line is complaining, which is how a pin stops guarding.

**The inventory is asserted as a set, not a count.** A count restates the size of the inventory, goes stale with no edit to any member, and cannot tell an addition from a removal — which is the whole question: one member leaving is progress, one arriving is a scan that has quietly stopped reading a member whole.

## Red-proofed

The pin was proved red before its green was trusted. Injecting one new instance of each of the three shapes into a scanned file adds three entries to the reported set and names all three. A fourth control in the same injection — an object initialiser with nothing after it — is correctly **not** reported, so the trim is doing work rather than hiding the class.

## Verification limit

`Darling.Tests` targets `net10.0-windows` and its test host needs `Microsoft.WindowsDesktop.App`, so none of this executes on macOS. It builds clean there, and the measurements above come from driving the real `CSharpMemberMap.Of` and `ShapeOf` out of a probe harness against the same trees. **CI is the only place the pin itself runs**, which is exactly the thing this change is about, so `TheMemberScan_ReadsEveryDeclarationWhole` executing green in CI is the gate — not the local build.

## CHANGELOG entry text

- **The member-range scan now reports ranges that stop short of their own content, which it previously read as healthy.** `ShapeOf` named two failing shapes and both were over-reads; a range ending early is closed, is under its successor's start, and overlaps nothing, so it satisfied every arm and reported `WholeMember`. `DeclaredRange` now carries a second, independently derived content boundary and `RangeShape.Truncated` reports the disagreement. Thirty members whose ranges stop short are carried as a set-asserted inventory rather than rewritten, because no merged consumer of the map under-reads because of them ([#3230]).
