### PR TITLE
Read the Azure sibling rows the size collector deliberately emits (#3262)

### DIFF
--- a/Darling/Darling.Tests/DarlingEmptyEnumerationInventoryTests.cs
+++ b/Darling/Darling.Tests/DarlingEmptyEnumerationInventoryTests.cs
@@ -289,6 +289,61 @@ public sealed class DarlingEmptyEnumerationInventoryTests
     }
 
     [Fact]
+    public async Task AnAzureSiblingRowIsInventoryDespiteItsNullDatabaseId_AgainstDevPostgres()
+    {
+        var cs = ConnectionString;
+        Assert.SkipWhen(string.IsNullOrEmpty(cs),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live sibling-inventory test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new NpgsqlConnection(cs);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteRowsAsync(connection, ct);
+
+        var bodySucceeded = false;
+        try
+        {
+            await DarlingMcpTestData.RegisterServerAsync(connection, ServerId, ServerName, ct);
+
+            /* #3262: on a master-connected Azure target the only evidence of user databases is the
+               sibling rows (#2643), and those deliberately carry NULL database_id — sys.resource_stats
+               has no id to give. They are user databases by construction (the view bills only user
+               databases, and the connected database is excluded by the arm), so the screen admits them
+               through its IS NULL arm; without it this target read as having no user databases at all. */
+            await SeedLogAsync(connection, ct, "query_store", MinutesAgo(30), EnumeratedCollectorDriver.EmptyEnumerationMessage);
+            await SeedLogAsync(connection, ct, "query_store", MinutesAgo(20), EnumeratedCollectorDriver.EmptyEnumerationMessage);
+            await SeedSiblingSizeAsync(connection, ct, "testdb1", MinutesAgo(25));
+
+            var qualified = EnumeratedCollectorDriver.EmptyEnumerationMessage
+                + " (all 2 runs, " + CollectorHealthClassifier.HasUserDatabasesQualifier + ")";
+
+            await using (var viewer = new ViewerDataService(cs!))
+            {
+                var queryStore = (await viewer.GetCollectionHealthAsync(ServerId, ct))
+                    .Single(h => h.CollectorName == "query_store");
+
+                Assert.True(queryStore.TargetHasUserDatabases);
+                Assert.Equal(qualified, queryStore.NoteFormatted);
+            }
+
+            await using (var postgres = NpgsqlDataSource.Create(cs!))
+            {
+                var health = await DarlingDataReader.GetCollectionHealthAsync(
+                    postgres, ServerId, DarlingMcpTestData.Naive(DateTime.UtcNow.AddDays(-7)), ct);
+
+                Assert.True(health.Single(h => h.CollectorName == "query_store").TargetHasUserDatabases);
+            }
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(cs!, bodySucceeded, DeleteRowsAsync);
+        }
+    }
+
+    [Fact]
     public async Task AnInventoryOutsideTheWindowAnotherServersOrSystemOnlySaysNothing_AgainstDevPostgres()
     {
         var cs = ConnectionString;
@@ -449,6 +504,19 @@ INSERT INTO database_size_stats
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
             CollectionIdGenerator.Next(), DarlingMcpTestData.Naive(collectionTimeUtc), serverId ?? ServerId, ServerName,
             databaseName, databaseId, 1, "ROWS", databaseName + "_data", "C:\\data\\" + databaseName + ".mdf", 128.00m);
+
+    /// <summary>The Azure sibling shape (#2643): NULL database_id / file_id / physical_name, a file_name
+    /// that says it is a whole database, and a real size — exactly what the arm projects.</summary>
+    private static async Task SeedSiblingSizeAsync(
+        NpgsqlConnection connection, CancellationToken ct,
+        string databaseName, DateTime collectionTimeUtc) =>
+        await DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO database_size_stats
+    (collection_id, collection_time, server_id, server_name, database_name, database_id,
+     file_id, file_type_desc, file_name, physical_name, total_size_mb)
+VALUES ($1, $2, $3, $4, $5, NULL, NULL, $6, $7, NULL, $8)",
+            CollectionIdGenerator.Next(), DarlingMcpTestData.Naive(collectionTimeUtc), ServerId, ServerName,
+            databaseName, "ROWS", "(whole database)", 23.00m);
 
     private static async Task DeleteRowsAsync(NpgsqlConnection connection, CancellationToken ct)
     {

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingDataReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingDataReader.cs
@@ -1325,7 +1325,10 @@ internal static class DarlingDataReader
             -- sys.master_files, so it still sees databases the monitoring login cannot ENTER — exactly
             -- the case being diagnosed. database_id > 4 excludes the system databases, tempdb
             -- included: the size collector takes every ONLINE database, so a bare row check
-            -- would be true on every server alive.
+            -- would be true on every server alive. A NULL database_id is an Azure sibling row
+            -- (#2643/#3262): sys.resource_stats carries no id, and it bills only USER databases,
+            -- so those rows are inventory too — without the IS NULL arm a master-connected Azure
+            -- target with fifty user databases would read as having none.
             --
             -- The inventory window is the health read's OWN ($2) — no second parameter, and an
             -- inventory that aged out says nothing rather than something stale. Uncorrelated, so both
@@ -1339,7 +1342,7 @@ internal static class DarlingDataReader
                          FROM v_database_size_stats
                          WHERE server_id = $1
                          AND   collection_time >= $2
-                         AND   database_id > 4
+                         AND   (database_id > 4 OR database_id IS NULL)
                      )
                 THEN 1
                 ELSE 0

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectionHealth.cs
@@ -96,7 +96,10 @@ public sealed partial class ViewerDataService
             -- sys.master_files, so it still sees databases the monitoring login cannot ENTER — exactly
             -- the case being diagnosed. database_id > 4 excludes the system databases, tempdb
             -- included: the size collector takes every ONLINE database, so a bare row check
-            -- would be true on every server alive.
+            -- would be true on every server alive. A NULL database_id is an Azure sibling row
+            -- (#2643/#3262): sys.resource_stats carries no id, and it bills only USER databases,
+            -- so those rows are inventory too — without the IS NULL arm a master-connected Azure
+            -- target with fifty user databases would read as having none.
             --
             -- The inventory window is the health read's OWN ($2) — no second parameter, and an
             -- inventory that aged out says nothing rather than something stale. Uncorrelated, so both
@@ -110,7 +113,7 @@ public sealed partial class ViewerDataService
                          FROM v_database_size_stats
                          WHERE server_id = $1
                          AND   collection_time >= $2
-                         AND   database_id > 4
+                         AND   (database_id > 4 OR database_id IS NULL)
                      )
                 THEN 1
                 ELSE 0

--- a/Lite.Tests/AgedDatabaseMigrationTests.cs
+++ b/Lite.Tests/AgedDatabaseMigrationTests.cs
@@ -125,6 +125,55 @@ public class AgedDatabaseMigrationTests : IDisposable
         Assert.Equal(1L, Convert.ToInt64(await countCmd.ExecuteScalarAsync()));
     }
 
