### PR TITLE
Make the server stale band honor each collector's own cadence (#3236)

### DIFF
--- a/Darling/Darling.Tests/DarlingFleetReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingFleetReaderTests.cs
@@ -152,6 +152,34 @@ public sealed class DarlingFleetReaderSqlTests
     }
 
     /// <summary>
+    /// #3236: the per-(server, collector) newest-run aggregate the cadence-aware stale threshold reads —
+    /// windowed like <see cref="DarlingFleetReader.FleetLastCollectionSql"/> (same chunk-exclusion
+    /// argument), grouped per collector, and with NO status filter: freshness is the rows-are-landing axis,
+    /// and a collector erroring on schedule is still landing rows.
+    /// </summary>
+    [Fact]
+    public void FleetCollectorCadenceSql_PerCollectorNewestRun_Windowed_AnyStatus()
+    {
+        var sql = DarlingFleetReader.FleetCollectorCadenceSql;
+        Assert.Contains("FROM v_collection_log", sql, StringComparison.Ordinal);
+        Assert.Contains("GROUP BY server_id, collector_name", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $1", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("status", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// #3236: the override read matches the worker's own (<c>StoreConfigProvider.ReadScheduleOverridesAsync</c>)
+    /// column-for-column, so the threshold resolves through EXACTLY the schedule the sweep runs on.
+    /// </summary>
+    [Fact]
+    public void FleetScheduleOverridesSql_MatchesTheWorkersOwnRead()
+    {
+        Assert.Equal(
+            "SELECT server_id, collector_name, frequency_minutes, retention_days, enabled FROM config_collector_schedules",
+            DarlingFleetReader.FleetScheduleOverridesSql);
+    }
+
+    /// <summary>
     /// The read-only fleet-tag join (#2020): every (server, tag) assignment, joined to the tag for its name and
     /// stored colour, ordered so a card's pills are stable. Bare table names resolve through the store's
     /// search_path to the config-schema tag tables, the same way FleetServersSql reads servers / config_mute_rules.
@@ -194,6 +222,8 @@ public sealed class DarlingFleetReaderSqlTests
     [InlineData(nameof(DarlingFleetReader.FleetDeadlockSql))]
     [InlineData(nameof(DarlingFleetReader.FleetLastCollectionSql))]
     [InlineData(nameof(DarlingFleetReader.FleetCollectionHealthSql))]
+    [InlineData(nameof(DarlingFleetReader.FleetCollectorCadenceSql))]
+    [InlineData(nameof(DarlingFleetReader.FleetScheduleOverridesSql))]
     public void EveryFleetSql_IsPgDialect_NoTSql(string constName)
     {
         var sql = (string)typeof(DarlingFleetReader).GetField(constName, BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
@@ -794,4 +824,68 @@ public sealed class DarlingFleetReaderLivePostgresTests
             await cleanup.ExecuteNonQueryAsync(ct);
         }
     }
+}
+
+/// <summary>
+/// #3236: the per-row voucher decision behind the cadence-aware stale threshold —
+/// <see cref="DarlingFleetReader.BuildCadenceSample"/>, pure over (collector, newest run, server, the
+/// sparse overrides). The resolution is <c>StoreConfigProvider.ResolveSchedule</c>'s (per-server &gt;
+/// fleet-wide &gt; code default), so these pin that the threshold honors the schedule the sweep actually
+/// runs — and that every exclusion (disabled, on-load, a collector this build has never heard of) falls
+/// toward the flat floor rather than widening anything.
+/// </summary>
+public sealed class DarlingFleetCadenceSampleTests
+{
+    private static readonly DateTime LastRun = new(2026, 9, 6, 12, 0, 0, DateTimeKind.Unspecified);
+    private static readonly System.Collections.Generic.List<PerformanceMonitor.Darling.Service.ScheduleOverride> NoOverrides = new();
+
+    [Fact]
+    public void NoOverrides_ResolvesTheCodeDefaultCadence()
+    {
+        var sample = DarlingFleetReader.BuildCadenceSample("pg_cpu_utilization", LastRun, serverId: 7, NoOverrides);
+
+        Assert.Equal(new CollectorCadenceSample(LastRun, 5), sample);
+    }
+
+    [Fact]
+    public void APerServerOverride_WinsOverAFleetWideOne()
+    {
+        var overrides = new System.Collections.Generic.List<PerformanceMonitor.Darling.Service.ScheduleOverride>
+        {
+            new(null, "pg_wait_stats", 10, null, true),
+            new(7, "pg_wait_stats", 30, null, true),
+        };
+
+        Assert.Equal(
+            new CollectorCadenceSample(LastRun, 30),
+            DarlingFleetReader.BuildCadenceSample("pg_wait_stats", LastRun, serverId: 7, overrides));
+
+        /* A different server sees only the fleet layer. */
+        Assert.Equal(
+            new CollectorCadenceSample(LastRun, 10),
+            DarlingFleetReader.BuildCadenceSample("pg_wait_stats", LastRun, serverId: 8, overrides));
+    }
+
+    [Fact]
+    public void ADisabledCollector_VouchesForNothing()
+    {
+        var overrides = new System.Collections.Generic.List<PerformanceMonitor.Darling.Service.ScheduleOverride>
+        {
+            new(7, "pg_wait_stats", null, null, false),
+        };
+
+        Assert.Null(DarlingFleetReader.BuildCadenceSample("pg_wait_stats", LastRun, serverId: 7, overrides));
+    }
+
+    [Fact]
+    public void AnOnLoadCollector_VouchesForNothing() =>
+        /* server_config's default FrequencyMinutes is 0: it runs on connects, not on the loop this
+           band watches. */
+        Assert.Null(DarlingFleetReader.BuildCadenceSample("server_config", LastRun, serverId: 7, NoOverrides));
+
+    [Fact]
+    public void ACollectorThisBuildDoesNotKnow_VouchesForNothing() =>
+        /* A store written by a newer build: no default row means no schedule this build can band
+           against — and no KeyNotFoundException out of the resolver, which indexes the defaults. */
+        Assert.Null(DarlingFleetReader.BuildCadenceSample("pg_collector_from_the_future", LastRun, serverId: 7, NoOverrides));
 }

--- a/Darling/Darling.Tests/FleetCardCollectionStaleNamesItsPopulationTests.cs
+++ b/Darling/Darling.Tests/FleetCardCollectionStaleNamesItsPopulationTests.cs
@@ -167,10 +167,12 @@ public sealed class FleetCardCollectionStaleNamesItsPopulationTests
     }
 
     /// <summary>
-    /// The reader's whole derivation, in the four lines that are all of it: classify the newest collection's
-    /// age, explode that band into the shared flags, take the flag, put it on the card. There is no error
-    /// count in the chain, no <c>collection_log</c> read, and no use of the roll-up's published window — which
-    /// is why the card's <c>window_start</c> / <c>window_end</c> never bounded it.
+    /// The reader's whole derivation, in the lines that are all of it: resolve this server's own stale
+    /// cutoff from its collectors' cadences (#3236), classify the newest collection's age against it,
+    /// explode that band into the shared flags, take the flag, put it on the card. There is no error count
+    /// in the chain, no <c>collection_log</c> STATUS read (the cadence samples are timestamps and
+    /// schedules, never outcomes), and no use of the roll-up's published window — which is why the card's
+    /// <c>window_start</c> / <c>window_end</c> never bounded it.
     /// </summary>
     [Fact]
     public void TheMcpCard_DerivesTheFlagFromFreshnessAndNothingElse()
@@ -179,11 +181,15 @@ public sealed class FleetCardCollectionStaleNamesItsPopulationTests
             "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingFleetReader.cs");
 
         Assert.Contains(
-            "var freshness = ServerHealthClassifier.ClassifyFreshness(lastCollection, now);\n"
+            "var freshness = ServerHealthClassifier.ClassifyFreshness(lastCollection, now, staleThreshold);\n"
           + "        var flags = ServerCollectionStatusRules.FlagsFor(freshness);",
             reader, StringComparison.Ordinal);
         Assert.Contains("var collectionStale = flags.CollectionStale;", reader, StringComparison.Ordinal);
         Assert.Contains("CollectionStale = collectionStale,", reader, StringComparison.Ordinal);
