### PR TITLE
Stop the truncation doc asserting counts no test holds

### DIFF
--- a/Darling/Darling.Tests/CSharpMemberMap.cs
+++ b/Darling/Darling.Tests/CSharpMemberMap.cs
@@ -424,9 +424,9 @@ internal static class CSharpMemberMap
     ///
     /// <para><b>Trailing <c>;</c> and whitespace are trimmed, which is what makes the disagreement mean
     /// something.</b> <c>=&gt; new T { … };</c> ends the range at the initialiser's brace and leaves the
-    /// <c>;</c> outside it — true of 510 members on the tree, and harmless, because no literal lives in a
-    /// semicolon — and they outnumber the members where real content falls outside the range by more than
-    /// ten to one, so reporting them would bury the set that matters. What is compared is therefore the end
+    /// <c>;</c> outside it, which is harmless because no literal lives in a semicolon — and those members
+    /// outnumber the ones where real content falls outside the range by more than ten to one, so reporting
+    /// them would bury the set that matters. What is compared is therefore the end
     /// of the declaration's CONTENT, and the shape reds only when something a scan could look for is
     /// stranded. Those semicolon-only members are the same defect one character short of mattering: append
     /// <c>.Normalize()</c> after the initialiser and one joins the reported set with nothing else changing,
@@ -622,9 +622,13 @@ internal static class CSharpMemberMap
     ///
     /// <para><b>Both of those are over-reads, and that was the gap.</b> A range that stops SHORT is closed,
     /// is under <c>NextStart</c>, and — ending early — cannot overlap its successor, so it satisfied every
-    /// arm above and read as <see cref="RangeShape.WholeMember"/>. Measured on the tree at the commit that
-    /// added this: 544 member ranges stop short, 34 of them by more than one character, and 13 strand a
-    /// string literal that <see cref="EnclosingMember"/> then answers <c>&lt;unknown&gt;</c> for.
+    /// arm above and read as <see cref="RangeShape.WholeMember"/>. The members this finds strand content
+    /// inside their own declaration, and where that content is a string literal
+    /// <see cref="EnclosingMember"/> answers <c>&lt;unknown&gt;</c> for it — a site that is in the source
+    /// and outside every range a census resolves through. How many there are is not written here: the live
+    /// figure is <c>TsqlConventionGuardTests.KnownTruncatedRanges</c>, which a test holds to the tree, and a
+    /// count repeated in prose goes stale the first time an unrelated PR rewrites one of those members —
+    /// which happened to this comment's own numbers within an hour of it being written.
     /// <see cref="RangeShape.Truncated"/> is that arm, and it is the reason
     /// <see cref="DeclaredRange.ContentEnd"/> is carried: it comes from
     /// <see cref="StatementEnd"/> rather than from a second run of the walk being checked.</para>

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1244,9 +1244,10 @@ public sealed class TsqlConventionGuardTests
     /// separately.</b> An OVER-EXTENDED body keeps containing the literals below it AND the next member's,
     /// so it hands out a name that is confidently wrong. An UNDER-READ body stops containing the literals
     /// below the cut, and a literal contained by nothing is labelled <see cref="Unknown"/> — which is only
-    /// loud if some census is looking for a site of that kind. Most of <see cref="KnownTruncatedRanges"/>
-    /// strands a literal, and no census looks for a site of that kind, so the whole class read as healthy
-    /// until the ranges themselves were checked against a second derivation.</para>
+    /// loud if some census is looking for a site of that kind. Entries in
+    /// <see cref="KnownTruncatedRanges"/> strand a literal and no census looks for a site of that kind, so
+    /// the whole class read as healthy until the ranges themselves were checked against a second
+    /// derivation.</para>
     ///
     /// <para>The two arms are complementary rather than redundant, and both are pinned by
     /// <see cref="TheMemberScan_IsBoundedByTheNextDeclaration_AndByTheBraceWalkAtTheEndOfTheFile"/>:
@@ -1401,7 +1402,7 @@ public sealed class TsqlConventionGuardTests
     /// <c>"Never"</c>, <c>"None scheduled"</c>, <c>"N0"</c> — never T-SQL and never a tempdb label. Rewriting
     /// these member bodies to satisfy a walker would be changing the subject to suit the instrument.</para>
     ///
-    /// <para><b>What the inventory is for is the day that stops being true.</b> Most of these strand a
+    /// <para><b>What the inventory is for is the day that stops being true.</b> Entries here strand a
     /// string literal, and <see cref="EnclosingMember"/> answers <c>&lt;unknown&gt;</c> for each one. A
     /// census that starts looking for a site of that kind — a format string, a renderer name — would
     /// silently miss it here, and the miss reads as absence rather than as error. This list is what makes
@@ -1414,7 +1415,7 @@ public sealed class TsqlConventionGuardTests
     /// carry. Count the entries; that answer cannot go stale.</para>
     ///
     /// <para>Scope: the trees <see cref="ScannedTrees"/> sweeps, so <c>Darling.Tests</c> and
-    /// <c>Lite.Tests</c> are outside it. A few truncated members live there and are not listed.</para>
+    /// <c>Lite.Tests</c> are outside it. Truncated members there are not listed.</para>
     /// </summary>
     private static readonly string[] KnownTruncatedRanges =
     [

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -196,8 +196,8 @@ public sealed class TsqlConventionGuardTests
                 Note: "Checked by tokenising, not by line prefix. This codebase does not put an asterisk on a "
                     + "block comment's continuation lines, so a prefix filter reads that prose as code and a "
                     + "comment mentioning the banned form becomes an offender — the #3052 defect "
-                    + "CommentFilterAdoptionTests exists to track. Six files carry a `--` inside block-comment "
-                    + "prose today and none of them is a violation."),
+                    + "CommentFilterAdoptionTests exists to track. Block-comment prose in the scanned trees "
+                    + "carries a `--` where a dash or a flag is meant, and none of those is a violation."),
 
             ["Functions"] = new(
                 Covered: new[] { CountBig, RowcountBig },
@@ -1554,7 +1554,7 @@ public sealed class TsqlConventionGuardTests
 
         /* A GENERIC member with a constraint, where the parameter list follows the > that closed the type
            parameters rather than the name itself. Left unhandled the scan reads past the parameter list
-           into the constraint and answers class. Nine members in the scanned trees carry a where-clause,
+           into the constraint and answers class. The scanned trees do carry members with a where-clause,
            so the shape is real; none of them holds T-SQL, which is why it is arranged here. */
         Assert.Equal(
             "Constrained",

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1244,9 +1244,9 @@ public sealed class TsqlConventionGuardTests
     /// separately.</b> An OVER-EXTENDED body keeps containing the literals below it AND the next member's,
     /// so it hands out a name that is confidently wrong. An UNDER-READ body stops containing the literals
     /// below the cut, and a literal contained by nothing is labelled <see cref="Unknown"/> — which is only
-    /// loud if some census is looking for a site of that kind. Thirteen members strand a literal today and
-    /// no census looks for those, so the whole class read as healthy until the ranges themselves were
-    /// checked against a second derivation.</para>
+    /// loud if some census is looking for a site of that kind. Most of <see cref="KnownTruncatedRanges"/>
+    /// strands a literal, and no census looks for a site of that kind, so the whole class read as healthy
+    /// until the ranges themselves were checked against a second derivation.</para>
     ///
     /// <para>The two arms are complementary rather than redundant, and both are pinned by
     /// <see cref="TheMemberScan_IsBoundedByTheNextDeclaration_AndByTheBraceWalkAtTheEndOfTheFile"/>:

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1398,18 +1398,23 @@ public sealed class TsqlConventionGuardTests
     /// scan a corpus none of these members are in (the first two read only
     /// <c>PerformanceMonitor.Darling.Storage</c>) or look for a kind of site none of them strand: what
     /// falls outside these ranges is date formats and UI fallbacks — <c>"yyyy-MM-dd HH:mm:ss"</c>,
-    /// <c>"Never"</c>, <c>"None scheduled"</c>, <c>"N0"</c> — never T-SQL and never a tempdb label. Editing
-    /// 31 member bodies to satisfy a walker would be changing the subject to suit the instrument.</para>
+    /// <c>"Never"</c>, <c>"None scheduled"</c>, <c>"N0"</c> — never T-SQL and never a tempdb label. Rewriting
+    /// these member bodies to satisfy a walker would be changing the subject to suit the instrument.</para>
     ///
-    /// <para><b>What the inventory is for is the day that stops being true.</b> Thirteen of these strand a
-    /// string literal, and <see cref="EnclosingMember"/> answers <c>&lt;unknown&gt;</c> for every one of
-    /// them today. A census that starts looking for a site of that kind — a format string, a renderer name —
-    /// would silently miss it here, and the miss reads as absence rather than as error. This list is what
-    /// makes such a member visible before a census is written against it, which is the opposite order from
-    /// how the current 31 were found.</para>
+    /// <para><b>What the inventory is for is the day that stops being true.</b> Most of these strand a
+    /// string literal, and <see cref="EnclosingMember"/> answers <c>&lt;unknown&gt;</c> for each one. A
+    /// census that starts looking for a site of that kind — a format string, a renderer name — would
+    /// silently miss it here, and the miss reads as absence rather than as error. This list is what makes
+    /// such a member visible before a census is written against it, which is the opposite order from how
+    /// the entries below were found.</para>
+    ///
+    /// <para><b>No count appears in this comment, deliberately.</b> The array is asserted at set equality,
+    /// so a numeral beside it is prose that nothing can fail on — and one that an unrelated PR invalidates
+    /// the moment it rewrites any listed member, which is what happened to the counts this comment used to
+    /// carry. Count the entries; that answer cannot go stale.</para>
     ///
     /// <para>Scope: the trees <see cref="ScannedTrees"/> sweeps, so <c>Darling.Tests</c> and
-    /// <c>Lite.Tests</c> are outside it. Three further truncated members live there and are not listed.</para>
+    /// <c>Lite.Tests</c> are outside it. A few truncated members live there and are not listed.</para>
     /// </summary>
     private static readonly string[] KnownTruncatedRanges =
     [


### PR DESCRIPTION
`ShapeOf`'s doc asserted four counts as facts: 544 ranges stopping short, 34 by more than one character, 13 stranding a string literal, and 510 losing only a semicolon.

**Two of them cannot be reproduced from the code they document.** 544 and 510 were measured before `StatementEnd` trimmed trailing `;` and whitespace. Run the shipped detector and you get neither number, so a reader checking the comment concludes the detector is broken rather than that the comment is old.

**The other two were already wrong when they merged.** #3227 rewrote `ViewerDataService.Deadlock.cs LastTranStartedLocal` onto `FormatServerClock`, into a shape the walk reads whole — so 34 became 33 and 13 became 12 about an hour after the sentence was written, from a PR that had nothing to do with this one. The same merge is why the shipped inventory is 30 rather than the 31 measured on the branch.

The counts are removed rather than corrected. `TsqlConventionGuardTests.KnownTruncatedRanges` is the live figure and a test holds it to the tree, so the comment points there instead. What stays is the ratio the argument actually needs — semicolon-only members outnumber the ones stranding real content by more than ten to one, which is why the trim exists — and it is stated as a ratio because that is what survives an edit to any one member.

`KnownTruncatedRanges`' own doc carried the same defect and is fixed in the same change: it said *"Editing **31** member bodies"*, *"the current **31**"* and *"**Thirteen** of these strand a string literal"*, sitting directly on top of an array of **30**. Recomputed against the shipped code rather than decremented — **30** in the swept trees, **12** stranding a literal, so "Thirteen" was wrong independently of the total.

That one is the sharpest instance: the array beside it is asserted at set equality, so the numeral in the prose is the one claim in the file that **nothing can fail on**. #3230's own argument is that a count "goes stale with no edit to any member" and belongs in a set — and the comment introducing that set violated it. Both figures are removed rather than corrected, and the comment now says why no count appears and tells the reader to count the entries.

Found by the CHANGELOG batch lane and github-03: the lane hit these numbers deciding what #3230's release note should say, and had to work out which of three disagreeing figures to believe. Both merged sources agreed on 31, which is why it did not look suspect.

## Two more counts in the same file, found by review of this PR

A bot thread objected that the fix had replaced *"Thirteen"* with *"**Most** of `KnownTruncatedRanges` strands a literal"*, and 12 of 30 is a minority. It was right, and it named a class the three prior sweeps over these two files could not see: **a sweep for stale figures cannot find a stale quantifier, because a quantifier carries no numeral, no number-word and no currency word.** Re-sweeping for quantifiers rather than digits found two more counts in `TsqlConventionGuardTests.cs`, both wrong, and one more bare quantifier.

**The generic-constraint comment said nine members in the scanned trees carry a where-clause. Seventeen do**, plus a type-level constraint on the `SettingsObjectRead<T>` record. The claim exists to argue the walker shape is worth arranging, so the wrong figure understated its own case.

**The comment-filter note said six files carry a `--` inside block-comment prose. Sixty do** with a `--` anywhere in a block comment, forty-eight on a non-asterisked continuation line — the line a prefix filter actually misreads, which is the scenario the note is about — and thirty-eight once files whose only hits are CLI flags come out. A second reader independently measured **seventy**, counting T-SQL block comments embedded in SQL literals as well; all fourteen of those extra matches sit inside verbatim `@"..."` strings, and on the words as written that reading is defensible too. They are also genuinely relevant to the guard — a `--` inside a T-SQL `/* */` must not be read as a line comment — just to its tokenizer rather than to its comment filter.

**That spread is the finding, more than any one of the numbers.** Five defensible answers — 70, 60, 48, 38, and the tokenizer's own view — against a sentence that named neither corpus nor predicate. It could not have been pinned even in principle, and there is no reading under which it is six.

Both sentences keep their universal and lose only the tally, which is this file's own stated doctrine: *a universal quantifier names the one counter-example that would break it, while a count only tells you to count again.* Neither "12 of these" nor "A minority" was substituted, because both would be true today and stale on the next merge that rewrites a listed member — which is exactly what #3227 did to "Thirteen".

**Two other numerals in the file were checked and deliberately left**, since removing a correct, held count would be the opposite lesson. The tenth-bullet reference is held by the disposition map's equality assertion against `CONTRIBUTING.md`, so it cannot drift without reddening first. The 101 figure is dated to when it landed, scoped to a retired SKU outside the scanned trees, and labelled as evidence for a past decision rather than a live figure. `most`/`several`/`many` elsewhere in both files were read individually and are qualitative claims about general behaviour, not counts of a tracked set.

`CommentFilterAdoptionTests` already holds prose counts against computed ones via `VerifySummaryCounts`, non-vacuously in both directions. That is the right tool for a count that is derivable and stable; neither of these two is, which is why both are removed rather than pinned.

## CHANGELOG entry text

- **The truncation detector's doc no longer asserts member counts that no test holds** ([#3233]) - it stated four figures as facts; two described a state before the content trim existed and cannot be reproduced from the shipped code at all, and the other two went stale within an hour when an unrelated PR rewrote one of the members. `KnownTruncatedRanges` is the live figure and a test holds it to the tree, so the comment points there and keeps only the ratio the argument needs. Review of the change found two more counts in the same file — nine where-clause members against seventeen, and six block-comment files against sixty — both removed the same way, and two correct held numerals left in place.