+    /// <summary>
+    /// v57 (#3262) drops NOT NULL from database_size_stats.database_id / file_id / physical_name so the
+    /// Azure sibling rows (#2643) — which deliberately carry NULL in all three — can actually be stored.
+    /// Same #2748 dependency trap as v48: any prior startup persisted idx_database_size_stats_time, and
+    /// DuckDB's ALTER COLUMN refuses on a table with ANY index, so the rung has to drop it first. Seeds
+    /// that exact precondition and asserts the upgrade both completes AND a sibling-shaped row is
+    /// actually insertable afterward, not merely that nothing threw.
+    /// </summary>
+    [Fact]
+    public async Task UpgradeFromV56_DropsDatabaseSizeStatsNotNull_EvenWithAPreExistingIndex()
+    {
+        using (var seed = new DuckDBConnection($"Data Source={_dbPath}"))
+        {
+            await seed.OpenAsync();
+            await ExecAsync(seed, "CREATE TABLE schema_version (version INTEGER NOT NULL)");
+            await ExecAsync(seed, "INSERT INTO schema_version VALUES (56)");
+            await ExecAsync(seed, @"CREATE TABLE database_size_stats (
+                server_id INTEGER NOT NULL,
+                collection_time TIMESTAMP NOT NULL,
+                database_name VARCHAR NOT NULL,
+                database_id INTEGER NOT NULL,
+                file_id INTEGER NOT NULL,
+                file_type_desc VARCHAR NOT NULL,
+                file_name VARCHAR NOT NULL,
+                physical_name VARCHAR NOT NULL,
+                total_size_mb DECIMAL(19,2) NOT NULL
+            )");
+            await ExecAsync(seed, "INSERT INTO database_size_stats VALUES (1, current_timestamp, 'master', 1, 1, 'ROWS', 'data_0', 'data_0.mdf', 4.00)");
+            /* The real dependent object: DuckDbSchemaGenerator.CreateIndex's default case for
+               database_size_stats is exactly this index/column shape. */
+            await ExecAsync(seed, "CREATE INDEX idx_database_size_stats_time ON database_size_stats(server_id, collection_time)");
+        }
+
+        var initializer = new DuckDbInitializer(_dbPath);
+        await initializer.InitializeAsync();
+
+        using var verify = new DuckDBConnection($"Data Source={_dbPath}");
+        await verify.OpenAsync();
+
+        /* The real assertion: a sibling-shaped row (NULL database_id / file_id / physical_name, real
+           name and size) must actually be insertable now — this is what the appender writes the moment
+           sys.resource_stats has rows for a master-connected Azure target. */
+        await ExecAsync(verify, "INSERT INTO database_size_stats VALUES (1, current_timestamp, 'testdb1', NULL, NULL, 'ROWS', '(whole database)', NULL, 23.00)");
+
+        using var countCmd = verify.CreateCommand();
+        countCmd.CommandText = "SELECT COUNT(*) FROM database_size_stats WHERE database_id IS NULL AND file_id IS NULL AND physical_name IS NULL";
+        Assert.Equal(1L, Convert.ToInt64(await countCmd.ExecuteScalarAsync()));
+    }
+
     private static async Task ExecAsync(DuckDBConnection connection, string sql)
     {
         using var cmd = connection.CreateCommand();

--- a/Lite.Tests/AzureDatabaseSizeSiblingTests.cs
+++ b/Lite.Tests/AzureDatabaseSizeSiblingTests.cs
@@ -10,6 +10,9 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Lite.Tests.Helpers;
 using PerformanceMonitor.Collectors;
 using Xunit;
 
@@ -113,6 +116,95 @@ public class AzureDatabaseSizeSiblingTests
     {
         Assert.Contains("ROW_NUMBER() OVER (PARTITION BY r.database_name ORDER BY r.end_time DESC)", AzureSql, StringComparison.Ordinal);
         Assert.Contains("WHERE rs.rn = 1", AzureSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #3262: the seam every test above leaves untested. They pin the SQL that EMITS a sibling row —
+    /// including the NULLs at database_id, file_id and physical_name — and <c>ReadAsync</c> read
+    /// exactly those three ordinals unguarded, so the two halves were each correct and had never been
+    /// run against each other. In the field the first sibling row arrived when
+    /// <c>sys.resource_stats</c> finished ingesting (about an hour after database creation, which is
+    /// why every fresh-server validation window missed it), and the cast threw
+    /// "Object cannot be cast from DBNull to other types." — aborting the whole read, master's own
+    /// file rows included, permanently.
+    ///
+    /// <para>The reader is driven over the arm's documented shape: a real file row for the connected
+    /// database first (the ORDER BY puts sibling rows last), then a sibling row that carries only
+    /// what the arm can measure. Both rows must come back, and the sibling's absent measurements
+    /// must arrive as nulls rather than exceptions.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheReaderSurvivesTheSiblingRow_TheArmDeliberatelyEmits()
+    {
+        using var reader = new FakeCollectorDataReader(
+            new object[]
+            {
+                "master", 1, 1, "ROWS", "data_0", "data_0.mdf", 4.00m, 2.63m,
+                16.00m, 2097152m, "FULL", 160, "ONLINE", DBNull.Value, DBNull.Value, DBNull.Value,
+                0, DBNull.Value, DBNull.Value,
+            },
+            new object[]
+            {
+                "testdb1", DBNull.Value, DBNull.Value, "ROWS", "(whole database)", DBNull.Value,
+                23.00m, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value,
+                "ONLINE", DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value,
+                DBNull.Value,
+            });
+
+        var rows = await DatabaseSizeStatsCollector.Instance.ReadAsync(
+            reader, CollectorTestContext.Make(new RecordingCollectorDeltaCalculator()), CancellationToken.None);
+
+        Assert.Equal(2, rows.Count);
+
+        /* The connected database's real file row is untouched by the guards. */
+        Assert.Equal("master", rows[0].DatabaseName);
+        Assert.Equal(1, rows[0].DatabaseId);
+        Assert.Equal(1, rows[0].FileId);
+        Assert.Equal("data_0.mdf", rows[0].PhysicalName);
+
+        /* The sibling row survives, and what the arm could not measure reads as null. */
+        Assert.Equal("testdb1", rows[1].DatabaseName);
+        Assert.Null(rows[1].DatabaseId);
+        Assert.Null(rows[1].FileId);
+        Assert.Null(rows[1].PhysicalName);
+        Assert.Equal("(whole database)", rows[1].FileName);
+        Assert.Equal(23.00m, rows[1].TotalSizeMb);
+        Assert.Null(rows[1].UsedSizeMb);
+        Assert.Equal("ONLINE", rows[1].StateDesc);
+    }
+
+    /// <summary>
+    /// The other half of the seam: the sibling row must also make it back OUT of the definition. The
+    /// positional writer contract (one value per declared payload column, nulls included) is what the
+    /// stores' appender / binary COPY adapters rest on, and both store schemas hold these three
+    /// columns nullable — so the row's nulls must be written as nulls, not skipped and not defaulted.
+    /// </summary>
+    [Fact]
+    public async Task TheSiblingRowWritesItsNulls_ThroughThePositionalContract()
+    {
+        using var reader = new FakeCollectorDataReader(
+            new object[]
+            {
+                "testdb1", DBNull.Value, DBNull.Value, "ROWS", "(whole database)", DBNull.Value,
+                23.00m, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value,
+                "ONLINE", DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value,
+                DBNull.Value,
+            });
+
+        var deltas = new RecordingCollectorDeltaCalculator();
+        var rows = await DatabaseSizeStatsCollector.Instance.ReadAsync(
+            reader, CollectorTestContext.Make(deltas), CancellationToken.None);
+
+        var writer = new RecordingCollectorRowWriter();
+        DatabaseSizeStatsCollector.Instance.WritePayload(Assert.Single(rows), writer, CollectorTestContext.Make(deltas));
+
+        Assert.Equal(DatabaseSizeStatsCollector.Instance.PayloadColumns.Count, writer.Values.Count);
+        Assert.Equal("testdb1", writer.Values[0]);
+        Assert.Null(writer.Values[1]);    /* database_id */
+        Assert.Null(writer.Values[2]);    /* file_id */
+        Assert.Equal("(whole database)", writer.Values[4]);
+        Assert.Null(writer.Values[5]);    /* physical_name */
+        Assert.Equal(23.00m, writer.Values[6]);
     }
 
     /// <summary>

--- a/Lite.Tests/DuckDbSchemaEquivalenceTests.cs
+++ b/Lite.Tests/DuckDbSchemaEquivalenceTests.cs
@@ -143,12 +143,24 @@ public class DuckDbSchemaEquivalenceTests : IDisposable
     /// keeps every permission-free column instead of losing the entire row — which only works if the
     /// columns can hold NULL. <see cref="DuckDbInitializer"/>'s v48 migration drops the constraint on
     /// existing databases.</para>
+    ///
+    /// <para>#3262 / schema v57: <c>database_size_stats.database_id</c>, <c>file_id</c> and
+    /// <c>physical_name</c> dropped NOT NULL. The Azure sibling arm (#2643) reads
+    /// <c>sys.resource_stats</c>, which carries per-DATABASE sizes with no per-file breakdown, so a
+    /// sibling row deliberately holds NULL in all three — the reader now passes those NULLs through
+    /// instead of dying on the cast, and the store has to accept them. Darling's Postgres store
+    /// always held these columns nullable; this brings Lite's DuckDB store to the same shape.
+    /// <see cref="DuckDbInitializer"/>'s v57 migration drops the constraint on existing
+    /// databases.</para>
     /// </summary>
     private static readonly HashSet<string> IntentionalStorageDivergences = new(StringComparer.Ordinal)
     {
         "server_properties.cpu_count",
         "server_properties.hyperthread_ratio",
         "server_properties.physical_memory_mb",
+        "database_size_stats.database_id",
+        "database_size_stats.file_id",
+        "database_size_stats.physical_name",
     };
 
     /// <summary>

--- a/Lite.Tests/EmptyEnumerationInventoryTests.cs
+++ b/Lite.Tests/EmptyEnumerationInventoryTests.cs
@@ -246,6 +246,28 @@ public sealed class EmptyEnumerationInventoryTests : IClassFixture<SharedDuckDbF
     }
 
     [Fact]
+    public async Task An_Azure_Sibling_Row_Is_Inventory_Despite_Its_Null_Database_Id()
+    {
+        var service = new LocalDataService(_duckDb);
+
+        /* #3262: on a master-connected Azure target the only evidence of user databases is the sibling
+           rows (#2643), and those deliberately carry NULL database_id — sys.resource_stats has no id to
+           give. They are user databases by construction (the view bills only user databases, and the
+           connected database is excluded by the arm), so the screen admits them through its IS NULL arm;
+           without it this target read as having no user databases at all. */
+        await SeedLogAsync("query_store", MinutesAgo(30), EnumeratedCollectorDriver.EmptyEnumerationMessage);
+        await SeedLogAsync("query_store", MinutesAgo(20), EnumeratedCollectorDriver.EmptyEnumerationMessage);
+        await SeedSiblingSizeAsync("testdb1", MinutesAgo(25));
+
+        var row = await ReadAsync(service, "query_store");
+
+        Assert.True(row.TargetHasUserDatabases);
+        Assert.Equal(
+            EnumeratedCollectorDriver.EmptyEnumerationMessage + " (all 2 runs, " + CollectorHealthClassifier.HasUserDatabasesQualifier + ")",
+            row.NoteFormatted);
+    }
+
+    [Fact]
     public async Task An_Inventory_Older_Than_The_Health_Window_Says_Nothing()
     {
         var service = new LocalDataService(_duckDb);
@@ -372,4 +394,15 @@ INSERT INTO database_size_stats
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
             _nextId++, collectionTimeUtc, serverId ?? ServerId, "TestSrv", databaseName, databaseId,
             1, "ROWS", databaseName + "_data", "C:\\data\\" + databaseName + ".mdf", 128.00m);
+
+    /// <summary>The Azure sibling shape (#2643): NULL database_id / file_id / physical_name, a file_name
+    /// that says it is a whole database, and a real size — exactly what the arm projects.</summary>
+    private async Task SeedSiblingSizeAsync(string databaseName, DateTime collectionTimeUtc) =>
+        await ExecAsync(@"
+INSERT INTO database_size_stats
+    (collection_id, collection_time, server_id, server_name, database_name, database_id,
+     file_id, file_type_desc, file_name, physical_name, total_size_mb)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+            _nextId++, collectionTimeUtc, ServerId, "TestSrv", databaseName, null,
+            null, "ROWS", "(whole database)", null, 23.00m);
 }

--- a/Lite.Tests/TempDbCeilingStoreTests.cs
+++ b/Lite.Tests/TempDbCeilingStoreTests.cs
@@ -44,7 +44,10 @@ public sealed class TempDbCeilingStoreTests : IClassFixture<SharedDuckDbFixture>
     [Fact]
     public void TheSchemaVersionMovedWithTheColumn()
     {
-        Assert.Equal(56, DuckDbInitializer.CurrentSchemaVersion);
+        /* At LEAST 56, not exactly: pinning the current version makes every later migration fail
+           this test for a column it never touched. What matters here is that the version moved
+           past the rung that adds the column, so an existing database cannot sit below it. */
+        Assert.True(DuckDbInitializer.CurrentSchemaVersion >= 56);
 
         var ddl = DuckDbSchemaGenerator.CreateTable(PerformanceMonitor.Collectors.TempDbStatsCollector.Instance);
         Assert.Contains("max_size_mb DECIMAL(18,2)", ddl, System.StringComparison.Ordinal);

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -271,7 +271,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 56;
+    internal const int CurrentSchemaVersion = 57;
 
     private readonly string _archivePath;
 
@@ -1505,6 +1505,47 @@ public class DuckDbInitializer
             catch (Exception ex)
             {
                 _logger?.LogWarning("Migration to v56 encountered an error (non-fatal): {Error}", ex.Message);
+            }
+        }
+
+        if (fromVersion < 57)
+        {
+            /* v57: drop NOT NULL from database_size_stats.database_id / file_id / physical_name
+                    (#3262). The Azure sibling arm (#2643) reads sys.resource_stats, which has
+                    per-DATABASE sizes and no per-file breakdown, so a sibling row deliberately
+                    carries NULL in all three — and the reader now passes those NULLs through
+                    instead of dying on the cast. An existing database has to have the constraint
+                    dropped or the appender fails the first sibling row and the whole batch with
+                    it. New databases get it from the generator; Darling's Postgres store was
+                    always nullable here. Column types and ordinals are unchanged, so the
+                    positional appender and old parquet are unaffected. */
+            _logger?.LogInformation("Running migration to v57: database_size_stats sibling-row columns become nullable");
+
+            /* Same trap as v48 (#2748): DuckDB's ALTER COLUMN refuses on a table with ANY index,
+               even one naming none of the altered columns. Drop it first;
+               Schema.GetAllIndexStatements()'s loop (called unconditionally right after
+               migrations, inside this same InitializeAsync) recreates it. */
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "DROP INDEX IF EXISTS idx_database_size_stats_time");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v57 could not drop idx_database_size_stats_time ahead of the ALTERs (non-fatal, the ALTERs below may still fail): {Error}", ex.Message);
+            }
+
+            foreach (var column in new[] { "database_id", "file_id", "physical_name" })
+            {
+                try
+                {
+                    await ExecuteNonQueryAsync(connection, $"ALTER TABLE database_size_stats ALTER COLUMN {column} DROP NOT NULL");
+                }
+                catch (Exception ex)
+                {
+                    /* Already nullable, or the table does not exist yet (fresh install creates it
+                       correctly from the generator) — neither is fatal. */
+                    _logger?.LogWarning("Migration to v57 on {Column} encountered an error (non-fatal): {Error}", column, ex.Message);
+                }
             }
         }
     }