+
+        /* #3236: and the cutoff itself comes from the SHARED reducer over the server's cadence samples —
+           a reader-local derivation here would be a second ladder, which is the #2473 shape. */
+        Assert.Contains("ServerHealthClassifier.EffectiveStaleThreshold(", reader, StringComparison.Ordinal);
 
         /* And the field is published under the name that derivation earns. */
         Assert.Contains(
@@ -210,6 +216,7 @@ public sealed class FleetCardCollectionStaleNamesItsPopulationTests
             IsOnline = true,
             CollectionStale = true,
             LastCollectionTime = new DateTime(2026, 9, 6, 11, 50, 0, DateTimeKind.Unspecified),
+            StaleThresholdMinutes = 2,
             FailedCollectorCount = 0,
             HealthyCollectorCount = 39,
             CollectorSeverity = HealthSeverity.Healthy,
@@ -219,6 +226,9 @@ public sealed class FleetCardCollectionStaleNamesItsPopulationTests
 
         JsonAssert.Contains("\"collection_stale\": true", json);
         JsonAssert.Contains("\"last_collection\": \"2026-09-06T11:50:00\"", json);
+        /* #3236: the cutoff the flag was decided against rides on the card — with a per-server threshold,
+           last_collection + generated_at alone no longer recompute the flag; the three together do. */
+        JsonAssert.Contains("\"stale_threshold_minutes\": 2", json);
         JsonAssert.Contains("\"status\": \"Warning\"", json);
 
         /* The error axis is still published, and still separately — the flag was renamed, not merged into

--- a/Darling/Darling.Tests/ServerHealthClassifierTests.cs
+++ b/Darling/Darling.Tests/ServerHealthClassifierTests.cs
@@ -41,6 +41,107 @@ public sealed class ServerHealthClassifierTests
     public void ClassifyFreshness_BandsByAge(int ageSeconds, ServerFreshness expected) =>
         Assert.Equal(expected, ServerHealthClassifier.ClassifyFreshness(Now.AddSeconds(-ageSeconds), Now));
 
+    /* ── #3236: the cadence-aware stale cutoff — a server is stale only when every enabled scheduled
+       collector is overdue against ITS OWN schedule, not against the flat 2-minute floor ── */
+
+    [Theory]
+    [InlineData(0, 2)]      // on-load / unknown — the floor
+    [InlineData(1, 2)]      // a 1-min collector keeps the flat threshold exactly
+    [InlineData(5, 10)]     // pg_cpu_utilization's tier: twice its own cadence
+    [InlineData(1440, 2880)] // a daily collector — wide, and the Offline band still fires first at 30 min
+    public void StaleThresholdFor_IsTwiceTheCadenceFlooredAtTheFlatThreshold(int frequencyMinutes, int expectedMinutes) =>
+        Assert.Equal(TimeSpan.FromMinutes(expectedMinutes), ServerHealthThresholds.StaleThresholdFor(frequencyMinutes));
+
+    [Fact]
+    public void EffectiveStaleThreshold_NoSamples_IsTheFlatFloor()
+    {
+        Assert.Equal(
+            ServerHealthThresholds.StaleThreshold,
+            ServerHealthClassifier.EffectiveStaleThreshold(Now, Array.Empty<CollectorCadenceSample>()));
+        Assert.Equal(
+            ServerHealthThresholds.StaleThreshold,
+            ServerHealthClassifier.EffectiveStaleThreshold(Now, null!));
+    }
+
+    [Fact]
+    public void EffectiveStaleThreshold_TheLatestCollectorExpiryWins()
+    {
+        var lastCollection = Now;
+
+        /* A 1-min collector current at the newest collection holds the floor; a 5-min collector whose
+           newest run is 60s older still vouches for 10min - 60s = 9min of the newest collection's age. */
+        var threshold = ServerHealthClassifier.EffectiveStaleThreshold(
+            lastCollection,
+            new[]
+            {
+                new CollectorCadenceSample(lastCollection, 1),
+                new CollectorCadenceSample(lastCollection.AddSeconds(-60), 5),
+            });
+
+        Assert.Equal(TimeSpan.FromMinutes(9), threshold);
+    }
+
+    [Fact]
+    public void EffectiveStaleThreshold_AStragglerCannotTightenTheFloor()
+    {
+        /* A 1-min collector that stopped 10 minutes before the newest collection contributes a negative
+           term; the floor is the answer, never less. */
+        var threshold = ServerHealthClassifier.EffectiveStaleThreshold(
+            Now, new[] { new CollectorCadenceSample(Now.AddMinutes(-10), 1) });
+
+        Assert.Equal(ServerHealthThresholds.StaleThreshold, threshold);
+    }
+
+    /// <summary>
+    /// The #3236 field case, to the second: the fleet snapshot landed 3m49s after the newest collection on
+    /// a target whose metric-driving collector (<c>pg_cpu_utilization</c>) legitimately runs every 5
+    /// minutes. On the flat floor that banded Warning — 14 healthy Aurora targets at once — and against
+    /// the collector's own schedule it is simply on time.
+    /// </summary>
+    [Fact]
+    public void ClassifyFreshness_FiveMinuteCadenceCollector_FourMinutesOld_IsFreshNotStale()
+    {
+        var lastCollection = Now.AddSeconds(-229);
+        var samples = new[] { new CollectorCadenceSample(lastCollection, 5) };
+
+        var threshold = ServerHealthClassifier.EffectiveStaleThreshold(lastCollection, samples);
+
+        Assert.Equal(TimeSpan.FromMinutes(10), threshold);
+        Assert.Equal(ServerFreshness.Fresh, ServerHealthClassifier.ClassifyFreshness(lastCollection, Now, threshold));
+
+        /* The flat overload still calls this Stale — that IS the false positive this fix removes, kept
+           here as the statement of what changed rather than deleted as an inconvenience. */
+        Assert.Equal(ServerFreshness.Stale, ServerHealthClassifier.ClassifyFreshness(lastCollection, Now));
+    }
+
+    /// <summary>The failure direction stays safe: past twice its OWN cadence, the same collector bands.</summary>
+    [Fact]
+    public void ClassifyFreshness_FiveMinuteCadenceCollector_PastTwiceItsCadence_IsStale()
+    {
+        var lastCollection = Now.AddSeconds(-601);
+        var samples = new[] { new CollectorCadenceSample(lastCollection, 5) };
+
+        var threshold = ServerHealthClassifier.EffectiveStaleThreshold(lastCollection, samples);
+
+        Assert.Equal(ServerFreshness.Stale, ServerHealthClassifier.ClassifyFreshness(lastCollection, Now, threshold));
+    }
+
+    /// <summary>
+    /// The Offline band is NOT cadence-relative (#2794's 30-minute contract with the alert engine): a
+    /// slow-cadence server whose stale window would stretch past it simply has no amber band, and the red
+    /// one still fires on schedule.
+    /// </summary>
+    [Fact]
+    public void ClassifyFreshness_CadenceAwareCutoff_NeverMovesTheOfflineBand()
+    {
+        var lastCollection = Now.AddSeconds(-1801);
+        var threshold = ServerHealthClassifier.EffectiveStaleThreshold(
+            lastCollection, new[] { new CollectorCadenceSample(lastCollection, 30) });
+
+        Assert.True(threshold > ServerHealthThresholds.OfflineThreshold);
+        Assert.Equal(ServerFreshness.Offline, ServerHealthClassifier.ClassifyFreshness(lastCollection, Now, threshold));
+    }
+
     /* ── per-metric bands ── */
 
     [Theory]

--- a/Darling/Darling.Tests/ViewerServerChromeTests.cs
+++ b/Darling/Darling.Tests/ViewerServerChromeTests.cs
@@ -34,7 +34,7 @@ public sealed class ViewerServerChromeTests
         var now = DateTime.UtcNow;
         var server = Server();
 
-        server.ApplyFreshness(now.AddSeconds(-30), now);
+        server.ApplyFreshness(now.AddSeconds(-30), now, ServerHealthThresholds.StaleThreshold);
 
         Assert.True(server.IsOnline);
         Assert.False(server.CollectionStale);
@@ -48,7 +48,7 @@ public sealed class ViewerServerChromeTests
         var server = Server();
 
         /* Older than 2x the 1-minute collector cadence but not yet offline (< 15 min). */
-        server.ApplyFreshness(now.AddMinutes(-5), now);
+        server.ApplyFreshness(now.AddMinutes(-5), now, ServerHealthThresholds.StaleThreshold);
 
         Assert.True(server.IsOnline);
         Assert.True(server.CollectionStale);
@@ -62,7 +62,7 @@ public sealed class ViewerServerChromeTests
         var server = Server();
 
         /* -31: exactly 30 minutes is the shared collection-stopped boundary and bands Stale (strict >, #2794). */
-        server.ApplyFreshness(now.AddMinutes(-31), now);
+        server.ApplyFreshness(now.AddMinutes(-31), now, ServerHealthThresholds.StaleThreshold);
 
         Assert.False(server.IsOnline);
         Assert.Equal("Offline", server.DotStatus);
@@ -79,7 +79,7 @@ public sealed class ViewerServerChromeTests
            freshness call, one panel over. The dot now says what the card says. */
         var server = Server();
 
-        server.ApplyFreshness(null, DateTime.UtcNow);
+        server.ApplyFreshness(null, DateTime.UtcNow, ServerHealthThresholds.StaleThreshold);
 
         Assert.Null(server.IsOnline);
         Assert.True(server.AwaitingFirstCollection);
@@ -96,7 +96,7 @@ public sealed class ViewerServerChromeTests
             if (e.PropertyName is nameof(DarlingServer.DotStatus)) changed++;
         };
 
-        server.ApplyFreshness(DateTime.UtcNow, DateTime.UtcNow);
+        server.ApplyFreshness(DateTime.UtcNow, DateTime.UtcNow, ServerHealthThresholds.StaleThreshold);
 
         Assert.True(changed > 0);
     }

--- a/Darling/Darling.Tests/ViewerSidebarDotRendersTheCardStatusTests.cs
+++ b/Darling/Darling.Tests/ViewerSidebarDotRendersTheCardStatusTests.cs
@@ -50,14 +50,14 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
     private static DarlingServer Dot(DateTime? lastCollectionUtc)
     {
         var server = new DarlingServer(1, "SQL2022", "Prod", true, 16);
-        server.ApplyFreshness(lastCollectionUtc, Now);
+        server.ApplyFreshness(lastCollectionUtc, Now, ServerHealthThresholds.StaleThreshold);
         return server;
     }
 
     private static ServerSummaryItem Card(DateTime? lastCollectionUtc)
     {
         var card = new ServerSummaryItem { ServerName = "SQL2022", ServerId = 1, LastCollectionTime = lastCollectionUtc };
-        card.ApplyFreshness(Now);
+        card.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         return card;
     }
 
@@ -250,7 +250,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
             DeadlockCount = 12,
             FailedCollectorCount = 3,
         };
-        onFire.ApplyFreshness(Now);
+        onFire.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
 
         Assert.Equal(ServerCollectionStatus.Online, onFire.CardStatus);
         Assert.Equal("Online", onFire.StatusDisplay);

--- a/Darling/Darling.Tests/ViewerW2aTests.cs
+++ b/Darling/Darling.Tests/ViewerW2aTests.cs
@@ -206,7 +206,7 @@ public sealed class ViewerServerSummaryDisplayTests
     {
         /* Never-collected is DISTINCT from Offline: during a slow fleet bootstrap a queued server
            must not render the red "data stopped" overlay (24-server field incident, 2026-07-17). */
-        Assert.Equal(ServerFreshness.NeverCollected, ServerSummaryItem.ClassifyFreshness(null, Now));
+        Assert.Equal(ServerFreshness.NeverCollected, ServerSummaryItem.ClassifyFreshness(null, Now, ServerHealthThresholds.StaleThreshold));
     }
 
     [Theory]
