### PR TITLE
Fleet cards read a PostgreSQL target's instance CPU, and stop claiming Healthy for what they never measured (#3267, #3272)

### DIFF
--- a/Darling/Darling.Tests/DarlingFleetReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingFleetReaderTests.cs
@@ -187,6 +187,7 @@ public sealed class DarlingFleetReaderSqlTests
     [InlineData(nameof(DarlingFleetReader.FleetTagsSql))]
     [InlineData(nameof(DarlingFleetReader.FleetTagForestSql))]
     [InlineData(nameof(DarlingFleetReader.FleetCpuSql))]
+    [InlineData(nameof(DarlingFleetReader.FleetPgCpuSql))]
     [InlineData(nameof(DarlingFleetReader.FleetMemorySql))]
     [InlineData(nameof(DarlingFleetReader.FleetMemoryPressureSql))]
     [InlineData(nameof(DarlingFleetReader.FleetThreadsSql))]

--- a/Darling/Darling.Tests/FleetCardPostgresCpuLivePostgresTests.cs
+++ b/Darling/Darling.Tests/FleetCardPostgresCpuLivePostgresTests.cs
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service.Mcp;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3267 end-to-end against a real store: <c>get_fleet_overview</c>'s own read really does return a
+/// PostgreSQL target's instance CPU, and the four source arms are distinguishable in ONE fleet call.
+///
+/// <para><b>Why this and not only the shape pins.</b> <c>FleetCardPostgresCpuTests</c> asserts the SQL's
+/// TEXT and the reduction's arithmetic; neither can see whether the query runs. The bare
+/// <c>pg_cpu_utilization</c> name has to resolve through the store's <c>search_path</c> to
+/// <c>collect.pg_cpu_utilization</c>, the naive-UTC bind has to compare against a naive <c>timestamp</c>
+/// column without Npgsql inferring <c>timestamptz</c> and zone-shifting it, and <c>DISTINCT ON</c> has to
+/// pick the row this reasoning says it picks. #2213's lesson was a feature whose SQL had been live-verified
+/// for weeks and which could not collect a row, because every defect was in the wiring.</para>
+///
+/// <para><b>The fixture is deliberately not one situation per store.</b> Four servers share the sample —
+/// each landing on a different <see cref="FleetCpuSource"/> arm — so a read that smeared one server's value
+/// across the fleet, or an <c>INNER JOIN</c>-shaped mistake that dropped the servers with no CPU row, fails
+/// here rather than in production. The names are chosen so that neither alphabetical order nor insertion
+/// order lines up with the expected values.</para>
+///
+/// <para><b>Three rows for the Aurora target, two of them traps.</b> The newest row by
+/// <c>sample_time</c> carries a NULL value, which is a real state (Performance Insights returns a data point
+/// with no value for a period it has no sample for, and the ingestor stores it) — so a read without
+/// <c>cpu_percent IS NOT NULL</c> returns "no CPU" for a server that has some. And a row outside the
+/// freshness bound carries a value in a DIFFERENT band, so a read whose bound does not work bands the card
+/// Healthy instead of Warning rather than merely reporting a stale number.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class FleetCardPostgresCpuLivePostgresTests
+{
+    /* NEGATIVE, per this family's convention: teardown deletes from `servers` by id and a real store assigns
+       ids from a sequence, so a positive sentinel is one collision away from removing an operator's row. */
+    private const int AuroraServerId = -993_2671;
+    private const int SelfHostedServerId = -993_2672;
+    private const int AuroraSilentServerId = -993_2673;
+    private const int SqlServerServerId = -993_2674;
+
+    private const string AuroraName = "zz-fleet-pg-cpu-aurora";
+    private const string SelfHostedName = "aa-fleet-pg-cpu-selfhosted";
+    private const string AuroraSilentName = "mm-fleet-pg-cpu-aurora-silent";
+    private const string SqlServerName = "kk-fleet-pg-cpu-sqlserver";
+
+    private static readonly int[] SentinelIds =
+        [AuroraServerId, SelfHostedServerId, AuroraSilentServerId, SqlServerServerId];
+
+    [Fact]
+    public async Task TheFleetCardsCarryEachEnginesCpu_AndNameWhichCollectorAnswered()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live fleet PostgreSQL-CPU test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteSentinelRowsAsync(connection, ct);
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+
+        var bodySucceeded = false;
+        try
+        {
+            var now = DateTime.UtcNow;
+
+            await InsertServerAsync(connection, AuroraServerId, AuroraName, MonitoredEngineKind.AuroraPostgres, ct);
+            await InsertServerAsync(connection, SelfHostedServerId, SelfHostedName, MonitoredEngineKind.Postgres, ct);
+            await InsertServerAsync(connection, AuroraSilentServerId, AuroraSilentName, MonitoredEngineKind.AuroraPostgres, ct);
+            await InsertServerAsync(connection, SqlServerServerId, SqlServerName, MonitoredEngineKind.SqlServer, ct);
+
+            /* Every server collected 30 seconds ago, so freshness is Fresh for all four and the CPU row is
+               the only thing that varies. Without this they would all band on collection state, which is
+               the reading the issue is about replacing. */
+            foreach (var (id, name) in new[]
+            {
+                (AuroraServerId, AuroraName), (SelfHostedServerId, SelfHostedName),
+                (AuroraSilentServerId, AuroraSilentName), (SqlServerServerId, SqlServerName),
+            })
+            {
+                await InsertCollectionLogAsync(connection, id, name, now.AddSeconds(-30), ct);
+            }
+
+            /* Trap 1: the newest sample has no value. */
+            await InsertPgCpuAsync(connection, AuroraServerId, AuroraName, now.AddMinutes(-2), now.AddMinutes(-2), null, ct);
+            /* The answer. */
+            await InsertPgCpuAsync(connection, AuroraServerId, AuroraName, now.AddMinutes(-2), now.AddMinutes(-3), 87.0, ct);
+            /* Trap 2: outside DarlingPgCpuUtilizationReader.Freshness, and in the Healthy band. */
+            await InsertPgCpuAsync(connection, AuroraServerId, AuroraName, now.AddMinutes(-90), now.AddMinutes(-90), 12.0, ct);
+
+            /* Trap 3: a value on ANOTHER server, so a read that lost its per-server key would hand the
+               Aurora card 3% and the assertion below would fail rather than pass on a smear. */
+            await InsertPgCpuAsync(connection, AuroraSilentServerId, AuroraSilentName, now.AddMinutes(-90), now.AddMinutes(-90), 3.0, ct);
+
+            /* The SQL Server arm, so "additive only" is asserted against a live read rather than argued. */
+            await InsertSqlServerCpuAsync(connection, SqlServerServerId, SqlServerName, now.AddMinutes(-1), 30, 4, ct);
+
+            var result = await DarlingFleetReader.GetFleetOverviewAsync(
+                postgres, now.AddHours(-1), now, now, cancellationToken: ct);
+
+            /* Accounting first: every seeded server is still in the answer. A join-shaped mistake in the new
+               read drops the three with no current PostgreSQL CPU row, and every per-card assertion below
+               would then fail with "sequence contains no matching element" — a confusing way to learn that
+               the fix removed servers from the fleet. */
+            var seeded = result.Cards.Where(c => SentinelIds.Contains(c.ServerId)).ToList();
+            Assert.Equal(
+                SentinelIds.OrderBy(i => i).ToArray(),
+                seeded.Select(c => c.ServerId).OrderBy(i => i).ToArray());
+
+            // ── the field case: an Aurora target reports its instance CPU and bands on it ────────────
+            var aurora = seeded.Single(c => c.ServerId == AuroraServerId);
+            Assert.Equal(87.0, aurora.InstanceCpuPercent);
+            Assert.Equal(87.0, aurora.TotalCpuPercent);
+            Assert.Equal(HealthSeverity.Warning, aurora.CpuSeverity);
+            Assert.Equal(FleetCpuSource.PerformanceInsights, aurora.CpuSource);
+            Assert.Equal(FleetHealthBand.Warning, aurora.Band);
+            /* No per-process attribution is claimed - Performance Insights publishes none. */
+            Assert.Null(aurora.CpuPercent);
+            Assert.Null(aurora.OtherProcessCpuPercent);
+            /* And no PostgreSQL source exists for these, so they stay null rather than reading as zero. */
+            Assert.Null(aurora.MemoryMb);
+            Assert.Null(aurora.BufferPoolMb);
+            Assert.Null(aurora.TotalThreads);
+            Assert.Equal(HealthSeverity.Unknown, aurora.ThreadsSeverity);
+
+            // ── a PostgreSQL target this build collects no instance CPU for ─────────────────────────
+            var selfHosted = seeded.Single(c => c.ServerId == SelfHostedServerId);
+            Assert.Null(selfHosted.TotalCpuPercent);
+            Assert.Equal(HealthSeverity.Unknown, selfHosted.CpuSeverity);
+            Assert.Equal(FleetCpuSource.NoSourceForEngine, selfHosted.CpuSource);
+
+            // ── an Aurora target whose ingest has produced nothing CURRENT ──────────────────────────
+            /* Its only row is 90 minutes old, so the bound excludes it. The arm has to be NotCollected and
+               not NoSourceForEngine: this one is a gap someone can go and fix. */
+            var silent = seeded.Single(c => c.ServerId == AuroraSilentServerId);
+            Assert.Null(silent.TotalCpuPercent);
+            Assert.Equal(HealthSeverity.Unknown, silent.CpuSeverity);
+            Assert.Equal(FleetCpuSource.NotCollected, silent.CpuSource);
+
+            // ── the SQL Server path, unchanged ──────────────────────────────────────────────────────
+            var sqlServer = seeded.Single(c => c.ServerId == SqlServerServerId);
+            Assert.Equal(30.0, sqlServer.CpuPercent);
+            Assert.Equal(4.0, sqlServer.OtherProcessCpuPercent);
+            Assert.Equal(34.0, sqlServer.TotalCpuPercent);
+            Assert.Equal(HealthSeverity.Healthy, sqlServer.CpuSeverity);
+            Assert.Equal(FleetCpuSource.RingBuffer, sqlServer.CpuSource);
+            Assert.Null(sqlServer.InstanceCpuPercent);
+
+            /* All four arms present in one call, which is what makes the read's per-server keying and the
+               classification jointly observable rather than one-at-a-time. */
+            Assert.Equal(4, seeded.Select(c => c.CpuSource).Distinct().Count());
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, DeleteSentinelRowsAsync);
+        }
+    }
+
+    private static async Task InsertServerAsync(
+        NpgsqlConnection connection, int serverId, string name, string engineKind, CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO servers (server_id, server_name, display_name, is_enabled, sql_engine_edition, engine_kind)
+VALUES ($1, $2, $2, TRUE, 0, $3)", connection);
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(name);
+        command.Parameters.AddWithValue(engineKind);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task InsertCollectionLogAsync(
+        NpgsqlConnection connection, int serverId, string name, DateTime collectionTime, CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO collection_log (log_id, server_id, server_name, collector_name, collection_time, status)
+VALUES ($1, $2, $3, 'pg_cpu_utilization', $4, 'SUCCESS')", connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(name);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTime, DateTimeKind.Unspecified));
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task InsertPgCpuAsync(
+        NpgsqlConnection connection, int serverId, string name,
+        DateTime collectionTime, DateTime sampleTime, double? cpuPercent, CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO pg_cpu_utilization (collection_id, collection_time, server_id, server_name, sample_time, cpu_percent)
+VALUES ($1, $2, $3, $4, $5, $6)", connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(name);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(sampleTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(cpuPercent ?? (object)DBNull.Value);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task InsertSqlServerCpuAsync(
+        NpgsqlConnection connection, int serverId, string name,
+        DateTime collectionTime, int sqlCpu, int otherCpu, CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO cpu_utilization_stats
+    (collection_id, collection_time, server_id, server_name,
+     sample_time, sqlserver_cpu_utilization, other_process_cpu_utilization)
+VALUES ($1, $2, $3, $4, $5, $6, $7)", connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(name);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(sqlCpu);
+        command.Parameters.AddWithValue(otherCpu);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task DeleteSentinelRowsAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        var ids = string.Join(", ", SentinelIds.Select(i => i.ToString(CultureInfo.InvariantCulture)));
+
+        foreach (var table in new[] { "pg_cpu_utilization", "cpu_utilization_stats", "collection_log", "servers" })
+        {
+            using var cleanup = new NpgsqlCommand($"DELETE FROM {table} WHERE server_id IN ({ids});", connection);
+            await cleanup.ExecuteNonQueryAsync(ct);
+        }
+    }
+}

--- a/Darling/Darling.Tests/FleetCardPostgresCpuLivePostgresTests.cs
+++ b/Darling/Darling.Tests/FleetCardPostgresCpuLivePostgresTests.cs
@@ -142,6 +142,19 @@ public sealed class FleetCardPostgresCpuLivePostgresTests
             Assert.Null(aurora.TotalThreads);
             Assert.Equal(HealthSeverity.Unknown, aurora.ThreadsSeverity);
 
+            /* #3272, end to end: the three DMV-sourced bands claim nothing for this engine. Worth a live
+               arm and not only the unit matrix, because the engine gate reads `servers.engine_kind` out of
+               the store — a column this test wrote and the reader round-tripped, which is the one part of
+               the decision no in-memory fixture exercises. */
+            Assert.Equal(HealthSeverity.Unknown, aurora.MemorySeverity);
+            Assert.Equal(HealthSeverity.Unknown, aurora.BlockingSeverity);
+            Assert.Equal(HealthSeverity.Unknown, aurora.DeadlockSeverity);
+            /* The counts and #3017's disclosure are deliberately untouched, so the fleet total and its
+               coverage denominator still reconcile. */
+            Assert.Equal(0, aurora.BlockingCount);
+            Assert.Equal(0, aurora.DeadlockCount);
+            Assert.Equal(FleetDeadlockSource.PostgresTarget, aurora.DeadlockSource);
+
             // ── a PostgreSQL target this build collects no instance CPU for ─────────────────────────
             var selfHosted = seeded.Single(c => c.ServerId == SelfHostedServerId);
             Assert.Null(selfHosted.TotalCpuPercent);
@@ -164,6 +177,14 @@ public sealed class FleetCardPostgresCpuLivePostgresTests
             Assert.Equal(HealthSeverity.Healthy, sqlServer.CpuSeverity);
             Assert.Equal(FleetCpuSource.RingBuffer, sqlServer.CpuSource);
             Assert.Null(sqlServer.InstanceCpuPercent);
+            /* #3272's other half, live: the same engine gate that made the Aurora card claim nothing must
+               leave a SQL Server card MEASURED. Healthy here is earned — the views exist for this engine
+               and hold no pressure, no blocking and no deadlock for this sentinel. The unit matrix covers
+               the Warning and Critical arms; what this adds is that the gate reads the real column. */
+            Assert.Equal(HealthSeverity.Healthy, sqlServer.MemorySeverity);
+            Assert.Equal(HealthSeverity.Healthy, sqlServer.BlockingSeverity);
+            Assert.Equal(HealthSeverity.Healthy, sqlServer.DeadlockSeverity);
+            Assert.Equal(FleetDeadlockSource.CollectorSilent, sqlServer.DeadlockSource);
 
             /* All four arms present in one call, which is what makes the read's per-server keying and the
                classification jointly observable rather than one-at-a-time. */

--- a/Darling/Darling.Tests/FleetCardPostgresCpuTests.cs
+++ b/Darling/Darling.Tests/FleetCardPostgresCpuTests.cs
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service.Mcp;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3267: a PostgreSQL/Aurora target's card carries its instance CPU, and says where the number came from.
+///
+/// <para><b>The defect.</b> <see cref="DarlingFleetReader"/> read CPU only from
+/// <c>v_cpu_utilization_stats</c>, which the SQL Server ring-buffer collector writes and a PostgreSQL target
+/// never has a row in. Instance CPU for those targets lands in <c>collect.pg_cpu_utilization</c> from the
+/// AWS Performance Insights API (#2719) and nothing on the fleet path looked at it, so every PostgreSQL
+/// card read <c>total_cpu_percent: null</c> / <c>cpu_severity: Unknown</c> — permanently, healthy or not —
+/// and such a server could only rank in the worst-first list by collector state, never by load.</para>
+///
+/// <para><b>Why one band over two collectors is correct, recorded rather than assumed.</b> The premise the
+/// issue offered was that the cutoffs "presumably apply as-is", and #3268 had just been reverted for
+/// shipping an unverified premise, so it was checked from both sides' source instead:
+/// <c>CpuUtilizationCollector</c> stores <c>100 - SystemIdle</c> (a host figure including non-database
+/// processes, one ring-buffer record a minute) and <c>RdsCpuIngestor</c> asks PI for
+/// <c>os.cpuUtilization.total.avg</c> at <c>PeriodInSeconds = 60</c> (a host OS counter, same units, same
+/// window). Same quantity, so one ladder. <see cref="ServerHealthClassifier.CpuSeverity"/>'s own doc carries
+/// the finding and the two caveats that survive it.</para>
+///
+/// <para><b>What is pinned here.</b> That the reduction really produces the number (the field case, red
+/// against the unfixed reader), that BOTH surfaces that band CPU produce the same answer from the same
+/// inputs and do so through the shared decision rather than by agreeing, that no source and 0% cannot read
+/// alike, and that the new cross-server read is bounded the way <see cref="DarlingFleetReader.FleetLastCollectionSql"/>'s
+/// comment demands of a read over a table that only grows.</para>
+/// </summary>
+public sealed class FleetCardPostgresCpuTests
+{
+    private static readonly DateTime Now = new(2026, 9, 10, 12, 0, 0, DateTimeKind.Utc);
+
+    private static FleetServerCard Card(
+        string? engineKind,
+        double? ringBufferSqlCpu = null,
+        double? ringBufferOtherCpu = null,
+        double? instanceCpu = null) =>
+        DarlingFleetReader.BuildCard(
+            new DarlingFleetReader.FleetServerRow(1, "pg-1", "pg-1", null, engineKind, false),
+            new DarlingFleetReader.CpuRow(ringBufferSqlCpu, ringBufferOtherCpu),
+            instanceCpu,
+            default,
+            default,
+            default,
+            default,
+            default,
+            Now.AddSeconds(-30),
+            default,
+            null,
+            Now);
+
+    private static ServerSummaryItem ViewerCard(
+        string? engineKind,
+        double? ringBufferSqlCpu = null,
+        double? ringBufferOtherCpu = null,
+        double? instanceCpu = null)
+    {
+        var card = new ServerSummaryItem
+        {
+            ServerName = "pg-1",
+            ServerId = 1,
+            CpuPercent = ringBufferSqlCpu,
+            OtherProcessCpuPercent = ringBufferOtherCpu,
+            InstanceCpuPercent = instanceCpu,
+            IsPostgres = MonitoredEngineKind.IsPostgres(engineKind),
+            IsAurora = MonitoredEngineKind.IsAurora(engineKind),
+            LastCollectionTime = Now.AddSeconds(-30),
+        };
+        card.ApplyFreshness(Now);
+        return card;
+    }
+
+    /* ─────────────────────────── the field case ─────────────────────────── */
+
+    /// <summary>
+    /// THE test: an Aurora PostgreSQL target with a current Performance Insights reading gets a real number
+    /// and a real band where it used to get null and Unknown. Red against the unfixed reader, which had no
+    /// route for this value to arrive by at all.
+    ///
+    /// <para>87% is chosen inside the Warning band rather than a comfortable 20%, because a fix that
+    /// delivered the number but left it out of <see cref="ServerHealthMetrics.CpuPercentForAlert"/> would
+    /// pass a value-only assertion and still leave the card uncoloured — which is most of what the issue is
+    /// about.</para>
+    /// </summary>
+    [Fact]
+    public void AnAuroraTargetWithAPerformanceInsightsReading_CarriesTheNumberAndTheBand()
+    {
+        var card = Card(MonitoredEngineKind.AuroraPostgres, instanceCpu: 87);
+
+        Assert.Equal(87, card.TotalCpuPercent);
+        Assert.Equal(87, card.InstanceCpuPercent);
+        Assert.Equal(HealthSeverity.Warning, card.CpuSeverity);
+        Assert.Equal(FleetCpuSource.PerformanceInsights, card.CpuSource);
+
+        /* And it reaches the card's OVERALL band, which is what puts it in the worst-first ranking at all. */
+        Assert.Equal(HealthSeverity.Warning, card.OverallMetricSeverity);
+        Assert.Equal(FleetHealthBand.Warning, card.Band);
+        Assert.Contains("CPU 87%", DarlingFleetReader.BuildReason(card), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The per-process fields stay NULL on that card rather than being filled from the total. Performance
+    /// Insights publishes the host figure and no breakdown, so a value in either of these would be an
+    /// attribution nothing measured — and <c>cpu_source</c> is what a consumer reads instead of inferring
+    /// provenance from which fields happen to be null.
+    /// </summary>
+    [Fact]
+    public void ThePerProcessSplitStaysNull_BecausePerformanceInsightsDoesNotPublishOne()
+    {
+        var card = Card(MonitoredEngineKind.AuroraPostgres, instanceCpu: 87);
+
+        Assert.Null(card.CpuPercent);
+        Assert.Null(card.OtherProcessCpuPercent);
+    }
+
+    /* ─────────────────────────── null is not zero ─────────────────────────── */
+
+    /// <summary>
+    /// A genuinely idle instance and one with no CPU source do not read alike — the trap this issue names
+    /// explicitly. 0% is a measurement (Healthy, source named) and no source is not (Unknown, and a source
+    /// arm that says nothing was read).
+    /// </summary>
+    [Fact]
+    public void AnIdleInstanceAndAnUnreadableOne_AreNotTheSameCard()
+    {
+        var idle = Card(MonitoredEngineKind.AuroraPostgres, instanceCpu: 0);
+        var unread = Card(MonitoredEngineKind.Postgres);
+
+        Assert.Equal(0d, idle.TotalCpuPercent);
+        Assert.Equal(HealthSeverity.Healthy, idle.CpuSeverity);
+        Assert.Equal(FleetCpuSource.PerformanceInsights, idle.CpuSource);
+
+        Assert.Null(unread.TotalCpuPercent);
+        Assert.Equal(HealthSeverity.Unknown, unread.CpuSeverity);
+        Assert.Equal(FleetCpuSource.NoSourceForEngine, unread.CpuSource);
+
+        Assert.NotEqual(idle.CpuSource, unread.CpuSource);
+        Assert.NotEqual(idle.CpuSeverity, unread.CpuSeverity);
+    }
+
+    /// <summary>The same distinction on the viewer's card, where it is a rendered STRING and so the one a
+    /// human actually sees: "0%" against "--".</summary>
+    [Fact]
+    public void TheViewerCardRendersIdleAndUnreadableDifferently()
+    {
+        Assert.Equal("0%", ViewerCard(MonitoredEngineKind.AuroraPostgres, instanceCpu: 0).CpuDisplay);
+        Assert.Equal("--", ViewerCard(MonitoredEngineKind.Postgres).CpuDisplay);
+        Assert.Equal("87%", ViewerCard(MonitoredEngineKind.AuroraPostgres, instanceCpu: 87).CpuDisplay);
+    }
+
+    /* ─────────────────────────── provenance, all four arms ─────────────────────────── */
+
+    /// <summary>
+    /// Every arm of the source classification, including the two that mean "no number" and take opposite
+    /// actions: one is a collector to look at, the other is a fact about the engine that no collector,
+    /// grant or upgrade changes.
+    /// </summary>
+    [Theory]
+    /* A ring-buffer reading, whatever the engine token says — the SQL Server path is untouched. */
+    [InlineData(MonitoredEngineKind.SqlServer, 40.0, 3.0, null, FleetCpuSource.RingBuffer)]
+    /* SQL Server on Linux before 2025 CU1: other-process is NULL and it still has a reading. */
+    [InlineData(MonitoredEngineKind.SqlServer, 40.0, null, null, FleetCpuSource.RingBuffer)]
+    [InlineData(MonitoredEngineKind.AuroraPostgres, null, null, 12.0, FleetCpuSource.PerformanceInsights)]
+    /* Aurora with no current reading: the ingestor should be producing one, so this is a gap to chase. */
+    [InlineData(MonitoredEngineKind.AuroraPostgres, null, null, null, FleetCpuSource.NotCollected)]
+    /* Not-Aurora PostgreSQL: this build collects no instance CPU here at all. */
+    [InlineData(MonitoredEngineKind.Postgres, null, null, null, FleetCpuSource.NoSourceForEngine)]
+    /* A SQL Server that has not collected yet. Fixable, so NOT the structural arm. */
+    [InlineData(MonitoredEngineKind.SqlServer, null, null, null, FleetCpuSource.NotCollected)]
+    /* No engine token at all — a row no connect has stamped since V82. Absence is not evidence for either
+       engine, so it falls to the arm that claims a gap someone can act on rather than the one that tells
+       them not to bother. Same asymmetry as MonitoredEngineKind.IsPostgres and ClassifyPlatform. */
+    [InlineData(null, null, null, null, FleetCpuSource.NotCollected)]
+    /* A token a NEWER service wrote and this build has never heard of: same reasoning, same arm. */
+    [InlineData("some-future-engine", null, null, null, FleetCpuSource.NotCollected)]
+    public void TheCpuSourceNamesTheArm(
+        string? engineKind, double? sqlCpu, double? otherCpu, double? instanceCpu, FleetCpuSource expected)
+    {
+        Assert.Equal(expected, Card(engineKind, sqlCpu, otherCpu, instanceCpu).CpuSource);
+        Assert.Equal(expected, ViewerCard(engineKind, sqlCpu, otherCpu, instanceCpu).CpuSource);
+    }
+
+    /// <summary>
+    /// <see cref="FleetCpuSource.NotCollected"/> is the enum's DEFAULT member, so a card assembled by a path
+    /// that sets no reading claims nothing rather than landing on an arm that means "measured". The same
+    /// discipline <see cref="FleetDeadlockSource"/> needed, and for the same reason: a default that means
+    /// "read" inflates a coverage figure silently and compiles.
+    /// </summary>
+    [Fact]
+    public void TheDefaultSourceArm_MeansNothingWasRead()
+    {
+        Assert.Equal(FleetCpuSource.NotCollected, default(FleetCpuSource));
+        Assert.Equal(FleetCpuSource.NotCollected, new FleetServerCard().CpuSource);
+    }
+
+    /// <summary>
+    /// <c>cpu_source</c> reaches the wire as its STRING name, like every other band on this card: a consumer
+    /// switches on a word rather than on an ordinal that adding an arm would move underneath it.
+    /// </summary>
+    [Fact]
+    public void TheCpuSourceSerializesAsItsName()
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            Card(MonitoredEngineKind.AuroraPostgres, instanceCpu: 87), DarlingFleetReader.JsonOptions);
+
+        JsonAssert.Contains("\"cpu_source\": \"PerformanceInsights\"", json);
+        JsonAssert.Contains("\"instance_cpu_percent\": 87", json);
+        JsonAssert.Contains("\"total_cpu_percent\": 87", json);
+        JsonAssert.Contains("\"cpu_percent\": null", json);
+        JsonAssert.Contains("\"other_process_cpu_percent\": null", json);
+        JsonAssert.DoesNotContain("\"cpu_source\": 2", json);
+
+        var none = System.Text.Json.JsonSerializer.Serialize(
+            Card(MonitoredEngineKind.Postgres), DarlingFleetReader.JsonOptions);
+
+        JsonAssert.Contains("\"cpu_source\": \"NoSourceForEngine\"", none);
+        JsonAssert.Contains("\"total_cpu_percent\": null", none);
+        JsonAssert.Contains("\"cpu_severity\": \"Unknown\"", none);
+    }
+
+    /* ─────────────────────────── the one-ladder rule (#2473) ─────────────────────────── */
+
+    /// <summary>
+    /// The two surfaces that band CPU agree, over every combination the arms above cover — the service's
+    /// fleet card (<c>get_fleet_overview</c> / <c>/api/fleet</c>) and the viewer's Overview card (which the
+    /// FleetView band and the worst-first reason are reduced from). #2473's rule is that a server bands the
+    /// same everywhere, and #3267 IS that defect for CPU: one surface read a source the other did not.
+    /// </summary>
+    [Theory]
+    [InlineData(MonitoredEngineKind.AuroraPostgres, null, null, 96.0)]
+    [InlineData(MonitoredEngineKind.AuroraPostgres, null, null, 87.0)]
+    [InlineData(MonitoredEngineKind.AuroraPostgres, null, null, 12.0)]
+    [InlineData(MonitoredEngineKind.AuroraPostgres, null, null, 0.0)]
+    [InlineData(MonitoredEngineKind.AuroraPostgres, null, null, null)]
+    [InlineData(MonitoredEngineKind.Postgres, null, null, null)]
+    [InlineData(MonitoredEngineKind.SqlServer, 60.0, 40.0, null)]
+    [InlineData(MonitoredEngineKind.SqlServer, 40.0, null, null)]
+    [InlineData(MonitoredEngineKind.SqlServer, null, null, null)]
+    public void BothCpuBandingSurfaces_AgreeOnTheSameServer(
+        string? engineKind, double? sqlCpu, double? otherCpu, double? instanceCpu)
+    {
+        var fleet = Card(engineKind, sqlCpu, otherCpu, instanceCpu);
+        var viewer = ViewerCard(engineKind, sqlCpu, otherCpu, instanceCpu);
+
+        Assert.Equal(fleet.TotalCpuPercent, viewer.TotalCpuPercent);
+        Assert.Equal(fleet.CpuSeverity, viewer.CpuSeverity);
+        Assert.Equal(fleet.CpuSource, viewer.CpuSource);
+    }
+
+    /// <summary>
+    /// And they agree BY CONSTRUCTION rather than by observation: the two surfaces above are the ONLY
+    /// places under <c>Darling/</c> that decide a CPU band, and both reach the shared decision. The theory
+    /// above would pass just as happily against two hand-written copies that currently agree, which is
+    /// precisely the state #2473 found the collection-status ladder in - three copies agreeing and a fourth
+    /// that did not.
+    ///
+    /// <para>Stated as a CENSUS of the deciding files rather than as a search for a bad copy, because the
+    /// failure mode is OMISSION: #3267 is a surface that computed a CPU band while never learning a second
+    /// source existed, and no scan for a duplicated expression can see that. A third surface arriving fails
+    /// here and has to be given the shared call, which is the decision this forces someone to make. It
+    /// fails in both directions - a new decider, or either of these two dropping the call.</para>
+    ///
+    /// <para>Read from the source tree so it reaches the WPF viewer without this net10.0-windows assembly
+    /// resolving a WPF project reference, and stripped with the shared lexer rather than a line prefix
+    /// because every doc comment in this family QUOTES the identifiers being counted.</para>
+    /// </summary>
+    [Fact]
+    public void TheOnlyTwoSurfacesThatBandCpu_BothReachTheSharedDecision()
+    {
+        var deciders = new List<string>();
+        var callers = new List<string>();
+        var scanned = 0;
+
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(RepoFile.Root, "Darling"), "*.cs", SearchOption.AllDirectories))
+        {
+            var segments = file.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (segments.Contains("bin") || segments.Contains("obj") || segments.Contains("Darling.Tests"))
+            {
+                continue;
+            }
+
+            scanned++;
+            var code = CSharpSourceWalker.StripCommentsAndStrings(File.ReadAllText(file));
+            var name = Path.GetFileName(file);
+
+            /* Constructing the metric bundle, or calling the CPU ladder directly, is what "decides a CPU
+               band" means. Either route counts: the fleet reader builds the bundle, the viewer's card
+               property calls the ladder, and a third surface could do either. */
+            if (code.Contains("new ServerHealthMetrics", StringComparison.Ordinal)
+                || code.Contains("ServerHealthClassifier.CpuSeverity(", StringComparison.Ordinal))
+            {
+                deciders.Add(name);
+            }
+
+            if (code.Contains("FleetCpuProvenance.TotalNonIdleCpuPercent", StringComparison.Ordinal)
+                && code.Contains("FleetCpuProvenance.ClassifyCpuSource", StringComparison.Ordinal))
+            {
+                callers.Add(name);
+            }
+        }
+
+        /* The scan is the enforcement, so finding almost nothing is a broken scan, not a clean tree. */
+        Assert.True(scanned > 50, $"scanned only {scanned} file(s) under Darling/");
+
+        var expected = new[] { "DarlingFleetReader.cs", "ViewerDataService.Overview.cs" };
+
+        Assert.Equal(expected, deciders.Distinct().OrderBy(n => n, StringComparer.Ordinal).ToArray());
+        Assert.Equal(expected, callers.Distinct().OrderBy(n => n, StringComparer.Ordinal).ToArray());
+    }
+
+    /* ─────────────────────────── the new read's shape ─────────────────────────── */
+
+    /// <summary>
+    /// The cross-server read is BOUNDED, for <see cref="DarlingFleetReader.FleetLastCollectionSql"/>'s
+    /// reason: <c>pg_cpu_utilization</c> is a hypertable that only grows, and a bare
+    /// <c>DISTINCT ON (server_id)</c> over it reads and sorts the whole retained relation on every fleet
+    /// call. Both predicates are asserted because they do different jobs — <c>collection_time</c> is the
+    /// partition dimension and the only one TimescaleDB can chunk-exclude on, <c>sample_time</c> is what the
+    /// reading is ABOUT and so the honest freshness test.
+    /// </summary>
+    [Fact]
+    public void FleetPgCpuSql_IsBoundedOnBothTheChunkKeyAndTheSampleTime()
+    {
+        var sql = DarlingFleetReader.FleetPgCpuSql;
+
+        Assert.Contains("FROM pg_cpu_utilization", sql, StringComparison.Ordinal);
+        Assert.Contains("DISTINCT ON (server_id)", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $1", sql, StringComparison.Ordinal);
+        Assert.Contains("sample_time >= $1", sql, StringComparison.Ordinal);
+
+        /* Ordered on the partition column first, with sample_time as the within-cycle tiebreak - the shape
+           LatestCpuReadShapeSqlTests pins for the SQL Server twin, earning ordered ChunkAppend. */
+        Assert.Contains("ORDER BY server_id, collection_time DESC, sample_time DESC", sql, StringComparison.Ordinal);
+
+        /* PI returns a data point with a NULL value for a period it has no sample for, and the ingestor
+           stores it, so the newest ROW is not necessarily the newest MEASUREMENT. */
+        Assert.Contains("cpu_percent IS NOT NULL", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>The viewer's per-server twin carries the same bound and the same ordering, so the two
+    /// surfaces cannot disagree about which sample is current for the same server.</summary>
+    [Fact]
+    public void TheViewersPerServerPgCpuRead_HasTheSameShape()
+    {
+        var sql = ViewerDataService.ServerSummaryPgCpuSql;
+
+        Assert.Contains("FROM pg_cpu_utilization", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("sample_time >= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("cpu_percent IS NOT NULL", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time DESC, sample_time DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Both reads take their staleness window from <c>DarlingPgCpuUtilizationReader.Freshness</c>, the
+    /// constant the High CPU alert already uses. Three surfaces answer "where does this server's CPU stand
+    /// right now"; two of them holding different windows is a drift of the #2473 kind, where the alert
+    /// evaluates a reading the card has already dropped.
+    ///
+    /// <para>Asserted as a source fact rather than by re-deriving the number, because the failure this
+    /// guards against is a second literal appearing, not a wrong value.</para>
+    /// </summary>
+    [Fact]
+    public void BothPgCpuReadsBindTheSharedFreshnessConstant()
+    {
+        Assert.Equal(TimeSpan.FromMinutes(15), DarlingPgCpuUtilizationReader.Freshness);
+
+        foreach (var path in new[]
+        {
+            Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingFleetReader.cs"),
+            Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.Overview.cs"),
+        })
+        {
+            var code = CSharpSourceWalker.StripCommentsAndStrings(RepoFile.ReadRepoFile(path));
+
+            Assert.Contains("DarlingPgCpuUtilizationReader.Freshness", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("TimeSpan.FromMinutes(15)", code, StringComparison.Ordinal);
+        }
+    }
+}

--- a/Darling/Darling.Tests/UnmeasuredMetricsAreNotHealthyTests.cs
+++ b/Darling/Darling.Tests/UnmeasuredMetricsAreNotHealthyTests.cs
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service.Mcp;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3272: a card stops reporting <b>Healthy</b> for a metric nothing measured.
+///
+/// <para><b>The defect.</b> A PostgreSQL target has no row in <c>v_memory_grant_stats</c>,
+/// <c>v_blocked_process_reports</c> / <c>v_dmv_blocking_snapshots</c> or <c>v_deadlocks</c>, so the
+/// per-metric reads handed its card zeros — and <c>MemorySeverity(bool)</c>,
+/// <c>BlockingSeverity(int, double)</c> and <c>DeadlockSeverity(int)</c> took non-nullable parameters, so
+/// there was no way for a zero to mean "absent" rather than "calm". All three answered Healthy and painted a
+/// green dot. That is a positive claim of health, which is worse than the null beside it, and worse than
+/// what <see cref="ServerHealthClassifier.CpuSeverity"/> and
+/// <see cref="ServerHealthClassifier.ThreadsSeverity"/> already did by taking nullable inputs.
+///
+/// <para><b>The invariant this is held to.</b> A MEASURED metric must band exactly as it does today. That is
+/// the real constraint, and it is not the same as "leave the SQL Server path alone": the fix necessarily
+/// edits functions every SQL Server surface calls. <see cref="AMeasuredCardBandsExactlyAsItDidBefore"/> is
+/// the pin, and it fails when the engine gate that decides "measured" is broken in either direction.</para>
+///
+/// <para><b>Why adding an Unknown cannot move a band or a rank.</b> Both reducers already treat Unknown as
+/// inert — <see cref="ServerHealthClassifier.OverallMetricSeverity"/> only escalates on <c>Warning</c> and
+/// <c>Critical</c>, and <see cref="ServerHealthClassifier.FleetHealthScore"/>'s magnitude counts only those
+/// two — so an unmeasured metric neither improves nor worsens a server's position. That is a property of the
+/// existing code rather than a happy accident of this change, and
+/// <see cref="UnknownIsBandAndRankNeutral_SoTheFixCannotReorderTheFleet"/> pins it so an "improvement" that
+/// made Unknown escalate would fail here instead of silently reordering the fleet.</para>
+/// </summary>
+public sealed class UnmeasuredMetricsAreNotHealthyTests
+{
+    private static readonly DateTime Now = new(2026, 9, 10, 12, 0, 0, DateTimeKind.Utc);
+
+    private static FleetServerCard Card(
+        string? engineKind,
+        bool memoryPressure = false,
+        int blocking = 0,
+        long maxBlockingWaitMs = 0,
+        int deadlocks = 0) =>
+        DarlingFleetReader.BuildCard(
+            new DarlingFleetReader.FleetServerRow(1, "t", "t", null, engineKind, false),
+            default,
+            null,
+            default,
+            memoryPressure ? new DarlingFleetReader.MemoryPressureRow(3, 0, 0, 128) : default,
+            default,
+            new DarlingFleetReader.BlockingRow(blocking, maxBlockingWaitMs, 0, 0),
+            new DarlingFleetReader.DeadlockRow(deadlocks, deadlocks > 0 ? Now.AddMinutes(-5) : null),
+            Now.AddSeconds(-30),
+            default,
+            null,
+            Now);
+
+    private static ServerSummaryItem ViewerCard(
+        string? engineKind,
+        bool memoryPressure = false,
+        int blocking = 0,
+        long maxBlockingWaitMs = 0,
+        int deadlocks = 0)
+    {
+        var card = new ServerSummaryItem
+        {
+            ServerName = "t",
+            ServerId = 1,
+            MemoryWaiterCount = memoryPressure ? 3 : 0,
+            BlockingCount = blocking,
+            MaxBlockingWaitMs = maxBlockingWaitMs,
+            DeadlockCount = deadlocks,
+            IsPostgres = MonitoredEngineKind.IsPostgres(engineKind),
+            IsAurora = MonitoredEngineKind.IsAurora(engineKind),
+            LastCollectionTime = Now.AddSeconds(-30),
+        };
+        card.ApplyFreshness(Now);
+        return card;
+    }
+
+    /* ─────────────────────────── the defect ─────────────────────────── */
+
+    /// <summary>
+    /// A PostgreSQL card's three DMV-sourced metrics read Unknown, not Healthy. Red against the unfixed
+    /// classifiers, which had no arm that could return anything else for a zero.
+    /// </summary>
+    [Theory]
+    [InlineData(MonitoredEngineKind.Postgres)]
+    [InlineData(MonitoredEngineKind.AuroraPostgres)]
+    public void APostgresCard_ClaimsNoHealthForWhatItNeverMeasured(string engineKind)
+    {
+        var card = Card(engineKind);
+
+        Assert.Equal(HealthSeverity.Unknown, card.MemorySeverity);
+        Assert.Equal(HealthSeverity.Unknown, card.BlockingSeverity);
+        Assert.Equal(HealthSeverity.Unknown, card.DeadlockSeverity);
+
+        /* Threads already reached Unknown on its own (a null ceiling), and CPU does since #3267. So after
+           this the card makes NO unearned claim on any metric row - which is the property worth asserting,
+           rather than three separate arms that happen to agree today. */
+        Assert.Equal(HealthSeverity.Unknown, card.ThreadsSeverity);
+        Assert.DoesNotContain(
+            HealthSeverity.Healthy,
+            new[] { card.MemorySeverity, card.BlockingSeverity, card.DeadlockSeverity, card.ThreadsSeverity, card.CpuSeverity });
+    }
+
+    /// <summary>The viewer's card, same server, same answer — the #2473 rule.</summary>
+    [Theory]
+    [InlineData(MonitoredEngineKind.Postgres)]
+    [InlineData(MonitoredEngineKind.AuroraPostgres)]
+    public void TheViewerCardAgrees(string engineKind)
+    {
+        var card = ViewerCard(engineKind);
+
+        Assert.Equal(HealthSeverity.Unknown, card.MemorySeverity);
+        Assert.Equal(HealthSeverity.Unknown, card.BlockingSeverity);
+        Assert.Equal(HealthSeverity.Unknown, card.DeadlockSeverity);
+    }
+
+    /// <summary>
+    /// The published COUNTS are deliberately unchanged, and #3017's disclosure still reads the same. The
+    /// fleet's <c>total_deadlocks</c> is summed from those zeros and <c>deadlock_coverage</c> is what
+    /// explains it; nulling them would leave that denominator describing nothing. So the band stopped
+    /// claiming health while the count kept saying what it counted — and the two now AGREE, where before
+    /// <c>deadlock_source: PostgresTarget</c> sat beside <c>deadlock_severity: Healthy</c>.
+    /// </summary>
+    [Fact]
+    public void TheCountsAndTheCoverageDisclosureAreUntouched()
+    {
+        var card = Card(MonitoredEngineKind.AuroraPostgres);
+
+        Assert.Equal(0, card.BlockingCount);
+        Assert.Equal(0, card.DeadlockCount);
+        Assert.False(card.HasMemoryPressure);
+        Assert.Equal(FleetDeadlockSource.PostgresTarget, card.DeadlockSource);
+    }
+
+    /* ─────────────────────────── the invariant ─────────────────────────── */
+
+    /// <summary>
+    /// A MEASURED card bands exactly as it did before, across the combinations that reach every arm of all
+    /// three classifiers. This is the pin the whole change is held to, and it fails in BOTH directions: an
+    /// engine gate that wrongly reports "not measured" drops a real Critical to Unknown, and one that
+    /// wrongly reports "measured" puts a green dot back on a PostgreSQL card.
+    ///
+    /// <para>The expected values are written out rather than computed, so the assertion cannot follow the
+    /// implementation. Every one of them is the answer the pre-#3272 classifiers gave.</para>
+    /// </summary>
+    [Theory]
+    /* calm SQL Server: all three measured and Healthy, card Healthy */
+    [InlineData(false, 0, 0L, 0, HealthSeverity.Healthy, HealthSeverity.Healthy, HealthSeverity.Healthy, FleetHealthBand.Healthy)]
+    /* memory pressure -> Critical */
+    [InlineData(true, 0, 0L, 0, HealthSeverity.Critical, HealthSeverity.Healthy, HealthSeverity.Healthy, FleetHealthBand.Critical)]
+    /* one blocking event -> Warning */
+    [InlineData(false, 1, 0L, 0, HealthSeverity.Healthy, HealthSeverity.Warning, HealthSeverity.Healthy, FleetHealthBand.Warning)]
+    /* two events -> Warning; five -> Critical */
+    [InlineData(false, 2, 0L, 0, HealthSeverity.Healthy, HealthSeverity.Warning, HealthSeverity.Healthy, FleetHealthBand.Warning)]
+    [InlineData(false, 5, 0L, 0, HealthSeverity.Healthy, HealthSeverity.Critical, HealthSeverity.Healthy, FleetHealthBand.Critical)]
+    /* a long wait alone -> Warning at 10s, Critical at 60s, with a count of 1 */
+    [InlineData(false, 1, 10_000L, 0, HealthSeverity.Healthy, HealthSeverity.Warning, HealthSeverity.Healthy, FleetHealthBand.Warning)]
+    [InlineData(false, 1, 60_000L, 0, HealthSeverity.Healthy, HealthSeverity.Critical, HealthSeverity.Healthy, FleetHealthBand.Critical)]
+    /* any deadlock -> Critical */
+    [InlineData(false, 0, 0L, 1, HealthSeverity.Healthy, HealthSeverity.Healthy, HealthSeverity.Critical, FleetHealthBand.Critical)]
+    public void AMeasuredCardBandsExactlyAsItDidBefore(
+        bool memoryPressure, int blocking, long maxWaitMs, int deadlocks,
+        HealthSeverity expectedMemory, HealthSeverity expectedBlocking, HealthSeverity expectedDeadlock,
+        FleetHealthBand expectedBand)
+    {
+        foreach (var engineKind in new string?[] { MonitoredEngineKind.SqlServer, null, "some-future-engine" })
+        {
+            var card = Card(engineKind, memoryPressure, blocking, maxWaitMs, deadlocks);
+
+            Assert.Equal(expectedMemory, card.MemorySeverity);
+            Assert.Equal(expectedBlocking, card.BlockingSeverity);
+            Assert.Equal(expectedDeadlock, card.DeadlockSeverity);
+            Assert.Equal(expectedBand, card.Band);
+
+            var viewer = ViewerCard(engineKind, memoryPressure, blocking, maxWaitMs, deadlocks);
+            Assert.Equal(expectedMemory, viewer.MemorySeverity);
+            Assert.Equal(expectedBlocking, viewer.BlockingSeverity);
+            Assert.Equal(expectedDeadlock, viewer.DeadlockSeverity);
+        }
+    }
+
+    /// <summary>
+    /// The classifiers' own arms, unchanged for every value that is a measurement — so the change is a NEW
+    /// arm rather than a re-banding. Held separately from the card-level pin above because a card can only
+    /// reach these through one read path each.
+    /// </summary>
+    [Fact]
+    public void TheClassifiersMeasuredArmsAreUnchanged()
+    {
+        Assert.Equal(HealthSeverity.Healthy, ServerHealthClassifier.MemorySeverity(false));
+        Assert.Equal(HealthSeverity.Critical, ServerHealthClassifier.MemorySeverity(true));
+        Assert.Equal(HealthSeverity.Unknown, ServerHealthClassifier.MemorySeverity(null));
+
+        Assert.Equal(HealthSeverity.Healthy, ServerHealthClassifier.BlockingSeverity(0, 0));
+        Assert.Equal(HealthSeverity.Warning, ServerHealthClassifier.BlockingSeverity(1, 0));
+        Assert.Equal(HealthSeverity.Critical, ServerHealthClassifier.BlockingSeverity(5, 0));
+        Assert.Equal(HealthSeverity.Unknown, ServerHealthClassifier.BlockingSeverity(null, 0));
+        /* A max wait with no population is still Unknown - the count is the only spelling of "unmeasured",
+           so a stray duration cannot smuggle a band back in. */
+        Assert.Equal(HealthSeverity.Unknown, ServerHealthClassifier.BlockingSeverity(null, 600));
+
+        Assert.Equal(HealthSeverity.Healthy, ServerHealthClassifier.DeadlockSeverity(0));
+        Assert.Equal(HealthSeverity.Critical, ServerHealthClassifier.DeadlockSeverity(1));
+        Assert.Equal(HealthSeverity.Unknown, ServerHealthClassifier.DeadlockSeverity(null));
+    }
+
+    /* ─────────────────────────── neutrality ─────────────────────────── */
+
+    /// <summary>
+    /// Replacing a Healthy with an Unknown changes neither the overall band nor the fleet score, so nothing
+    /// this fix touches can reorder the worst-first ranking. The property the coordinator asked to be
+    /// checked, asserted rather than argued — and it holds because both reducers already ignore Unknown, not
+    /// because of anything added here.
+    ///
+    /// <para>Written over a card that is otherwise WARNING as well as one that is calm: a neutrality claim
+    /// tested only on a healthy card would not notice a reducer that let Unknown suppress an existing
+    /// escalation.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(0, 0L)]
+    [InlineData(2, 0L)]
+    [InlineData(1, 60_000L)]
+    public void UnknownIsBandAndRankNeutral_SoTheFixCannotReorderTheFleet(int blocking, long maxWaitMs)
+    {
+        var measured = new ServerHealthMetrics
+        {
+            CpuPercentForAlert = 85,
+            HasMemoryPressure = false,
+            BlockingCount = blocking,
+            MaxBlockedSeconds = maxWaitMs / 1000.0,
+            DeadlockCount = 0,
+            TotalThreads = 512,
+            AvailableThreads = 500,
+            FailedCollectorCount = 0,
+        };
+
+        /* The same server with the three DMV metrics unmeasured instead of measured-and-calm. Blocking keeps
+           its value where it was non-zero, because nulling a real reading would be a different change. */
+        var unmeasured = measured with
+        {
+            HasMemoryPressure = null,
+            DeadlockCount = null,
+            BlockingCount = blocking == 0 ? null : blocking,
+        };
+
+        var measuredOverall = ServerHealthClassifier.OverallMetricSeverity(measured);
+        var unmeasuredOverall = ServerHealthClassifier.OverallMetricSeverity(unmeasured);
+        Assert.Equal(measuredOverall, unmeasuredOverall);
+
+        var band = ServerHealthClassifier.ClassifyBand(true, false, false, measuredOverall);
+        Assert.Equal(
+            ServerHealthClassifier.FleetHealthScore(band, measured),
+            ServerHealthClassifier.FleetHealthScore(band, unmeasured));
+    }
+
+    /// <summary>
+    /// <c>default(ServerHealthMetrics)</c> flipped from "all zero, therefore Healthy" to "all null,
+    /// therefore Unknown" when the fields became nullable. That is only safe BECAUSE Unknown is inert, so it
+    /// is pinned rather than assumed: a bundle nobody populated still bands and scores as it did.
+    /// </summary>
+    [Fact]
+    public void AnUnpopulatedMetricBundleBandsAndScoresAsItAlwaysDid()
+    {
+        var empty = default(ServerHealthMetrics);
+
+        Assert.Equal(HealthSeverity.Healthy, ServerHealthClassifier.OverallMetricSeverity(empty));
+        Assert.Equal(0L, ServerHealthClassifier.FleetHealthScore(FleetHealthBand.Healthy, empty));
+    }
+
+    /* ─────────────────────────── the ordering the guards depend on ─────────────────────────── */
+
+    /// <summary>
+    /// <see cref="HealthSeverity.Unknown"/> must stay the LOWEST member. Several surfaces gate on
+    /// <c>severity &gt;= HealthSeverity.Warning</c> — <c>DarlingFleetReader.BuildReason</c>, the viewer's
+    /// <c>FleetRollup.BuildReason</c> and its Needs-Attention filter — and this change makes three more
+    /// metrics able to return Unknown, so those guards now depend on the ordering for correctness rather
+    /// than incidentally. Reorder the enum to make Unknown "worst" and every one of them starts writing
+    /// clauses about metrics that were never read.
+    /// </summary>
+    [Fact]
+    public void UnknownIsTheLowestSeverity_BecauseTheReasonGuardsCompareOnIt()
+    {
+        Assert.Equal(0, (int)HealthSeverity.Unknown);
+        Assert.True(HealthSeverity.Unknown < HealthSeverity.Healthy);
+        Assert.True(HealthSeverity.Unknown < HealthSeverity.Warning);
+        Assert.Equal(
+            new[] { HealthSeverity.Unknown, HealthSeverity.Healthy, HealthSeverity.Warning, HealthSeverity.Critical },
+            Enum.GetValues<HealthSeverity>().OrderBy(s => (int)s).ToArray());
+    }
+
+    /// <summary>
+    /// And the consequence, on the string a reader actually sees: a PostgreSQL card's worst-first reason
+    /// names none of the three unmeasured metrics. Before the enum check above this was luck; it is now
+    /// covered from both ends.
+    /// </summary>
+    [Fact]
+    public void APostgresCardsReasonNamesNoUnmeasuredMetric()
+    {
+        var reason = DarlingFleetReader.BuildReason(Card(MonitoredEngineKind.AuroraPostgres));
+
+        Assert.DoesNotContain("Memory", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Blocking", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Deadlock", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Threads", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /* ─────────────────────────── one decision, both surfaces ─────────────────────────── */
+
+    /// <summary>
+    /// Both surfaces reach the shared "is this a measurement" decision, and no third file decides it for
+    /// itself. Same census shape as <c>FleetCardPostgresCpuTests</c>'s, and the same reason: the failure
+    /// mode is a surface that never learns the concept exists.
+    /// </summary>
+    [Fact]
+    public void BothSurfacesReachTheSharedMeasuredDecision()
+    {
+        var callers = System.IO.Directory
+            .EnumerateFiles(System.IO.Path.Combine(RepoFile.Root, "Darling"), "*.cs", System.IO.SearchOption.AllDirectories)
+            .Where(f =>
+            {
+                var segments = f.Split(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
+                return !segments.Contains("bin") && !segments.Contains("obj") && !segments.Contains("Darling.Tests");
+            })
+            .Where(f => CSharpSourceWalker
+                .StripCommentsAndStrings(System.IO.File.ReadAllText(f))
+                .Contains("ServerMetricSources.DmvSourced", StringComparison.Ordinal))
+            .Select(System.IO.Path.GetFileName)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(new[] { "DarlingFleetReader.cs", "ViewerDataService.Overview.cs" }, callers);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using Npgsql;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Storage;
 
 namespace PerformanceMonitor.Darling.Service.Mcp;
 
@@ -135,6 +136,49 @@ SELECT DISTINCT ON (server_id)
     sqlserver_cpu_utilization,
     other_process_cpu_utilization
 FROM v_cpu_utilization_stats
+ORDER BY server_id, collection_time DESC, sample_time DESC";
+
+    /// <summary>Latest instance CPU per PostgreSQL/Aurora target — the newest Performance Insights sample
+    /// per server, within the freshness bound. $1 the freshness cutoff (naive UTC).
+    ///
+    /// <para><b>Why a second CPU read rather than a wider first one</b> (#3267). <see cref="FleetCpuSql"/>
+    /// reads <c>v_cpu_utilization_stats</c>, which the SQL Server ring-buffer collector writes and a
+    /// PostgreSQL target never has a row in; instance CPU for those targets lands in
+    /// <c>collect.pg_cpu_utilization</c> from the AWS API (#2719), a different table with different
+    /// columns. Nothing joins them and nothing should — the two carry different detail (see
+    /// <see cref="FleetCpuSource"/>) and the SQL Server path is deliberately untouched.</para>
+    ///
+    /// <para><b>Both predicates are load-bearing, and they are not the same predicate.</b>
+    /// <c>collection_time</c> is the hypertable's partition dimension, so it is the one that lets
+    /// TimescaleDB chunk-exclude — the same reasoning as <see cref="FleetLastCollectionSql"/>, and the
+    /// mistake to avoid is a bare <c>DISTINCT ON</c> that reads this table's whole retained history on
+    /// every fleet call. <c>sample_time</c> is what the reading is ABOUT, and it is the honest freshness
+    /// test: a cycle backfills up to <c>RdsCpuIngestor.LookbackWindow</c> of points under one
+    /// <c>collection_time</c>, so a row inside the collection bound can still carry a sample older than
+    /// it. Unlike the SQL Server arm, comparing <c>sample_time</c> to a store-derived instant is
+    /// frame-correct here: Performance Insights stamps its data points in UTC and the ingestor stores them
+    /// naive-UTC unchanged, where the ring buffer's <c>sample_time</c> is the monitored server's LOCAL wall
+    /// clock (see <c>LatestCpuReadShapeSqlTests</c> for what a bound on that one costs).</para>
+    ///
+    /// <para><b>Falling out of this read is the correct answer, unlike
+    /// <see cref="FleetLastCollectionSql"/>'s 48 hours.</b> That read's value is "when did we last see this
+    /// server", which a long-dark server must still report or its card drops out entirely. A CPU LEVEL is
+    /// the opposite: a four-hour-old reading is not this server's CPU now, and the card says so by carrying
+    /// null and banding Unknown. The bound is <c>DarlingPgCpuUtilizationReader.Freshness</c> — three times
+    /// the collector's own 5-minute cadence, so two missed cycles are tolerated — and it is that constant
+    /// rather than a new number so the card and the High CPU alert agree on what "current" means.</para>
+    ///
+    /// <para><c>cpu_percent IS NOT NULL</c> because Performance Insights returns a data point with a null
+    /// value for a period it has no sample for, and the ingestor stores it; the newest row is not
+    /// necessarily the newest MEASUREMENT.</para></summary>
+    public const string FleetPgCpuSql = @"
+SELECT DISTINCT ON (server_id)
+    server_id,
+    cpu_percent
+FROM pg_cpu_utilization
+WHERE collection_time >= $1
+AND   sample_time >= $1
+AND   cpu_percent IS NOT NULL
 ORDER BY server_id, collection_time DESC, sample_time DESC";
 
     /// <summary>Latest total server memory + buffer pool (MB) per server. $ none.</summary>
@@ -312,6 +356,7 @@ GROUP BY server_id, collector_name";
         var servers = await ReadServersAsync(postgres, cancellationToken);
 
         var cpu = await ReadCpuAsync(postgres, cancellationToken);
+        var pgCpu = await ReadPgCpuAsync(postgres, now, cancellationToken);
         var memory = await ReadMemoryAsync(postgres, cancellationToken);
         var memoryPressure = await ReadMemoryPressureAsync(postgres, cancellationToken);
         var threads = await ReadThreadsAsync(postgres, cancellationToken);
@@ -326,6 +371,9 @@ GROUP BY server_id, collector_name";
         foreach (var server in servers)
         {
             cpu.TryGetValue(server.ServerId, out var c);
+            /* Not TryGetValue into a double: a miss must stay null, because null is the reading
+               ("no current instance CPU") and 0.0 would be a measurement. */
+            double? pg = pgCpu.TryGetValue(server.ServerId, out var pgValue) ? pgValue : null;
             memory.TryGetValue(server.ServerId, out var m);
             memoryPressure.TryGetValue(server.ServerId, out var mp);
             threads.TryGetValue(server.ServerId, out var t);
@@ -344,17 +392,26 @@ GROUP BY server_id, collector_name";
             failingCollectors.TryGetValue(server.ServerId, out var collectors);
             tags.TryGetValue(server.ServerId, out var serverTags);
 
-            cards.Add(BuildCard(server, c, m, mp, t, b, deadlock, lastColl, collectors, serverTags, now));
+            cards.Add(BuildCard(server, c, pg, m, mp, t, b, deadlock, lastColl, collectors, serverTags, now));
         }
 
         return BuildRollup(cards, now, windowStartUtc, windowEndUtc, worstCount, tagForest);
     }
 
     /// <summary>Builds one pre-banded card from a server's raw cross-server reads (pure — the reduction the WPF
-    /// <c>ServerSummaryItem</c> does, minus the brushes, over the shared classifier).</summary>
-    private static FleetServerCard BuildCard(
+    /// <c>ServerSummaryItem</c> does, minus the brushes, over the shared classifier).
+    ///
+    /// <para><b>Internal, not private</b>, for the reason <see cref="BuildRollup"/> is public: this is the
+    /// step that decides what a card CLAIMS, so it is worth asserting without a store. #3267 was a defect in
+    /// exactly this reduction — a whole engine's cards carrying null where a reading existed — and the only
+    /// tests that could see it before were the live-Postgres ones. A caller with no interest in a given
+    /// metric passes <c>default</c> for its row, which is why those types never have to be NAMED in a test
+    /// — they are internal only because CS0051 requires every parameter type of an internal method to be
+    /// at least as accessible as it.</para></summary>
+    internal static FleetServerCard BuildCard(
         FleetServerRow server,
         CpuRow cpu,
+        double? instanceCpuPercent,
         MemoryRow memory,
         MemoryPressureRow pressure,
         ThreadsRow threads,
@@ -374,7 +431,19 @@ GROUP BY server_id, collector_name";
 
         var cpuPercent = cpu.SqlCpu;
         var otherCpu = cpu.OtherCpu;
-        var totalCpu = cpuPercent.HasValue ? cpuPercent.Value + (otherCpu ?? 0) : (double?)null;
+
+        /* Per-server target ENGINE (#2530), the axis the platform flags below cannot express: they are all
+           derived from a SQL Server SERVERPROPERTY, which a PostgreSQL target does not have. Read up here
+           rather than beside ClassifyPlatform because the CPU source classification needs it. */
+        var (isPostgres, isAurora) = ClassifyEngineKind(server.EngineKind);
+
+        /* One expression for "total non-idle host CPU, from whichever collector has it" (#3267), shared with
+           the viewer's card so the two cannot drift on the fallback. cpuPercent stays the SQL-Server-process
+           share and is NOT filled from the PostgreSQL arm: Performance Insights publishes only the host
+           total, so there is no per-process split to claim, and cpu_source says which arm answered rather
+           than leaving a consumer to infer it from which fields are null. */
+        var totalCpu = FleetCpuProvenance.TotalNonIdleCpuPercent(cpuPercent, otherCpu, instanceCpuPercent);
+        var cpuSource = FleetCpuProvenance.ClassifyCpuSource(cpuPercent, instanceCpuPercent, isPostgres, isAurora);
         var cpuForAlert = totalCpu ?? cpuPercent;
 
         var availableThreads = threads.TotalThreads.HasValue
@@ -415,10 +484,6 @@ GROUP BY server_id, collector_name";
            deliberately not surfaced. */
         var (isAzureSqlDb, isAzureManagedInstance) = ClassifyPlatform(server.EngineEdition);
 
-        /* Per-server target ENGINE (#2530), the axis the platform flags above cannot express: they are all
-           derived from a SQL Server SERVERPROPERTY, which a PostgreSQL target does not have. */
-        var (isPostgres, isAurora) = ClassifyEngineKind(server.EngineKind);
-
         return new FleetServerCard
         {
             ServerId = server.ServerId,
@@ -442,6 +507,8 @@ GROUP BY server_id, collector_name";
             OtherProcessCpuPercent = otherCpu,
             TotalCpuPercent = totalCpu,
             CpuSeverity = ServerHealthClassifier.CpuSeverity(cpuForAlert),
+            InstanceCpuPercent = instanceCpuPercent,
+            CpuSource = cpuSource,
             MemoryMb = memory.MemoryMb,
             BufferPoolMb = memory.BufferPoolMb,
             GrantedMemoryMb = pressure.GrantedMemoryMb,
@@ -754,6 +821,27 @@ GROUP BY server_id, collector_name";
         return map;
     }
 
+    /// <summary>The newest current Performance Insights CPU reading per PostgreSQL/Aurora target (#3267).
+    /// Keyed by <c>server_id</c> with a plain <c>double</c> value and no entry for a server without one, so
+    /// the caller's miss is an absent key rather than a zero — see the call site.</summary>
+    private static async Task<Dictionary<int, double>> ReadPgCpuAsync(NpgsqlDataSource postgres, DateTime nowUtc, CancellationToken cancellationToken)
+    {
+        var map = new Dictionary<int, double>();
+        await using var command = postgres.CreateCommand(FleetPgCpuSql);
+        command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
+        /* Naive UTC at the bind, matching every other comparison against the store's naive `timestamp`
+           columns: Kind=Utc is not rejected, Npgsql infers `timestamptz` and PostgreSQL zone-shifts it. */
+        command.Parameters.AddWithValue(
+            DateTime.SpecifyKind(nowUtc - DarlingPgCpuUtilizationReader.Freshness, DateTimeKind.Unspecified));
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            map[reader.GetInt32(0)] = Convert.ToDouble(reader.GetValue(1));
+        }
+
+        return map;
+    }
+
     private static async Task<Dictionary<int, MemoryRow>> ReadMemoryAsync(NpgsqlDataSource postgres, CancellationToken cancellationToken)
     {
         var map = new Dictionary<int, MemoryRow>();
@@ -914,19 +1002,19 @@ GROUP BY server_id, collector_name";
 
     /* ─────────────────────────── raw-read carriers (internal) ─────────────────────────── */
 
-    private readonly record struct FleetServerRow(int ServerId, string DisplayName, string ServerName, int? EngineEdition, string? EngineKind, bool IsSilenced);
-    private readonly record struct CpuRow(double? SqlCpu, double? OtherCpu);
-    private readonly record struct MemoryRow(double? MemoryMb, double? BufferPoolMb);
-    private readonly record struct MemoryPressureRow(long WaiterCount, long TimeoutCount, long ForcedCount, double? GrantedMemoryMb);
-    private readonly record struct ThreadsRow(int? TotalThreads, int? CurrentWorkers, int RunnableTasks, long WorkQueue);
-    private readonly record struct BlockingRow(int XeCount, long XeMaxWait, int DmvCount, long DmvMaxWait);
-    private readonly record struct DeadlockRow(int Count, DateTime? LastSeen);
+    internal readonly record struct FleetServerRow(int ServerId, string DisplayName, string ServerName, int? EngineEdition, string? EngineKind, bool IsSilenced);
+    internal readonly record struct CpuRow(double? SqlCpu, double? OtherCpu);
+    internal readonly record struct MemoryRow(double? MemoryMb, double? BufferPoolMb);
+    internal readonly record struct MemoryPressureRow(long WaiterCount, long TimeoutCount, long ForcedCount, double? GrantedMemoryMb);
+    internal readonly record struct ThreadsRow(int? TotalThreads, int? CurrentWorkers, int RunnableTasks, long WorkQueue);
+    internal readonly record struct BlockingRow(int XeCount, long XeMaxWait, int DmvCount, long DmvMaxWait);
+    internal readonly record struct DeadlockRow(int Count, DateTime? LastSeen);
     /// <param name="DeadlockBand">The <c>deadlocks</c> collector's own 7-day band for this server, or null
     /// when that collector left no row in the health window at all (#3017). Null and
     /// <see cref="CollectorHealthClassifier.NeverRun"/> mean the same thing to a reader and take the same
     /// action, but they arrive differently: null is the absent GROUP, NEVER_RUN would be a present group with
     /// no runs in it.</param>
-    private readonly record struct CollectorCounts(int Healthy, int Failing, string? DeadlockBand = null);
+    internal readonly record struct CollectorCounts(int Healthy, int Failing, string? DeadlockBand = null);
 }
 
 /// <summary>
@@ -1039,9 +1127,33 @@ public sealed class FleetServerCard
     [JsonPropertyName("collection_stale")] public bool CollectionStale { get; init; }
     [JsonPropertyName("last_collection")] public DateTime? LastCollectionTime { get; init; }
 
+    /// <summary>SQL Server's OWN share of host CPU, from the ring buffer. Null on Azure SQL DB and on every
+    /// PostgreSQL target: Performance Insights reports the host total and no per-process breakdown, so there
+    /// is no value to put here and filling it from the total would claim an attribution nothing measured.
+    /// <see cref="CpuSource"/> says which arm answered — do not infer it from this field being null.</summary>
     [JsonPropertyName("cpu_percent")] public double? CpuPercent { get; init; }
+
+    /// <summary>Non-database CPU on the host, from the ring buffer. Null wherever <see cref="CpuPercent"/>
+    /// is, and additionally on SQL Server on Linux before 2025 CU1 (<c>SystemIdle</c> reports 0 there, so
+    /// the host share is not derivable).</summary>
     [JsonPropertyName("other_process_cpu_percent")] public double? OtherProcessCpuPercent { get; init; }
+
+    /// <summary>Total non-idle host CPU — the quantity <see cref="CpuSeverity"/> bands, and the one field
+    /// that is populated on BOTH engines (#3267). SQL Server's ring buffer reaches it as
+    /// <c>sqlserver + other_process</c>; a PostgreSQL/Aurora target's is Performance Insights'
+    /// <c>os.cpuUtilization.total.avg</c> verbatim.</summary>
     [JsonPropertyName("total_cpu_percent")] public double? TotalCpuPercent { get; init; }
+
+    /// <summary>The Performance Insights instance reading on its own (#2719/#3267) — the same number
+    /// <see cref="TotalCpuPercent"/> carries on a PostgreSQL target, published separately so a consumer can
+    /// see the raw per-source value without unpicking the fallback. Null on every SQL Server target.</summary>
+    [JsonPropertyName("instance_cpu_percent")] public double? InstanceCpuPercent { get; init; }
+
+    /// <summary>Which collector produced this card's CPU number, and when there is none, which of the two
+    /// reasons (#3267). The default arm is <see cref="FleetCpuSource.NotCollected"/>, so a card built
+    /// without either reading claims nothing rather than sitting at an arm that means "measured".</summary>
+    [JsonPropertyName("cpu_source")] public FleetCpuSource CpuSource { get; init; }
+
     [JsonPropertyName("cpu_severity")] public HealthSeverity CpuSeverity { get; init; }
 
     [JsonPropertyName("memory_mb")] public double? MemoryMb { get; init; }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
@@ -453,13 +453,23 @@ GROUP BY server_id, collector_name";
         var hasMemoryPressure = pressure.WaiterCount > 0 || pressure.TimeoutCount > 0 || pressure.ForcedCount > 0;
         var maxBlockedSeconds = maxBlockingWaitMs / 1000.0;
 
+        /* The three DMV-sourced readings, with "not measured" expressed as null for an engine that has no
+           row in the views behind them (#3272). The reads above produced zeros for such a target, and a
+           zero here argued Healthy — a green dot for a metric nothing measured. The published COUNTS are
+           left exactly as they are: #3017's deadlock_source and the fleet coverage block explain a total
+           built out of those zeros, and nulling them would make the total's own denominator unreadable.
+           It is the BAND that stops claiming health. */
+        var memoryPressureForBand = ServerMetricSources.DmvSourced(hasMemoryPressure, isPostgres);
+        var blockingForBand = ServerMetricSources.DmvSourced(blockingCount, isPostgres);
+        var deadlocksForBand = ServerMetricSources.DmvSourced(deadlockCount, isPostgres);
+
         var metrics = new ServerHealthMetrics
         {
             CpuPercentForAlert = cpuForAlert,
-            HasMemoryPressure = hasMemoryPressure,
-            BlockingCount = blockingCount,
+            HasMemoryPressure = memoryPressureForBand,
+            BlockingCount = blockingForBand,
             MaxBlockedSeconds = maxBlockedSeconds,
-            DeadlockCount = deadlockCount,
+            DeadlockCount = deadlocksForBand,
             TotalThreads = threads.TotalThreads,
             AvailableThreads = availableThreads,
             ThreadsWaitingForCpu = threads.RunnableTasks,
@@ -516,13 +526,13 @@ GROUP BY server_id, collector_name";
             MemoryTimeoutCount = pressure.TimeoutCount,
             MemoryForcedCount = pressure.ForcedCount,
             HasMemoryPressure = hasMemoryPressure,
-            MemorySeverity = ServerHealthClassifier.MemorySeverity(hasMemoryPressure),
+            MemorySeverity = ServerHealthClassifier.MemorySeverity(memoryPressureForBand),
             BlockingCount = blockingCount,
             MaxBlockingWaitMs = maxBlockingWaitMs,
-            BlockingSeverity = ServerHealthClassifier.BlockingSeverity(blockingCount, maxBlockedSeconds),
+            BlockingSeverity = ServerHealthClassifier.BlockingSeverity(blockingForBand, maxBlockedSeconds),
             DeadlockCount = deadlockCount,
             DeadlockLastSeen = deadlock.LastSeen,
-            DeadlockSeverity = ServerHealthClassifier.DeadlockSeverity(deadlockCount),
+            DeadlockSeverity = ServerHealthClassifier.DeadlockSeverity(deadlocksForBand),
             DeadlockCollectorBand = collectors.DeadlockBand,
             TotalThreads = threads.TotalThreads,
             CurrentWorkers = threads.CurrentWorkers,
@@ -1213,10 +1223,13 @@ public sealed class FleetServerCard
     internal ServerHealthMetrics ToHealthMetrics() => new()
     {
         CpuPercentForAlert = TotalCpuPercent ?? CpuPercent,
-        HasMemoryPressure = HasMemoryPressure,
-        BlockingCount = BlockingCount,
+        /* Re-derived from IsPostgres rather than read back off the published counts, because those are
+           deliberately left as zeros (#3017) — reading them here would hand the ranking a measurement the
+           card's own severity says it does not have. */
+        HasMemoryPressure = ServerMetricSources.DmvSourced(HasMemoryPressure, IsPostgres),
+        BlockingCount = ServerMetricSources.DmvSourced(BlockingCount, IsPostgres),
         MaxBlockedSeconds = MaxBlockingWaitMs / 1000.0,
-        DeadlockCount = DeadlockCount,
+        DeadlockCount = ServerMetricSources.DmvSourced(DeadlockCount, IsPostgres),
         TotalThreads = TotalThreads,
         AvailableThreads = AvailableThreads,
         ThreadsWaitingForCpu = ThreadsWaitingForCpu,

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpFleetTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpFleetTools.cs
@@ -38,7 +38,17 @@ public sealed class DarlingMcpFleetTools
         "blocking, deadlocks, worker threads, and collector health, each with a Healthy/Warning/Critical band), " +
         "plus a rollup — counts by band, cross-server blocking and deadlock totals, and a worst-first 'needs " +
         "attention' ranking. Use this first to decide which server to drill into, then call the per-server tools. " +
-        "This cross-server view is unique to the central store.")]
+        "This cross-server view is unique to the central store. " +
+        "cpu_source names which collector produced each card's total_cpu_percent, so a missing number is never " +
+        "ambiguous: RingBuffer (SQL Server, and the only arm that also fills cpu_percent / " +
+        "other_process_cpu_percent with the per-process split), PerformanceInsights (an Aurora/RDS PostgreSQL " +
+        "target's instance CPU, total only), NotCollected (a source that applies here produced no current " +
+        "reading — check get_collection_health), or NoSourceForEngine (a PostgreSQL target not known to be " +
+        "Aurora; PostgreSQL exposes no instance-CPU counter and nothing collects one here, so that null is " +
+        "structural). A PostgreSQL target's memory_mb, buffer_pool_mb and the whole threads block are null for " +
+        "the same structural reason and no band is claimed for them — those metrics are SQL Server DMV " +
+        "readings with no PostgreSQL equivalent collected; get_pg_buffer_usage, get_pg_kernel_stats and " +
+        "get_pg_session_states are the reads that answer the nearest PostgreSQL questions.")]
     public static async Task<string> GetFleetOverview(
         NpgsqlDataSource postgres,
         [Description("Hours of blocking/deadlock history the per-server cards and fleet totals window over. Default 1.")] int hours_back = 1)

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpFleetTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpFleetTools.cs
@@ -41,11 +41,13 @@ public sealed class DarlingMcpFleetTools
         "This cross-server view is unique to the central store. " +
         "cpu_source names which collector produced each card's total_cpu_percent, so a missing number is never " +
         "ambiguous: RingBuffer (SQL Server, and the only arm that also fills cpu_percent / " +
-        "other_process_cpu_percent with the per-process split), PerformanceInsights (an Aurora/RDS PostgreSQL " +
-        "target's instance CPU, total only), NotCollected (a source that applies here produced no current " +
-        "reading — check get_collection_health), or NoSourceForEngine (a PostgreSQL target not known to be " +
-        "Aurora; PostgreSQL exposes no instance-CPU counter and nothing collects one here, so that null is " +
-        "structural). A PostgreSQL target's memory_mb, buffer_pool_mb and the whole threads block are null for " +
+        "other_process_cpu_percent with the per-process split), PerformanceInsights (an Aurora PostgreSQL " +
+        "target's instance CPU from the AWS API, total only — no per-process breakdown exists), NotCollected " +
+        "(a source that applies here produced no current reading — check get_collection_health), or " +
+        "NoSourceForEngine (a PostgreSQL target not known to be Aurora, INCLUDING plain RDS for PostgreSQL: " +
+        "PostgreSQL exposes no instance-CPU counter and the Performance Insights ingest is gated to Aurora, " +
+        "so that null is structural and no grant or upgrade changes it). A PostgreSQL target's memory_mb, " +
+        "buffer_pool_mb and the whole threads block are null for " +
         "the same structural reason and no band is claimed for them — those metrics are SQL Server DMV " +
         "readings with no PostgreSQL equivalent collected; get_pg_buffer_usage, get_pg_kernel_stats and " +
         "get_pg_session_states are the reads that answer the nearest PostgreSQL questions.")]

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgCpuUtilizationReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgCpuUtilizationReader.cs
@@ -27,8 +27,14 @@ public static class DarlingPgCpuUtilizationReader
     /// the alert going silent, narrower than <see cref="DarlingPostgresAlertReadAdapter.Freshness"/>'s 2 hours
     /// because a stale CPU reading is a much weaker signal about "right now" than a wraparound age is — CPU
     /// moves in seconds, not days.
+    ///
+    /// <para><b>Public because the fleet card shares it</b> (#3267). <c>DarlingFleetReader</c>'s
+    /// cross-server read answers the same question this one does — "where does this server's CPU stand
+    /// right now" — and two surfaces answering that with different staleness windows is a surface drift of
+    /// the #2473 kind: the High CPU alert would be evaluating a reading the card had already dropped, or
+    /// the reverse. One constant, two consumers.</para>
     /// </summary>
-    internal static readonly TimeSpan Freshness = TimeSpan.FromMinutes(15);
+    public static readonly TimeSpan Freshness = TimeSpan.FromMinutes(15);
 
     internal const string LatestCpuSql = """
         SELECT cpu_percent, sample_time

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -1449,6 +1449,10 @@ public partial class MainWindow : Window
                        coverage apart from a quiet SQL Server fleet: v_deadlocks holds the SQL Server
                        extended-event capture and nothing else. */
                     summary.IsPostgres = server.IsPostgres;
+                    /* #3267: and the Aurora half of the same discriminator, for the CPU row. Both are
+                       stamped from the one registry row, so a card cannot end up claiming Aurora-ness the
+                       engine token does not support. */
+                    summary.IsAurora = server.IsAurora;
                     summary.ApplyFreshness(nowUtc);
                     found.Add(summary);
                 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -785,17 +785,36 @@ public sealed class ServerSummaryItem
     /// <summary>CPU band — total non-idle CPU: >= 95% Critical, >= 80% Warning.</summary>
     public HealthSeverity CpuSeverity => ServerHealthClassifier.CpuSeverity(CpuPercentForAlert);
 
-    /// <summary>True when the resource semaphore shows grant waiters, timeouts, or forced grants.</summary>
+    /// <summary>True when the resource semaphore shows grant waiters, timeouts, or forced grants. The raw
+    /// reading, unqualified by whether there was anything to read — see
+    /// <see cref="MemoryPressureForBand"/>.</summary>
     public bool HasMemoryPressure => MemoryWaiterCount > 0 || MemoryTimeoutCount > 0 || MemoryForcedCount > 0;
 
-    /// <summary>Memory band — Critical on any resource-semaphore pressure, else Healthy.</summary>
-    public HealthSeverity MemorySeverity => ServerHealthClassifier.MemorySeverity(HasMemoryPressure);
+    /* The three DMV-sourced readings with "not measured" expressed as null (#3272), through the SAME shared
+       decision the service's fleet card uses so the two cannot disagree about whether this server's zero
+       means anything. The raw counts above and beside stay as they are: they are what the fleet total is
+       summed from, and #3017's coverage block is what explains that total. */
 
-    /// <summary>Blocking band — >= 60s max wait or >= 5 events Critical; >= 10s, >= 2 events, or any blocking Warning.</summary>
-    public HealthSeverity BlockingSeverity => ServerHealthClassifier.BlockingSeverity(BlockingCount, MaxBlockedSeconds);
+    /// <summary>Resource-semaphore pressure as a BANDABLE reading — null when this target's engine has no
+    /// semaphore to read (every PostgreSQL target).</summary>
+    public bool? MemoryPressureForBand => ServerMetricSources.DmvSourced(HasMemoryPressure, IsPostgres);
 
-    /// <summary>Deadlock band — any deadlock in the window is Critical.</summary>
-    public HealthSeverity DeadlockSeverity => ServerHealthClassifier.DeadlockSeverity(DeadlockCount);
+    /// <summary>Blocking events as a BANDABLE reading — null when this card reads no blocking source for
+    /// this engine.</summary>
+    public int? BlockingCountForBand => ServerMetricSources.DmvSourced(BlockingCount, IsPostgres);
+
+    /// <summary>Deadlocks as a BANDABLE reading — null when this card reads no deadlock source for this
+    /// engine. <see cref="DeadlockSource"/> is the same fact named for a reader (#3017).</summary>
+    public int? DeadlockCountForBand => ServerMetricSources.DmvSourced(DeadlockCount, IsPostgres);
+
+    /// <summary>Memory band — Critical on any resource-semaphore pressure, else Healthy; no source Unknown.</summary>
+    public HealthSeverity MemorySeverity => ServerHealthClassifier.MemorySeverity(MemoryPressureForBand);
+
+    /// <summary>Blocking band — >= 60s max wait or >= 5 events Critical; >= 10s, >= 2 events, or any blocking Warning; no source Unknown.</summary>
+    public HealthSeverity BlockingSeverity => ServerHealthClassifier.BlockingSeverity(BlockingCountForBand, MaxBlockedSeconds);
+
+    /// <summary>Deadlock band — any deadlock in the window is Critical; no source Unknown.</summary>
+    public HealthSeverity DeadlockSeverity => ServerHealthClassifier.DeadlockSeverity(DeadlockCountForBand);
 
     /// <summary>Threads band — work-queue starvation Critical; >= 20 runnable-waiting or under 10% available Warning; no snapshot Unknown.</summary>
     public HealthSeverity ThreadsSeverity =>
@@ -818,10 +837,10 @@ public sealed class ServerSummaryItem
     public ServerHealthMetrics ToHealthMetrics() => new()
     {
         CpuPercentForAlert = CpuPercentForAlert,
-        HasMemoryPressure = HasMemoryPressure,
-        BlockingCount = BlockingCount,
+        HasMemoryPressure = MemoryPressureForBand,
+        BlockingCount = BlockingCountForBand,
         MaxBlockedSeconds = MaxBlockedSeconds,
-        DeadlockCount = DeadlockCount,
+        DeadlockCount = DeadlockCountForBand,
         TotalThreads = TotalThreads,
         AvailableThreads = AvailableThreads,
         ThreadsWaitingForCpu = ThreadsWaitingForCpu,

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -15,6 +15,7 @@ using System.Windows.Media;
 using Npgsql;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Storage;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -58,6 +59,28 @@ public sealed partial class ViewerDataService
 SELECT sqlserver_cpu_utilization, other_process_cpu_utilization
 FROM v_cpu_utilization_stats
 WHERE server_id = $1
+ORDER BY collection_time DESC, sample_time DESC
+LIMIT 1";
+
+    /// <summary>The newest current instance-CPU reading for one PostgreSQL/Aurora target — Performance
+    /// Insights' <c>os.cpuUtilization.total.avg</c> (#2719). $1 server_id, $2 the freshness cutoff (naive
+    /// UTC).
+    ///
+    /// <para>A SECOND read rather than a widened first one, because a PostgreSQL target has no row in
+    /// <c>v_cpu_utilization_stats</c> at all and this table has different columns (#3267). Run
+    /// unconditionally: the per-server summary reads carry no engine column, and a SQL Server target has no
+    /// row here either, so the read gates itself rather than needing the engine threaded into this method.
+    /// The bound, the two predicates and why falling out of it is the right answer are all
+    /// <c>DarlingFleetReader.FleetPgCpuSql</c>'s — the same reading for the same card, so the service and
+    /// the viewer share the shape and the <c>DarlingPgCpuUtilizationReader.Freshness</c> constant rather
+    /// than each picking a staleness window.</para></summary>
+    public const string ServerSummaryPgCpuSql = @"
+SELECT cpu_percent
+FROM pg_cpu_utilization
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   sample_time >= $2
+AND   cpu_percent IS NOT NULL
 ORDER BY collection_time DESC, sample_time DESC
 LIMIT 1";
 
@@ -162,6 +185,7 @@ WHERE server_id = $1";
 
         double? cpuPercent = null;
         double? otherProcessCpuPercent = null;
+        double? instanceCpuPercent = null;
         double? memoryMb = null;
         double? bufferPoolMb = null;
         var blockingCount = 0;
@@ -192,6 +216,23 @@ WHERE server_id = $1";
             {
                 cpuPercent = reader.IsDBNull(0) ? null : Convert.ToDouble(reader.GetValue(0));
                 otherProcessCpuPercent = reader.IsDBNull(1) ? null : Convert.ToDouble(reader.GetValue(1));
+            }
+        }
+
+        /* Latest instance CPU, for a PostgreSQL/Aurora target (#3267). Returns nothing for a SQL Server
+           target, which is why it needs no engine test — see ServerSummaryPgCpuSql. */
+        await using (var command = _dataSource.CreateCommand(ServerSummaryPgCpuSql))
+        {
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
+            command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+            command.Parameters.Add(new NpgsqlParameter<DateTime>
+            {
+                TypedValue = DateTime.SpecifyKind(nowUtc - DarlingPgCpuUtilizationReader.Freshness, DateTimeKind.Unspecified),
+            });
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                instanceCpuPercent = reader.IsDBNull(0) ? null : Convert.ToDouble(reader.GetValue(0));
             }
         }
 
@@ -314,6 +355,7 @@ WHERE server_id = $1";
             ServerId = serverId,
             CpuPercent = cpuPercent,
             OtherProcessCpuPercent = otherProcessCpuPercent,
+            InstanceCpuPercent = instanceCpuPercent,
             MemoryMb = memoryMb,
             BufferPoolMb = bufferPoolMb,
             GrantedMemoryMb = grantedMemoryMb,
@@ -436,9 +478,21 @@ public sealed class ServerSummaryItem
     /// <summary>Non-SQL-Server CPU on the host (100 - SystemIdle - ProcessUtilization). NULL on Azure SQL DB.</summary>
     public double? OtherProcessCpuPercent { get; set; }
 
-    /// <summary>Total non-idle CPU on the host = sql_server + other_process. Tracks OS user+system counters.</summary>
+    /// <summary>
+    /// Instance CPU from AWS Performance Insights (<c>os.cpuUtilization.total.avg</c>) for a
+    /// PostgreSQL/Aurora target (#2719/#3267) — the host total with no per-process split, which is why it is
+    /// its own field rather than being written into <see cref="CpuPercent"/>. NULL on every SQL Server
+    /// target, and on a PostgreSQL target this build collects no instance CPU for; <see cref="CpuSource"/>
+    /// separates those two.
+    /// </summary>
+    public double? InstanceCpuPercent { get; set; }
+
+    /// <summary>Total non-idle CPU on the host — sql_server + other_process where the ring buffer reached
+    /// it, else the Performance Insights instance reading (#3267). Tracks OS user+system counters either
+    /// way; the fallback lives in <see cref="FleetCpuProvenance"/> so this card and the service's fleet card
+    /// cannot drift on it.</summary>
     public double? TotalCpuPercent =>
-        CpuPercent.HasValue ? CpuPercent.Value + (OtherProcessCpuPercent ?? 0) : null;
+        FleetCpuProvenance.TotalNonIdleCpuPercent(CpuPercent, OtherProcessCpuPercent, InstanceCpuPercent);
 
     /// <summary>
     /// The CPU value the headline display / colour band uses. The viewer has no per-app CpuAlertMode, so
@@ -489,6 +543,32 @@ public sealed class ServerSummaryItem
     /// posture <c>DarlingServer.IsPostgres</c> takes.</para>
     /// </summary>
     public bool IsPostgres { get; set; }
+
+    /// <summary>
+    /// Whether the store says this target is Amazon Aurora PostgreSQL specifically — stamped by the Overview
+    /// loader from the registry row (<c>DarlingServer.IsAurora</c>), the same way
+    /// <see cref="IsPostgres"/> is and for the same reason (the per-server summary reads carry no engine
+    /// column).
+    ///
+    /// <para>It is here for <see cref="CpuSource"/>: instance CPU comes from Performance Insights, which
+    /// <c>PgCpuUtilizationCollector.AppliesTo</c> gates to Aurora, so this flag is what separates a
+    /// reading that has not arrived from one this build never collects. Default false keeps the
+    /// conservative reading — a card whose loader did not stamp it claims a gap someone can act on rather
+    /// than a structural absence.</para>
+    /// </summary>
+    public bool IsAurora { get; set; }
+
+    /// <summary>
+    /// Which collector produced this card's CPU number, and when there is none, which of the two reasons
+    /// (#3267) — the shared <see cref="FleetCpuProvenance.ClassifyCpuSource"/>, so this card and the
+    /// service's fleet card cannot disagree about the same server.
+    ///
+    /// <para>DERIVED rather than assigned, for <see cref="DeadlockSource"/>'s reason: a card built by a path
+    /// that sets no reading reads as <see cref="FleetCpuSource.NotCollected"/> — nothing was read — rather
+    /// than sitting at an enum default that would mean a measurement.</para>
+    /// </summary>
+    public FleetCpuSource CpuSource =>
+        FleetCpuProvenance.ClassifyCpuSource(CpuPercent, InstanceCpuPercent, IsPostgres, IsAurora);
 
     /// <summary>
     /// The <c>deadlocks</c> collector's own 7-day band for this server, or null when that collector left no
@@ -543,13 +623,20 @@ public sealed class ServerSummaryItem
     /// <summary>
     /// Headline CPU display: total non-idle CPU prominently with the SQL-only number alongside, e.g.
     /// "64% (SQL 60%)". Falls back to a single number when only one value is available.
+    ///
+    /// <para>A PostgreSQL/Aurora target reaches the single-number form (#3267): the reading is the host
+    /// total and there is no per-process share to put in the parenthetical. It renders through
+    /// <see cref="TotalCpuPercent"/> rather than a second branch on <see cref="InstanceCpuPercent"/> so
+    /// there is one place the headline number is chosen. "--" is reserved for having NO reading, which is
+    /// what keeps it distinguishable from a real 0% — and <see cref="CpuSource"/> is what says which kind of
+    /// absence "--" is.</para>
     /// </summary>
     public string CpuDisplay
     {
         get
         {
-            if (!CpuPercent.HasValue) return "--";
-            if (!OtherProcessCpuPercent.HasValue) return $"{CpuPercent:F0}%";
+            if (!TotalCpuPercent.HasValue) return "--";
+            if (!CpuPercent.HasValue || !OtherProcessCpuPercent.HasValue) return $"{TotalCpuPercent:F0}%";
             return $"{TotalCpuPercent:F0}% (SQL {CpuPercent:F0}%)";
         }
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -97,6 +97,14 @@ public sealed class DarlingServer : INotifyPropertyChanged
     public bool IsPostgres => MonitoredEngineKind.IsPostgres(EngineKind);
 
     /// <summary>
+    /// True only when the store says this target is Amazon Aurora PostgreSQL specifically. Same asymmetry as
+    /// <see cref="IsPostgres"/>. Read for the Overview card's CPU row (#3267): instance CPU comes from
+    /// Performance Insights, which <c>PgCpuUtilizationCollector.AppliesTo</c> gates to Aurora, so this is
+    /// what separates "no reading yet" from "this build collects no instance CPU here at all".
+    /// </summary>
+    public bool IsAurora => MonitoredEngineKind.IsAurora(EngineKind);
+
+    /// <summary>
     /// How the engine reads in the per-server header, or null when the store makes no claim - in which case
     /// the header shows NO engine label rather than "SQL Server", because the tabs such a server gets are a
     /// default rather than a finding. An unrecognised token renders as the raw token: the describer's

--- a/PerformanceMonitor.Common/FleetCpuSource.cs
+++ b/PerformanceMonitor.Common/FleetCpuSource.cs
@@ -39,9 +39,14 @@ public enum FleetCpuSource
     /// <c>CpuUtilizationCollector</c>.</summary>
     RingBuffer,
 
-    /// <summary>AWS Performance Insights' <c>os.cpuUtilization.total.avg</c> for an Aurora/RDS PostgreSQL
-    /// target (#2719) — a host-level OS counter, so the same quantity the ring-buffer arm's total is, but
-    /// with no per-process split to publish beside it.</summary>
+    /// <summary>AWS Performance Insights' <c>os.cpuUtilization.total.avg</c> (#2719) — a host-level OS
+    /// counter, so the same quantity the ring-buffer arm's total is, but with no per-process split to
+    /// publish beside it.
+    ///
+    /// <para>This arm means a Performance Insights reading is PRESENT, and in this build only an Aurora
+    /// PostgreSQL target produces one: <c>PgCpuUtilizationCollector.AppliesTo</c> gates the ingest on
+    /// <c>IsAurora</c>, so a plain RDS-for-PostgreSQL target lands on <see cref="NoSourceForEngine"/>
+    /// instead — see that arm for why the gate, not the API's reach, is what decides.</para></summary>
     PerformanceInsights,
 
     /// <summary>This build collects no instance CPU for this target at all: a PostgreSQL target the store

--- a/PerformanceMonitor.Common/FleetCpuSource.cs
+++ b/PerformanceMonitor.Common/FleetCpuSource.cs
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitor.Common;
+
+/// <summary>
+/// Where one server's CPU reading came from, and when there is none, which of the two reasons it is
+/// (#3267). Serialized as its STRING name (the fleet DTOs' <c>JsonStringEnumConverter</c>), so a consumer
+/// switches on a word rather than on an ordinal a reordering would move underneath it.
+///
+/// <para><b>Why a number needs this beside it.</b> The band is the same ladder either way
+/// (<see cref="ServerHealthClassifier.CpuSeverity"/> over total non-idle host CPU), but the two read arms
+/// carry different DETAIL: the ring buffer splits SQL Server's own CPU from the rest of the host, and
+/// Performance Insights reports only the total, so <c>cpu_percent</c> / <c>other_process_cpu_percent</c>
+/// are legitimately null on a card whose <c>total_cpu_percent</c> is a real measurement. Without this a
+/// consumer has to infer provenance from which fields happen to be null, which is exactly the kind of
+/// derived-from-absence reading that gets read wrong.</para>
+///
+/// <para><b>And the two unread arms take opposite actions</b>, which is the same reasoning
+/// <see cref="FleetDeadlockSource"/> splits its uncovered arms on: one is a collector to go and look at,
+/// the other is a fact about the engine that no collector, grant or upgrade changes.</para>
+/// </summary>
+public enum FleetCpuSource
+{
+    /// <summary>No CPU reading for this server, from a source that DOES apply to it — a SQL Server whose
+    /// <c>cpu_utilization</c> collector has not landed a sample yet (or has stopped), or an Aurora target
+    /// whose Performance Insights ingest is not producing points. Something to go and look at
+    /// (<c>get_collection_health</c>). It is the default arm on purpose: a card assembled by a path that
+    /// sets neither reading reads as "nothing was read", never as a measurement.</summary>
+    NotCollected,
+
+    /// <summary>SQL Server's <c>SCHEDULER_MONITOR</c> ring buffer — <c>100 - SystemIdle</c>, published as
+    /// SQL Server's own utilization plus the rest of the host separately. See
+    /// <c>CpuUtilizationCollector</c>.</summary>
+    RingBuffer,
+
+    /// <summary>AWS Performance Insights' <c>os.cpuUtilization.total.avg</c> for an Aurora/RDS PostgreSQL
+    /// target (#2719) — a host-level OS counter, so the same quantity the ring-buffer arm's total is, but
+    /// with no per-process split to publish beside it.</summary>
+    PerformanceInsights,
+
+    /// <summary>This build collects no instance CPU for this target at all: a PostgreSQL target the store
+    /// does not know to be Aurora. Core PostgreSQL exposes no instance-CPU-percent counter in any version
+    /// — <c>pg_stat_kcache</c> measures per-QUERY kernel time, not whether the instance is saturated — so
+    /// the only source is the AWS API, and <c>PgCpuUtilizationCollector.AppliesTo</c> gates that to Aurora
+    /// (#2719's documented limitation). Structurally absent, not late: no grant, collector run or upgrade
+    /// of the monitored server produces this number, and <c>get_pg_kernel_stats</c> is the read that
+    /// answers the nearest adjacent question.
+    ///
+    /// <para><b>This names what THIS BUILD collects, not what AWS offers.</b> The registry token for RDS
+    /// for PostgreSQL is <c>postgres</c>, the same as a self-hosted instance, so the store cannot tell them
+    /// apart — and Performance Insights does reach the RDS one. Widening the collector's gate is what would
+    /// move such a target to <see cref="PerformanceInsights"/>; until then "we collect none" is the true
+    /// statement and "none exists" would be the overclaim.</para></summary>
+    NoSourceForEngine,
+}
+
+/// <summary>
+/// The one place a CPU reading's provenance is decided, so the service's fleet card and the viewer's
+/// Overview card cannot disagree about the same server (#2473's rule applied to the CPU row: the two are
+/// the only surfaces that band CPU, and the band is worthless if they disagree about whether there is a
+/// number to band).
+/// </summary>
+public static class FleetCpuProvenance
+{
+    /// <summary>
+    /// Which source a card's CPU number came from, from the two readings and the target's engine.
+    ///
+    /// <para><b>The ring buffer wins when it has a reading</b>, so the SQL Server path is untouched by the
+    /// PostgreSQL one existing: a server with a ring-buffer sample classifies and bands exactly as it did
+    /// before <see cref="PerformanceInsights"/> was an arm. The precedence is not a tie-break for a real
+    /// state — one registry row is one engine — it is the statement that this is additive.</para>
+    ///
+    /// <para><b>The presence test is the SQL Server half specifically</b>, not the derived total.
+    /// <c>other_process_cpu_utilization</c> is legitimately NULL on SQL Server on Linux before 2025 CU1
+    /// (<c>SystemIdle</c> reports 0 there, so host CPU is not derivable), and such a server still has a
+    /// ring-buffer reading.</para>
+    ///
+    /// <para><b>Absence of an engine token means SQL Server for this decision</b>, matching
+    /// <c>MonitoredEngineKind.IsPostgres</c>'s own asymmetry and <c>ClassifyPlatform</c>'s null edition: a
+    /// row no connect has stamped falls to <see cref="NotCollected"/>, which claims a gap someone can act
+    /// on, rather than to <see cref="NoSourceForEngine"/>, which would tell them not to bother.</para>
+    /// </summary>
+    /// <param name="ringBufferCpuPercent">SQL Server's own utilization from the ring buffer, or null.</param>
+    /// <param name="instanceCpuPercent">The Performance Insights instance total, or null.</param>
+    /// <param name="isPostgres">Whether the store says this target is PostgreSQL.</param>
+    /// <param name="isAurora">Whether the store says it is Aurora PostgreSQL specifically.</param>
+    public static FleetCpuSource ClassifyCpuSource(
+        double? ringBufferCpuPercent,
+        double? instanceCpuPercent,
+        bool isPostgres,
+        bool isAurora)
+    {
+        if (ringBufferCpuPercent.HasValue)
+        {
+            return FleetCpuSource.RingBuffer;
+        }
+
+        if (instanceCpuPercent.HasValue)
+        {
+            return FleetCpuSource.PerformanceInsights;
+        }
+
+        return isPostgres && !isAurora
+            ? FleetCpuSource.NoSourceForEngine
+            : FleetCpuSource.NotCollected;
+    }
+
+    /// <summary>
+    /// The total non-idle host CPU a card bands on, from whichever source has a reading — the ring buffer's
+    /// <c>SQL Server + other-process</c> sum, else the Performance Insights instance total.
+    ///
+    /// <para>Here rather than written out on each card so the two surfaces cannot drift on the fallback
+    /// (which is the whole defect #3267 is: one surface reading a source the other does not). The
+    /// <c>?? 0</c> on other-process is the pre-existing SQL-Server-on-Linux behaviour and is deliberately
+    /// unchanged — it treats an underivable host share as zero, which under-reports rather than
+    /// invents.</para>
+    /// </summary>
+    public static double? TotalNonIdleCpuPercent(
+        double? ringBufferCpuPercent,
+        double? otherProcessCpuPercent,
+        double? instanceCpuPercent) =>
+        ringBufferCpuPercent.HasValue
+            ? ringBufferCpuPercent.Value + (otherProcessCpuPercent ?? 0)
+            : instanceCpuPercent;
+}

--- a/PerformanceMonitor.Common/ServerHealthBands.cs
+++ b/PerformanceMonitor.Common/ServerHealthBands.cs
@@ -291,17 +291,24 @@ namespace PerformanceMonitor.Common
         /// <summary>Total non-idle CPU the CPU band evaluates (SQL + other-process), or null with no snapshot.</summary>
         public double? CpuPercentForAlert { get; init; }
 
-        /// <summary>True when the resource semaphore shows grant waiters, timeouts, or forced grants.</summary>
-        public bool HasMemoryPressure { get; init; }
+        /// <summary>True when the resource semaphore shows grant waiters, timeouts, or forced grants;
+        /// <c>null</c> when this target has no resource-semaphore source at all (#3272 — every PostgreSQL
+        /// target). Nullable for the reason <see cref="TotalThreads"/> is: <c>false</c> is a MEASUREMENT
+        /// meaning the semaphore is calm, and a target with nothing to read must not be able to make
+        /// it.</summary>
+        public bool? HasMemoryPressure { get; init; }
 
-        /// <summary>Blocking events in the window.</summary>
-        public int BlockingCount { get; init; }
+        /// <summary>Blocking events in the window, or <c>null</c> when this target has no blocking source
+        /// the card reads (#3272). Same reasoning as <see cref="HasMemoryPressure"/>: <c>0</c> is a
+        /// measured quiet window.</summary>
+        public int? BlockingCount { get; init; }
 
         /// <summary>The worst blocking wait in the window, in seconds.</summary>
         public double MaxBlockedSeconds { get; init; }
 
-        /// <summary>Deadlocks in the window.</summary>
-        public int DeadlockCount { get; init; }
+        /// <summary>Deadlocks in the window, or <c>null</c> when this target has no deadlock source the
+        /// card reads (#3272). Same reasoning as <see cref="HasMemoryPressure"/>.</summary>
+        public int? DeadlockCount { get; init; }
 
         /// <summary>Worker-thread ceiling (max_workers_count), or null with no scheduler snapshot (e.g. Azure SQL DB).</summary>
         public int? TotalThreads { get; init; }
@@ -317,6 +324,42 @@ namespace PerformanceMonitor.Common
 
         /// <summary>Collectors whose 7-day band is FAILING (no success in over 24h).</summary>
         public int FailedCollectorCount { get; init; }
+    }
+
+    /// <summary>
+    /// Whether a card's SQL-Server-DMV-sourced metric readings are measurements at all, for this target's
+    /// engine (#3272) — the ONE place that decision is made, so the service's fleet card and the viewer's
+    /// Overview card cannot disagree about whether a zero means anything.
+    ///
+    /// <para><b>Why these three travel together.</b> The memory-pressure, blocking and deadlock rows on a
+    /// card come from <c>v_memory_grant_stats</c>, <c>v_blocked_process_reports</c> /
+    /// <c>v_dmv_blocking_snapshots</c> and <c>v_deadlocks</c> — all SQL Server captures, none of which a
+    /// PostgreSQL target has a single row in. The per-metric reads therefore hand the card zeros, and a zero
+    /// is indistinguishable from a genuinely calm SQL Server. Threads already escaped this because its
+    /// ceiling is nullable and CPU escaped it in #3267; these three had no way to say "not measured" at all.
+    /// </para>
+    ///
+    /// <para><b>It names the ENGINE, not the collector state.</b> A SQL Server whose deadlock collector is
+    /// permission-denied also reads zero, and that stays Healthy here on purpose: #3017 routed that case to
+    /// <c>failed_collector_count</c> / <see cref="ServerHealthClassifier.CollectorSeverity"/> and the fleet
+    /// coverage block, which is where a fixable gap belongs. This distinguishes only the structural case,
+    /// where no grant, collector run or upgrade of the monitored server produces the number.</para>
+    /// </summary>
+    public static class ServerMetricSources
+    {
+        /// <summary>
+        /// The reading as measured, or <c>null</c> when this target's engine has no source behind it.
+        /// Generic over the reading's own type because the three metrics are a <c>bool</c> and two
+        /// <c>int</c>s, and the DECISION is the same for all three — one function rather than three that
+        /// could drift.
+        /// </summary>
+        /// <param name="reading">What the SQL Server metric read produced (a zero, for a target with no rows).</param>
+        /// <param name="isPostgres">Whether the store SAYS this target is PostgreSQL. Absence of an engine
+        /// token is false, matching <c>MonitoredEngineKind.IsPostgres</c>'s asymmetry: a row no connect has
+        /// stamped keeps the SQL Server reading rather than being told its metrics do not exist.</param>
+        public static T? DmvSourced<T>(T reading, bool isPostgres)
+            where T : struct =>
+            isPostgres ? null : reading;
     }
 
     /// <summary>
@@ -395,13 +438,39 @@ namespace PerformanceMonitor.Common
             return HealthSeverity.Healthy;
         }
 
-        /// <summary>Memory band — Critical on any resource-semaphore pressure, else Healthy.</summary>
-        public static HealthSeverity MemorySeverity(bool hasMemoryPressure) =>
-            hasMemoryPressure ? HealthSeverity.Critical : HealthSeverity.Healthy;
-
-        /// <summary>Blocking band: >= 60s max wait or >= 5 events Critical; >= 10s max wait, >= 2 events, or any blocking Warning.</summary>
-        public static HealthSeverity BlockingSeverity(int blockingCount, double maxBlockedSeconds)
+        /// <summary>Memory band — Critical on any resource-semaphore pressure, else Healthy; no source
+        /// Unknown (#3272).
+        ///
+        /// <para><b>The Unknown arm is not cosmetic.</b> This band is read off
+        /// <c>v_memory_grant_stats</c>, a SQL Server DMV capture a PostgreSQL target has no row in, so the
+        /// zero counters such a card carried argued <c>false</c> and this returned <b>Healthy</b> — a
+        /// positive claim of health about a metric nothing measured, rendered as a green dot. That is worse
+        /// than the null it sat beside, and it is the same failure <see cref="CpuSeverity"/> and
+        /// <see cref="ThreadsSeverity"/> already avoid by taking a nullable input.</para></summary>
+        public static HealthSeverity MemorySeverity(bool? hasMemoryPressure)
         {
+            if (!hasMemoryPressure.HasValue)
+            {
+                return HealthSeverity.Unknown;
+            }
+
+            return hasMemoryPressure.Value ? HealthSeverity.Critical : HealthSeverity.Healthy;
+        }
+
+        /// <summary>Blocking band: >= 60s max wait or >= 5 events Critical; >= 10s max wait, >= 2 events, or any blocking Warning; no source Unknown (#3272).
+        ///
+        /// <para>The COUNT carries the measured/not-measured distinction on its own — there is no second
+        /// spelling of "unknown" to get wrong — because a max wait means nothing without a population to
+        /// have waited. See <see cref="MemorySeverity"/> for why the arm exists.</para></summary>
+        public static HealthSeverity BlockingSeverity(int? blockingCountOrNullWhenUnmeasured, double maxBlockedSeconds)
+        {
+            if (!blockingCountOrNullWhenUnmeasured.HasValue)
+            {
+                return HealthSeverity.Unknown;
+            }
+
+            var blockingCount = blockingCountOrNullWhenUnmeasured.Value;
+
             if (maxBlockedSeconds >= 60)
             {
                 return HealthSeverity.Critical;
@@ -430,9 +499,26 @@ namespace PerformanceMonitor.Common
             return HealthSeverity.Healthy;
         }
 
-        /// <summary>Deadlock band — any deadlock in the window is Critical.</summary>
-        public static HealthSeverity DeadlockSeverity(int deadlockCount) =>
-            deadlockCount > 0 ? HealthSeverity.Critical : HealthSeverity.Healthy;
+        /// <summary>Deadlock band — any deadlock in the window is Critical; no source Unknown (#3272).
+        ///
+        /// <para><b>This completes #3017 rather than reversing it.</b> That issue established that a
+        /// PostgreSQL target's zero is structural — <c>v_deadlocks</c> is the SQL Server extended-event
+        /// capture and nothing joins <c>pg_deadlocks</c> into it — and gave the CARD
+        /// <see cref="FleetDeadlockSource"/> plus the fleet total a coverage denominator to say so. It
+        /// deliberately added no band to the FLEET ROLLUP, so that a quiet, fully-covered SQL Server fleet
+        /// keeps reading healthy; that reasoning is untouched here. What it left behind was this
+        /// per-metric severity still answering <b>Healthy</b> for the same uncountable zero, so the card
+        /// disclosed the gap in <c>deadlock_source</c> and contradicted itself on the dot beside
+        /// it.</para></summary>
+        public static HealthSeverity DeadlockSeverity(int? deadlockCount)
+        {
+            if (!deadlockCount.HasValue)
+            {
+                return HealthSeverity.Unknown;
+            }
+
+            return deadlockCount.Value > 0 ? HealthSeverity.Critical : HealthSeverity.Healthy;
+        }
 
         /// <summary>
         /// Threads band: work-queue starvation Critical; >= 20 runnable-waiting or under 10% workers available
@@ -557,7 +643,12 @@ namespace PerformanceMonitor.Common
             }
 
             long magnitude = (criticals * 100L) + (warnings * 10L);
-            long incidents = Math.Min(m.BlockingCount + m.DeadlockCount, 99);
+            /* An unmeasured count contributes nothing, which is what keeps the whole Unknown arm
+               rank-neutral: the magnitude terms above already skip Unknown exactly as they skip Healthy,
+               so a card that gained an Unknown where it used to claim Healthy scores identically and
+               cannot move in the worst-first ranking. Pinned by
+               UnmeasuredMetricsAreNotHealthyTests. */
+            long incidents = Math.Min((m.BlockingCount ?? 0) + (m.DeadlockCount ?? 0), 99);
             return bandRank + magnitude + incidents;
         }
 

--- a/PerformanceMonitor.Common/ServerHealthBands.cs
+++ b/PerformanceMonitor.Common/ServerHealthBands.cs
@@ -353,7 +353,28 @@ namespace PerformanceMonitor.Common
             return ServerFreshness.Fresh;
         }
 
-        /// <summary>CPU band on total non-idle CPU: >= 95% Critical, >= 80% Warning; no snapshot Unknown.</summary>
+        /// <summary>
+        /// CPU band on total non-idle CPU: &gt;= 95% Critical, &gt;= 80% Warning; no snapshot Unknown.
+        ///
+        /// <para><b>The cutoffs are stated against a QUANTITY, not against a source</b> (#3267), because two
+        /// collectors now produce it. SQL Server's arm is <c>100 - SystemIdle</c> from the
+        /// <c>SCHEDULER_MONITOR</c> ring buffer; a PostgreSQL/Aurora target's is Performance Insights'
+        /// <c>os.cpuUtilization.total.avg</c>. What makes one ladder correct over both is that they are the
+        /// same measurement of the same thing: percent of the host's own CPU capacity that is not idle,
+        /// including processes outside the database engine, averaged over one minute
+        /// (<c>RdsCpuIngestor</c> asks PI for <c>PeriodInSeconds = 60</c>; the ring buffer publishes one
+        /// record a minute). Units, denominator, and averaging window all agree, so 80 means the same
+        /// "the host is approaching saturation" on both.</para>
+        ///
+        /// <para>Two things about the PI arm are deliberately recorded rather than assumed. It is the OS
+        /// counter and NOT CloudWatch's <c>CPUUtilization</c>, which reads capacity-relative and runs roomy
+        /// on Aurora Serverless v2 — measured on one instance over one window at 6.8% against PI's 16.8%
+        /// (see <c>PgCpuUtilizationCollector</c>); banding the CloudWatch figure on these cutoffs would
+        /// under-read badly. And on Serverless v2 the denominator is the CURRENT ACU allocation, which
+        /// scales: a high reading there is a true statement that the instance is saturated at its present
+        /// capacity, and the follow-up question is the cluster's max-ACU ceiling rather than the
+        /// workload.</para>
+        /// </summary>
         public static HealthSeverity CpuSeverity(double? cpuPercentForAlert)
         {
             if (!cpuPercentForAlert.HasValue)


### PR DESCRIPTION
## What

Fixes **#3267** and **#3272**. `get_fleet_overview` / `/api/fleet` and the WPF viewer's Overview cards read CPU only from `v_cpu_utilization_stats`, which the SQL Server ring-buffer collector writes and a PostgreSQL target never has a row in. Instance CPU for those targets lands in `collect.pg_cpu_utilization` from the Performance Insights API (#2719) and nothing on the fleet path looked at it, so every PostgreSQL card read `total_cpu_percent: null` / `cpu_severity: Unknown` permanently and could only rank in the worst-first list by collector state, never by load.

## The premise the issue offered, tested rather than inherited

The issue said `CpuSeverity`'s thresholds "presumably apply as-is to `os.cpuUtilization.total.avg`". #3268 was reverted the same night for shipping an unverified premise, so this one was checked from both sides' source before any severity was wired:

| | SQL Server arm | PostgreSQL/Aurora arm |
|---|---|---|
| quantity | `100 - SystemIdle` (`CpuUtilizationCollector`) | `os.cpuUtilization.total.avg` (`RdsCpuIngestor`) |
| denominator | the host's own CPU capacity | the host's own CPU capacity (OS counter) |
| includes non-database processes | yes, published separately as `other_process_cpu_utilization` | yes, and only as the total |
| averaging window | one ring-buffer record per minute | `PeriodInSeconds = 60` |
| range | 0-100 | 0-100 |

Same quantity, same units, same window, so one ladder is correct and 80 means "the host is approaching saturation" on both. Two things I did **not** find equivalent and recorded on `CpuSeverity` instead of assuming away:

- It is the **PI OS counter and not CloudWatch's `CPUUtilization`**, which reads capacity-relative and runs roomy on Serverless v2 — `PgCpuUtilizationCollector` records a live measurement of 6.8% against PI's 16.8% on one instance over one window. Banding the CloudWatch figure on these cutoffs would under-read badly; nothing here does, but that is the trap that was one collector choice away.
- On **Aurora Serverless v2 the denominator is the current ACU allocation, which scales.** A high reading there is a true statement that the instance is saturated at its present capacity; the follow-up question is the cluster's max-ACU ceiling rather than the workload. Recorded on the field rather than compensated for, because compensating would be inventing a second meaning for the band.

What I could not verify from our source is PI's `total` composition against `100 - idle` — whether it sums enumerated busy states (and so could omit one) or is literally the complement of idle. Every plausible discrepancy makes PI read **low**, i.e. fails toward Healthy, which is the direction of the `Unknown` this replaces rather than a new false red. The distribution check is below and it passed.

### The falsifier came back: the cutoffs transfer

Run against the pgmon store (50 real PG targets), the distribution confirms it empirically rather than by argument:

| | |
|---|---|
| servers with CPU rows in the 15-minute window | **50 of 50** |
| p50 / p95 / p99 | **8.4%** / 13.35% / 50% |
| max | **exactly 100** — no unit error, and nothing above 100 |
| samples at or above 80 | **348 of 71,990 (0.48%)** |
| servers with a median at or above 80 | **zero** |

So 80 is an exception signal on this population too, not an operating point — the same shape as the use2 SQL Server fleet (3–37% total across 42 servers at one instant, `other_process` 2–3%), which is the population the cutoffs were tuned on. The band is not going to paint a healthy PG fleet amber.

**Two servers do carry a p95 of 100, so this legitimately turns two cards red on arrival.** That is real sustained load that was previously hidden behind `Unknown`, which is the whole point of the issue — not a regression to tune away. Worth expecting rather than being surprised by.

## The two decisions the issue left open

**1. Memory, buffer pool, memory-pressure and the threads block stay null on a PostgreSQL card.** No PostgreSQL equivalent is collected and none is invented here. `ThreadsSeverity` already reports `Unknown` on a null ceiling, which is the honest reading. `get_fleet_overview`'s description now says so and names `get_pg_buffer_usage` / `get_pg_kernel_stats` / `get_pg_session_states` as the reads that answer the nearest PostgreSQL questions, so a persistently-null field stops looking like a collector problem.

**2. A null is disclosed by cause, not just left null.** `cpu_source` rides on each card naming which collector answered, mirroring `deadlock_source`/#3017:

- `RingBuffer` — SQL Server, and the only arm that also fills `cpu_percent` / `other_process_cpu_percent`
- `PerformanceInsights` — an **Aurora** PostgreSQL target's instance CPU, total only. The arm means "a PI reading is present", and only Aurora produces one in this build
- `NotCollected` — a source that applies here produced no current reading. Fixable; the default arm, so a card built without either reading claims nothing
- `NoSourceForEngine` — a PostgreSQL target not known to be Aurora. Structural: PostgreSQL exposes no instance-CPU counter in any version, and `PgCpuUtilizationCollector.AppliesTo` gates the AWS route to Aurora, so no grant or upgrade produces this number

That arm names what **this build collects**, not what AWS offers — the registry token for RDS for PostgreSQL is `postgres`, identical to self-hosted, and PI does reach the RDS one. "We collect none" is the true statement; "none exists" would be the overclaim.

`cpu_percent` and `other_process_cpu_percent` stay **null** on a PostgreSQL card rather than being filled from the total: PI publishes no per-process breakdown, so a value there would be an attribution nothing measured.

## #3272, folded in: a card stops claiming Healthy for what it never measured

The fence in my brief said "additive only, do not touch the SQL Server metric path." That is what made filing the only option; the coordinator lifted it and replaced it with the constraint that actually matters — **a measured metric must band exactly as it does today** — which permits editing the shared classifier.

`MemorySeverity(bool)`, `BlockingSeverity(int, double)` and `DeadlockSeverity(int)` took non-nullable parameters, so a zero could not mean "absent". A PostgreSQL target has no row in `v_memory_grant_stats`, `v_blocked_process_reports` / `v_dmv_blocking_snapshots` or `v_deadlocks`, so its card was handed zeros and all three answered **Healthy** — a green dot claiming health about a metric nothing read. All three now take a nullable reading and return `Unknown` for absence, exactly as `CpuSeverity` and `ThreadsSeverity` already did.

**Deadlocks is included, and that is a judgement worth objecting to if you disagree.** `FleetDeadlockCoverage`'s doc says the coverage work was "deliberately not a new band, for #1852's reason. A quiet SQL Server fleet with full coverage is healthy and must keep reading that way." I read that as scoping the **fleet rollup** — don't turn a coverage gap into a fleet-level alarm — and that reasoning is untouched here. What #3017 left behind was the **per-card severity** still answering Healthy for the same uncountable zero, so the card disclosed the gap in `deadlock_source: PostgresTarget` and contradicted itself on the dot beside it. This makes the two agree. It is completion, not reversal — but it is the one place I am extending another lane's recorded decision, so it is called out rather than buried.

**Scope I did not take:** the discriminant is the **engine**, not the collector state. A SQL Server whose deadlock collector is permission-denied also reads zero and still bands Healthy, on purpose — #3017 routed that case to `failed_collector_count` / `CollectorSeverity` and the coverage block, which is where a *fixable* gap belongs. Only the structural case changes, so the blast radius is PostgreSQL cards.

**Corrections to the framing I was given**, since two of the three named metrics needed nothing:

- **Buffer pool** was already honest — `memory_mb` / `buffer_pool_mb` are `double?` read from `v_memory_stats`, so a PG card already carried null.
- **Threads** was already honest — `ThreadsSeverity` returns `Unknown` on a null ceiling, which is also how Azure SQL DB has always read.
- Only **memory-grant pressure**, **blocking** and **deadlocks** actually claimed false Healthy.

**Counts and disclosure are deliberately unchanged.** `blocking_count: 0`, `deadlock_count: 0` and `has_memory_pressure: false` stay on the wire: `total_deadlocks` / `total_blocking_events` are summed from them and #3017's `deadlock_coverage` is what explains a total built out of zeros — nulling them would leave that denominator describing nothing, and would change the wire type for every consumer. Only the band stops claiming health.

### Why this cannot move a band or a rank

The property the coordinator asked me to check, and it holds by construction rather than by luck: **both reducers already ignore `Unknown`.** `OverallMetricSeverity` escalates only on `Warning` and `Critical`; `FleetHealthScore`'s magnitude counts only those two. So a card that gained an `Unknown` where it claimed `Healthy` bands identically and scores identically — it cannot reorder the worst-first list in either direction. `HealthSeverity.Unknown` is also the enum's **lowest** member, which is what keeps the `severity >= HealthSeverity.Warning` guards in both `BuildReason` implementations and the Needs-Attention filter from writing clauses about metrics nothing read.

Three things follow, and all three are pinned rather than assumed: the neutrality itself, the enum ordering (reorder it to make `Unknown` "worst" and every `>=` guard flips), and `default(ServerHealthMetrics)` — which flipped from all-zero-therefore-Healthy to all-null-therefore-Unknown when the fields became nullable, and is only safe *because* Unknown is inert.

**The nullable widening is silent, so the compiler found nothing.** `bool` → `bool?` is an implicit conversion, so the whole solution still built with every call site passing measured values. I enumerated the sites by hand instead: three severity calls plus one `ServerHealthMetrics` construction on each of the two surfaces, two `ToHealthMetrics()`, and Lite — which turns out to call only `ClassifyFreshness`, so it is genuinely untouched.

## Surfaces wired (the #2473 one-ladder rule)

`ServerHealthMetrics` is constructed in exactly two production places, and they are the only two surfaces that band CPU — verified two ways (by `CpuSeverity` callers and by `ServerHealthMetrics` constructions):

- **Darling service** — `DarlingFleetReader` (`get_fleet_overview` + `/api/fleet`)
- **Darling WPF viewer** — `ServerSummaryItem`, which the Overview card, the FleetView band and the worst-first reason are all reduced from

`list_servers` and the sidebar dot band *collection status*, not CPU, so they are untouched. Both surfaces reach one shared decision (`FleetCpuProvenance`) rather than each writing the fallback, and a census test pins that the deciding set is exactly those two — a third surface arriving fails and has to be given the shared call.

**Lite is out of scope by construction**: `DuckDbSchemaGenerator` filters `TargetEngine == SqlServer`, so there is no PostgreSQL seam to keep parity with.

## The bound

The new cross-server read carries two predicates that do different jobs:

- `collection_time >= $1` is the hypertable's partition dimension and the only one TimescaleDB can chunk-exclude on — `FleetLastCollectionSql`'s reason, since this table only grows
- `sample_time >= $1` is the honest freshness test: a cycle backfills up to `RdsCpuIngestor.LookbackWindow` of points under one `collection_time`, so a row inside the collection bound can still carry an older sample. Unlike the SQL Server arm this comparison is frame-correct — PI stamps its points in UTC and the ingestor stores them naive-UTC unchanged, where the ring buffer's `sample_time` is the monitored server's local wall clock

**Falling out of this read is the correct answer, unlike `FleetLastCollectionSql`'s 48 hours.** That read's value is "when did we last see this server", which a long-dark server must still report or its card drops out. A CPU *level* is the opposite: a four-hour-old reading is not this server's CPU now, and the card says so by carrying null and banding Unknown — the Offline band, from `FleetLastCollectionSql`, is what reports darkness.

The window is `DarlingPgCpuUtilizationReader.Freshness` (15 minutes, 3x the collector's cadence) rather than a new number, so the fleet card and the High CPU alert agree on what "current" means. Promoted from `internal` to `public` for that; a test pins that neither read carries a second literal.

## Tests

Red-first on the field case, and every pin mutation-tested:

| mutation | goes red |
|---|---|
| `TotalNonIdleCpuPercent` ignores the instance reading (pre-fix behaviour) | the field case: `total_cpu_percent` null, `cpu_severity` Unknown, band Healthy, reason "Needs attention" |
| the viewer writes its own source classification | the census (callers) |
| a third file bands CPU | the census (deciders) |
| the `sample_time` bound is dropped | the bound pin |
| the engine gate says "not measured" for everything | the invariant — **seven SQL Server cards collapse from Critical/Warning to Healthy**, 93 assertions red |
| the engine gate says "measured" for everything (the #3272 defect restored) | every PG card's memory/blocking/deadlock Unknown assertion |
| `Unknown` made to escalate in `OverallMetricSeverity` | three SQL Server bands move Healthy → Warning, plus the default-bundle pin |
| the incident tiebreak stops tolerating a null (`?? 7`) | the rank-neutrality pin (2010 vs 2017) and the default-bundle score |

Also: all four `cpu_source` arms including an absent and an unrecognised engine token, `cpu_source` serializing as its name and not an ordinal, `0%` and "no source" rendering differently on both surfaces (`"0%"` vs `"--"`), the two surfaces agreeing over nine input combinations, and the SQL Server path byte-identical (60+40 → 100 Critical; Linux `other_process` NULL → 40; a ring-buffer reading takes precedence over an instance one).

`FleetCardPostgresCpuLivePostgresTests` is the live-store round trip the shape pins cannot substitute for — #2213's lesson was a feature whose SQL had been live-verified for weeks and could not collect a row, because every defect was in the wiring. Four servers share one sample so all four arms are observable in one fleet call, with a NULL-valued newest sample and an out-of-band row in a *different* band as the two traps, plus an accounting assertion that no seeded server was dropped from the fleet.

`BuildCard` and its row structs went `private` → `internal` so the reduction that decides what a card *claims* is assertable without a store, the reason `BuildRollup` is already public. Nothing else about them changed.

## What I could not run

`Darling.Tests` targets `net10.0-windows` and cannot execute on macOS, so **CI is the arbiter for the xUnit suite**. What I did run locally: a throwaway `net10.0` harness named `Darling.Tests` (so `InternalsVisibleTo` admits it) calling the real `DarlingFleetReader.BuildCard` and `FleetCpuProvenance` out of the built assemblies — 60 assertions, all pass, and the four mutations above verified red through it. It cannot reach `ServerSummaryItem` (WPF), so the viewer half of the ladder theory and the `CpuDisplay` strings are reasoned-and-compiled, not executed. The live-Postgres class has never run: there is no Postgres on this host, so `DARLING_TEST_PG` is unset and it skips.

Full solution build: **0 warnings, 0 errors**.

## Deliberately out of scope

- **`get_server_summary`** reports `cpu_percent` (SQL-only, unbanded) and is null for a PostgreSQL target. Its *whole* payload is SQL-Server-shaped — `memory_mb` from `v_memory_stats`, blocking from `v_dmv_blocking_snapshots`, deadlocks from `v_deadlocks` — so populating only its CPU would make it more misleading, not less. It needs a whole-payload PostgreSQL story, which is its own issue.
- **Wiring `pg_blocking` / `pg_deadlocks` into the fleet card's counts** — a feature, with the sampled-denominator problem `get_pg_blocking` already reports `captures_total` for. #3272 is rescoped to that question. This PR only stops those rows claiming health they did not measure; it does not decide where a real PostgreSQL blocking count belongs.

## Proposed CHANGELOG entry

```
- Fleet cards now report a PostgreSQL/Aurora target's instance CPU. `get_fleet_overview`, `/api/fleet` and the viewer's Overview cards read CPU only from the SQL Server ring-buffer table, so every PostgreSQL card carried a null CPU and an Unknown band permanently; instance CPU is read from `collect.pg_cpu_utilization` (Performance Insights) through the same severity ladder, and a new `cpu_source` field on each card names which collector answered — separating a reading that has not arrived from a PostgreSQL target for which none is collected at all. Memory, buffer pool and the threads block stay null on those cards: no PostgreSQL equivalent is collected and none is invented (#3267).
- A server card no longer reports a metric as Healthy when nothing measured it. The memory-pressure, blocking and deadlock bands read off SQL Server DMV captures a PostgreSQL target has no row in, and their non-nullable inputs meant the resulting zeros banded Healthy — a green dot claiming health, beside a `deadlock_source` already saying the count was structurally uncountable. All three now band Unknown for an absent source, as CPU and worker threads already did. The published counts are unchanged, so the fleet totals and their coverage denominator still reconcile, and an Unknown cannot move a band or the worst-first ranking (#3272).
```

## Still open, for whoever takes #3272's remaining half

Before choosing merge-vs-leave for PostgreSQL blocking/deadlock counts:

```sql
SELECT count(DISTINCT server_id) AS servers_with_sampled_blocking,
       count(*)                  AS edges
FROM collect.pg_blocking
WHERE collection_time >= now() AT TIME ZONE 'UTC' - interval '24 hours';
```

If the PostgreSQL fleet has real blocking the fleet total silently omits, merging is worth the denominator problem. If it is near-zero, the `Unknown` this PR ships is the whole honest answer and the sampled count stays where `get_pg_blocking` can qualify it.