--- a/Lite/Database/DuckDbSchemaGenerator.cs
+++ b/Lite/Database/DuckDbSchemaGenerator.cs
@@ -232,11 +232,14 @@ public static class DuckDbSchemaGenerator
             ["running_jobs.successful_run_count"] = "NOT NULL",
             ["running_jobs.is_running_long"] = "NOT NULL",
             ["database_size_stats.database_name"] = "NOT NULL",
-            ["database_size_stats.database_id"] = "NOT NULL",
-            ["database_size_stats.file_id"] = "NOT NULL",
+            /* database_id / file_id / physical_name are deliberately NULLABLE (#3262): the Azure
+               sibling arm (#2643) reads sys.resource_stats, which has per-DATABASE sizes and no
+               per-file breakdown, so a sibling row honestly carries NULL for all three. NOT NULL
+               here would fail the appender on the first sibling row and lose the whole batch --
+               the same shape as #1591's server_properties hardware columns. Schema v57 drops the
+               constraint on existing databases. */
             ["database_size_stats.file_type_desc"] = "NOT NULL",
             ["database_size_stats.file_name"] = "NOT NULL",
-            ["database_size_stats.physical_name"] = "NOT NULL",
             ["database_size_stats.total_size_mb"] = "NOT NULL",
             ["index_object_stats.database_name"] = "NOT NULL",
             ["index_object_stats.database_id"] = "NOT NULL",