@@ -223,14 +223,14 @@ public sealed class ViewerServerSummaryDisplayTests
     public void ClassifyFreshness_BandsByAge(int ageSeconds, ServerFreshness expected)
     {
         var lastCollection = Now.AddSeconds(-ageSeconds);
-        Assert.Equal(expected, ServerSummaryItem.ClassifyFreshness(lastCollection, Now));
+        Assert.Equal(expected, ServerSummaryItem.ClassifyFreshness(lastCollection, Now, ServerHealthThresholds.StaleThreshold));
     }
 
     [Fact]
     public void ApplyFreshness_Fresh_IsOnline()
     {
         var item = new ServerSummaryItem { LastCollectionTime = Now.AddSeconds(-30) };
-        item.ApplyFreshness(Now);
+        item.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.True(item.IsOnline);
         Assert.False(item.CollectionStale);
         Assert.False(item.IsOffline);
@@ -241,7 +241,7 @@ public sealed class ViewerServerSummaryDisplayTests
     public void ApplyFreshness_Stale_IsWarning()
     {
         var item = new ServerSummaryItem { LastCollectionTime = Now.AddMinutes(-5) };
-        item.ApplyFreshness(Now);
+        item.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.True(item.IsOnline);
         Assert.True(item.CollectionStale);
         Assert.False(item.IsOffline);
@@ -252,14 +252,14 @@ public sealed class ViewerServerSummaryDisplayTests
     public void ApplyFreshness_Offline_ShowsOverlay()
     {
         var offlineByAge = new ServerSummaryItem { LastCollectionTime = Now.AddMinutes(-31) };
-        offlineByAge.ApplyFreshness(Now);
+        offlineByAge.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.False(offlineByAge.IsOnline);
         Assert.True(offlineByAge.IsOffline);
         Assert.Equal("Offline", offlineByAge.StatusDisplay);
 
         /* No collection EVER is not an outage — it renders as the amber awaiting state. */
         var neverCollected = new ServerSummaryItem { LastCollectionTime = null };
-        neverCollected.ApplyFreshness(Now);
+        neverCollected.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.Null(neverCollected.IsOnline);
         Assert.False(neverCollected.IsOffline);
         Assert.True(neverCollected.AwaitingFirstCollection);
@@ -268,7 +268,7 @@ public sealed class ViewerServerSummaryDisplayTests
 
         /* And a later real collection clears the awaiting state through the same path. */
         neverCollected.LastCollectionTime = Now.AddSeconds(-30);
-        neverCollected.ApplyFreshness(Now);
+        neverCollected.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.False(neverCollected.AwaitingFirstCollection);
         Assert.True(neverCollected.IsOnline);
         Assert.Equal("Online", neverCollected.StatusDisplay);
@@ -339,11 +339,11 @@ public sealed class ViewerServerSummaryDisplayTests
     public void CardBorderBrush_RedForDeadlock_DefaultOtherwise()
     {
         var deadlocked = new ServerSummaryItem { DeadlockCount = 1, LastCollectionTime = Now };
-        deadlocked.ApplyFreshness(Now);
+        deadlocked.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.Equal("#FFE57373", deadlocked.CardBorderBrush.Color.ToString());
 
         var calm = new ServerSummaryItem { LastCollectionTime = Now };
-        calm.ApplyFreshness(Now);
+        calm.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.Equal("#FF2A2D35", calm.CardBorderBrush.Color.ToString());
     }
 
@@ -557,11 +557,11 @@ public sealed class ViewerServerSummaryDisplayTests
         {
             TotalThreads = 512, CurrentWorkers = 100, RequestsWaitingForThreads = 1, LastCollectionTime = Now,
         };
-        threadsCritical.ApplyFreshness(Now);
+        threadsCritical.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.Equal("#FFE57373", threadsCritical.CardBorderBrush.Color.ToString());
 
         var collectorsWarning = new ServerSummaryItem { FailedCollectorCount = 1, LastCollectionTime = Now };
-        collectorsWarning.ApplyFreshness(Now);
+        collectorsWarning.ApplyFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.Equal("#FFFFD54F", collectorsWarning.CardBorderBrush.Color.ToString());
     }
 
@@ -708,7 +708,7 @@ public sealed class ViewerW2aLivePostgresTests
 
             var summary = await viewer.GetServerSummaryAsync(SummaryServerId, "Summary E2E");
             summary.ServerName = ServerName;
-            summary.ApplyFreshness(DateTime.UtcNow);
+            summary.ApplyFreshness(DateTime.UtcNow, ServerHealthThresholds.StaleThreshold);
 
             Assert.Equal(42.0, summary.CpuPercent);
             Assert.Equal(8.0, summary.OtherProcessCpuPercent);

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
@@ -31,8 +31,9 @@ namespace PerformanceMonitor.Darling.Service.Mcp;
 /// refresh; that does not scale to a 500-server central store. Because Darling keys every row by
 /// <c>server_id</c> in ONE Postgres database, this reader instead runs a BOUNDED set of cross-server aggregates
 /// (one <c>DISTINCT ON (server_id)</c> latest-snapshot read per metric, one <c>GROUP BY server_id</c> windowed
-/// count per incident source, one cross-server collection-health aggregate) — a fixed ~9 round-trips regardless
-/// of fleet size — then assembles the per-server cards in C#.</para>
+/// count per incident source, one cross-server collection-health aggregate, and the #3236 pair — the sparse
+/// schedule overrides plus a per-(server, collector) newest-run aggregate — feeding the cadence-aware stale
+/// threshold) — a fixed ~11 round-trips regardless of fleet size — then assembles the per-server cards in C#.</para>
 ///
 /// <para><b>Banding lives once.</b> Every band (per-metric severity, the card's overall band, collection
 /// freshness, the fleet band + worst-first score) comes from <see cref="ServerHealthClassifier"/> in
@@ -238,6 +239,27 @@ FROM v_collection_log
 WHERE collection_time >= $1
 GROUP BY server_id";
 
+    /// <summary>Newest run of ANY status per (server, collector) — the raw side of the per-server
+    /// cadence-aware stale threshold (#3236): each enabled scheduled collector's newest row, beside its
+    /// effective cadence, decides how long the newest collection may age before the card bands Warning
+    /// (<see cref="ServerHealthClassifier.EffectiveStaleThreshold"/>). Any status on purpose — freshness is
+    /// the rows-are-landing axis, and a collector erroring on schedule is still landing rows; the failures
+    /// band on the collector axis. Same 48-hour bound as <see cref="FleetLastCollectionSql"/>, for the same
+    /// chunk-exclusion reason and so the two reads describe the same span. $1 window start.</summary>
+    public const string FleetCollectorCadenceSql = @"
+SELECT server_id, collector_name, MAX(collection_time) AS last_run_time
+FROM v_collection_log
+WHERE collection_time >= $1
+GROUP BY server_id, collector_name";
+
+    /// <summary>The sparse schedule-override rows the cadence-aware stale threshold resolves through
+    /// (#3236) — the same SELECT <c>StoreConfigProvider.ReadScheduleOverridesAsync</c> feeds the worker's
+    /// scheduling from, so the threshold honors EXACTLY the schedule the sweep actually runs on: per-server
+    /// override &gt; fleet-wide override (<c>server_id</c> NULL) &gt; the <c>CollectorScheduleDefaults</c>
+    /// code default, per column, via <see cref="StoreConfigProvider.ResolveSchedule"/>. $ none.</summary>
+    public const string FleetScheduleOverridesSql =
+        "SELECT server_id, collector_name, frequency_minutes, retention_days, enabled FROM config_collector_schedules";
+
     /// <summary>Cross-server per-collector 7-day health aggregate — one row per (server, collector) pair carrying
     /// the columns the shared <c>CollectorHealth.HealthStatus</c> banding needs, so the caller counts each
     /// server's FAILING collectors exactly as the per-server Collection Health tab does. $1 window start (the
@@ -318,6 +340,7 @@ GROUP BY server_id, collector_name";
         var blocking = await ReadBlockingAsync(postgres, windowStartUtc, windowEndUtc, cancellationToken);
         var deadlocks = await ReadDeadlocksAsync(postgres, windowStartUtc, windowEndUtc, cancellationToken);
         var lastCollection = await ReadLastCollectionAsync(postgres, now, cancellationToken);
+        var cadenceSamples = await ReadCollectorCadenceSamplesAsync(postgres, now, cancellationToken);
         var failingCollectors = await ReadFailingCollectorCountsAsync(postgres, now, cancellationToken);
         var tags = await ReadTagsAsync(postgres, cancellationToken);
         var tagForest = await ReadTagForestAsync(postgres, cancellationToken);
@@ -341,10 +364,11 @@ GROUP BY server_id, collector_name";
             DateTime? lastColl = lastCollection.TryGetValue(server.ServerId, out var lastCollValue)
                 ? lastCollValue
                 : null;
+            cadenceSamples.TryGetValue(server.ServerId, out var serverCadenceSamples);
             failingCollectors.TryGetValue(server.ServerId, out var collectors);
             tags.TryGetValue(server.ServerId, out var serverTags);
 
-            cards.Add(BuildCard(server, c, m, mp, t, b, deadlock, lastColl, collectors, serverTags, now));
+            cards.Add(BuildCard(server, c, m, mp, t, b, deadlock, lastColl, serverCadenceSamples, collectors, serverTags, now));
         }
 
         return BuildRollup(cards, now, windowStartUtc, windowEndUtc, worstCount, tagForest);
@@ -361,6 +385,7 @@ GROUP BY server_id, collector_name";
         BlockingRow blocking,
         DeadlockRow deadlock,
         DateTime? lastCollection,
+        List<CollectorCadenceSample>? cadenceSamples,
         CollectorCounts collectors,
         List<FleetTag>? tags,
         DateTime now)
@@ -400,8 +425,15 @@ GROUP BY server_id, collector_name";
 
         /* Freshness -> the card's collection state, through the SAME mapping the WPF card and the sidebar
            row use (#2473). It was a hand-written copy of ApplyFreshness that happened to agree; the copy on
-           the sidebar row happened not to, which is the argument for none of them writing it out. */
-        var freshness = ServerHealthClassifier.ClassifyFreshness(lastCollection, now);
+           the sidebar row happened not to, which is the argument for none of them writing it out. The stale
+           cutoff is the server's own (#3236) — each enabled collector's newest run against its effective
+           cadence — so a target whose collectors legitimately run every 5 minutes no longer bands Warning
+           on any snapshot landing in the back half of that window. */
+        var staleThreshold = lastCollection is DateTime lastCollectionValue
+            ? ServerHealthClassifier.EffectiveStaleThreshold(
+                lastCollectionValue, cadenceSamples ?? (IEnumerable<CollectorCadenceSample>)Array.Empty<CollectorCadenceSample>())
+            : ServerHealthThresholds.StaleThreshold;
+        var freshness = ServerHealthClassifier.ClassifyFreshness(lastCollection, now, staleThreshold);
         var flags = ServerCollectionStatusRules.FlagsFor(freshness);
         var isOnline = flags.IsOnline;
         var awaitingFirstCollection = flags.AwaitingFirstCollection;
@@ -438,6 +470,7 @@ GROUP BY server_id, collector_name";
             AwaitingFirstCollection = awaitingFirstCollection,
             CollectionStale = collectionStale,
             LastCollectionTime = lastCollection,
+            StaleThresholdMinutes = staleThreshold.TotalMinutes,
             CpuPercent = cpuPercent,
             OtherProcessCpuPercent = otherCpu,
             TotalCpuPercent = totalCpu,
@@ -864,6 +897,93 @@ GROUP BY server_id, collector_name";
         return map;
     }
 
+    /// <summary>
+    /// Per-server <see cref="CollectorCadenceSample"/> lists for the cadence-aware stale threshold (#3236):
+    /// each enabled scheduled collector's newest run beside the cadence the store actually schedules it on.
+    /// Shared with <c>list_servers</c> so the fleet card and the discovery row cannot band the same server's
+    /// freshness differently — the #2473 lesson, applied before the drift exists this time.
+    /// </summary>
+    internal static async Task<Dictionary<int, List<CollectorCadenceSample>>> ReadCollectorCadenceSamplesAsync(
+        NpgsqlDataSource postgres, DateTime now, CancellationToken cancellationToken = default)
+    {
+        var overrides = await ReadScheduleOverridesAsync(postgres, cancellationToken);
+
+        var map = new Dictionary<int, List<CollectorCadenceSample>>();
+        await using var command = postgres.CreateCommand(FleetCollectorCadenceSql);
+        command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
+        AddTimestamp(command, DateTime.SpecifyKind(now.AddHours(-48), DateTimeKind.Unspecified));
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            if (reader.IsDBNull(2))
+            {
+                continue;
+            }
+
+            var serverId = reader.GetInt32(0);
+            var sample = BuildCadenceSample(reader.GetString(1), reader.GetDateTime(2), serverId, overrides);
+            if (sample is not CollectorCadenceSample value)
+            {
+                continue;
+            }
+
+            if (!map.TryGetValue(serverId, out var list))
+            {
+                list = new List<CollectorCadenceSample>();
+                map[serverId] = list;
+            }
+
+            list.Add(value);
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// One (server, collector, newest run) row resolved to a cadence sample, or null when the collector must
+    /// not vouch for the server's freshness: unknown to this build's <see cref="CollectorScheduleDefaults"/>
+    /// (a store written by a newer build — <see cref="StoreConfigProvider.ResolveSchedule"/> would throw on
+    /// it, and a schedule this build cannot know is not one it can band against), disabled on this server's
+    /// effective schedule (a cadence nothing runs on), or on-load (<c>FrequencyMinutes == 0</c> — those run
+    /// on connects, not on the loop this band watches). Every exclusion falls toward the flat floor, which
+    /// is the direction that still bands a genuinely quiet server.
+    /// </summary>
+    internal static CollectorCadenceSample? BuildCadenceSample(
+        string collectorName, DateTime lastRunUtc, int serverId, IReadOnlyList<ScheduleOverride> overrides)
+    {
+        if (!CollectorScheduleDefaults.All.ContainsKey(collectorName))
+        {
+            return null;
+        }
+
+        var effective = StoreConfigProvider.ResolveSchedule(collectorName, serverId, overrides);
+        if (!effective.Enabled || effective.FrequencyMinutes <= 0)
+        {
+            return null;
+        }
+
+        return new CollectorCadenceSample(lastRunUtc, effective.FrequencyMinutes);
+    }
+
+    private static async Task<List<ScheduleOverride>> ReadScheduleOverridesAsync(NpgsqlDataSource postgres, CancellationToken cancellationToken)
+    {
+        var overrides = new List<ScheduleOverride>();
+        await using var command = postgres.CreateCommand(FleetScheduleOverridesSql);
+        command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            overrides.Add(new ScheduleOverride(
+                reader.IsDBNull(0) ? null : reader.GetInt32(0),
+                reader.GetString(1),
+                reader.IsDBNull(2) ? null : reader.GetInt32(2),
+                reader.IsDBNull(3) ? null : reader.GetInt32(3),
+                reader.GetBoolean(4)));
+        }
+
+        return overrides;
+    }
+
     /// <summary>Reads the cross-server 7-day collector health and counts each server's HEALTHY / FAILING
     /// collectors through the shared <see cref="CollectorHealth.HealthStatus"/> banding.</summary>
     private static async Task<Dictionary<int, CollectorCounts>> ReadFailingCollectorCountsAsync(
@@ -1019,17 +1139,22 @@ public sealed class FleetServerCard
     [JsonPropertyName("awaiting_first_collection")] public bool AwaitingFirstCollection { get; init; }
 
     /// <summary>
-    /// The newest collection has lagged past <see cref="ServerHealthThresholds.StaleThreshold"/> without being
-    /// old enough to call the server dark — <see cref="ServerFreshness.Stale"/>, from
+    /// The newest collection has lagged past this server's stale threshold without being old enough to call
+    /// the server dark — <see cref="ServerFreshness.Stale"/>, from
     /// <see cref="ServerCollectionStatusRules.FlagsFor"/>. It is what bands an otherwise-calm card Warning.
+    /// The threshold is the server's own (#3236): each enabled collector's newest run against its effective
+    /// cadence (<see cref="ServerHealthClassifier.EffectiveStaleThreshold"/>), never the flat two-minute
+    /// floor alone — 14 healthy Aurora targets on a legitimate 5-minute <c>pg_cpu_utilization</c> rhythm
+    /// banded Warning together on that floor.
     ///
     /// <para><b>Derivable from this same payload, which is the point.</b> The flag is a function of
-    /// <c>last_collection</c> against the roll-up's <c>generated_at</c>, and <c>status</c> reads
-    /// <c>"Warning"</c> whenever it is true on a reachable server. A reader who cannot check a field's name
-    /// against its population has to trust the name, and #3098 measured what that costs on this one: two
-    /// agents drew four wrong conclusions from it in a single day, one of them a retracted claim about WHEN a
-    /// cluster of collector errors happened. Every field on this card that cannot be recomputed from the card
-    /// is one more that has to be trusted.</para>
+    /// <c>last_collection</c> against the roll-up's <c>generated_at</c> and this card's own
+    /// <c>stale_threshold_minutes</c>, and <c>status</c> reads <c>"Warning"</c> whenever it is true on a
+    /// reachable server. A reader who cannot check a field's name against its population has to trust the
+    /// name, and #3098 measured what that costs on this one: two agents drew four wrong conclusions from it
+    /// in a single day, one of them a retracted claim about WHEN a cluster of collector errors happened.
+    /// Every field on this card that cannot be recomputed from the card is one more that has to be
+    /// trusted.</para>
     ///
     /// <para><b>Not an error signal, and there are two that are.</b> <c>failed_collector_count</c> counts
     /// collectors currently failing and <c>collector_severity</c> bands it. Those and this one disagree
@@ -1038,6 +1163,15 @@ public sealed class FleetServerCard
     /// </summary>
     [JsonPropertyName("collection_stale")] public bool CollectionStale { get; init; }
     [JsonPropertyName("last_collection")] public DateTime? LastCollectionTime { get; init; }
+
+    /// <summary>
+    /// The stale cutoff <see cref="CollectionStale"/> was decided against, in minutes — what keeps that flag
+    /// recomputable from the card now that the threshold is per-server (#3236): stale is
+    /// <c>generated_at - last_collection</c> past this, on a card that is not Offline. The flat two-minute
+    /// floor when no enabled scheduled collector has a recent run; otherwise the age at which the last
+    /// current collector's own <c>2 x cadence</c> window expires.
+    /// </summary>
+    [JsonPropertyName("stale_threshold_minutes")] public double StaleThresholdMinutes { get; init; }
 
     [JsonPropertyName("cpu_percent")] public double? CpuPercent { get; init; }
     [JsonPropertyName("other_process_cpu_percent")] public double? OtherProcessCpuPercent { get; init; }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpDataTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpDataTools.cs
@@ -809,7 +809,7 @@ public sealed class DarlingMcpDataTools
 
     /* ═══════════════════════════ discovery / health ═══════════════════════════ */
 
-    [McpServerTool(Name = "list_servers"), Description("Lists all monitored servers — SQL Server and PostgreSQL — with their collection freshness status and last collection time. Use this first to see available servers before calling other tools. Each row says which engine it describes: engine_kind is the raw registry token (sqlserver, postgres, aurora-postgres; null when no connect has stamped the row — the same vocabulary get_fleet_overview uses) and engine_version is the engine-aware version label (\"SQL Server 2022\", \"PostgreSQL 18\"; empty when no version has been collected). sql_version is a DEPRECATED legacy alias carrying the same value as engine_version, kept so existing consumers keep working — read engine_version instead, and never infer the engine from that key's name: a PostgreSQL row's sql_version reads \"PostgreSQL 18\". The service has no live connection to the monitored servers, so status is derived from how recently each server was collected (Online = fresh, Warning = stale, Offline = no recent collection). The peer_fleets block names the SIBLING Darling stores that monitor the rest of a split fleet, with what each one covers — this server can only NAME them (no cross-store reads), and peer_note says what an empty peer_fleets does and does not prove.")]
+    [McpServerTool(Name = "list_servers"), Description("Lists all monitored servers — SQL Server and PostgreSQL — with their collection freshness status and last collection time. Use this first to see available servers before calling other tools. Each row says which engine it describes: engine_kind is the raw registry token (sqlserver, postgres, aurora-postgres; null when no connect has stamped the row — the same vocabulary get_fleet_overview uses) and engine_version is the engine-aware version label (\"SQL Server 2022\", \"PostgreSQL 18\"; empty when no version has been collected). sql_version is a DEPRECATED legacy alias carrying the same value as engine_version, kept so existing consumers keep working — read engine_version instead, and never infer the engine from that key's name: a PostgreSQL row's sql_version reads \"PostgreSQL 18\". The service has no live connection to the monitored servers, so status is derived from how recently each server was collected (Online = fresh, Warning = stale, Offline = no recent collection). The stale cutoff is cadence-aware, per server: a target bands Warning only when every enabled collector is overdue against its OWN effective schedule (twice its cadence, floored at 2 minutes), and stale_threshold_minutes on each row is the cutoff that row's status was decided against — the same threshold get_fleet_overview's card for the server uses, so the two tools cannot disagree about one server. The peer_fleets block names the SIBLING Darling stores that monitor the rest of a split fleet, with what each one covers — this server can only NAME them (no cross-store reads), and peer_note says what an empty peer_fleets does and does not prove.")]
     public static async Task<string> ListServers(
         NpgsqlDataSource postgres)
     {
@@ -834,7 +834,23 @@ public sealed class DarlingMcpDataTools
                 return "No servers are registered yet. The service registers each monitored server on its first successful connection."
                     + DarlingPeerDirectory.EmptyRegistryDisclosure(DarlingPeerDirectory.Current);
 
-            return RenderServerList(servers, DateTime.UtcNow, DarlingPeerDirectory.Current);
+            var nowUtc = DateTime.UtcNow;
+
+            /* #3236: the same per-server cadence samples the fleet cards band with, so this row and that
+               card cannot call the same server's freshness differently. Failure-isolated — discovery must
+               not break because the staleness refinement read did; on a miss every row bands on the flat
+               floor, which is exactly the pre-#3236 reading. */
+            Dictionary<int, List<CollectorCadenceSample>> cadenceSamples;
+            try
+            {
+                cadenceSamples = await DarlingFleetReader.ReadCollectorCadenceSamplesAsync(postgres, nowUtc);
+            }
+            catch (Exception)
+            {
+                cadenceSamples = new Dictionary<int, List<CollectorCadenceSample>>();
+            }
+
+            return RenderServerList(servers, nowUtc, DarlingPeerDirectory.Current, cadenceSamples);
         }
         catch (Exception ex)
         {
@@ -856,7 +872,8 @@ public sealed class DarlingMcpDataTools
     internal static string RenderServerList(
         IReadOnlyList<DarlingDataReader.ServerListRow> servers,
         DateTime nowUtc,
-        DarlingPeerDirectory.Snapshot peers)
+        DarlingPeerDirectory.Snapshot peers,
+        IReadOnlyDictionary<int, List<CollectorCadenceSample>>? cadenceSamples = null)
     {
         var result = servers.Select(s =>
         {
@@ -864,6 +881,15 @@ public sealed class DarlingMcpDataTools
                target reads "PostgreSQL 18" instead of the "SQL Server v0" its 0-valued sql_major_version
                used to produce. Computed once because it rides under two keys below. */
             var engineVersion = MonitoredEngineVersion.DescribeEngineVersion(s.EngineKind, s.SqlMajorVersion, s.PostgresMajorVersion);
+
+            /* #3236: this server's own stale cutoff — each enabled collector's newest run against its
+               effective cadence — floored at the flat threshold; absent samples (no rows, or the read
+               was skipped) mean the floor, the pre-#3236 reading. */
+            var staleThreshold = s.LastCollection is DateTime lastCollection
+                && cadenceSamples is not null
+                && cadenceSamples.TryGetValue(s.ServerId, out var samples)
+                    ? ServerHealthClassifier.EffectiveStaleThreshold(lastCollection, samples)
+                    : ServerHealthThresholds.StaleThreshold;
 
             return new
             {
@@ -880,9 +906,12 @@ public sealed class DarlingMcpDataTools
                    sql_version: "PostgreSQL 18" — so it is documented as deprecated everywhere the payload
                    is described, and retiring it belongs to a later major of the MCP contract, not here. */
                 sql_version = engineVersion,
-                status = FreshnessStatus(s.LastCollection, nowUtc),
+                status = FreshnessStatus(s.LastCollection, nowUtc, staleThreshold),
                 read_only = s.ServerName.EndsWith(":RO", StringComparison.Ordinal),
-                last_collection = s.LastCollection?.ToString("o")
+                last_collection = s.LastCollection?.ToString("o"),
+                /* #3236: what the Warning/Online call above was decided against, so the status stays
+                   recomputable from the row — the same derivability the fleet card's twin field keeps. */
+                stale_threshold_minutes = staleThreshold.TotalMinutes
             };
         });
 
@@ -1243,10 +1272,13 @@ public sealed class DarlingMcpDataTools
     /// it does NOT share is the vocabulary: <see cref="ServerCollectionStatusRules.McpToken"/> spells the
     /// never-collected state as one word because that value was published to MCP clients, and a status value
     /// a client keys on is a consumer API.</para>
+    /// <para><paramref name="staleThreshold"/> is this server's own cutoff (#3236) —
+    /// <see cref="ServerHealthClassifier.EffectiveStaleThreshold"/> over the same cadence samples the fleet
+    /// cards band with, so a discovery row and the fleet card cannot disagree about the same server.</para>
     /// </summary>
-    private static string FreshnessStatus(DateTime? lastCollectionUtc, DateTime nowUtc) =>
+    private static string FreshnessStatus(DateTime? lastCollectionUtc, DateTime nowUtc, TimeSpan staleThreshold) =>
         ServerCollectionStatusRules
-            .FromFreshness(ServerHealthClassifier.ClassifyFreshness(lastCollectionUtc, nowUtc))
+            .FromFreshness(ServerHealthClassifier.ClassifyFreshness(lastCollectionUtc, nowUtc, staleThreshold))
             .McpToken();
 
     [McpServerTool(Name = "get_collection_log"), Description("Gets the RAW per-run collection log for a server, newest first: one row per collector run with its total duration, the part spent querying the monitored server, the part spent writing to the store, rows collected, status and any error. get_collection_health rolls seven days of these into a per-collector verdict; this is the underlying runs, which is what you need when the rollup says healthy and collection still looks wrong, or when you want to see what a collector was doing during a specific incident window. Also carries the phase decomposition where the run recorded one, as nested blocks that are null when the run took a path that does not report them — and a row carries at most ONE family. Server-scoped collectors fill sql_phases (open_ms, drain_ms, other_ms which is derived, watermark_ms) and drain (rows_read, bytes_read, last_read_ms, target_session_id). Per-database collectors that perform a deferred plan or statement-text fetch instead fill plan_fetch and/or text_fetch, each carrying probe_ms, target_ms, write_ms, ids_attempted and probe_ids summed across that run's databases. sweep_peer_max_ms is flat and present on every row: it is the slowest peer collector in the same sweep, the denominator for asking whether a slow run was slow alone or the whole sweep was. A null block means the run took the other path, not that the phase was free — most runs perform no deferred fetch at all. Divide target_ms by ids_attempted for the per-id target cost, probe_ms by probe_ids for the per-reference probe cost. CRITICAL for reading sql_duration_ms on a fetching collector: it is NOT purely target-side there. The deferred fetches run inside the driver's per-item SQL stopwatch and each one round-trips the MONITORING STORE to decide what plan XML and statement text are already held before writing back what came off the target, so the store's probe and write are billed to the column documented as the monitored server's. The probe is the largest single term in both fetches on this fleet — 55.4% of plan_fetch and 80.6% of text_fetch — and on one production run it was 107,334 ms of a 124,972 ms sql_duration_ms, 86%, against a plan-plus-text target time of 6,494 ms. sql_store_ms is that store share, derived from the two fetch blocks (probe_ms + write_ms of each) and null when no fetch ran. It is a FLOOR, not the whole: the per-item watermark refresh is also a store read inside the same stopwatch, the enumerated path records no watermark_ms, and that component is stored nowhere — so sql_duration_ms minus sql_store_ms is an UPPER bound on target-side time rather than the target-side time. store_duration_ms is not where the probe went either: it is the binary COPY of the collected rows and nothing else. Do NOT conclude a monitored server is slow from a large sql_duration_ms on query_store without reading sql_store_ms beside it.")]

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpFleetTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpFleetTools.cs
@@ -38,7 +38,12 @@ public sealed class DarlingMcpFleetTools
         "blocking, deadlocks, worker threads, and collector health, each with a Healthy/Warning/Critical band), " +
         "plus a rollup — counts by band, cross-server blocking and deadlock totals, and a worst-first 'needs " +
         "attention' ranking. Use this first to decide which server to drill into, then call the per-server tools. " +
-        "This cross-server view is unique to the central store.")]
+        "This cross-server view is unique to the central store. A card's collection_stale flag is cadence-aware: " +
+        "a server bands stale only when every enabled collector is overdue against its OWN effective schedule " +
+        "(twice its cadence, floored at 2 minutes), so a target whose collectors legitimately run every 5 " +
+        "minutes is not stale 4 minutes after its last collection. stale_threshold_minutes on each card is the " +
+        "cutoff that card was decided against — collection_stale is exactly generated_at minus last_collection " +
+        "exceeding it on a card that is not Offline.")]
     public static async Task<string> GetFleetOverview(
         NpgsqlDataSource postgres,
         [Description("Hours of blocking/deadlock history the per-server cards and fleet totals window over. Default 1.")] int hours_back = 1)

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
@@ -166,6 +166,21 @@ public partial class MainWindow
             return;
         }
 