--- a/Lite/Services/LocalDataService.CollectionHealth.cs
+++ b/Lite/Services/LocalDataService.CollectionHealth.cs
@@ -118,7 +118,10 @@ SELECT
     -- no index at all; and it reads sys.master_files, so it still sees databases the monitoring login
     -- cannot ENTER — which is exactly the case being diagnosed. database_id > 4 excludes the system
     -- databases, tempdb included: the size collector takes every ONLINE database, so a bare row check
-    -- would be true on every server alive.
+    -- would be true on every server alive. A NULL database_id is an Azure sibling row (#2643/#3262):
+    -- sys.resource_stats carries no id, and it bills only USER databases, so those rows are inventory
+    -- too — without the IS NULL arm a master-connected Azure target with fifty user databases would
+    -- read as having none.
     --
     -- The inventory window is the health read's OWN ($2) — no second parameter, and an inventory that
     -- aged out says nothing rather than something stale. Uncorrelated, so both engines evaluate it
@@ -131,7 +134,7 @@ SELECT
                  FROM v_database_size_stats
                  WHERE server_id = $1
                  AND   collection_time >= $2
-                 AND   database_id > 4
+                 AND   (database_id > 4 OR database_id IS NULL)
              )
         THEN 1
         ELSE 0

--- a/PerformanceMonitor.Collectors/DatabaseSizeStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/DatabaseSizeStatsCollector.cs
@@ -44,13 +44,19 @@ public sealed class DatabaseSizeStatsCollector : CollectorDefinitionBase<Databas
     {
     }
 