+        /* #3236: the per-server cadence samples the dot's stale cutoff honors — the SAME derivation the
+           Overview cards and the service's fleet reader band with, so all three keep saying one thing
+           about one server. Failure-isolated separately from the freshness read above: dots on the flat
+           floor beat no dots. */
+        Dictionary<int, List<PerformanceMonitor.Common.CollectorCadenceSample>> cadenceSamples;
+        try
+        {
+            cadenceSamples = await _dataService.GetCollectorCadenceSamplesAsync();
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("ServerStatus", $"cadence-sample read failed, dots band on the flat threshold: {ex.Message}");
+            cadenceSamples = new Dictionary<int, List<PerformanceMonitor.Common.CollectorCadenceSample>>();
+        }
+
         var nowUtc = DateTime.UtcNow;
         var servers = _fleet.All;
 
@@ -174,7 +189,7 @@ public partial class MainWindow
         foreach (var s in servers)
         {
             DateTime? last = freshness.TryGetValue(s.ServerId, out var t) ? t : null;
-            s.ApplyFreshness(last, nowUtc);
+            s.ApplyFreshness(last, nowUtc, EffectiveStaleThreshold(last, s.ServerId, cadenceSamples));
 
             if (last.HasValue && (newest is null || last.Value > newest.Value))
             {
@@ -197,6 +212,22 @@ public partial class MainWindow
                 ? "Collection: Active"
                 : $"Collection: {FormatAge(age)} ago";
         }
+    }
+
+    /// <summary>
+    /// One server's stale cutoff (#3236) from this refresh's cadence samples: the shared
+    /// <see cref="PerformanceMonitor.Common.ServerHealthClassifier.EffectiveStaleThreshold"/> where the
+    /// server has a last collection and samples, the flat floor otherwise. One helper for the sidebar dots
+    /// and the Overview cards, so the two surfaces cannot resolve the same server to different numbers.
+    /// </summary>
+    private static TimeSpan EffectiveStaleThreshold(
+        DateTime? lastCollectionUtc,
+        int serverId,
+        Dictionary<int, List<PerformanceMonitor.Common.CollectorCadenceSample>> cadenceSamples)
+    {
+        return lastCollectionUtc is DateTime lastCollection && cadenceSamples.TryGetValue(serverId, out var samples)
+            ? PerformanceMonitor.Common.ServerHealthClassifier.EffectiveStaleThreshold(lastCollection, samples)
+            : PerformanceMonitor.Common.ServerHealthThresholds.StaleThreshold;
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -1424,6 +1424,22 @@ public partial class MainWindow : Window
 
         var service = _dataService;
         var nowUtc = DateTime.UtcNow;
+
+        /* #3236: this refresh's per-server cadence samples, read ONCE for the whole grid — each card's
+           stale cutoff honors its collectors' own schedules instead of the flat two-minute floor, so a
+           server legitimately collecting every 5 minutes stops banding amber for the back half of every
+           window. Failure-isolated: with no samples every card bands on the floor, the pre-#3236 reading. */
+        Dictionary<int, List<PerformanceMonitor.Common.CollectorCadenceSample>> cadenceSamples;
+        try
+        {
+            cadenceSamples = await service.GetCollectorCadenceSamplesAsync();
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("Overview", $"cadence-sample read failed, freshness bands on the flat threshold: {ex.Message}");
+            cadenceSamples = new Dictionary<int, List<PerformanceMonitor.Common.CollectorCadenceSample>>();
+        }
+
         /* #3016: pool-many lanes, not fleet-many reads — see the inventory overlay in FinOpsTab.Loaders.
            A fleet wider than the pool used to render SHORT here rather than slowly: the per-server catch
            below turned each pool-exhaustion failure into an absent card, so the panel a fleet is watched
@@ -1449,7 +1465,7 @@ public partial class MainWindow : Window
                        coverage apart from a quiet SQL Server fleet: v_deadlocks holds the SQL Server
                        extended-event capture and nothing else. */
                     summary.IsPostgres = server.IsPostgres;
-                    summary.ApplyFreshness(nowUtc);
+                    summary.ApplyFreshness(nowUtc, EffectiveStaleThreshold(summary.LastCollectionTime, server.ServerId, cadenceSamples));
                     found.Add(summary);
                 }
                 catch

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -417,10 +417,11 @@ public sealed class ServerSummaryItem
     public System.Collections.Generic.IReadOnlyList<ServerTagPill> TagPills { get; set; } =
         System.Array.Empty<ServerTagPill>();
 
-    /// <summary>Warning (amber) state: the newest collection has lagged past
-    /// <see cref="ServerHealthThresholds.StaleThreshold"/>. Freshness only — collectors that are failing are
-    /// counted by <see cref="FailedCollectorCount"/> and banded by <see cref="CollectorSeverity"/>, and the two
-    /// axes disagree routinely and correctly (#3098).</summary>
+    /// <summary>Warning (amber) state: the newest collection has lagged past this server's stale threshold —
+    /// cadence-aware where the loader supplied samples, the flat
+    /// <see cref="ServerHealthThresholds.StaleThreshold"/> floor otherwise (#3236). Freshness only —
+    /// collectors that are failing are counted by <see cref="FailedCollectorCount"/> and banded by
+    /// <see cref="CollectorSeverity"/>, and the two axes disagree routinely and correctly (#3098).</summary>
     public bool CollectionStale { get; set; }
 
     /// <summary>
@@ -774,13 +775,16 @@ public sealed class ServerSummaryItem
     }
 
     /// <summary>
-    /// The viewer's status derivation (#1262): classify how fresh the newest collection is. Pure over
-    /// (last-collection, now) so it can be pinned without a store. Both instants are UTC (the store is
-    /// naive UTC; <paramref name="nowUtc"/> is <see cref="DateTime.UtcNow"/>), so the subtraction is a
-    /// true elapsed-time regardless of Kind.
+    /// The viewer's status derivation (#1262): classify how fresh the newest collection is, against this
+    /// server's own stale cutoff (#3236) — <see cref="ServerHealthClassifier.EffectiveStaleThreshold"/>
+    /// over the cadence samples <c>ViewerDataService.GetCollectorCadenceSamplesAsync</c> reads, or the flat
+    /// <see cref="ServerHealthThresholds.StaleThreshold"/> when the caller has none. Pure over
+    /// (last-collection, now, threshold) so it can be pinned without a store. Both instants are UTC (the
+    /// store is naive UTC; <paramref name="nowUtc"/> is <see cref="DateTime.UtcNow"/>), so the subtraction
+    /// is a true elapsed-time regardless of Kind.
     /// </summary>
-    public static ServerFreshness ClassifyFreshness(DateTime? lastCollectionUtc, DateTime nowUtc) =>
-        ServerHealthClassifier.ClassifyFreshness(lastCollectionUtc, nowUtc);
+    public static ServerFreshness ClassifyFreshness(DateTime? lastCollectionUtc, DateTime nowUtc, TimeSpan staleThreshold) =>
+        ServerHealthClassifier.ClassifyFreshness(lastCollectionUtc, nowUtc, staleThreshold);
 
     /// <summary>
     /// Maps the freshness band onto the card's three status flags, taking the live-ping's place: Fresh →
@@ -792,10 +796,15 @@ public sealed class ServerSummaryItem
     /// row and the service's fleet reader. It was written out here in longhand, and the sidebar's longhand
     /// copy set two of the three flags and dropped <c>AwaitingFirstCollection</c> — an omission that is
     /// invisible in a block of assignments and impossible when the three arrive together (#2473).</para>
+    ///
+    /// <para><paramref name="staleThreshold"/> is REQUIRED rather than defaulted (#3236): every caller must
+    /// decide which cutoff this server bands on — the cadence-aware one where samples exist, the flat
+    /// <see cref="ServerHealthThresholds.StaleThreshold"/> where they do not — because a defaulted flat
+    /// value is exactly the silent drift that had the fleet card and this card answering differently.</para>
     /// </summary>
-    public void ApplyFreshness(DateTime nowUtc)
+    public void ApplyFreshness(DateTime nowUtc, TimeSpan staleThreshold)
     {
-        var flags = ServerCollectionStatusRules.FlagsFor(ClassifyFreshness(LastCollectionTime, nowUtc));
+        var flags = ServerCollectionStatusRules.FlagsFor(ClassifyFreshness(LastCollectionTime, nowUtc, staleThreshold));
         IsOnline = flags.IsOnline;
         CollectionStale = flags.CollectionStale;
         AwaitingFirstCollection = flags.AwaitingFirstCollection;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerStatus.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerStatus.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -41,6 +42,21 @@ GROUP BY server_id";
     public const string StoreSizeSql = "SELECT pg_database_size(current_database())";
 
     /// <summary>
+    /// Newest run of ANY status per (server, collector) — the raw side of the per-server cadence-aware
+    /// stale threshold (#3236), the same aggregate the service's <c>DarlingFleetReader</c> reads so a
+    /// viewer card and a fleet card cannot band the same server's freshness differently. Bounded to 48
+    /// hours (TimescaleDB chunk exclusion; a collector quiet longer than that vouches for nothing anyway)
+    /// and excluding the <c>server_id = 0</c> retention sentinel like <see cref="ServerFreshnessSql"/>.
+    /// $1 window start (naive UTC).
+    /// </summary>
+    public const string CollectorCadenceSamplesSql = @"
+SELECT server_id, collector_name, MAX(collection_time) AS last_run_time
+FROM v_collection_log
+WHERE server_id <> 0
+AND   collection_time >= $1
+GROUP BY server_id, collector_name";
+
+    /// <summary>
     /// Reads MAX(collection_time) for every server in a single query, keyed by server_id. A server with no
     /// collection rows simply isn't in the dictionary (the caller treats a miss as "no collection" → Offline).
     /// </summary>
@@ -69,5 +85,79 @@ GROUP BY server_id";
         command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         var result = await command.ExecuteScalarAsync(cancellationToken);
         return result is null || result == DBNull.Value ? null : Convert.ToInt64(result);
+    }
+
+    /// <summary>
+    /// Per-server <see cref="CollectorCadenceSample"/> lists for the cadence-aware stale threshold (#3236):
+    /// each enabled scheduled collector's newest run beside the cadence it actually runs on for that server.
+    /// Cadence resolution goes through the viewer's own <see cref="CollectorScheduleOverlay"/> — the SAME
+    /// per-column layering (per-server override &gt; fleet override &gt; code default) the service's
+    /// <c>StoreConfigProvider.ResolveSchedule</c> applies, already pinned against it by the schedule-editor
+    /// tests — so the viewer bands on the schedule the sweep genuinely runs, not on the shipped defaults.
+    /// A collector the overlay does not know (a store written by a newer build) or that resolves disabled /
+    /// on-load contributes nothing, which falls toward the flat floor.
+    /// </summary>
+    public async Task<Dictionary<int, List<CollectorCadenceSample>>> GetCollectorCadenceSamplesAsync(CancellationToken cancellationToken = default)
+    {
+        var overrides = await GetCollectorSchedulesAsync(cancellationToken);
+
+        /* (server, collector, newest run) first, then one effective-schedule overlay per server — the
+           overlay builds the full per-collector schedule, so resolving it once per server rather than once
+           per row keeps this a cheap pass even on a wide fleet. */
+        var lastRuns = new Dictionary<int, List<(string CollectorName, DateTime LastRunUtc)>>();
+        await using (var command = _dataSource.CreateCommand(CollectorCadenceSamplesSql))
+        {
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
+            command.Parameters.Add(new NpgsqlParameter<DateTime>
+            {
+                TypedValue = DateTime.SpecifyKind(DateTime.UtcNow.AddHours(-48), DateTimeKind.Unspecified),
+            });
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                if (reader.IsDBNull(2))
+                {
+                    continue;
+                }
+
+                var serverId = reader.GetInt32(0);
+                if (!lastRuns.TryGetValue(serverId, out var list))
+                {
+                    list = new List<(string, DateTime)>();
+                    lastRuns[serverId] = list;
+                }
+
+                list.Add((reader.GetString(1), reader.GetDateTime(2)));
+            }
+        }
+
+        var samples = new Dictionary<int, List<CollectorCadenceSample>>(lastRuns.Count);
+        foreach (var (serverId, runs) in lastRuns)
+        {
+            var effective = CollectorScheduleOverlay.BuildEffectiveSchedule(overrides, serverId);
+            var byName = new Dictionary<string, CollectorScheduleEditItem>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in effective)
+            {
+                byName[item.Name] = item;
+            }
+
+            var serverSamples = new List<CollectorCadenceSample>(runs.Count);
+            foreach (var (collectorName, lastRunUtc) in runs)
+            {
+                if (byName.TryGetValue(collectorName, out var schedule)
+                    && schedule.Enabled
+                    && schedule.FrequencyMinutes > 0)
+                {
+                    serverSamples.Add(new CollectorCadenceSample(lastRunUtc, schedule.FrequencyMinutes));
+                }
+            }
+
+            if (serverSamples.Count > 0)
+            {
+                samples[serverId] = serverSamples;
+            }
+        }
+
+        return samples;
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -163,9 +163,10 @@ public sealed class DarlingServer : INotifyPropertyChanged
 
     private bool _collectionStale;
 
-    /// <summary>Warning (amber) state: the newest collection has lagged past
-    /// <see cref="ServerHealthThresholds.StaleThreshold"/>. Freshness only, and named for it — a collector that
-    /// is failing is a different axis, reported by the Collection Health tab (#3098).</summary>
+    /// <summary>Warning (amber) state: the newest collection has lagged past this server's stale threshold —
+    /// cadence-aware where samples exist, the flat <see cref="ServerHealthThresholds.StaleThreshold"/> floor
+    /// otherwise (#3236). Freshness only, and named for it — a collector that is failing is a different
+    /// axis, reported by the Collection Health tab (#3098).</summary>
     public bool CollectionStale
     {
         get => _collectionStale;
@@ -264,11 +265,15 @@ public sealed class DarlingServer : INotifyPropertyChanged
     /// <para>This method used to set two flags out of three by hand and drop the awaiting marker on the floor.
     /// Nothing about a block of assignments makes a missing one visible, which is why the flags now arrive as
     /// a single value (#2473).</para>
+    ///
+    /// <para><paramref name="staleThreshold"/> is this server's own stale cutoff (#3236) — required, not
+    /// defaulted, for the reason <see cref="ServerSummaryItem.ApplyFreshness"/> gives: the dot and the card
+    /// must band off the same number, and a silently defaulted flat value is how they would stop.</para>
     /// </summary>
-    public void ApplyFreshness(DateTime? lastCollectionUtc, DateTime nowUtc)
+    public void ApplyFreshness(DateTime? lastCollectionUtc, DateTime nowUtc, TimeSpan staleThreshold)
     {
         var flags = ServerCollectionStatusRules.FlagsFor(
-            ServerSummaryItem.ClassifyFreshness(lastCollectionUtc, nowUtc));
+            ServerSummaryItem.ClassifyFreshness(lastCollectionUtc, nowUtc, staleThreshold));
         IsOnline = flags.IsOnline;
         CollectionStale = flags.CollectionStale;
         AwaitingFirstCollection = flags.AwaitingFirstCollection;

--- a/Lite.Tests/ServerCollectionFreshnessTests.cs
+++ b/Lite.Tests/ServerCollectionFreshnessTests.cs
@@ -57,7 +57,9 @@ public class ServerCollectionFreshnessTests
             LastCollectionTime = sinceLastCollection.HasValue ? Now - sinceLastCollection.Value : null,
         };
 
-        card.ApplyCollectionFreshness(Now);
+        /* The flat floor on purpose: these tests pin the DEFAULT band arithmetic; the cadence-aware
+           cutoff (#3236) is pinned separately below and in the shared classifier's own suite. */
+        card.ApplyCollectionFreshness(Now, ServerHealthThresholds.StaleThreshold);
         return card;
     }
 
@@ -300,11 +302,36 @@ public class ServerCollectionFreshnessTests
     {
         var card = new ServerSummaryItem { LastCollectionTime = Now };
 
-        card.ApplyCollectionFreshness(Now);
+        card.ApplyCollectionFreshness(Now, ServerHealthThresholds.StaleThreshold);
         Assert.Equal(ServerFreshness.Fresh, card.CollectionFreshness);
 
-        card.ApplyCollectionFreshness(Now + ServerHealthThresholds.OfflineThreshold + TimeSpan.FromMinutes(1));
+        card.ApplyCollectionFreshness(Now + ServerHealthThresholds.OfflineThreshold + TimeSpan.FromMinutes(1), ServerHealthThresholds.StaleThreshold);
         Assert.Equal(ServerFreshness.Offline, card.CollectionFreshness);
+    }
+
+    /// <summary>
+    /// #3236: the stamped cutoff is the one the band AND the tooltip read. A 5-minute-cadence install
+    /// (the shipped Low-Impact preset runs every collector at 5+ minutes) whose newest collection is
+    /// 3m49s old is ON SCHEDULE — the field false positive was exactly this reading "(stale)" — and the
+    /// tooltip quotes the widened number, not the flat floor it no longer bands by. A collection past
+    /// the widened cutoff must still band, in the same words.
+    /// </summary>
+    [Fact]
+    public void ACadenceAwareThresholdWidensTheBandAndTheTooltipQuotesIt()
+    {
+        var fiveMinuteCadence = ServerHealthClassifier.EffectiveStaleThreshold(
+            Now - TimeSpan.FromSeconds(229),
+            new[] { new CollectorCadenceSample(Now - TimeSpan.FromSeconds(229), 5) });
+
+        var onSchedule = new ServerSummaryItem { LastCollectionTime = Now - TimeSpan.FromSeconds(229) };
+        onSchedule.ApplyCollectionFreshness(Now, fiveMinuteCadence);
+        Assert.Equal(ServerFreshness.Fresh, onSchedule.CollectionFreshness);
+        Assert.Contains("10 minutes", onSchedule.CollectionFreshnessTooltip!, StringComparison.Ordinal);
+
+        var overdue = new ServerSummaryItem { LastCollectionTime = Now - TimeSpan.FromMinutes(11) };
+        overdue.ApplyCollectionFreshness(Now, TimeSpan.FromMinutes(10));
+        Assert.Equal(ServerFreshness.Stale, overdue.CollectionFreshness);
+        Assert.Contains("10 minutes", overdue.CollectionFreshnessTooltip!, StringComparison.Ordinal);
     }
 
     // ── Wiring: the half that lives in XAML, where no assertion about a C# object can reach it ─────────
@@ -342,14 +369,20 @@ public class ServerCollectionFreshnessTests
         var source = ParitySource.ReadFile("Lite/Services/LocalDataService.Overview.cs");
 
         Assert.Equal(1, CountOccurrences(source, "new ServerSummaryItem"));
-        Assert.Equal(1, CountOccurrences(source, "ApplyCollectionFreshness(DateTime.UtcNow)"));
+        Assert.Equal(1, CountOccurrences(source, "ApplyCollectionFreshness(DateTime.UtcNow, staleThreshold)"));
 
         /* And the stamp is after the object is built: banding an object that has already been handed back
            would band nothing, and the ordering is the half a count cannot see. */
         Assert.True(
             source.IndexOf("new ServerSummaryItem", StringComparison.Ordinal)
-                < source.IndexOf("ApplyCollectionFreshness(DateTime.UtcNow)", StringComparison.Ordinal),
+                < source.IndexOf("ApplyCollectionFreshness(DateTime.UtcNow, staleThreshold)", StringComparison.Ordinal),
             "The freshness stamp no longer follows the summary it is meant to band.");
+
+        /* #3236: and the cutoff it stamps is resolved through the service-installed cadence lookup, not a
+           constant — deleting the lookup wiring compiles clean and silently returns every card to the flat
+           floor, which is the field false positive one level up. */
+        Assert.Contains("EffectiveCadenceLookup", source, StringComparison.Ordinal);
+        Assert.Contains("ServerHealthClassifier.EffectiveStaleThreshold", source, StringComparison.Ordinal);
     }
 
     /// <summary>The two Grid.Row="4" TextBlocks of the Overview card template — the "Last Collect:" label

--- a/Lite/MainWindow.AlertEngine.cs
+++ b/Lite/MainWindow.AlertEngine.cs
@@ -208,6 +208,35 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
+    /// #3236: a server's whole effective schedule — collector name → cadence minutes for the ENABLED,
+    /// scheduled collectors — for the Overview card's cadence-aware stale band
+    /// (<see cref="LocalDataService.EffectiveCadenceLookup"/>). Same hash-match as
+    /// <see cref="ResolveCollectorCadenceForAlerts"/>: the store keys servers by the deterministic int
+    /// hash, ScheduleManager by the connection GUID. Null for an unknown server — the band then uses the
+    /// flat floor, which is the reading it always had.
+    /// </summary>
+    private Dictionary<string, int>? ResolveEffectiveCadencesForFreshness(int serverId)
+    {
+        var server = _serverManager.GetAllServers().FirstOrDefault(s =>
+            RemoteCollectorService.GetDeterministicHashCode(RemoteCollectorService.GetServerNameForStorage(s)) == serverId);
+        if (server is null)
+        {
+            return null;
+        }
+
+        var cadences = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var schedule in _scheduleManager.GetSchedulesForServer(server.Id))
+        {
+            if (schedule.Enabled && schedule.FrequencyMinutes > 0)
+            {
+                cadences[schedule.Name] = schedule.FrequencyMinutes;
+            }
+        }
+
+        return cadences;
+    }
+
+    /// <summary>
     /// The engine's live-msdb failed-jobs fetcher. Failure outcomes aren't part of the collected
     /// running_jobs snapshot, so this queries the monitored server directly at alert-check time via
     /// the collector's connection path (async SqlClient, already off the UI thread; MFA

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -240,6 +240,12 @@ public partial class MainWindow : Window
             // Initialize data service for overview
             _dataService = new LocalDataService(_databaseInitializer);
 