+    /// <summary>
+    /// <c>DatabaseId</c>, <c>FileId</c> and <c>PhysicalName</c> are nullable because the Azure
+    /// sibling arm (#2643) deliberately emits them as NULL: <c>sys.resource_stats</c> has no
+    /// per-file breakdown, so a sibling row carries a database name and a total size and honestly
+    /// nothing else. Both stores hold the columns nullable (#3262).
+    /// </summary>
     public readonly record struct Row(
         string DatabaseName,
-        int DatabaseId,
-        int FileId,
+        int? DatabaseId,
+        int? FileId,
         string FileTypeDesc,
         string FileName,
-        string PhysicalName,
+        string? PhysicalName,
         decimal TotalSizeMb,
         decimal? UsedSizeMb,
         decimal? AutoGrowthMb,
@@ -441,13 +447,17 @@ OPTION(RECOMPILE);";
 
         while (await reader.ReadAsync(cancellationToken))
         {
+            /* Ordinals 1, 2 and 5 are NULL on every Azure sibling row (#2643's arm omits what
+               sys.resource_stats cannot measure), and an unguarded read here killed the whole
+               collection — master's own rows included — the moment the first sibling row appeared
+               (#3262). */
             rows.Add(new Row(
                 reader.GetString(0),
-                Convert.ToInt32(reader.GetValue(1), CultureInfo.InvariantCulture),
-                Convert.ToInt32(reader.GetValue(2), CultureInfo.InvariantCulture),
+                reader.IsDBNull(1) ? null : Convert.ToInt32(reader.GetValue(1), CultureInfo.InvariantCulture),
+                reader.IsDBNull(2) ? null : Convert.ToInt32(reader.GetValue(2), CultureInfo.InvariantCulture),
                 reader.GetString(3),
                 reader.GetString(4),
-                reader.GetString(5),
+                reader.IsDBNull(5) ? null : reader.GetString(5),
                 reader.GetDecimal(6),
                 reader.IsDBNull(7) ? null : reader.GetDecimal(7),
                 reader.IsDBNull(8) ? null : reader.GetDecimal(8),


### PR DESCRIPTION
## What broke

#2643 taught the Azure arm of `database_size_stats` to report sibling databases from `sys.resource_stats` on a master connection. That view has per-database sizes and no per-file breakdown, so the arm deliberately emits sibling rows with `database_id`, `file_id` and `physical_name` NULL ("file_id NULL and a file_name that says so, never a fabricated file"). `ReadAsync` read exactly those three ordinals unguarded, so the first sibling row threw `Object cannot be cast from DBNull to other types.` and aborted the whole read - master's own file rows included, permanently. Only master-connected Azure targets are affected; the collector is shared, so both SKUs carry it, and it ships in v3.6.0.

## Why validation missed it

Two independent gaps that line up:

- `AzureDatabaseSizeSiblingTests` pins the SQL shape - including `TheSiblingInsertOmitsWhatItCannotMeasure`, which asserts the very NULLs that kill the reader - but never drove `ReadAsync` over that shape. Each half was correct; the seam between them was untested.
- Release validation uses fresh throwaway servers, and `sys.resource_stats` stays empty for the first ~45-60 minutes, so the sibling arm returned 0 rows in every validation window and the reader never met a sibling row until the nightly dogfood box aged past an hour.

## The fix

- **Reader** (`DatabaseSizeStatsCollector.cs`): guard ordinals 1, 2 and 5 with `IsDBNull`; `Row.DatabaseId` / `FileId` / `PhysicalName` become `int?` / `int?` / `string?`. `WritePayload` is unchanged - both row writers (DuckDB appender, Npgsql binary COPY) already carry null-writing `int?`/`string?` overloads.
- **Lite store**: the DuckDB schema held all three columns NOT NULL, so the fixed reader alone would only have moved the crash from the read to the append. The generator overlay drops the constraints, the equivalence ledger records the deliberate divergence (the #1591/v48 pattern - the frozen golden snapshot stays frozen), and schema **v57** migrates existing stores, dropping `idx_database_size_stats_time` first because DuckDB's `ALTER COLUMN` refuses on a table with any index (#2748's trap, same as v48).
- **Darling store**: `collect.database_size_stats` was always nullable on these columns - verified against the pinned migration-ladder DDL, not assumed - so no migration and no numbering claim.
- **Consumer sweep** (both SKUs): the one thing the NULLs actually broke is the `has_user_databases` inventory screen (`database_id > 4`) in Lite's collection health, the Darling viewer's twin, and the Darling MCP reader's twin - on a master-connected Azure target the sibling rows are the only evidence of user databases, and the screen read such a target as having none. All three now admit NULL ids, which are sibling rows by construction (`sys.resource_stats` bills only user databases and the arm excludes the connected one). Everything else survives on inspection: both name-map readers already skip NULL ids row-by-row, both analysis fact/drilldown reads filter on `is_percent_growth = true` which NULL fails, FinOps/MCP/compose surfaces aggregate by database_name with IsDBNull-guarded readers, no rollup or retention SQL touches the three columns, and the deprecated Dashboard's T-SQL collector has no sibling arm so its store never sees the shape.

## Test evidence

**Seam test proven red first** - `Lite.Tests.AzureDatabaseSizeSiblingTests` gains two reader-level tests driving the real `ReadAsync` over the arm's documented shape. Against the unfixed reader (fix stashed):

```
Lite.Tests.AzureDatabaseSizeSiblingTests.TheReaderSurvivesTheSiblingRow_TheArmDeliberatelyEmits [FAIL]
  System.InvalidCastException : Object cannot be cast from DBNull to other types.
  at System.DBNull.System.IConvertible.ToInt32(IFormatProvider provider)
  at PerformanceMonitor.Collectors.DatabaseSizeStatsCollector.ReadAsync(...)
Lite.Tests.AzureDatabaseSizeSiblingTests.TheSiblingRowWritesItsNulls_ThroughThePositionalContract [FAIL]
  System.InvalidCastException : Object cannot be cast from DBNull to other types.
Total: 9, Failed: 2  (the seven SQL-shape pins stay green)
```

With the fix restored: `Total: 9, Failed: 0`.

**Store proof, both directions**: `AgedDatabaseMigrationTests.UpgradeFromV56_DropsDatabaseSizeStatsNotNull_EvenWithAPreExistingIndex` runs the real v57 migration against a real DuckDB seeded with the old NOT NULL shape plus the persisted index, then inserts a sibling-shaped row; the equivalence ledger forces the generator to emit the columns nullable for fresh stores. `DarlingEmptyEnumerationInventoryTests` gains a live-Postgres sibling-inventory test (gated on `DARLING_TEST_PG`, runs in the darling-pg CI job) whose seed INSERT itself proves the Pg store accepts the NULLs.

**Full suites on the rebased tree**: Lite.Tests 3631/0 failed. Darling.Tests 8406 total, 334 live-gated skips, 1 failure - `NpgsqlRootCertificateValidationTests.ChainShape_VerifyFullWithPrintedRoot_...`, which fails identically on a clean origin/dev build on this machine (verified in a throwaway dev worktree) and is unrelated TLS/platform behavior.

**Warnings**: zero new - both test projects build 0 Warning(s) / 0 Error(s) on the rebased tree (dev's #3241 cleanup holds).

**Live verify**: skipped cleanly - pm-nightly-0910 answers but refuses the stored credential (rotated or replaced post-validation), which the task treats as the server being gone; the seam test carries the proof.

CHANGELOG deliberately untouched per the wave protocol; the entry goes in the post-wave consolidated splice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtjWJJ3NnSkDSrPBsGywoZ