+            /* #3236: the Overview card's stale band honors the schedule this install actually runs — a
+               Low-Impact preset runs EVERY collector at 5+ minutes, and on the flat two-minute floor that
+               read "(stale)" for three of every five minutes on a healthy server. Installed on the
+               service, not passed by a caller, so the band cannot depend on which caller asked. */
+            _dataService.EffectiveCadenceLookup = ResolveEffectiveCadencesForFreshness;
+
             /* #1812: the adapter's snapshot-freshness bound needs the server's EFFECTIVE running_jobs
                cadence. The adapter keys servers by the deterministic int hash; ScheduleManager keys by
                the connection GUID — the same hash-match FetchFailedJobsForAlertAsync already does. */

--- a/Lite/Services/LocalDataService.Overview.cs
+++ b/Lite/Services/LocalDataService.Overview.cs
@@ -111,6 +111,40 @@ WHERE server_id = $1";
             }
         }
 
+        /* #3236: each enabled scheduled collector's newest run beside its effective cadence — what lets
+           the stale band honor the schedule this install actually runs instead of the flat two-minute
+           floor. Any status on purpose: freshness is the rows-are-landing axis, and a collector erroring
+           on schedule still lands rows; failures band on the collector axis (#3098). 48-hour bound to
+           match the Darling readers — a collector quiet longer than that vouches for nothing anyway. */
+        var cadenceSamples = new List<CollectorCadenceSample>();
+        if (lastCollection.HasValue && EffectiveCadenceLookup?.Invoke(serverId) is { } cadences)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+SELECT collector_name, MAX(collection_time)
+FROM v_collection_log
+WHERE server_id = $1
+AND   collection_time >= $2
+GROUP BY collector_name";
+            cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
+            cmd.Parameters.Add(new DuckDBParameter { Value = DateTime.UtcNow.AddHours(-48) });
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                if (!reader.IsDBNull(0)
+                    && !reader.IsDBNull(1)
+                    && cadences.TryGetValue(reader.GetString(0), out var frequencyMinutes)
+                    && frequencyMinutes > 0)
+                {
+                    cadenceSamples.Add(new CollectorCadenceSample(reader.GetDateTime(1), frequencyMinutes));
+                }
+            }
+        }
+
+        var staleThreshold = lastCollection.HasValue
+            ? ServerHealthClassifier.EffectiveStaleThreshold(lastCollection.Value, cadenceSamples)
+            : ServerHealthThresholds.StaleThreshold;
+
         var summary = new ServerSummaryItem
         {
             DisplayName = displayName,
@@ -127,8 +161,10 @@ WHERE server_id = $1";
            place a ServerSummaryItem is built: the two MCP reads call this method too, and a band only the
            Overview applied would be a fact that depended on which caller asked. The clock is handed in
            rather than read inside the band, so the classification stays a pure function of
-           (last collection, now) — the shape the viewer's ApplyFreshness already has. */
-        summary.ApplyCollectionFreshness(DateTime.UtcNow);
+           (last collection, now, threshold) — the shape the viewer's ApplyFreshness already has. The
+           threshold is stamped from the SAME place for the same reason (#3236): the cadence lookup is
+           installed on this service once, so the band cannot depend on which caller asked. */
+        summary.ApplyCollectionFreshness(DateTime.UtcNow, staleThreshold);
         return summary;
     }
 }
@@ -312,14 +348,27 @@ public class ServerSummaryItem
     public ServerFreshness? CollectionFreshness { get; set; }
 
     /// <summary>
-    /// Stamp <see cref="CollectionFreshness"/> from this card's own <see cref="LastCollectionTime"/>. Pure
-    /// over (last collection, now): both instants are UTC (the DuckDB store is naive UTC and
-    /// <paramref name="nowUtc"/> is <see cref="DateTime.UtcNow"/>), so the subtraction inside the classifier
-    /// is a true elapsed time regardless of Kind. Stamped rather than computed on read so the band cannot
-    /// change between the row's brush binding and the tooltip that explains it.
+    /// The stale cutoff <see cref="CollectionFreshness"/> was banded against (#3236) — this server's own,
+    /// from <see cref="ServerHealthClassifier.EffectiveStaleThreshold"/> over its enabled collectors'
+    /// newest runs and effective cadences, or the flat floor when no cadence lookup is installed. Stamped
+    /// beside the band so the tooltip quotes the number the band was actually decided by, never a constant
+    /// that stopped being the rule.
     /// </summary>
-    public void ApplyCollectionFreshness(DateTime nowUtc) =>
-        CollectionFreshness = ServerHealthClassifier.ClassifyFreshness(LastCollectionTime, nowUtc);
+    public TimeSpan StaleThreshold { get; set; } = ServerHealthThresholds.StaleThreshold;
+
+    /// <summary>
+    /// Stamp <see cref="CollectionFreshness"/> from this card's own <see cref="LastCollectionTime"/>,
+    /// against this server's own stale cutoff (#3236). Pure over (last collection, now, threshold): both
+    /// instants are UTC (the DuckDB store is naive UTC and <paramref name="nowUtc"/> is
+    /// <see cref="DateTime.UtcNow"/>), so the subtraction inside the classifier is a true elapsed time
+    /// regardless of Kind. Stamped rather than computed on read so the band cannot change between the
+    /// row's brush binding and the tooltip that explains it.
+    /// </summary>
+    public void ApplyCollectionFreshness(DateTime nowUtc, TimeSpan staleThreshold)
+    {
+        StaleThreshold = staleThreshold;
+        CollectionFreshness = ServerHealthClassifier.ClassifyFreshness(LastCollectionTime, nowUtc, staleThreshold);
+    }
 
     /// <summary>
     /// The Last Collect row. Names its band in words when the collection is not current, because a colour
@@ -368,15 +417,17 @@ public class ServerSummaryItem
     /// axis it is about, in words, on the row the band is on. It is deliberately NOT folded into the status
     /// word: see the note on <see cref="CardStatus"/>.</para>
     ///
-    /// <para>The thresholds are read from <see cref="ServerHealthThresholds"/> rather than typed, so the
-    /// sentence cannot come to disagree with the band it is explaining.</para>
+    /// <para>The thresholds are read from the STAMPED <see cref="StaleThreshold"/> and the shared
+    /// <see cref="ServerHealthThresholds"/> rather than typed, so the sentence cannot come to disagree
+    /// with the band it is explaining — including when the cutoff is this server's own cadence-aware one
+    /// (#3236) rather than the flat two-minute floor.</para>
     /// </summary>
     public string? CollectionFreshnessTooltip => CollectionFreshness switch
     {
         ServerFreshness.Fresh =>
-            $"Collection is current — something landed within the last {Minutes(ServerHealthThresholds.StaleThreshold)}.",
+            $"Collection is current — something landed within the last {Minutes(StaleThreshold)}.",
         ServerFreshness.Stale =>
-            $"Collection is stale — nothing has landed for over {Minutes(ServerHealthThresholds.StaleThreshold)}.\n" +
+            $"Collection is stale — nothing has landed for over {Minutes(StaleThreshold)}.\n" +
             "This is about collection stopping, not about the server's metrics: the connection check can " +
             "still be passing and no collector reporting an error.",
         ServerFreshness.Offline =>

--- a/Lite/Services/LocalDataService.cs
+++ b/Lite/Services/LocalDataService.cs
@@ -33,6 +33,21 @@ public partial class LocalDataService
     }
 
     /// <summary>
+    /// #3236: the app-installed lookup from a storage server id to that server's effective per-collector
+    /// cadences — collector name → <c>FrequencyMinutes</c>, for the ENABLED, scheduled
+    /// (<c>FrequencyMinutes &gt; 0</c>) collectors only — off the live <c>ScheduleManager</c>, which this
+    /// data-only service cannot reference. Installed ONCE at startup rather than passed per call, because
+    /// the freshness band is stamped where the summary is BUILT precisely so it cannot depend on which
+    /// caller asked (see <see cref="GetServerSummaryAsync"/>); a per-call parameter would hand every
+    /// caller that decision back. Null — never installed, or no server matches the id — means the summary
+    /// bands on the flat <see cref="PerformanceMonitor.Common.ServerHealthThresholds.StaleThreshold"/>
+    /// floor, the pre-#3236 reading. A Lite install on the shipped Low-Impact preset runs EVERY collector
+    /// at 5+ minutes, so without this the Last Collect row read "(stale)" for three of every five minutes
+    /// on a perfectly healthy server.
+    /// </summary>
+    public Func<int, IReadOnlyDictionary<string, int>?>? EffectiveCadenceLookup { get; set; }
+
+    /// <summary>
     /// Creates and opens a DuckDB connection wrapped in a read lock.
     /// The lock prevents CHECKPOINT and compaction from reorganizing the database file
     /// while this connection is reading from it.

--- a/PerformanceMonitor.Common/ServerHealthBands.cs
+++ b/PerformanceMonitor.Common/ServerHealthBands.cs
@@ -19,10 +19,11 @@ namespace PerformanceMonitor.Common
     /// </summary>
     public enum ServerFreshness
     {
-        /// <summary>The newest collection is within twice the fastest collector's cadence — Online (green).</summary>
+        /// <summary>The newest collection is inside the server's stale threshold — twice the collectors'
+        /// own cadence where the surface knows it (#3236), the flat two-minute floor otherwise — Online (green).</summary>
         Fresh,
 
-        /// <summary>Collection has lagged past twice the cadence but the server isn't long-dead — Warning (amber).</summary>
+        /// <summary>Collection has lagged past the stale threshold but the server isn't long-dead — Warning (amber).</summary>
         Stale,
 
         /// <summary>The newest collection is long-dead — the Offline overlay (red).</summary>
@@ -87,9 +88,11 @@ namespace PerformanceMonitor.Common
     /// Returning them together is what makes dropping one a visible edit rather than an omission.
     /// </summary>
     /// <param name="IsOnline">Reachability: true = fresh or stale, false = offline, null = not reached yet.</param>
-    /// <param name="CollectionStale">The amber warning flag: the newest collection has lagged past
-    /// <see cref="ServerHealthThresholds.StaleThreshold"/> but is not old enough to call the server dark. It is
-    /// <see cref="ServerFreshness.Stale"/> and nothing else — no error count, no <c>collection_log</c> read.
+    /// <param name="CollectionStale">The amber warning flag: the newest collection has lagged past the
+    /// server's stale threshold — <see cref="ServerHealthClassifier.EffectiveStaleThreshold"/> where the
+    /// surface knows the server's collectors, the flat <see cref="ServerHealthThresholds.StaleThreshold"/>
+    /// floor otherwise (#3236) — but is not old enough to call the server dark. It is
+    /// <see cref="ServerFreshness.Stale"/> and nothing else — no error count, no <c>collection_log</c> status read.
     ///
     /// <para><b>It is named for freshness because that is its whole population, and the name is load-bearing.</b>
     /// Lite carries a flag of the same shape on its own card (<c>ServerCardStatusRules.Classify</c>) fed from
@@ -251,8 +254,38 @@ namespace PerformanceMonitor.Common
         /// </summary>
         public static readonly TimeSpan CollectorCadence = TimeSpan.FromMinutes(1);
 
-        /// <summary>Older than twice the cadence = the collection has visibly lagged (Warning).</summary>
+        /// <summary>
+        /// Older than twice the cadence = the collection has visibly lagged (Warning). Since #3236 this flat
+        /// value is the FLOOR, not the whole rule: a surface that knows the server's own collectors compares
+        /// against <see cref="ServerHealthClassifier.EffectiveStaleThreshold"/> instead, which widens the
+        /// window for a server whose collectors legitimately run slower than the one-minute default — the
+        /// field case was 14 Aurora targets whose 5-minute <c>pg_cpu_utilization</c> rhythm banded Warning
+        /// on every fleet snapshot landing in the back half of its window. A caller with no per-collector
+        /// data still bands on this floor, which fails toward the label that asks for attention.
+        /// </summary>
         public static readonly TimeSpan StaleThreshold = TimeSpan.FromTicks(CollectorCadence.Ticks * 2);
+
+        /// <summary>
+        /// How many of a collector's OWN cadence intervals may elapse since its newest run before that
+        /// collector stops vouching for the server's freshness — the same "twice the cadence" grace
+        /// <see cref="StaleThreshold"/> has always applied to the assumed one-minute default, now applied to
+        /// each collector's actual schedule (#3236). One missed cycle is scheduling jitter; two is a lag a
+        /// human would call visible, whatever the cadence.
+        /// </summary>
+        public const int StaleCadenceGraceMultiplier = 2;
+
+        /// <summary>
+        /// The stale cutoff for a collector of the given cadence: <see cref="StaleCadenceGraceMultiplier"/>
+        /// times its own interval, floored at the flat <see cref="StaleThreshold"/> so a frequent collector
+        /// bands exactly as it always has — the same max(floor, multiplier x cadence) shape
+        /// <see cref="CollectorHealthClassifier.StaleThresholdHours"/> established for the per-collector
+        /// bands in #1573. A cadence of 0 (on-load / unknown) yields the floor.
+        /// </summary>
+        public static TimeSpan StaleThresholdFor(int frequencyMinutes)
+        {
+            var cadenceWindow = TimeSpan.FromMinutes((double)frequencyMinutes * StaleCadenceGraceMultiplier);
+            return cadenceWindow > StaleThreshold ? cadenceWindow : StaleThreshold;
+        }
 
         /// <summary>
         /// The ONE default for "collection has stopped", shared by the display's Offline band and the alert
@@ -320,6 +353,17 @@ namespace PerformanceMonitor.Common
     }
 
     /// <summary>
+    /// One enabled, SCHEDULED collector's newest <c>collection_log</c> row (any status — freshness is the
+    /// rows-are-landing axis, never the succeeding axis, per the #3098 separation) beside the cadence that
+    /// collector actually runs on for this server — the effective schedule, store override over code default.
+    /// The inputs <see cref="ServerHealthClassifier.EffectiveStaleThreshold"/> reduces to one per-server
+    /// stale cutoff (#3236). Callers exclude disabled and on-load (<c>FrequencyMinutes == 0</c>) collectors:
+    /// a disabled collector's cadence is not a schedule anything runs on, and an on-load collector runs on
+    /// connects, not on the loop this band watches.
+    /// </summary>
+    public readonly record struct CollectorCadenceSample(DateTime LastRunUtc, int FrequencyMinutes);
+
+    /// <summary>
     /// The single, app-agnostic source of truth for a server's per-metric health bands, its overall card band,
     /// the collection-freshness band, and the fleet-ranking score. Reproduces the Dashboard's <c>ServerHealthStatus</c>
     /// CASE logic exactly. Pure + static so every host (web, MCP tool, WPF viewer) bands identically and the whole
@@ -328,11 +372,25 @@ namespace PerformanceMonitor.Common
     public static class ServerHealthClassifier
     {
         /// <summary>
-        /// Classify how fresh the newest collection is. Pure over (last-collection, now). Both instants are UTC
-        /// (the store is naive UTC; <paramref name="nowUtc"/> is <see cref="DateTime.UtcNow"/>), so the
-        /// subtraction is a true elapsed-time regardless of Kind.
+        /// Classify how fresh the newest collection is against the FLAT default threshold — for callers with
+        /// no per-collector schedule data, whose behavior is unchanged. A caller that knows the server's own
+        /// collectors passes <see cref="EffectiveStaleThreshold"/>'s answer to the three-argument overload
+        /// instead (#3236). Pure over (last-collection, now). Both instants are UTC (the store is naive UTC;
+        /// <paramref name="nowUtc"/> is <see cref="DateTime.UtcNow"/>), so the subtraction is a true
+        /// elapsed-time regardless of Kind.
         /// </summary>
-        public static ServerFreshness ClassifyFreshness(DateTime? lastCollectionUtc, DateTime nowUtc)
+        public static ServerFreshness ClassifyFreshness(DateTime? lastCollectionUtc, DateTime nowUtc) =>
+            ClassifyFreshness(lastCollectionUtc, nowUtc, ServerHealthThresholds.StaleThreshold);
+
+        /// <summary>
+        /// <see cref="ClassifyFreshness(DateTime?, DateTime)"/> with the server's own stale cutoff
+        /// (<see cref="EffectiveStaleThreshold"/>) in place of the flat default (#3236). The Offline band is
+        /// deliberately NOT cadence-relative: 30 minutes is the #2794 contract shared with the alert
+        /// engine's Collection Stopped window, and it is checked first — so a server whose effective stale
+        /// threshold exceeds it (only slow-cadence collectors enabled) simply has no amber band and goes
+        /// straight to the red one, which is the stronger claim of the two.
+        /// </summary>
+        public static ServerFreshness ClassifyFreshness(DateTime? lastCollectionUtc, DateTime nowUtc, TimeSpan staleThreshold)
         {
             if (!lastCollectionUtc.HasValue)
             {
@@ -345,12 +403,57 @@ namespace PerformanceMonitor.Common
                 return ServerFreshness.Offline;
             }
 
-            if (age > ServerHealthThresholds.StaleThreshold)
+            if (age > staleThreshold)
             {
                 return ServerFreshness.Stale;
             }
 
             return ServerFreshness.Fresh;
+        }
+
+        /// <summary>
+        /// The one stale cutoff that makes the server-level band honor each collector's OWN schedule (#3236):
+        /// the newest collection is fresh while ANY enabled scheduled collector's newest row is inside
+        /// <see cref="ServerHealthThresholds.StaleThresholdFor"/> of its own cadence, and stale only when
+        /// every one of them is overdue. Returned as a single threshold on the newest collection's age —
+        /// the age at which the LAST collector's window expires — so the band stays a pure ladder over
+        /// (last collection, now, threshold) and a surface can publish the number beside the flag it
+        /// explains.
+        ///
+        /// <para><b>Why "any collector current", not "the fastest cadence".</b> The field signature this
+        /// fixes: 14 Aurora targets whose <c>pg_cpu_utilization</c> legitimately runs every 5 minutes
+        /// banded Warning on any fleet snapshot landing in the back half of that window, while faster
+        /// collectors on the same servers were demonstrably current. A threshold derived from the fastest
+        /// cadence alone still bands a server whose slower collectors are all exactly on schedule; the
+        /// server is only honestly "lagging" when nothing on it is inside its own window.</para>
+        ///
+        /// <para><b>The failure direction stays safe.</b> With no samples — a caller without schedule data,
+        /// a store written by a newer build, every collector disabled — this is exactly the flat
+        /// <see cref="ServerHealthThresholds.StaleThreshold"/>, today's behavior. A genuinely quiet server
+        /// exhausts every collector's window and still bands, and the Offline band is untouched.</para>
+        /// </summary>
+        public static TimeSpan EffectiveStaleThreshold(DateTime lastCollectionUtc, IEnumerable<CollectorCadenceSample> scheduledCollectors)
+        {
+            var threshold = ServerHealthThresholds.StaleThreshold;
+            if (scheduledCollectors is null)
+            {
+                return threshold;
+            }
+
+            foreach (var collector in scheduledCollectors)
+            {
+                /* The instant this collector's own window expires, expressed as an age of the NEWEST
+                   collection — lastRun never exceeds lastCollection (it is the max over these), so each
+                   term is at most the collector's own window and the floor keeps a straggler from
+                   tightening anything. */
+                var expiresAtAge = collector.LastRunUtc + ServerHealthThresholds.StaleThresholdFor(collector.FrequencyMinutes) - lastCollectionUtc;
+                if (expiresAtAge > threshold)
+                {
+                    threshold = expiresAtAge;
+                }
+            }
+
+            return threshold;
         }
 
         /// <summary>CPU band on total non-idle CPU: >= 95% Critical, >= 80% Warning; no snapshot Unknown.</summary>


### PR DESCRIPTION
## What

Fixes #3236: `get_fleet_overview` banded 14 healthy Aurora PostgreSQL targets Warning in a single tick via `collection_stale: true`, because the freshness band compared each server's `MAX(collection_time)` against a flat 2-minute threshold (`ServerHealthThresholds.StaleThreshold`, tuned for the 1-minute SQL Server collectors) while the metric-driving collector on those targets (`pg_cpu_utilization`) legitimately runs every 5 minutes. Any snapshot landing in the back half of that window read stale with every collector on the server demonstrably on schedule.

## The fix

The stale cutoff is now per server, derived from the schedule the sweep actually runs:

- A target is stale only when **every enabled scheduled collector is overdue against its own effective cadence** - twice the cadence, floored at the flat 2 minutes (`ServerHealthThresholds.StaleThresholdFor`), the same `max(floor, multiplier x cadence)` shape #1573 established for the per-collector STALE/FAILING bands.
- `ServerHealthClassifier.EffectiveStaleThreshold` (PerformanceMonitor.Common) reduces per-collector `(newest run, cadence)` samples to one threshold, so the band stays a pure ladder over `(last collection, now, threshold)` and every surface can publish the number beside the flag.
- Cadence resolution honors the store: per-server override > fleet-wide override > `CollectorScheduleDefaults`, via `StoreConfigProvider.ResolveSchedule` on the service and the viewer's own pinned `CollectorScheduleOverlay`; Lite resolves through its live `ScheduleManager`. Disabled, on-load (`FrequencyMinutes == 0`), and unknown-to-this-build collectors vouch for nothing, which falls toward the flat floor - the direction that still bands a genuinely quiet server.
- The **Offline band is untouched** (flat 30 minutes, #2794's contract with the alert engine's Collection Stopped window) and is checked first.

## Surfaces wired (the #2473 one-ladder rule)

- **Darling service**: `DarlingFleetReader` (`get_fleet_overview` + `/api/fleet`) and `list_servers` share one cadence-sample read; cards and rows now carry `stale_threshold_minutes` so `collection_stale`/`status` stay recomputable from the payload.
- **Darling WPF viewer**: Overview cards and sidebar dots band off the same samples (`GetCollectorCadenceSamplesAsync`); the threshold parameter is required, not defaulted, so a call site cannot silently fall back to the floor.
- **Lite (parity)**: the Overview card's Last Collect band resolves through `ScheduleManager` - the shipped **Low-Impact preset runs every collector at 5+ minutes**, so Lite read "(stale)" for three of every five minutes on a healthy server. The tooltip now quotes the stamped cutoff.

## The null metric fields

The issue's `cpu_percent`/`memory_mb` nulls are a separate, structural gap: the fleet reader only queries the SQL Server metric views (`v_cpu_utilization_stats`, `v_memory_stats`, ...), which a PostgreSQL target never writes; the reads are unbounded latest-row reads, so there was no too-tight window to widen here. Filed as #3267 with the file-level evidence.

## Tests

- Red/green on the exact field case: a 5-minute-cadence collector with a last run 3m49s old must not read stale (`ClassifyFreshness_FiveMinuteCadenceCollector_FourMinutesOld_IsFreshNotStale`) - verified failing with the reducer neutered to the flat behavior, passing with the fix; one past twice its cadence must (`..._PastTwiceItsCadence_IsStale`).
- Threshold arithmetic (floor, latest-expiry-wins, stragglers cannot tighten, Offline unmoved), the override-resolution seam (`BuildCadenceSample`: per-server > fleet > default, disabled/on-load/unknown excluded), SQL dialect + shape pins for the two new reads, the updated source pins, and Lite's stamped-threshold tooltip.
- Full suites: Darling.Tests 8448 (1 known machine-local TLS red, pre-existing on clean dev), Lite.Tests 3638, all green. Both build chains: 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtjWJJ3NnSkDSrPBsGywoZ