### PR TITLE
get_pg_index_bloat: population-level coverage census with bytes per suppression reason

### DIFF
--- a/Darling/Darling.Tests/DarlingPgIndexBloatCoverageLivePostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingPgIndexBloatCoverageLivePostgresTests.cs
@@ -137,8 +137,8 @@ public sealed class DarlingPgIndexBloatCoverageLivePostgresTests
 
             Assert.Equal(PgIndexBloatCoverageArm.PartialCoverage, verdict.Arm);
 
-            /* ARM 2: ONE ROW PER INDEX. Six distinct indexes, eleven rows across two cycles, and the
-               population is SIX - the denominator error that flatters coverage would report eleven.
+            /* ARM 2: ONE ROW PER INDEX. Six distinct indexes, twelve rows across two cycles, and the
+               population is SIX - the denominator error that flatters coverage would report twelve.
 
                Derived below as well as stated: the literal is what a reader checks the fixture against, and
                the identity is what catches a fixture edit that changes the population without changing the

--- a/Darling/Darling.Tests/DarlingPgIndexBloatCoverageLivePostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingPgIndexBloatCoverageLivePostgresTests.cs
@@ -131,16 +131,21 @@ public sealed class DarlingPgIndexBloatCoverageLivePostgresTests
             Assert.False(
                 verdict.Arm == PgIndexBloatCoverageArm.Undetermined,
                 "the coverage census answered Undetermined over a store that was just seeded with a "
-                + "SUCCESS run and five indexes. GetCoverageVerdictAsync swallows read failures by design, "
+                + "SUCCESS run and six indexes. GetCoverageVerdictAsync swallows read failures by design, "
                 + "so this is what a census that does not PARSE looks like from the outside: check "
                 + "CoverageEvidenceSql against the live store. Census: " + verdict.Census);
 
             Assert.Equal(PgIndexBloatCoverageArm.PartialCoverage, verdict.Arm);
 
-            /* ARM 2: ONE ROW PER INDEX. Five distinct indexes seeded across two cycles - ten rows - and the
-               population is five. Ten would be the denominator error that makes coverage look better than
-               it is. */
-            Assert.Equal(5, verdict.Candidates.IndexCount);
+            /* ARM 2: ONE ROW PER INDEX. Six distinct indexes, eleven rows across two cycles, and the
+               population is SIX - the denominator error that flatters coverage would report eleven.
+
+               Derived below as well as stated: the literal is what a reader checks the fixture against, and
+               the identity is what catches a fixture edit that changes the population without changing the
+               literal. Writing the literal from memory got it wrong once already. */
+            Assert.Equal(6, verdict.Candidates.IndexCount);
+            Assert.Equal(
+                DistinctSeededIndexes, verdict.Candidates.IndexCount);
 
             /* ARM 3: the tie-break. shipments_pkey's newest row carries a reason and its older row carries
                an exact measurement, and it counts as EXACTLY MEASURED - the same row the grid shows. */
@@ -217,6 +222,13 @@ public sealed class DarlingPgIndexBloatCoverageLivePostgresTests
                 });
         }
     }
+
+    /// <summary>
+    /// Distinct (database, schema, table, index) tuples the fixture seeds: five written on both cycles plus
+    /// <c>shipments_pkey</c>, which is written once per cycle with a DIFFERENT outcome each time. Named so
+    /// the population assertion above has something to check besides a number somebody typed.
+    /// </summary>
+    private const int DistinctSeededIndexes = 6;
 
     /// <summary>A trusted ESTIMATE row: no reason, and a modelled tuple width, which is the provenance
     /// discriminator the reader keys <c>measurement_kind</c> on.</summary>

--- a/Darling/Darling.Tests/DarlingPgIndexBloatCoverageLivePostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingPgIndexBloatCoverageLivePostgresTests.cs
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The #3278 coverage census EXECUTES, and it answers over the population rather than over a page.
+///
+/// <para><b>Why this needs a live store, and it is the only pin that can say so.</b>
+/// <see cref="DarlingPgIndexBloatReader.GetCoverageVerdictAsync"/> catches every exception and answers
+/// <see cref="PgIndexBloatCoverageArm.Undetermined"/> — deliberately, because the census runs to EXPLAIN a
+/// result the caller already has and must not turn that into a read error. The cost of that decision is that
+/// a census which does not PARSE degrades to a polite sentence, on every server, forever, with nothing that
+/// fails. Every other pin in <c>PgIndexBloatCoverageTests</c> is a pure function or a source scan, and not
+/// one of them can tell a working query from a syntactically broken one. This can.</para>
+///
+/// <para><b>Three properties only a real store can settle.</b> The census reduces the window to one row per
+/// index, so a collector that writes every btree on every cycle cannot inflate the denominator — the failure
+/// that flatters coverage. It applies the row read's measured-row-wins tie-break, so an index whose NEWEST
+/// row is a label and whose earlier row is an answer counts as answered in both places. And the run probe is
+/// what separates "no indexes" from "no evidence", which needs a <c>collection_log</c> row to exist and then
+/// not to.</para>
+///
+/// <para><b>The seeded shape is the fleet's, not a convenient one.</b> The two suppression buckets are
+/// weighted so the ROW ranking and the BYTE ranking disagree, because that is the condition the whole issue
+/// turns on and a fixture where the two agree would pass whichever ordering shipped.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class DarlingPgIndexBloatCoverageLivePostgresTests
+{
+    /// <summary>
+    /// NEGATIVE, the convention the live classes here follow and not decoration: teardown deletes from
+    /// <c>servers</c> by id, and a real store assigns ids from a sequence, so a positive sentinel is one
+    /// collision away from removing an operator's own registry row.
+    /// </summary>
+    private const int ServerId = -993_278;
+
+    private const string ServerName = "pg-index-bloat-coverage-probe";
+
+    private const long Mib = 1024L * 1024L;
+    private const long Gib = Mib * 1024L;
+
+    /// <summary>
+    /// The collector's own prose for the two buckets, PREFIXED with the markers
+    /// <see cref="PgIndexBloatCoverage.Markers"/> keys on. Quoted rather than generated so this test seeds
+    /// what a real collector writes; <c>PgIndexBloatCoverageTests</c> is what pins the markers against the
+    /// shipped query, so a drift there fails loudly rather than turning this fixture into two
+    /// <see cref="PgIndexBloatSuppression.Unrecognized"/> rows that still add up.
+    /// </summary>
+    private const string WidthsReason =
+        "column widths are not visible for every key: pg_stats filters on has_column_privilege, so a "
+        + "monitoring role without SELECT sees nothing, and a never-analyzed parent has no rows either. "
+        + "Grant pg_read_all_data, or ANALYZE the parent.";
+
+    private const string NeverAnalyzedReason =
+        "the parent table has never been analyzed (reltuples = -1), so there is no row count to model from. "
+        + "An ANALYZE of the parent makes this index estimable.";
+
+    /// <summary>
+    /// The census executes, counts the POPULATION once per index, applies the row read's tie-break, and
+    /// ranks its buckets by bytes.
+    /// </summary>
+    [Fact]
+    public async Task TheCensusExecutesAndAnswersOverThePopulation()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live #3278 coverage census test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteRowsAsync(connection, ct);
+
+        var bodySucceeded = false;
+        try
+        {
+            await DarlingMcpTestData.RegisterServerAsync(connection, ServerId, ServerName, ct);
+
+            var now = DarlingMcpTestData.TruncateToSeconds(DateTime.UtcNow);
+            var newest = now.AddHours(-2);
+            var older = now.AddHours(-26);
+
+            /* TWO cycles, both inside the 48h evidence window, both writing every index - which is what
+               this collector does. A census without DISTINCT ON would report every figure below DOUBLED. */
+            foreach (var cycle in new[] { older, newest })
+            {
+                await SeedEstimateAsync(connection, ct, cycle, "orders", "orders_pkey", 40 * Gib);
+                await SeedSuppressedAsync(
+                    connection, ct, cycle, "orders", "orders_wide_ix", 300 * Gib, WidthsReason);
+                await SeedSuppressedAsync(
+                    connection, ct, cycle, "audit", "audit_a_ix", 4 * Mib, NeverAnalyzedReason);
+                await SeedSuppressedAsync(
+                    connection, ct, cycle, "audit", "audit_b_ix", 4 * Mib, NeverAnalyzedReason);
+                await SeedSuppressedAsync(
+                    connection, ct, cycle, "audit", "audit_c_ix", 4 * Mib, NeverAnalyzedReason);
+            }
+
+            /* THE TIE-BREAK'S OWN CASE: measured on the OLDER cycle, labelled on the NEWER one. The row read
+               keeps the measurement, so the census has to as well - otherwise it publishes a trusted count
+               the grid beside it contradicts, for this index, with nothing that fails. */
+            await SeedMeasuredAsync(connection, ct, older, "shipments", "shipments_pkey", 10 * Gib);
+            await SeedSuppressedAsync(
+                connection, ct, newest, "shipments", "shipments_pkey", 10 * Gib, WidthsReason);
+
+            await LogRunAsync(connection, ct, newest, "SUCCESS");
+
+            await using var postgres = NpgsqlDataSource.Create(connectionString!);
+
+            var verdict = await DarlingPgIndexBloatReader.GetCoverageVerdictAsync(
+                postgres, ServerId, DarlingMcpTestData.Naive(now), returnedRows: 2, ct);
+
+            /* ARM 1: it PARSED. Undetermined here is what a broken query looks like, so this assertion is
+               the whole reason the class exists - and it names that, because the message is what somebody
+               reads when it goes red. */
+            Assert.False(
+                verdict.Arm == PgIndexBloatCoverageArm.Undetermined,
+                "the coverage census answered Undetermined over a store that was just seeded with a "
+                + "SUCCESS run and five indexes. GetCoverageVerdictAsync swallows read failures by design, "
+                + "so this is what a census that does not PARSE looks like from the outside: check "
+                + "CoverageEvidenceSql against the live store. Census: " + verdict.Census);
+
+            Assert.Equal(PgIndexBloatCoverageArm.PartialCoverage, verdict.Arm);
+
+            /* ARM 2: ONE ROW PER INDEX. Five distinct indexes seeded across two cycles - ten rows - and the
+               population is five. Ten would be the denominator error that makes coverage look better than
+               it is. */
+            Assert.Equal(5, verdict.Candidates.IndexCount);
+
+            /* ARM 3: the tie-break. shipments_pkey's newest row carries a reason and its older row carries
+               an exact measurement, and it counts as EXACTLY MEASURED - the same row the grid shows. */
+            Assert.Equal(1, verdict.ExactlyMeasured.IndexCount);
+            Assert.Equal(10 * Gib, verdict.ExactlyMeasured.IndexBytes);
+
+            Assert.Equal(1, verdict.Estimated.IndexCount);
+            Assert.Equal(40 * Gib, verdict.Estimated.IndexBytes);
+            Assert.Equal(2, verdict.Trusted.IndexCount);
+            Assert.Equal(50 * Gib, verdict.Trusted.IndexBytes);
+
+            /* ARM 4: est_tuple_bytes is populated on every suppressed row seeded here, exactly as it is on
+               100% of the fleet's, and none of them counts as trusted. This is incident four's route. */
+            Assert.Equal(4, verdict.Suppressed.Sum(bucket => bucket.IndexCount));
+            Assert.Equal(
+                verdict.Trusted.IndexCount + verdict.Suppressed.Sum(bucket => bucket.IndexCount),
+                verdict.Candidates.IndexCount);
+
+            /* ARM 5: ranked BY BYTES, over a fixture where the row ranking disagrees - three
+               never-analyzed indexes at 4 MB each against one permission index at 300 GB. Counts alone
+               would put the 12 MB bucket first. */
+            Assert.Equal(
+                new[] { PgIndexBloatSuppression.ColumnWidthsNotVisible, PgIndexBloatSuppression.ParentNeverAnalyzed },
+                verdict.Suppressed.Select(bucket => bucket.Reason).ToArray());
+
+            Assert.Equal(1, verdict.Suppressed[0].IndexCount);
+            Assert.Equal(300 * Gib, verdict.Suppressed[0].IndexBytes);
+            Assert.Equal(3, verdict.Suppressed[1].IndexCount);
+            Assert.Equal(12 * Mib, verdict.Suppressed[1].IndexBytes);
+
+            /* And the fixture really is one where the two rankings disagree, or ARM 5 asserts nothing. */
+            Assert.NotEqual(
+                verdict.Suppressed.OrderByDescending(b => b.IndexCount).Select(b => b.Reason).ToArray(),
+                verdict.Suppressed.Select(b => b.Reason).ToArray());
+
+            /* The stored prose reaches the bucket ONCE rather than per row, which is the point of keying on
+               a short identifier - the never-analyzed bucket is three rows carrying one paragraph. */
+            Assert.Equal(NeverAnalyzedReason, verdict.Suppressed[1].Detail);
+
+            /* ARM 6: no evidence is not no indexes. With the run gone the same rows answer Undetermined and
+               publish NO population figure - not a zero, and not the figures it could still read. */
+            await DarlingMcpTestData.ExecAsync(
+                connection, ct, "DELETE FROM collection_log WHERE server_id = $1", ServerId);
+
+            var unevidenced = await DarlingPgIndexBloatReader.GetCoverageVerdictAsync(
+                postgres, ServerId, DarlingMcpTestData.Naive(now), returnedRows: 2, ct);
+
+            Assert.Equal(PgIndexBloatCoverageArm.Undetermined, unevidenced.Arm);
+            Assert.Equal(default, unevidenced.Candidates);
+            Assert.Empty(unevidenced.Suppressed);
+
+            /* ARM 7: and an ERRORED run is not evidence either. Measured on a live Aurora target, 3 of this
+               collector's 7 runs in a week errored - one a 300-second client-side deadline that stored
+               nothing - so an unfiltered probe would report "it ran" over whatever the window happens to
+               hold and the classifier would answer over a population no run in it established. */
+            await LogRunAsync(connection, ct, newest, "ERROR");
+
+            var erroredOnly = await DarlingPgIndexBloatReader.GetCoverageVerdictAsync(
+                postgres, ServerId, DarlingMcpTestData.Naive(now), returnedRows: 2, ct);
+
+            Assert.Equal(PgIndexBloatCoverageArm.Undetermined, erroredOnly.Arm);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunOwnedAsync(
+                bodySucceeded,
+                async () =>
+                {
+                    await using var cleanup = new NpgsqlConnection(connectionString);
+                    await cleanup.OpenAsync(CancellationToken.None);
+                    await DeleteRowsAsync(cleanup, CancellationToken.None);
+                });
+        }
+    }
+
+    /// <summary>A trusted ESTIMATE row: no reason, and a modelled tuple width, which is the provenance
+    /// discriminator the reader keys <c>measurement_kind</c> on.</summary>
+    private static Task SeedEstimateAsync(
+        NpgsqlConnection connection, CancellationToken ct, DateTime collectionTimeUtc,
+        string tableName, string indexName, long indexBytes) =>
+        SeedAsync(
+            connection, ct, collectionTimeUtc, tableName, indexName, indexBytes,
+            estTupleBytes: 48L, estBloatPct: 12.5, skippedReason: null);
+
+    /// <summary>A historical EXACT row: no reason and NO modelled width, which is what a pre-#3234
+    /// <c>pgstatindex</c> measurement still inside retention looks like.</summary>
+    private static Task SeedMeasuredAsync(
+        NpgsqlConnection connection, CancellationToken ct, DateTime collectionTimeUtc,
+        string tableName, string indexName, long indexBytes) =>
+        SeedAsync(
+            connection, ct, collectionTimeUtc, tableName, indexName, indexBytes,
+            estTupleBytes: null, estBloatPct: null, skippedReason: null);
+
+    /// <summary>
+    /// A SUPPRESSED row, carrying <c>est_tuple_bytes</c> and no <c>est_bloat_pct</c> — the fleet's measured
+    /// shape on 100% of suppressed rows in every bucket, and the reason a census keyed on the intermediate
+    /// would count this row as covered.
+    /// </summary>
+    private static Task SeedSuppressedAsync(
+        NpgsqlConnection connection, CancellationToken ct, DateTime collectionTimeUtc,
+        string tableName, string indexName, long indexBytes, string skippedReason) =>
+        SeedAsync(
+            connection, ct, collectionTimeUtc, tableName, indexName, indexBytes,
+            estTupleBytes: 48L, estBloatPct: null, skippedReason: skippedReason);
+
+    private static Task SeedAsync(
+        NpgsqlConnection connection, CancellationToken ct, DateTime collectionTimeUtc,
+        string tableName, string indexName, long indexBytes, long? estTupleBytes, double? estBloatPct,
+        string? skippedReason) =>
+        DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO pg_index_bloat
+    (collection_id, collection_time, server_id, server_name, database_name, schema_name,
+     table_name, index_name, index_bytes, skipped_reason, est_tuple_bytes, est_bloat_pct)
+VALUES ($1::bigint, $2::timestamp, $3::integer, $4::text, $5::text, $6::text,
+        $7::text, $8::text, $9::bigint, $10::text, $11::bigint, $12::double precision)",
+            CollectionIdGenerator.Next(), DarlingMcpTestData.Naive(collectionTimeUtc), ServerId, ServerName,
+            "appdb", "public", tableName, indexName, indexBytes, skippedReason, estTupleBytes, estBloatPct);
+
+    private static Task LogRunAsync(
+        NpgsqlConnection connection, CancellationToken ct, DateTime collectionTimeUtc, string status) =>
+        DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO collection_log
+    (log_id, server_id, server_name, collector_name, collection_time, status)
+VALUES ($1::bigint, $2::integer, $3::text, 'pg_index_bloat', $4::timestamp, $5::text)",
+            CollectionIdGenerator.Next(), ServerId, ServerName,
+            DarlingMcpTestData.Naive(collectionTimeUtc), status);
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        await DarlingMcpTestData.ExecAsync(
+            connection, ct, "DELETE FROM pg_index_bloat WHERE server_id = $1", ServerId);
+        await DarlingMcpTestData.ExecAsync(
+            connection, ct, "DELETE FROM collection_log WHERE server_id = $1", ServerId);
+        await DarlingMcpTestData.ExecAsync(
+            connection, ct, "DELETE FROM servers WHERE server_id = $1", ServerId);
+    }
+}

--- a/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
+++ b/Darling/Darling.Tests/DarlingPgReadSqlParsesLiveTests.cs
@@ -84,6 +84,11 @@ public sealed class DarlingPgReadSqlParsesLiveTests
     private static readonly HashSet<string> NotQueryFields = new(StringComparer.Ordinal)
     {
         "DarlingPgColumnStatsReader.EvidenceStatusList",
+        /* #3278's twin of the line above, and the same reasoning: an IN-list fragment built from
+           EnumeratedCollectorDriver.FreshnessSuccessStatuses, so it is 'SUCCESS', 'SKIPPED' and not a
+           statement. The query it is spliced into - CoverageEvidenceSql - IS in the parse-checked
+           population, so the fragment is verified where it is used rather than left unverified. */
+        "DarlingPgIndexBloatReader.EvidenceStatusList",
         "DarlingPgServerConfigReader.SessionScopedSources",
         "DarlingPgTableBloatReader.StaleStatisticsChurnRatioSql",
     };

--- a/Darling/Darling.Tests/PgIndexBloatCoverageTests.cs
+++ b/Darling/Darling.Tests/PgIndexBloatCoverageTests.cs
@@ -706,6 +706,73 @@ public sealed class PgIndexBloatCoverageTests
         {
             Assert.Contains(figure, populated, StringComparison.Ordinal);
         }
+
+        /* THE CHECK THE LIST ABOVE CANNOT MAKE. A fixed list of input figures only catches an input being
+           echoed; a mutation that appended the DERIVED candidate total passed every assertion above and was
+           caught only by an unrelated pin. The claim is that the cause is a function of the ARM and its
+           dominant bucket, so the falsifier has to be invariance: same arm, same dominant reason, wildly
+           different figures, identical cause. That catches any figure - raw, summed or formatted. */
+        foreach (var (arm, lean, heavy) in FigureInvariancePairs)
+        {
+            Assert.Equal(arm, lean.Arm);
+            Assert.Equal(arm, heavy.Arm);
+            Assert.Equal(lean.Cause, heavy.Cause);
+
+            /* And the two really do hold different figures, or "identical cause" is a claim about one
+               input rendered twice. */
+            Assert.NotEqual(lean.Census, heavy.Census);
+        }
+
+        /* Every arm but one is swept. NoCandidates is a single input point - it requires zero candidates AND
+           zero returned rows - so there are no two figure sets reaching it to compare, and saying so here
+           beats leaving a reader to assume the sweep was total. */
+        Assert.Equal(
+            Enum.GetValues<PgIndexBloatCoverageArm>()
+                .Where(a => a != PgIndexBloatCoverageArm.NoCandidates)
+                .OrderBy(a => a)
+                .ToArray(),
+            FigureInvariancePairs.Select(pair => pair.Arm).Distinct().OrderBy(a => a).ToArray());
+    }
+
+    /// <summary>
+    /// Per arm, two verdicts reaching it from very different figures with the same dominant suppression
+    /// reason. The input to <see cref="TheCauseCarriesNoneOfTheInputFigures"/>'s invariance half.
+    /// </summary>
+    private static IEnumerable<(PgIndexBloatCoverageArm Arm,
+        PgIndexBloatCoverageVerdict Lean, PgIndexBloatCoverageVerdict Heavy)> FigureInvariancePairs
+    {
+        get
+        {
+            var thin = new PgIndexBloatTally(3, 7 * Mib);
+            var thick = new PgIndexBloatTally(424_242, 777 * Gib);
+            var oneBucket = new[] { Bucket(PgIndexBloatSuppression.Partial, 2, 5 * Mib) };
+            var manyBuckets = new[] { Bucket(PgIndexBloatSuppression.Partial, 90_210, 333 * Gib) };
+
+            yield return (
+                PgIndexBloatCoverageArm.Undetermined,
+                PgIndexBloatCoverage.Classify(false, thin, Nothing, oneBucket, 1),
+                PgIndexBloatCoverage.Classify(false, thick, thin, manyBuckets, 9_999));
+
+            yield return (
+                PgIndexBloatCoverageArm.NothingTrusted,
+                PgIndexBloatCoverage.Classify(true, Nothing, Nothing, oneBucket, 1),
+                PgIndexBloatCoverage.Classify(true, Nothing, Nothing, manyBuckets, 9_999));
+
+            yield return (
+                PgIndexBloatCoverageArm.PartialCoverage,
+                PgIndexBloatCoverage.Classify(true, thin, Nothing, oneBucket, 1),
+                PgIndexBloatCoverage.Classify(true, thick, thin, manyBuckets, 9_999));
+
+            yield return (
+                PgIndexBloatCoverageArm.FullyTrusted,
+                PgIndexBloatCoverage.Classify(true, thin, Nothing, [], 1),
+                PgIndexBloatCoverage.Classify(true, thick, thin, [], 9_999));
+
+            yield return (
+                PgIndexBloatCoverageArm.EvidenceStale,
+                PgIndexBloatCoverage.Classify(true, Nothing, Nothing, [], 1),
+                PgIndexBloatCoverage.Classify(true, Nothing, Nothing, [], 9_999));
+        }
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/PgIndexBloatCoverageTests.cs
+++ b/Darling/Darling.Tests/PgIndexBloatCoverageTests.cs
@@ -1,0 +1,1045 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3278: a <c>get_pg_index_bloat</c> read must say what share of the SERVER it covers, in bytes as well as
+/// in rows, from a figure no row limit can reach.
+///
+/// <para><b>The property, in one sentence.</b> Every figure this surface publishes is true of the population
+/// it appears to describe: a page-scoped count is named as such, the population figures come from a separate
+/// query the caller's limit does not touch, each of them carries BYTES beside its count, and the read either
+/// names which coverage arm produced the result or states that it cannot tell and why.</para>
+///
+/// <para><b>Derived from the property's violation routes, not from reading the code.</b> Enumerating how a
+/// truncated page can be mistaken for a coverage claim is the work here:</para>
+///
+/// <list type="number">
+/// <item>A page of all-suppressed rows read as the server's coverage. Structurally guaranteed, not
+/// probabilistic: answerless rows sort FIRST, so any limit below the answerless population returns 100% of
+/// them. Four independent sessions did this in one night. Guarded by
+/// <see cref="BothSurfacesPrintTheSharedVerdict"/> and <see cref="EveryOutcomeSelectsAnArm"/>.</item>
+/// <item>The population figure computed and then NOT reaching the surface where the page is seen — captured
+/// and unread. Guarded by <see cref="BothSurfacesPrintTheSharedVerdict"/> and
+/// <see cref="BothSurfacesPrintTheVerdictOnThePopulatedPathToo"/>.</item>
+/// <item>A surface calling the classifier and then AUTHORING its own verdict, which passes any presence
+/// check. Guarded by the <c>DoesNotContain</c> half of <see cref="BothSurfacesPrintTheSharedVerdict"/>.</item>
+/// <item>Counts published WITHOUT bytes, which ranks the suppression buckets wrongly. Not a preference: on
+/// the fleet at 2026-09-10 the second largest bucket by rows is the LAST by footprint at 0.0004% of it, and
+/// the fourth by rows is second by bytes at 1,385 GB. Guarded by
+/// <see cref="TheSuppressionBucketsAreRankedByBytesAndNeverByRows"/> and
+/// <see cref="EveryPublishedCountCarriesItsBytes"/>.</item>
+/// <item>Trust keyed on <c>est_tuple_bytes</c> rather than on <c>skipped_reason IS NULL</c> — incident four,
+/// which reported 461 GB covered against a real 214 of 5,954. The intermediate is populated on 100% of
+/// answerless rows and both conclusions on 0% of them. Guarded by
+/// <see cref="TheOnlyTrustPredicateIsTheAbsenceOfAReason"/>.</item>
+/// <item>The census and the row list disagreeing about which of an index's rows is current, so the published
+/// trusted count contradicts the grid printed beside it index by index. Guarded by
+/// <see cref="TheCensusAndTheRowReadAgreeWhichRowIsCurrent"/>.</item>
+/// <item>A double-counted denominator: <c>pg_index_bloat</c> writes every btree every cycle, so an
+/// aggregate without <c>DISTINCT ON</c> reports twice the indexes and twice the footprint — wrong in the
+/// direction that flatters coverage. Guarded by <see cref="TheCensusAndTheRowReadAgreeWhichRowIsCurrent"/>
+/// and <see cref="TheCensusIsOnePopulationAndItsPartsAddUp"/>.</item>
+/// <item>An absent or ERRORING collector answering "nothing to fix". Measured: 3 of 7 runs in a week errored
+/// on a live target, one on a 300-second client-side deadline that stored nothing. Guarded by
+/// <see cref="NoEvidenceIsNotTheSameAsNoIndexes"/>.</item>
+/// <item>Evidence read over the CALLER's window, which manufactures a verdict from the panel's own zoom
+/// level. Guarded by <see cref="TheEvidenceLookbackIsFixedRatherThanTakenFromTheCallersWindow"/>.</item>
+/// <item>The reason markers drifting from the prose the collector actually writes, which sends a whole
+/// bucket to <see cref="PgIndexBloatSuppression.Unrecognized"/> silently. Guarded by
+/// <see cref="EveryReasonMarkerStillAppearsInTheShippedCollectorQuery"/>.</item>
+/// <item>A verdict contradicting the row set printed beside it. Guarded by
+/// <see cref="NoVerdictContradictsTheRowSetPrintedBesideIt"/>, which enumerates input REGIONS rather than
+/// arms — reading branches finds a wrong assertion, only sweeping regions finds a missing one.</item>
+/// </list>
+/// </summary>
+public sealed class PgIndexBloatCoverageTests
+{
+    private const long Kib = 1024L;
+    private const long Mib = Kib * 1024L;
+    private const long Gib = Mib * 1024L;
+
+    private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+
+    private const string ReaderFile =
+        "Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs";
+
+    /// <summary>
+    /// The fleet's own suppression shape, 2026-09-10: 50 targets, 7,597 rows, 5,970 GB of index footprint.
+    /// Typed in the order the ISSUE reports them — by rows — deliberately, so a classifier that preserved
+    /// input order would fail <see cref="TheSuppressionBucketsAreRankedByBytesAndNeverByRows"/> rather than
+    /// pass it by accident.
+    /// </summary>
+    private static readonly PgIndexBloatSuppressionBucket[] FleetBuckets =
+    [
+        Bucket(PgIndexBloatSuppression.ColumnWidthsNotVisible, 2_954, 4_144 * Gib),
+        Bucket(PgIndexBloatSuppression.ParentNeverAnalyzed, 2_225, 22 * Mib),
+        Bucket(PgIndexBloatSuppression.NegativeBloat, 803, 211 * Gib),
+        Bucket(PgIndexBloatSuppression.Partial, 698, 1_385 * Gib),
+    ];
+
+    /// <summary>The fleet's trusted tally over the same capture: 917 indexes holding 229 GB, 3.84%.</summary>
+    private static readonly PgIndexBloatTally FleetTrusted = new(917, 229 * Gib);
+
+    private static readonly PgIndexBloatTally Nothing = default;
+
+    /// <summary>
+    /// Every arm, reached from the figures that produce it. Named cases rather than a loop so a failure says
+    /// which situation regressed.
+    /// </summary>
+    private static readonly (string Name, PgIndexBloatCoverageVerdict Verdict, PgIndexBloatCoverageArm Expected)[] s_cases =
+    {
+        ("collector recorded no succeeding run, nothing returned",
+            PgIndexBloatCoverage.Classify(
+                evidenceCollectorRan: false, Nothing, Nothing, [], 0),
+            PgIndexBloatCoverageArm.Undetermined),
+        ("collector recorded no succeeding run, rows returned anyway",
+            PgIndexBloatCoverage.Classify(false, FleetTrusted, Nothing, FleetBuckets, 1_000),
+            PgIndexBloatCoverageArm.Undetermined),
+        ("the evidence read itself failed",
+            PgIndexBloatCoverage.EvidenceUnreadable(0),
+            PgIndexBloatCoverageArm.Undetermined),
+        ("collector ran, server holds no btree index",
+            PgIndexBloatCoverage.Classify(true, Nothing, Nothing, [], 0),
+            PgIndexBloatCoverageArm.NoCandidates),
+        ("the fleet's pre-grant answer: candidates, not one trusted",
+            PgIndexBloatCoverage.Classify(true, Nothing, Nothing, FleetBuckets, 1_000),
+            PgIndexBloatCoverageArm.NothingTrusted),
+        ("the fleet as measured: 917 trusted of 7,597, 3.84% of the bytes",
+            PgIndexBloatCoverage.Classify(true, FleetTrusted, Nothing, FleetBuckets, 25),
+            PgIndexBloatCoverageArm.PartialCoverage),
+        ("every candidate index answered",
+            PgIndexBloatCoverage.Classify(true, FleetTrusted, Nothing, [], 25),
+            PgIndexBloatCoverageArm.FullyTrusted),
+        ("rows returned and the evidence window holds no candidate",
+            PgIndexBloatCoverage.Classify(true, Nothing, Nothing, [], 25),
+            PgIndexBloatCoverageArm.EvidenceStale),
+    };
+
+    /// <summary>R1: no outcome may arrive without an arm, and every arm must be reachable.</summary>
+    [Fact]
+    public void EveryOutcomeSelectsAnArm()
+    {
+        foreach (var (name, verdict, expected) in s_cases)
+        {
+            Assert.Equal(expected, verdict.Arm);
+            Assert.False(string.IsNullOrWhiteSpace(verdict.Cause), name + " produced no cause");
+            Assert.False(string.IsNullOrWhiteSpace(verdict.Census), name + " produced no census");
+        }
+
+        /* Both directions. A classifier collapsed to one arm would satisfy the loop above for whichever arm
+           survived, and an arm nothing can reach is a branch no test covers. */
+        Assert.Equal(
+            Enum.GetValues<PgIndexBloatCoverageArm>().OrderBy(a => a).ToArray(),
+            s_cases.Select(c => c.Verdict.Arm).Distinct().OrderBy(a => a).ToArray());
+    }
+
+    /// <summary>
+    /// R4, the requirement this issue turns on: the suppression buckets are ranked by BYTES, and the cause
+    /// names the byte-dominant one.
+    ///
+    /// <para>The fleet's figures are the input because the two rankings DISAGREE on them, which is what
+    /// makes this pin able to fail. A census reporting counts alone would point an operator at
+    /// <see cref="PgIndexBloatSuppression.ParentNeverAnalyzed"/> — second largest of five by rows, last by
+    /// footprint at 22 MB of 5,970 GB — and hide the 1,385 GB one.</para>
+    /// </summary>
+    [Fact]
+    public void TheSuppressionBucketsAreRankedByBytesAndNeverByRows()
+    {
+        var verdict = Case(PgIndexBloatCoverageArm.NothingTrusted);
+
+        Assert.Equal(
+            new[]
+            {
+                PgIndexBloatSuppression.ColumnWidthsNotVisible,
+                PgIndexBloatSuppression.Partial,
+                PgIndexBloatSuppression.NegativeBloat,
+                PgIndexBloatSuppression.ParentNeverAnalyzed,
+            },
+            verdict.Suppressed.Select(b => b.Reason).ToArray());
+
+        /* THE FALSIFIER. Without this the assertion above is satisfied by any stable ordering that happens
+           to agree on this input - and the whole claim is that ordering by rows gives a DIFFERENT answer.
+           If a later edit makes the two orderings agree, this pin stops being able to fail and says so. */
+        Assert.NotEqual(
+            FleetBuckets.OrderByDescending(b => b.IndexCount).Select(b => b.Reason).ToArray(),
+            verdict.Suppressed.Select(b => b.Reason).ToArray());
+
+        /* And the CAUSE names the byte-dominant bucket, not the row-dominant one. The remedy an operator
+           acts on is attached to that name, so getting it from the wrong ranking sends them at 22 MB. */
+        Assert.Contains(
+            PgIndexBloatCoverage.Label(PgIndexBloatSuppression.ColumnWidthsNotVisible),
+            verdict.Cause,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            PgIndexBloatCoverage.Label(PgIndexBloatSuppression.ParentNeverAnalyzed),
+            verdict.Cause,
+            StringComparison.Ordinal);
+
+        /* The byte-dominant bucket here is the remediable one, so its remedy - not a structural refusal -
+           is what the cause carries. */
+        Assert.Contains("GRANT pg_read_all_data", verdict.Cause, StringComparison.Ordinal);
+
+        /* PartialCoverage ranks them the same way. Two surfaces reading two orderings is the defect one
+           level up; two ARMS reading two orderings is the same defect one level down. */
+        Assert.Equal(
+            verdict.Suppressed.Select(b => b.Reason).ToArray(),
+            Case(PgIndexBloatCoverageArm.PartialCoverage).Suppressed.Select(b => b.Reason).ToArray());
+    }
+
+    /// <summary>
+    /// R4's other half: every count the census publishes carries its BYTES, and a non-zero byte figure never
+    /// renders as a zero.
+    ///
+    /// <para>The second clause is not pedantry. The fleet's buckets span 22 MB to 4,144 GB, so a census
+    /// fixed on one unit prints "0.0 GB" beside 2,225 indexes — which recreates, inside the fix, the exact
+    /// confusion between "none" and "a small amount" that the whole class exists to prevent.</para>
+    /// </summary>
+    [Fact]
+    public void EveryPublishedCountCarriesItsBytes()
+    {
+        var verdict = Case(PgIndexBloatCoverageArm.PartialCoverage);
+
+        /* Each bucket: its count AND its bytes, adjacent, so neither can be read without the other. */
+        foreach (var bucket in verdict.Suppressed)
+        {
+            Assert.Contains(
+                PgIndexBloatCoverage.Label(bucket.Reason) + " " + bucket.IndexCount.ToString("N0", Inv) + " / ",
+                verdict.Census,
+                StringComparison.Ordinal);
+        }
+
+        /* The two ends of the fleet's range, each in a unit that carries information. */
+        Assert.Contains("4,144.0 GB", verdict.Census, StringComparison.Ordinal);
+        Assert.Contains("22.0 MB", verdict.Census, StringComparison.Ordinal);
+
+        /* The population totals and both trusted halves, count and bytes - the expected strings BUILT from
+           the same constants the input is built from. Typing the sums by hand got both of them wrong on the
+           first pass (5,971 and 5,742 against a real 5,969 and 5,740), which is the reason a pin over a
+           derived figure should derive it rather than restate it. */
+        var suppressedCount = FleetBuckets.Sum(b => b.IndexCount);
+        var suppressedBytes = FleetBuckets.Sum(b => b.IndexBytes);
+
+        Assert.Contains(
+            Expect(FleetTrusted.IndexCount + suppressedCount, FleetTrusted.IndexBytes + suppressedBytes),
+            verdict.Census,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            Expect(FleetTrusted.IndexCount, FleetTrusted.IndexBytes),
+            verdict.Census,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            Expect(suppressedCount, suppressedBytes), verdict.Census, StringComparison.Ordinal);
+
+        /* And those really are the fleet's published figures, so the derivation above is anchored to the
+           measurement rather than to whatever the constants happen to say. */
+        Assert.Equal(7_597, FleetTrusted.IndexCount + suppressedCount);
+        Assert.Equal(6_680, suppressedCount);
+
+        /* THE BYTE-WEIGHTED SHARE, which is the figure the row share gets wrong: 917 of 7,597 reads as 12%
+           by rows and is 3.84% of the footprint. Both are asserted - the right one present and the wrong
+           one absent - because a census printing the row share would look like it had answered. */
+        Assert.Contains("3.84% of the candidate footprint", verdict.Census, StringComparison.Ordinal);
+        Assert.DoesNotContain("12.07%", verdict.Census, StringComparison.Ordinal);
+
+        /* And the returned row count is LABELLED as the page it is, beside figures that are not. */
+        Assert.Contains(
+            "Rows returned (over the window you asked for, and capped by your row limit): 25.",
+            verdict.Census,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// R7: the census is ONE population and its parts add up — the candidate total is derived from the
+    /// trusted tallies and the buckets rather than separately queried, so it cannot disagree with the
+    /// breakdown printed to explain it.
+    /// </summary>
+    [Fact]
+    public void TheCensusIsOnePopulationAndItsPartsAddUp()
+    {
+        var verdict = Case(PgIndexBloatCoverageArm.PartialCoverage);
+
+        var suppressedCount = verdict.Suppressed.Sum(b => b.IndexCount);
+        var suppressedBytes = verdict.Suppressed.Sum(b => b.IndexBytes);
+
+        Assert.Equal(verdict.Trusted.IndexCount + suppressedCount, verdict.Candidates.IndexCount);
+        Assert.Equal(verdict.Trusted.IndexBytes + suppressedBytes, verdict.Candidates.IndexBytes);
+
+        /* Trusted is itself derived from its two halves, so a surface cannot print a trusted total that
+           differs from the estimated/measured split beside it. */
+        Assert.Equal(
+            verdict.Estimated.IndexCount + verdict.ExactlyMeasured.IndexCount,
+            verdict.Trusted.IndexCount);
+        Assert.Equal(
+            verdict.Estimated.IndexBytes + verdict.ExactlyMeasured.IndexBytes,
+            verdict.Trusted.IndexBytes);
+
+        /* And the fleet's own numbers arrive intact rather than being reduced to a ratio somewhere. */
+        Assert.Equal(7_597, verdict.Candidates.IndexCount);
+        Assert.Equal(917, verdict.Trusted.IndexCount);
+
+        /* Merging is by KEY, so two stored prose strings mapping to one bucket become ONE entry. Two
+           entries under one key would let a reader add a bucket to itself. */
+        var merged = PgIndexBloatCoverage.Classify(
+            true,
+            Nothing,
+            Nothing,
+            [
+                Bucket(PgIndexBloatSuppression.Partial, 10, 10 * Gib),
+                Bucket(PgIndexBloatSuppression.Partial, 5, 5 * Gib),
+            ],
+            0);
+
+        var single = Assert.Single(merged.Suppressed);
+        Assert.Equal(15, single.IndexCount);
+        Assert.Equal(15 * Gib, single.IndexBytes);
+    }
+
+    /// <summary>
+    /// R5: <c>skipped_reason IS NULL</c> is the only trust predicate, at every layer that could substitute
+    /// another one.
+    ///
+    /// <para>This is incident four's guard. <c>est_tuple_bytes</c> is populated on 100% of answerless rows
+    /// in every bucket — 2954/2954, 2225/2225, 803/803, 698/698 — while <c>est_bloat_pct</c> and
+    /// <c>est_reclaimable_bytes</c> are populated on 0% of them. So a census keyed on the intermediate would
+    /// count every row as covered and print complete coverage over a population with 3.84%.</para>
+    /// </summary>
+    [Fact]
+    public void TheOnlyTrustPredicateIsTheAbsenceOfAReason()
+    {
+        var census = DarlingPgIndexBloatReader.CoverageEvidenceSql;
+
+        /* The two CONCLUSION columns appear nowhere in the census. Their absence is the property: a query
+           that does not read them cannot be keyed on them. */
+        Assert.DoesNotContain("est_bloat_pct", census, StringComparison.Ordinal);
+        Assert.DoesNotContain("est_reclaimable_bytes", census, StringComparison.Ordinal);
+
+        /* The grouping key IS the reason, so trusted and suppressed are separated by the reason and by
+           nothing else. */
+        Assert.Contains("GROUP BY latest.skipped_reason", census, StringComparison.Ordinal);
+
+        /* est_tuple_bytes appears only as the PROVENANCE test, never as a filter deciding whether a row
+           counts. A WHERE or FILTER on it would be the substitution this pin exists to catch. */
+        Assert.Contains("est_tuple_bytes IS NOT NULL", census, StringComparison.Ordinal);
+        Assert.DoesNotContain("WHERE est_tuple_bytes", census, StringComparison.Ordinal);
+        Assert.DoesNotContain("FILTER (WHERE latest.est_tuple_bytes", census, StringComparison.Ordinal);
+
+        /* AND THE MAPPING ASKS THE REASON FIRST. The reader turns census groups into tallies, and that is
+           the one place the two could be transposed: every suppressed group's est_tuple_bytes is non-null,
+           so a mapping that split on provenance BEFORE testing the reason would file 6,680 answerless
+           indexes as estimates and publish them as coverage. Source order is the only thing that notices,
+           because both orderings compile and both return a plausible number. */
+        var mapping = CSharpSourceWalker.StripCommentsAndStrings(
+            MemberBody(ReaderFile, "GetCoverageVerdictAsync"));
+
+        var reasonTest = mapping.IndexOf("group.SkippedReason is null", StringComparison.Ordinal);
+        var provenance = mapping.IndexOf("group.IsEstimate", StringComparison.Ordinal);
+
+        Assert.True(reasonTest > 0, "the reader no longer tests the reason when mapping census groups");
+        Assert.True(provenance > 0, "the reader no longer splits trusted groups by provenance");
+        Assert.True(
+            reasonTest < provenance,
+            "the census mapping splits on provenance BEFORE asking whether the group has an answer at all, "
+            + "which files every suppressed bucket as an estimate");
+    }
+
+    /// <summary>
+    /// R6 and R7: the census and the row read agree which of an index's rows is current, and both reduce the
+    /// window to ONE row per index.
+    ///
+    /// <para>Two distinct failures, one pin. If the tie-breaks differed the census would publish a trusted
+    /// count the grid contradicts index by index. And without <c>DISTINCT ON</c> the census would count every
+    /// index once per cycle — this collector writes every btree on every run — reporting twice the population
+    /// and twice the footprint, which is wrong in the direction that flatters coverage.</para>
+    /// </summary>
+    [Fact]
+    public void TheCensusAndTheRowReadAgreeWhichRowIsCurrent()
+    {
+        const string TieBreak = "(skipped_reason IS NULL) DESC, collection_time DESC";
+        const string Identity = "DISTINCT ON (database_name, schema_name, table_name, index_name)";
+
+        foreach (var (name, sql) in new[]
+        {
+            ("the row read", DarlingPgIndexBloatReader.PgIndexBloatSql),
+            ("the coverage census", DarlingPgIndexBloatReader.CoverageEvidenceSql),
+        })
+        {
+            Assert.Contains(TieBreak, sql);
+            Assert.Contains(Identity, sql);
+            Assert.False(string.IsNullOrWhiteSpace(name));
+        }
+    }
+
+    /// <summary>
+    /// R8: no evidence is not the same as no indexes, and an ERRORING collector must not answer "nothing to
+    /// fix".
+    ///
+    /// <para>The pair the live store confirms. Measured on an Aurora target at 2026-09-10, this collector
+    /// recorded 7 runs in seven days and 3 of them ERRORED — one a 300-second client-side command deadline
+    /// that stored nothing at all. So the failing-run case is not hypothetical here, and an unfiltered run
+    /// probe would report "it ran" over zero rows and take the innocent arm.</para>
+    /// </summary>
+    [Fact]
+    public void NoEvidenceIsNotTheSameAsNoIndexes()
+    {
+        var measured = PgIndexBloatCoverage.Classify(true, Nothing, Nothing, [], 0);
+        var unmeasured = PgIndexBloatCoverage.Classify(false, Nothing, Nothing, [], 0);
+
+        Assert.Equal(PgIndexBloatCoverageArm.NoCandidates, measured.Arm);
+        Assert.Equal(PgIndexBloatCoverageArm.Undetermined, unmeasured.Arm);
+        Assert.NotEqual(measured.Cause, unmeasured.Cause);
+
+        /* A measured zero prints as a FIGURE; an unmeasured one prints as a WORD. Rendering both as 0 is how
+           "we looked and there is nothing" became indistinguishable from "we never looked". */
+        var label = "independently of your row limit): ";
+
+        Assert.Contains(label + "0 holding 0 B", measured.Census, StringComparison.Ordinal);
+        Assert.DoesNotContain(PgIndexBloatCoverage.NotMeasured, measured.Census, StringComparison.Ordinal);
+        Assert.Contains(
+            label + PgIndexBloatCoverage.NotMeasured, unmeasured.Census, StringComparison.Ordinal);
+
+        /* A THIRD token, and it is not decoration. The byte-weighted share is 0 of 0 bytes on the measured
+           arm - undefined arithmetic over a real measurement - and the first draft printed NotMeasured
+           there, which put the no-evidence word on the one arm that HAS evidence and defeated the
+           assertion above. Failing toward "we did not look" is the wrong direction even for a ratio. */
+        Assert.Contains(PgIndexBloatCoverage.NotApplicable, measured.Census, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            PgIndexBloatCoverage.NotApplicable, unmeasured.Census, StringComparison.Ordinal);
+        Assert.NotEqual(PgIndexBloatCoverage.NotApplicable, PgIndexBloatCoverage.NotMeasured);
+
+        /* The Undetermined arm must not smuggle a verdict in, and must name the erroring-collector case as
+           one of the things it refuses to distinguish. */
+        Assert.Contains("cannot be established", unmeasured.Cause, StringComparison.Ordinal);
+        Assert.DoesNotContain("nothing to fix", unmeasured.Cause, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("erroring on every", unmeasured.Cause, StringComparison.Ordinal);
+
+        /* And the RUN PROBE counts only runs that SUCCEEDED - asserted against the SHARED status list, not
+           a retyped copy, so the bar for "valid evidence" is the one the freshness reads and the self-alert
+           evaluator apply and a status added there reaches this probe. */
+        var census = DarlingPgIndexBloatReader.CoverageEvidenceSql;
+
+        Assert.Contains("FROM collection_log", census, StringComparison.Ordinal);
+        Assert.Contains("collector_name = 'pg_index_bloat'", census, StringComparison.Ordinal);
+        Assert.Contains("FROM pg_index_bloat", census, StringComparison.Ordinal);
+        Assert.Contains("AND   status IN (", census, StringComparison.Ordinal);
+
+        foreach (var status in EnumeratedCollectorDriver.FreshnessSuccessStatuses)
+        {
+            Assert.Contains("'" + status + "'", census, StringComparison.Ordinal);
+        }
+
+        /* The probe is a single-row relation the groups hang off, which is what lets a server whose
+           collector ran and stored NOTHING still report that it ran. An inner join would drop exactly the
+           row separating NoCandidates from Undetermined. */
+        Assert.Contains("LEFT JOIN grouped ON true", census, StringComparison.Ordinal);
+
+        /* The two Undetermined situations are deliberately NOT one sentence: "this collector does not run
+           here" is the design working on a replica, and "the store read failed" is a monitoring fault. */
+        Assert.NotEqual(
+            unmeasured.Cause,
+            PgIndexBloatCoverage.EvidenceUnreadable(0).Cause);
+    }
+
+    /// <summary>
+    /// R9: the evidence lookback is a FIXED span ending where the read ends, not the caller's window — and
+    /// the label the census prints is that same figure.
+    /// </summary>
+    [Fact]
+    public void TheEvidenceLookbackIsFixedRatherThanTakenFromTheCallersWindow()
+    {
+        var end = new DateTime(2026, 9, 10, 20, 0, 0, DateTimeKind.Utc);
+        var hours = PgIndexBloatCoverage.EvidenceHours;
+
+        Assert.Equal(end.AddHours(-hours), DarlingPgIndexBloatReader.EvidenceStart(end));
+
+        /* Anchored on the END, so an as_of read gets evidence contemporary with the data it explains. */
+        var earlier = end.AddDays(-10);
+        Assert.Equal(earlier.AddHours(-hours), DarlingPgIndexBloatReader.EvidenceStart(earlier));
+
+        /* MORE than one of the subject collector's cadences, which is the whole derivation. pg_index_bloat
+           runs every 1440 minutes, so a lookback of exactly one cadence straddles zero or one run and a
+           single lost cycle manufactures Undetermined - measured, 3 of 7 runs errored in a week on one
+           live target. Two cadences is the smallest span that survives one lost cycle. */
+        Assert.True(
+            hours > 24,
+            $"the evidence lookback is {hours}h, which is one of pg_index_bloat's own 1440-minute cadences "
+            + "or less - a single lost cycle then reads as no evidence");
+        Assert.True(
+            hours >= 48,
+            $"the evidence lookback is {hours}h, shorter than two of this collector's cadences");
+
+        /* AND THE LABEL DESCRIBES THE SPAN THE QUERY USED. They are one figure by construction, and "by
+           construction" is what a retyped literal quietly ends - this label is the only thing telling a
+           reader that the population figures and the returned row count span different intervals, which is
+           what makes EvidenceStale intelligible rather than a contradiction. */
+        Assert.Contains(
+            hours.ToString(Inv) + "h",
+            PgIndexBloatCoverage.EvidenceHoursDescription,
+            StringComparison.Ordinal);
+
+        foreach (var (name, verdict, _) in s_cases)
+        {
+            Assert.Contains(
+                PgIndexBloatCoverage.EvidenceHoursDescription,
+                verdict.Census,
+                StringComparison.Ordinal);
+            Assert.False(string.IsNullOrWhiteSpace(name));
+        }
+
+        /* AND THE VERDICT READ ACTUALLY APPLIES IT. Everything above tests a pure function; deleting the
+           one call that applies it leaves every assertion here green, which is the seam this defect class
+           keeps arriving through - a correct mechanism nothing reaches. */
+        var verdictRead = CSharpSourceWalker.StripCommentsAndStrings(
+            MemberBody(ReaderFile, "GetCoverageVerdictAsync"));
+
+        Assert.Contains("EvidenceStart(endUtc)", verdictRead, StringComparison.Ordinal);
+
+        /* And it does not ACCEPT a window start it would then ignore. The SIGNATURE is the guard, not the
+           body: a parameter passed and dropped is worse than an absent one, because the caller believes its
+           window was honoured and neither the compiler nor the answer says otherwise. Scoped to the
+           declaration so the ROW read's own startUtc - which it does use - is out of scope by
+           construction. */
+        var verdictSignature = MemberSignature(ReaderFile, "GetCoverageVerdictAsync");
+
+        Assert.DoesNotContain("startUtc", verdictSignature, StringComparison.Ordinal);
+        Assert.Contains("DateTime endUtc", verdictSignature, StringComparison.Ordinal);
+
+        /* The raw-groups reader is the opposite case and stays that way: it takes both ends BECAUSE it uses
+           both, and it is what a caller wanting its own span reaches for. Asserting it keeps the narrowing
+           above from being read as "windows are not a thing here". */
+        var evidenceSignature = MemberSignature(ReaderFile, "GetCoverageEvidenceAsync");
+
+        Assert.Contains("DateTime startUtc", evidenceSignature, StringComparison.Ordinal);
+        Assert.Contains("DateTime endUtc", evidenceSignature, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// R10: the reason markers still match the prose the collector actually writes.
+    ///
+    /// <para>Read from the SHIPPED query rather than from a retyped copy. A marker that has drifted sends
+    /// every row of its bucket to <see cref="PgIndexBloatSuppression.Unrecognized"/> — which fails toward
+    /// "we cannot attribute this" rather than toward a wrong remedy, deliberately, and is still a whole
+    /// bucket losing its name with nothing that complains.</para>
+    /// </summary>
+    [Fact]
+    public void EveryReasonMarkerStillAppearsInTheShippedCollectorQuery()
+    {
+        var collectorSql = PgIndexBloatCollector.Instance.BuildQuery(new CollectorContext
+        {
+            ServerId = 1,
+            ServerName = "server",
+            CollectionTime = DateTime.UtcNow,
+            Deltas = null!,
+        }).Text;
+
+        foreach (var (marker, reason) in PgIndexBloatCoverage.Markers)
+        {
+            Assert.Contains(marker, collectorSql, StringComparison.OrdinalIgnoreCase);
+            Assert.NotEqual(PgIndexBloatSuppression.Unrecognized, reason);
+        }
+
+        /* Every named bucket HAS a marker, derived from the enum rather than from a list somebody remembered
+           to extend - a seventh reason added to the collector with no marker here would arrive as
+           Unrecognized on live data and pass every assertion above. */
+        Assert.Equal(
+            Enum.GetValues<PgIndexBloatSuppression>()
+                .Where(r => r != PgIndexBloatSuppression.Unrecognized)
+                .OrderBy(r => r)
+                .ToArray(),
+            PgIndexBloatCoverage.Markers.Select(m => m.Reason).Distinct().OrderBy(r => r).ToArray());
+
+        /* Sorted longest-first BY CONSTRUCTION, so a marker that is also the start of another cannot decide
+           the match by declaration accident. */
+        var lengths = PgIndexBloatCoverage.Markers.Select(m => m.Marker.Length).ToArray();
+
+        Assert.Equal(lengths.OrderByDescending(l => l).ToArray(), lengths);
+
+        /* Each marker actually selects its own bucket off the FULL stored prose, not merely off itself. */
+        Assert.Equal(
+            PgIndexBloatSuppression.ColumnWidthsNotVisible,
+            PgIndexBloatCoverage.Bucket(
+                "column widths are not visible for every key: pg_stats filters on has_column_privilege, so "
+                + "a monitoring role without SELECT sees nothing"));
+        Assert.Equal(
+            PgIndexBloatSuppression.Partial,
+            PgIndexBloatCoverage.Bucket("partial index: the model scales the parent reltuples"));
+
+        /* And unknown prose does NOT take a named bucket - it fails toward "we do not know which", which is
+           the direction that keeps its bytes in the suppressed total rather than attaching a wrong remedy
+           to them. */
+        Assert.Equal(
+            PgIndexBloatSuppression.Unrecognized,
+            PgIndexBloatCoverage.Bucket("a reason some later collector writes"));
+        Assert.Equal(PgIndexBloatSuppression.Unrecognized, PgIndexBloatCoverage.Bucket(null));
+        Assert.Equal(PgIndexBloatSuppression.Unrecognized, PgIndexBloatCoverage.Bucket("   "));
+
+        /* Unrecognized is the enum's DEFAULT, so a bucket nobody set lands on "we do not know which"
+           instead of on a named cause with a remedy attached. */
+        Assert.Equal(PgIndexBloatSuppression.Unrecognized, default(PgIndexBloatSuppression));
+
+        /* Every reason has a remedy and a label, and no two share either - the remedy is what an operator
+           acts on, so two buckets rendering the same one is a bucket that cannot be acted on correctly. */
+        var reasons = Enum.GetValues<PgIndexBloatSuppression>();
+
+        Assert.Equal(
+            reasons.Length,
+            reasons.Select(PgIndexBloatCoverage.Remedy).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(
+            reasons.Length,
+            reasons.Select(PgIndexBloatCoverage.Label).Distinct(StringComparer.Ordinal).Count());
+
+        /* The remediable and the structural say which they are, because that decides whether an operator
+           has anything to do at all. */
+        Assert.Contains(
+            "GRANT pg_read_all_data",
+            PgIndexBloatCoverage.Remedy(PgIndexBloatSuppression.ColumnWidthsNotVisible),
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ANALYZE",
+            PgIndexBloatCoverage.Remedy(PgIndexBloatSuppression.ParentNeverAnalyzed),
+            StringComparison.Ordinal);
+
+        foreach (var structural in new[]
+        {
+            PgIndexBloatSuppression.Partial,
+            PgIndexBloatSuppression.NegativeBloat,
+            PgIndexBloatSuppression.NameTypedKey,
+        })
+        {
+            var remedy = PgIndexBloatCoverage.Remedy(structural);
+
+            Assert.Contains("STRUCTURAL", remedy, StringComparison.Ordinal);
+            Assert.DoesNotContain("GRANT", remedy, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// R3: different arm, different verdict — over DIFFERING arms rather than over every case, because two
+    /// inputs reaching the same arm are REQUIRED to render the same cause.
+    /// </summary>
+    [Fact]
+    public void NoTwoDifferentArmsRenderTheSameCause()
+    {
+        var collisions =
+            (from a in s_cases
+             from b in s_cases
+             where a.Verdict.Arm != b.Verdict.Arm
+             && string.Equals(a.Verdict.Cause, b.Verdict.Cause, StringComparison.Ordinal)
+             select a.Name + " reads the same as " + b.Name).ToList();
+
+        Assert.Empty(collisions);
+
+        /* Two inputs differing only in their FIGURES reach the same arm and must render the same cause -
+           otherwise the text is a function of the numbers rather than of the verdict. */
+        Assert.Equal(
+            PgIndexBloatCoverage.Classify(true, new PgIndexBloatTally(1, Gib), Nothing, FleetBuckets, 25).Cause,
+            PgIndexBloatCoverage.Classify(true, FleetTrusted, Nothing, FleetBuckets, 1_000).Cause);
+    }
+
+    /// <summary>
+    /// R3's falsifier. Without this, <see cref="NoTwoDifferentArmsRenderTheSameCause"/> is satisfied by a
+    /// classifier that had stopped selecting anything and merely echoed its inputs — the arms can never hold
+    /// identical figures, so their composed messages differ whatever the verdict says.
+    ///
+    /// <para>Every arm, not one: a probe set that reached only some of them would make "no arm echoes its
+    /// inputs" a claim about however many this list happens to visit.</para>
+    /// </summary>
+    [Fact]
+    public void TheCauseCarriesNoneOfTheInputFigures()
+    {
+        var loud = new PgIndexBloatTally(424_242, 777 * Gib);
+        var quieter = new PgIndexBloatTally(31_337, 555 * Mib);
+        var buckets = new[] { Bucket(PgIndexBloatSuppression.Partial, 90_210, 333 * Gib) };
+
+        var probes = new[]
+        {
+            PgIndexBloatCoverage.Classify(false, loud, quieter, buckets, 8_675_309),
+            PgIndexBloatCoverage.Classify(true, Nothing, Nothing, [], 0),
+            PgIndexBloatCoverage.Classify(true, Nothing, Nothing, buckets, 8_675_309),
+            PgIndexBloatCoverage.Classify(true, loud, quieter, buckets, 8_675_309),
+            PgIndexBloatCoverage.Classify(true, loud, quieter, [], 8_675_309),
+            PgIndexBloatCoverage.Classify(true, Nothing, Nothing, [], 8_675_309),
+            PgIndexBloatCoverage.EvidenceUnreadable(8_675_309),
+        };
+
+        /* And the probe set really does visit every arm. */
+        Assert.Equal(
+            Enum.GetValues<PgIndexBloatCoverageArm>().OrderBy(a => a).ToArray(),
+            probes.Select(p => p.Arm).Distinct().OrderBy(a => a).ToArray());
+
+        var figures = new[]
+        {
+            "424242", "424,242", "31337", "31,337", "90210", "90,210", "8675309", "8,675,309",
+            "777.0 GB", "555.0 MB", "333.0 GB",
+        };
+
+        foreach (var probe in probes)
+        {
+            foreach (var figure in figures)
+            {
+                Assert.DoesNotContain(figure, probe.Cause, StringComparison.Ordinal);
+            }
+        }
+
+        /* And the figures are not merely absent from the cause - they are PRESENT in the census, or every
+           check above is satisfied by a class that had stopped reporting them at all. */
+        var populated = probes[3].Census;
+
+        foreach (var figure in new[]
+            { "424,242", "31,337", "90,210", "8,675,309", "777.0 GB", "555.0 MB", "333.0 GB" })
+        {
+            Assert.Contains(figure, populated, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// R2 and R3: both surfaces print the SHARED verdict, and neither builds one of its own.
+    ///
+    /// <para>The MCP tool and the WPF panel answer the same question for the same operator, so a fix applied
+    /// to one of them is this defect class's usual shape. Scanning for the shared call is what makes "they
+    /// cannot disagree" a property rather than a hope.</para>
+    /// </summary>
+    [Fact]
+    public void BothSurfacesPrintTheSharedVerdict()
+    {
+        foreach (var (file, member, accessor) in Surfaces)
+        {
+            /* CODE only. A design comment saying "this calls the shared classifier" would satisfy a raw
+               scan while the call itself had been removed - correct narration over absent behaviour. */
+            var code = CSharpSourceWalker.StripCommentsAndStrings(MemberBody(file, member));
+
+            Assert.Contains(accessor, code, StringComparison.Ordinal);
+            Assert.Contains("coverage.Message", code, StringComparison.Ordinal);
+
+            /* And neither surface may build a verdict of its own. Calling the accessor is only half the
+               claim: a body that called it and then overwrote the result would pass the line above. */
+            Assert.DoesNotContain("new PgIndexBloatCoverageVerdict", code, StringComparison.Ordinal);
+
+            /* Nor may it re-rank the buckets. The classifier orders them by bytes; a surface applying its
+               own OrderBy is how one operator gets two "largest cause" answers from one store. */
+            Assert.DoesNotContain("Suppressed.OrderBy", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("Suppressed.OrderByDescending", code, StringComparison.Ordinal);
+        }
+
+        /* The viewer reaches the classifier through its data service, so the CHAIN is what the property is
+           about - pinning the panel's call alone would leave a passthrough free to author its own answer. */
+        var passthrough = CSharpSourceWalker.StripCommentsAndStrings(MemberBody(
+            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs",
+            "GetPgIndexBloatCoverageAsync"));
+
+        Assert.Contains(
+            "DarlingPgIndexBloatReader.GetCoverageVerdictAsync", passthrough, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// R2 at the surface. The census has to ride the POPULATED branch as well, or a truncated page is
+    /// explained only in the one case where nobody needs the explanation — and the truncated page is the
+    /// whole defect. Asserted by counting the prints: one branch printing it twice would satisfy a presence
+    /// check.
+    /// </summary>
+    [Fact]
+    public void BothSurfacesPrintTheVerdictOnThePopulatedPathToo()
+    {
+        foreach (var (file, member, _) in Surfaces)
+        {
+            var code = CSharpSourceWalker.StripCommentsAndStrings(MemberBody(file, member));
+            var prints = code.Split("coverage.Message", StringSplitOptions.None).Length - 1;
+
+            Assert.True(
+                prints >= 2,
+                $"{member} prints the coverage census {prints} time(s); it has to reach the empty result AND "
+                + "the populated one, or a page of answerless rows is only ever explained when it is empty");
+        }
+    }
+
+    /// <summary>
+    /// The three miss answers are asked in <c>CollectorRuntimePrecondition</c>'s documented order —
+    /// capability, then precondition, then this read's own miss — and the coverage census is not queried
+    /// ahead of the branch that might not need it.
+    ///
+    /// <para>The cost is the visible half: a server that cannot have this surface at all, or whose collector
+    /// recorded a denial, would pay for a census the chain then discards. The half worth guarding is the
+    /// other one: computing the LAST of three ranked answers FIRST is how somebody later reorders the chain
+    /// and does not notice they have changed which one wins. A source-order assertion is the only thing that
+    /// notices, because every ordering compiles and every ordering returns a plausible answer.</para>
+    /// </summary>
+    [Fact]
+    public void TheMissAnswersAreAskedInTheirDocumentedPrecedenceOrder()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(MemberBody(
+            "Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs",
+            "GetPgIndexBloat"));
+
+        var branch = code.IndexOf("rows.Count == 0", StringComparison.Ordinal);
+        var capability = code.IndexOf("NotCollectedStatusAsync", StringComparison.Ordinal);
+        var precondition = code.IndexOf("DarlingRuntimePrecondition.StatusAsync", StringComparison.Ordinal);
+        var coverage = code.IndexOf("GetCoverageVerdictAsync", StringComparison.Ordinal);
+
+        Assert.True(branch > 0, "the empty-result branch is gone");
+        Assert.True(capability > 0, "the capability answer is gone");
+        Assert.True(precondition > 0, "the precondition answer is gone");
+        Assert.True(coverage > 0, "the coverage answer is gone");
+
+        Assert.True(
+            branch < coverage,
+            "the coverage census is queried BEFORE the branch that decides whether anything needs it");
+        Assert.True(
+            capability < precondition,
+            "a precondition is answered ahead of a permanent engine gap, which #2511 closed");
+        Assert.True(
+            precondition < coverage,
+            "the coverage verdict is computed ahead of the precondition that outranks it");
+    }
+
+    /// <summary>
+    /// The invariant, swept over the whole input space: <b>the verdict never contradicts the row set printed
+    /// beside it.</b>
+    ///
+    /// <para>This enumerates input REGIONS where the arm cases above enumerate ARMS, and that is the
+    /// difference between finding a wrong assertion and finding a missing one. The population figures and
+    /// the returned row count are measured over different spans — a fixed
+    /// <see cref="PgIndexBloatCoverage.EvidenceHours"/> lookback against the caller's own window — so zero
+    /// candidates beside a non-empty result is reachable, and it is the combination that took the innocent
+    /// arm one collector over.</para>
+    ///
+    /// <para>Two directions, because the contradiction has two: a non-empty result must never be told there
+    /// is nothing here, and an empty one must never be told coverage is whole or partial — partial coverage
+    /// of nothing is not something an operator can act on.</para>
+    /// </summary>
+    [Fact]
+    public void NoVerdictContradictsTheRowSetPrintedBesideIt()
+    {
+        var seen = new HashSet<PgIndexBloatCoverageArm>();
+        var regions = 0;
+
+        foreach (var ran in new[] { false, true })
+        foreach (var trusted in new[] { 0L, 1L, 917L })
+        foreach (var suppressed in new[] { 0L, 1L, 6_680L })
+        foreach (var returned in new[] { 0, 1, 25, 1_000 })
+        {
+            regions++;
+
+            var verdict = PgIndexBloatCoverage.Classify(
+                ran,
+                new PgIndexBloatTally(trusted, trusted * Gib),
+                Nothing,
+                suppressed == 0
+                    ? []
+                    : [Bucket(PgIndexBloatSuppression.ColumnWidthsNotVisible, suppressed, suppressed * Gib)],
+                returned);
+
+            seen.Add(verdict.Arm);
+
+            var inputs = $"ran={ran} trusted={trusted} suppressed={suppressed} returned={returned} "
+                + $"-> {verdict.Arm}";
+
+            Assert.False(string.IsNullOrWhiteSpace(verdict.Cause), "unclassified region: " + inputs);
+            Assert.False(string.IsNullOrWhiteSpace(verdict.Census), "censusless region: " + inputs);
+
+            /* The census figures always agree with the verdict's own tallies, whatever the arm - a census
+               computed off different numbers than the arm was decided from is the contradiction this whole
+               class is about, arriving inside the fix. */
+            Assert.Equal(
+                verdict.Trusted.IndexCount + verdict.Suppressed.Sum(b => b.IndexCount),
+                verdict.Candidates.IndexCount);
+
+            if (returned > 0)
+            {
+                Assert.NotEqual(PgIndexBloatCoverageArm.NoCandidates, verdict.Arm);
+                Assert.DoesNotContain("Nothing to fix", verdict.Cause, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("NO CANDIDATES", verdict.Cause, StringComparison.Ordinal);
+            }
+
+            if (trusted > 0 && ran)
+            {
+                /* Coverage exists, so no arm may claim there is none. */
+                Assert.NotEqual(PgIndexBloatCoverageArm.NothingTrusted, verdict.Arm);
+                Assert.DoesNotContain("NO COVERAGE AT ALL", verdict.Cause, StringComparison.Ordinal);
+            }
+
+            if (suppressed > 0 && ran)
+            {
+                /* Something is withheld, so no arm may claim the ranking describes the whole server. */
+                Assert.NotEqual(PgIndexBloatCoverageArm.FullyTrusted, verdict.Arm);
+                Assert.DoesNotContain("FULL COVERAGE", verdict.Cause, StringComparison.Ordinal);
+            }
+
+            if (!ran)
+            {
+                /* An unmeasured region publishes no population figure at all - not a zero, and not the
+                   figures it was handed. Failing toward "we do not know" is the direction that costs least
+                   when it is wrong. */
+                Assert.Equal(PgIndexBloatCoverageArm.Undetermined, verdict.Arm);
+                Assert.Equal(default, verdict.Candidates);
+                Assert.Empty(verdict.Suppressed);
+                Assert.Contains(
+                    PgIndexBloatCoverage.NotMeasured, verdict.Census, StringComparison.Ordinal);
+            }
+        }
+
+        /* The sweep is only worth its assertions if it reaches everything. Both halves: enough regions to be
+           a sweep, and every arm visited - an arm the sweep cannot reach is an arm this invariant says
+           nothing about. */
+        Assert.True(regions >= 60, $"the sweep covered only {regions} region(s)");
+        Assert.Equal(
+            Enum.GetValues<PgIndexBloatCoverageArm>().OrderBy(a => a).ToArray(),
+            seen.OrderBy(a => a).ToArray());
+    }
+
+    /// <summary>
+    /// How the census renders one count-and-bytes pair, built from the figures rather than typed out. A
+    /// literal expectation for a DERIVED figure is a second calculation, and the second one is the one that
+    /// is wrong.
+    /// </summary>
+    private static string Expect(long count, long bytes) =>
+        count.ToString("N0", Inv) + " holding "
+        + (bytes / (double)Gib).ToString("N1", Inv) + " GB";
+
+    private static PgIndexBloatSuppressionBucket Bucket(
+        PgIndexBloatSuppression reason, long count, long bytes) =>
+        new(reason, count, bytes, "stored prose for " + reason);
+
+    private static PgIndexBloatCoverageVerdict Case(PgIndexBloatCoverageArm arm) =>
+        s_cases.First(c => c.Verdict.Arm == arm).Verdict;
+
+    /// <summary>
+    /// The two surfaces that report this collector's coverage to a person, the member on each that does it,
+    /// and the accessor that member has to obtain the verdict FROM.
+    ///
+    /// <para>The accessor differs per surface and that is not incidental: the MCP tool calls the store reader
+    /// directly while the panel goes through the viewer's data service, and asserting one name for both would
+    /// have to be the looser of the two to pass.</para>
+    /// </summary>
+    private static IEnumerable<(string File, string Member, string Accessor)> Surfaces =>
+    [
+        ("Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs",
+            "GetPgIndexBloat", "DarlingPgIndexBloatReader.GetCoverageVerdictAsync"),
+        ("Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs",
+            "LoadPgIndexBloatAsync", "_dataService.GetPgIndexBloatCoverageAsync"),
+    ];
+
+    /// <summary>
+    /// One member's brace-balanced body, verbatim. Callers narrow it themselves — the call-presence scans
+    /// strip comments and literals — because a single pre-stripped form would answer the wrong question
+    /// against the wrong half of the text.
+    /// </summary>
+    private static string MemberBody(string relativePath, string member)
+    {
+        var source = ReadSource(relativePath);
+
+        /* The signature is located on a comment-and-string-stripped copy so a mention of the member name
+           inside a doc comment cannot be mistaken for its declaration; the OFFSETS are then used against
+           the original text, which the walker guarantees are the same because it replaces rather than
+           removes.
+
+           The DECLARATION, not the first occurrence: the viewer CALLS LoadPgIndexBloatAsync from the
+           storage-tab loader above declaring it, so a first-match scan lands on the call site,
+           brace-balances the WRONG method and reports whatever that one happens to contain. Every
+           occurrence is classified and exactly one must be a declaration, so a rename or an added overload
+           fails loudly rather than silently re-aiming. */
+        var stripped = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var declarations = Declarations(stripped, member).ToList();
+
+        var at = Assert.Single(declarations);
+        var open = stripped.IndexOf('{', at);
+        var semicolon = stripped.IndexOf(';', at);
+
+        Assert.True(open > at || semicolon > at, $"{member} in {relativePath} has no body of either shape");
+
+        /* Expression-bodied members are in scope rather than an exception to skip: the viewer's data-service
+           passthrough is one, and it is the middle link of the chain this asserts. Whichever terminator
+           comes first decides the shape - a `;` before any `{` is `=> expression;`, and reaching for the
+           brace regardless would balance the NEXT member's block. */
+        if (semicolon > at && (open < 0 || semicolon < open))
+        {
+            return source[at..(semicolon + 1)];
+        }
+
+        var extent = CSharpSourceWalker.BraceBalanced(stripped, open).Length;
+
+        return source[open..(open + extent)];
+    }
+
+    /// <summary>
+    /// Offsets in <paramref name="stripped"/> where <paramref name="member"/> is DECLARED rather than
+    /// called. A declaration carries an access modifier ahead of it within its own statement; a call site
+    /// carries <c>await</c>, a receiver, or nothing at all.
+    /// </summary>
+    private static IEnumerable<int> Declarations(string stripped, string member)
+    {
+        for (var at = stripped.IndexOf(member + "(", StringComparison.Ordinal);
+             at >= 0;
+             at = stripped.IndexOf(member + "(", at + 1, StringComparison.Ordinal))
+        {
+            var statementStart = stripped.LastIndexOfAny([';', '{', '}'], at) + 1;
+            var head = stripped[statementStart..at];
+
+            if (head.Contains(" private ", StringComparison.Ordinal)
+                || head.Contains(" public ", StringComparison.Ordinal)
+                || head.Contains(" internal ", StringComparison.Ordinal)
+                || head.Contains(" protected ", StringComparison.Ordinal))
+            {
+                yield return at;
+            }
+        }
+    }
+
+    /// <summary>
+    /// One member's SIGNATURE — the declaration up to the brace or arrow beginning its body, comments and
+    /// literals blanked. Separate from <see cref="MemberBody"/> because a claim about what a method ACCEPTS
+    /// cannot be made against its body: the body is where an ignored parameter is conspicuously absent.
+    /// </summary>
+    private static string MemberSignature(string relativePath, string member)
+    {
+        var stripped = CSharpSourceWalker.StripCommentsAndStrings(ReadSource(relativePath));
+        var declarations = Declarations(stripped, member).ToList();
+
+        var at = Assert.Single(declarations);
+        var open = stripped.IndexOf('{', at);
+        var arrow = stripped.IndexOf("=>", at, StringComparison.Ordinal);
+        var stops = new[] { open, arrow }.Where(i => i > at).ToArray();
+
+        Assert.NotEmpty(stops);
+
+        return stripped[at..stops.Min()];
+    }
+
+    private static string ReadSource(string relative)
+    {
+        var path = Path.Combine(RepoRoot(), relative);
+
+        Assert.True(File.Exists(path), $"#3278 scan target not found: {path}");
+
+        return File.ReadAllText(path);
+    }
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null
+               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
+               && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}

--- a/Darling/Darling.Tests/PgIndexBloatCoverageTests.cs
+++ b/Darling/Darling.Tests/PgIndexBloatCoverageTests.cs
@@ -978,6 +978,73 @@ public sealed class PgIndexBloatCoverageTests
         count.ToString("N0", Inv) + " holding "
         + (bytes / (double)Gib).ToString("N1", Inv) + " GB";
 
+    /// <summary>
+    /// R2 on the THIRD surface. The web dashboard renders the same read, and before #3278 its populated path
+    /// dropped the server's note entirely — so a web operator got the capped grid and none of the census.
+    ///
+    /// <para>The empty envelope already reached that page: <c>panels.js</c> mounts
+    /// <c>emptyStrip(res.message)</c>, and the MCP tool's empty status carries the census. It was the
+    /// POPULATED path that lost it, which is the path the caveat matters on — a page of answerless rows
+    /// looks like a working read.</para>
+    ///
+    /// <para><b>Read raw, not through the C# walker.</b> These are JavaScript: the walker knows
+    /// <c>@"</c> and <c>"""</c> and does not know single quotes or backticks, so running it here would
+    /// blank the wrong spans. Every existing pin over <c>server-tabs.js</c> reads it raw, and the strings
+    /// asserted below are chosen so no comment in either file can satisfy or defeat one.</para>
+    /// </summary>
+    [Fact]
+    public void TheWebDashboardPrintsTheCensusOnItsPopulatedPathToo()
+    {
+        var renderer = ReadSource("Darling/PerformanceMonitor.Darling.Service/wwwroot/js/panels.js");
+
+        /* The hook exists, is fed from the READ's own response, and renders as a notice. */
+        Assert.Contains("desc.noteKey", renderer, StringComparison.Ordinal);
+        Assert.Contains("noticeStrip(note)", renderer, StringComparison.Ordinal);
+        Assert.Contains("noticeStrip,", renderer, StringComparison.Ordinal);
+
+        /* ON THE POPULATED PATH. The empty and error branches return before the viz runs, so a note read
+           above them would never reach a rendered body - and that is precisely the half that was missing. */
+        var emptyBranch = renderer.IndexOf("res.kind === \"empty\"", StringComparison.Ordinal);
+        var noteRead = renderer.IndexOf("desc.noteKey", StringComparison.Ordinal);
+        var vizCall = renderer.IndexOf("render(res.data, desc)", StringComparison.Ordinal);
+
+        Assert.True(emptyBranch > 0, "panels.js no longer maps the empty envelope");
+        Assert.True(noteRead > 0, "panels.js no longer reads a server-supplied note");
+        Assert.True(vizCall > 0, "panels.js no longer calls the viz");
+        Assert.True(
+            noteRead > emptyBranch,
+            "the note is read ahead of the empty/error branches, where a rendered body it could sit above "
+            + "does not exist yet");
+
+        /* Through getPath, so it is a data lookup rather than a hard-coded key, and rendered as TEXT. */
+        Assert.Contains("getPath(res.data, desc.noteKey)", renderer, StringComparison.Ordinal);
+
+        var tabs = ReadSource(
+            "Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/server-tabs.js");
+
+        /* The helper forwards it to the descriptor, or the panel below configures something nothing reads. */
+        Assert.Contains("noteKey = null", tabs, StringComparison.Ordinal);
+        Assert.Contains("span, noteKey }", tabs, StringComparison.Ordinal);
+
+        /* And THIS panel asks for it. Scoped to a window after its own title so a noteKey on some other
+           panel cannot satisfy the claim. */
+        var title = tabs.IndexOf("\"Index Bloat (estimated)\"", StringComparison.Ordinal);
+
+        Assert.True(title > 0, "the index bloat panel's title is gone or renamed");
+
+        var panel = tabs[title..Math.Min(tabs.Length, title + 1_200)];
+
+        Assert.Contains("\"get_pg_index_bloat\"", panel, StringComparison.Ordinal);
+        Assert.Contains("\"note\"", panel, StringComparison.Ordinal);
+
+        /* THE #3234 PROSE IS GONE. This panel told a web operator the collector walks the index and that a
+           missing figure means a per-cycle budget skipped it. Neither has been true since the estimate arm
+           shipped, and a coverage census printed under a title saying "measured" would contradict itself.
+           These two literals appear in no comment in the file. */
+        Assert.DoesNotContain("\"Index Bloat (measured)\"", tabs, StringComparison.Ordinal);
+        Assert.DoesNotContain("measured by walking the index", tabs, StringComparison.Ordinal);
+    }
+
     private static PgIndexBloatSuppressionBucket Bucket(
         PgIndexBloatSuppression reason, long count, long bytes) =>
         new(reason, count, bytes, "stored prose for " + reason);

--- a/Darling/Darling.Tests/ServerPageTabsTests.cs
+++ b/Darling/Darling.Tests/ServerPageTabsTests.cs
@@ -812,7 +812,15 @@ public sealed class ServerPageTabsTests
            moment a comment happened to contain one, which is the shape of check that converts an open question
            into false confidence. The helper THROWS without an emptyText, and every tab is built during the
            DOM-shim run, so a table panel that forgot one cannot reach a browser. */
-        Assert.Contains("function table(title, read, params, rowsKey, columns, subtitle, emptyText, span = 2)", js, StringComparison.Ordinal);
+        /* The WHOLE signature, so emptyText is asserted to be a declared parameter rather than something
+           read off an options object. #3278 appended `noteKey = null` - an opt-in server-supplied caveat,
+           unrelated to this guard - and the literal is spelled out here rather than truncated at emptyText
+           because a prefix match would stop noticing a parameter inserted BEFORE it. */
+        Assert.Contains(
+            "function table(title, read, params, rowsKey, columns, subtitle, emptyText, span = 2, "
+            + "noteKey = null)",
+            js,
+            StringComparison.Ordinal);
         Assert.Contains(
             "if (!emptyText) throw new Error(\"table(\" + title + \"): a table panel must explain its own empty state.\");",
             js,

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1421,6 +1421,12 @@ public sealed class TsqlConventionGuardTests
     [
         "PerformanceMonitor.Collectors/CollectorRuntimePrecondition.cs DescribeObserved",
         "PerformanceMonitor.Collectors/PgColumnStatsCoverage.cs Figure",
+        /* #3278: the same expression-bodied formatter shape as the Figure line above, in the classifier
+           beside it. What each strands is a format fragment and nothing else - Count strands "N0" and
+           Tally strands " holding ", both of which this comment's own list of examples already names.
+           Neither is T-SQL and neither is a tempdb label, so no census reads a site of that kind here. */
+        "PerformanceMonitor.Collectors/PgIndexBloatCoverage.cs Count",
+        "PerformanceMonitor.Collectors/PgIndexBloatCoverage.cs Tally",
         "PerformanceMonitor.Collectors/StallWaitProbe.cs TriggerElapsedFor",
         "PerformanceMonitor.Collectors/StallWaitProbe.cs FitsUnderBudget",
         "PerformanceMonitor.Common/SystemHealthParser.cs GbFromBytes",

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs
@@ -46,7 +46,7 @@ namespace PerformanceMonitor.Darling.Service.Mcp;
 [McpServerToolType]
 public sealed class DarlingMcpPgIndexTools
 {
-    [McpServerTool(Name = "get_pg_index_bloat"), Description("Gets ESTIMATED PostgreSQL btree index bloat, computed from catalog statistics with NO page reads: how many bytes a REINDEX could plausibly reclaim, the modelled tuple width and leaf-page count it rests on, and the parent row count and fillfactor those came from. Ranked by reclaimable BYTES and never by percentage - a 64 kB index at 20% tops a percentage-ranked list and is worth 50 kB next to a 10 GB index at 45% worth 5.37 GB. Read measurement_kind: 'estimated' rows come from the statistics model, 'measured' rows are older pgstatindex measurements still inside the retention window. Accuracy against pgstatindex ground truth on a live 2,500-index target: median absolute error 2.79 percentage points, p90 6.63. A row with a skipped_reason has NO answer rather than a healthy one - never read a missing estimate as a clean bill of health - and the reason says whether it is remediable: a never-analyzed parent needs an ANALYZE, invisible column widths need the pg_read_all_data grant, while a PARTIAL index and a DEDUPLICATED one (low-cardinality, non-unique) are structurally unmodellable at any grant or statistics freshness and need the exact function instead. Every row carries exact_measurement_command, which is the pgstatindex call for that index: it walks every page, so run it deliberately on the one index you are about to act on rather than on a schedule - the same relationship SQL Server has between LIMITED and DETAILED index physical stats. This is the COMPLETE btree census with no size floor, so it returns MORE rows than get_pg_index_usage, which floors at 64 kB - 2,500 against 1,517 on one measured target. Neither census is missing objects.")]
+    [McpServerTool(Name = "get_pg_index_bloat"), Description("Gets ESTIMATED PostgreSQL btree index bloat, computed from catalog statistics with NO page reads: how many bytes a REINDEX could plausibly reclaim, the modelled tuple width and leaf-page count it rests on, and the parent row count and fillfactor those came from. Ranked by reclaimable BYTES and never by percentage - a 64 kB index at 20% tops a percentage-ranked list and is worth 50 kB next to a 10 GB index at 45% worth 5.37 GB. Read measurement_kind: 'estimated' rows come from the statistics model, 'measured' rows are older pgstatindex measurements still inside the retention window. Accuracy against pgstatindex ground truth on a live 2,500-index target: median absolute error 2.79 percentage points, p90 6.63. A row with a skipped_reason has NO answer rather than a healthy one - never read a missing estimate as a clean bill of health - and the reason says whether it is remediable: a never-analyzed parent needs an ANALYZE, invisible column widths need the pg_read_all_data grant, while a PARTIAL index and a DEDUPLICATED one (low-cardinality, non-unique) are structurally unmodellable at any grant or statistics freshness and need the exact function instead. Every row carries exact_measurement_command, which is the pgstatindex call for that index: it walks every page, so run it deliberately on the one index you are about to act on rather than on a schedule - the same relationship SQL Server has between LIMITED and DETAILED index physical stats. This is the COMPLETE btree census with no size floor, so it returns MORE rows than get_pg_index_usage, which floors at 64 kB - 2,500 against 1,517 on one measured target. Neither census is missing objects. ALWAYS read the coverage field before concluding anything about how much of a server this covers, and never infer that from the rows: answerless rows sort FIRST by design, so any limit smaller than the answerless population returns 100% skipped rows structurally rather than by chance, and raising the limit does not fix it while that population is still larger. coverage comes from a separate population-level query that no limit touches - candidate indexes, trusted versus suppressed, and each suppression reason - and every count carries its BYTES because the two rankings disagree: on a live fleet the reason that is second largest by row count is the SMALLEST by footprint at 0.0004% of it, while the fourth largest by rows is second by bytes at 1.4 TB. Judge the gap by bytes. And skipped_reason IS NULL is the ONLY trust predicate here: est_tuple_bytes is populated on 100% of the rows that have no answer and est_bloat_pct on 0% of them, so filtering on est_tuple_bytes returns every row and reads as complete coverage.")]
     public static async Task<string> GetPgIndexBloat(
         NpgsqlDataSource postgres,
         [Description("Server name or display name.")] string? server_name = null,
@@ -67,18 +67,41 @@ public sealed class DarlingMcpPgIndexTools
             var rows = await DarlingPgIndexBloatReader.GetPgIndexBloatAsync(
                 postgres, resolved.ServerId, windowEnd.AddHours(-hours_back), windowEnd, limit);
 
+            /* Asked on BOTH paths, not just the empty one (#3278). A returned page that is 100% suppressed
+               rows is the same defect as an unexplained empty and strictly harder to see: the read looks
+               like it worked, and the unmeasured-first sort GUARANTEES that shape whenever the suppressed
+               population exceeds the limit. */
+            PgIndexBloatCoverageVerdict coverage;
+
             if (rows.Count == 0)
             {
-                return await DarlingEngineCapability.NotCollectedStatusAsync(
-                    postgres, resolved.ServerId, resolved.ServerName, "pg_index_bloat")
-                    ?? await DarlingRuntimePrecondition.StatusAsync(
-                        postgres, resolved.ServerId, resolved.ServerName, "pg_index_bloat")
-                    ?? McpHelpers.Status(
-                        "empty",
-                        $"No index bloat measurements for {resolved.ServerName} in the last {hours_back} "
-                        + "hour(s). This collector runs DAILY, so a window shorter than a day can be empty "
-                        + "on a perfectly healthy server — widen it before concluding anything.");
+                /* CAPABILITY, then PRECONDITION, then this read's own miss - the order
+                   CollectorRuntimePrecondition documents, asked in it rather than composed with ?? over
+                   three already-computed values. Computing the LAST of three ranked answers FIRST is how
+                   somebody later reorders the chain and does not notice they have changed which one wins. */
+                var capability = await DarlingEngineCapability.NotCollectedStatusAsync(
+                    postgres, resolved.ServerId, resolved.ServerName, "pg_index_bloat");
+
+                if (capability != null) return capability;
+
+                var precondition = await DarlingRuntimePrecondition.StatusAsync(
+                    postgres, resolved.ServerId, resolved.ServerName, "pg_index_bloat");
+
+                if (precondition != null) return precondition;
+
+                coverage = await DarlingPgIndexBloatReader.GetCoverageVerdictAsync(
+                    postgres, resolved.ServerId, windowEnd, rows.Count);
+
+                return McpHelpers.Status(
+                    "empty",
+                    $"No index bloat rows for {resolved.ServerName} in the last {hours_back} "
+                    + "hour(s). This collector runs DAILY, so a window shorter than a day can be empty "
+                    + "on a perfectly healthy server — widen it before concluding anything. "
+                    + coverage.Message);
             }
+
+            coverage = await DarlingPgIndexBloatReader.GetCoverageVerdictAsync(
+                postgres, resolved.ServerId, windowEnd, rows.Count);
 
             var truncated = rows.Count >= limit;
             var answered = rows.Count(r => r.SkippedReason is null);
@@ -159,6 +182,43 @@ public sealed class DarlingMcpPgIndexTools
                 answered_count = truncated ? (int?)null : answered,
                 estimated_count = truncated ? (int?)null : estimated,
                 exactly_measured_count = truncated ? (int?)null : measured,
+
+                /* THE POPULATION FIGURES, which the three above are not and were never able to be (#3278).
+                   These come from a separate query over every candidate index on the server, so they are
+                   unaffected by the limit and by the unmeasured-first sort - which is what lets a page of
+                   all-skipped rows stop reading as a coverage claim. Every count carries its BYTES, because
+                   on the live fleet the two rank the suppression buckets differently: the bucket that is
+                   second of five by rows is LAST by footprint at 0.0004% of it. */
+                coverage = new
+                {
+                    /* The arm as its own field, beside the sentence. Automation keys on names rather than
+                       parsing prose, and a caller deciding whether this ranking is safe to act on needs the
+                       partial-coverage answer in a form it can branch on. */
+                    arm = coverage.Arm.ToString(),
+                    evidence_hours = PgIndexBloatCoverage.EvidenceHours,
+                    candidate_index_count = coverage.Candidates.IndexCount,
+                    candidate_index_bytes = coverage.Candidates.IndexBytes,
+                    trusted_index_count = coverage.Trusted.IndexCount,
+                    trusted_index_bytes = coverage.Trusted.IndexBytes,
+                    estimated_index_count = coverage.Estimated.IndexCount,
+                    estimated_index_bytes = coverage.Estimated.IndexBytes,
+                    exactly_measured_index_count = coverage.ExactlyMeasured.IndexCount,
+                    exactly_measured_index_bytes = coverage.ExactlyMeasured.IndexBytes,
+                    /* Ranked by BYTES by the classifier, not here - one ordering, so this payload and the
+                       WPF note cannot present two different "largest cause". */
+                    suppressed_by_reason = coverage.Suppressed.Select(bucket => new
+                    {
+                        reason = bucket.Reason.ToString(),
+                        label = PgIndexBloatCoverage.Label(bucket.Reason),
+                        index_count = bucket.IndexCount,
+                        index_bytes = bucket.IndexBytes,
+                        remedy = PgIndexBloatCoverage.Remedy(bucket.Reason),
+                        /* The collector's stored explanation ONCE per bucket. It is a 250-character
+                           paragraph repeated on every row - 2,954 identical copies in the fleet's largest
+                           bucket - so per-row is where it does not belong. */
+                        detail = bucket.Detail,
+                    }),
+                },
                 note = "These are ESTIMATES from catalog statistics, not measurements: no index page is "
                      + "read. Measured against pgstatindex ground truth on a live 2,500-index target, "
                      + "median absolute error is 2.79 percentage points and p90 is 6.63, which is close "
@@ -191,9 +251,18 @@ public sealed class DarlingMcpPgIndexTools
                            + "which is why estimated_reclaimable_bytes is 0 rather than null."
                          : string.Empty)
                      + (truncated
-                         ? " TRUNCATED at the row limit: there are more indexes than this. Raise the limit "
-                           + "before concluding anything about the server as a whole."
-                         : string.Empty),
+                         ? " TRUNCATED at the row limit: there are more indexes than this, and because rows "
+                           + "with no answer sort FIRST, a page smaller than the answerless population is "
+                           + "100% of them by construction rather than by chance - raising the limit does "
+                           + "not fix that while that population is still larger. Do not infer coverage "
+                           + "from this page; the coverage field below is measured over every candidate "
+                           + "index on the server and needs no limit raised."
+                         : string.Empty)
+                     /* The census on the POPULATED path too, and last so it is the sentence a reader
+                        finishes on. A page that ranks four answered indexes while six thousand are
+                        withheld reads as a ranking of the server, and nothing in the rows themselves shows
+                        the difference. */
+                     + " " + coverage.Message,
                 indexes,
             }, McpHelpers.JsonOptions);
         }

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/server-tabs.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/server-tabs.js
@@ -470,9 +470,15 @@ function pivot(rows, { xKey, seriesKey, valueKey }, maxSeries = 8) {
  * opt-in, or daily reads as a fault. Every tab is built during the DOM-shim run, so a missing sentence fails
  * there rather than shipping as a blank rectangle nobody notices.
  */
-function table(title, read, params, rowsKey, columns, subtitle, emptyText, span = 2) {
+/**
+ * `noteKey` names a field on the READ's own response to render above the rows (#3278) — a caveat the server
+ * computed and the client could not, because a subtitle is written before the read. Optional and absent on
+ * every panel but one: a capped page of rows is normally just the top of a ranking, and a panel whose rows
+ * cannot be read as a population figure is the exception that needs saying so with figures.
+ */
+function table(title, read, params, rowsKey, columns, subtitle, emptyText, span = 2, noteKey = null) {
   if (!emptyText) throw new Error("table(" + title + "): a table panel must explain its own empty state.");
-  return renderPanel({ title, subtitle, read, params, viz: "table", rowsKey, columns, emptyText, span });
+  return renderPanel({ title, subtitle, read, params, viz: "table", rowsKey, columns, emptyText, span, noteKey });
 }
 
 /**
@@ -2024,19 +2030,28 @@ export const POSTGRES_TABS = [
             "No index of at least 64 KB was recorded on this server, so there is nothing here to judge. This collector runs daily and is gated off on read replicas, where scan counts are the replica's own rather than the writer's.",
         },
       ]),
-      /* #2629: MEASURED index bloat, beside the ESTIMATED table bloat above and the usage counts. The
-         three answer one question in sequence — how much space, is it earning its keep, and is the index
-         itself wasting it — and measured bloat sits last deliberately: it is the only one of the three
-         that is not an estimate, so a reader who has just been warned about estimates meets the real
-         measurement immediately after. */
+      /* #2629: index bloat, beside the table bloat above and the usage counts. The three answer one
+         question in sequence — how much space, is it earning its keep, and is the index itself wasting it.
+
+         #3234 made this an ESTIMATE from catalog statistics; it no longer walks a page, and there is no
+         per-cycle measurement budget to be skipped by. The title, subtitle and empty text all described the
+         old census until #3278 came through here.
+
+         `noteKey` carries the server's coverage census (#3278). It has to come from the read rather than
+         from the subtitle below, because the whole content of it is FIGURES about this server's population
+         — and because this panel's rows are the one set on the page that cannot be read as a coverage
+         claim: answerless rows sort FIRST by design, so a page capped at 25 is 100% of them whenever they
+         outnumber 25, structurally rather than by chance. */
       table(
-        "Index Bloat (measured)",
+        "Index Bloat (estimated)",
         "get_pg_index_bloat",
         { server, hours: ctx.hours, limit: 25 },
         "indexes",
         PG_INDEX_BLOAT_COLUMNS,
-        ctx.label + ", measured by walking the index; a value in Not Measured means the collector's per-cycle budget skipped it",
-        "No index was measured on this server. This collector runs DAILY and measuring walks the index, so a short window or a fresh install is legitimately empty here."
+        ctx.label + ", ESTIMATED from catalog statistics with no page reads; a row with a reason instead of a number has NO answer, not a healthy one",
+        "Nothing recorded for this server. That is not the same as no bloat: this collector runs DAILY, so a short window or a fresh install is legitimately empty here. Read the coverage sentence for which it is.",
+        2,
+        "note"
       ),
     ],
   },

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/panels.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/panels.js
@@ -28,6 +28,7 @@ import {
   errorStrip,
   readErrorStrip,
   emptyStrip,
+  noticeStrip,
   readTool,
   apiGet,
   buildQuery,
@@ -73,7 +74,22 @@ async function loadPanel(desc, body) {
     return;
   }
   try {
-    mount(body, render(res.data, desc));
+    /* A SERVER-SUPPLIED caveat, above the rendered body (#3278). Opt-in: a descriptor without `noteKey` is
+       untouched, which is every panel but the one that needs it.
+
+       The empty envelope already carries the server's sentence through emptyStrip above, so before this the
+       populated path was the ONLY one that dropped it — and that is the path the caveat matters on. A panel
+       whose rows are a capped page of a much larger population looks like it worked; nothing in the rows
+       shows the difference, and a client-authored subtitle cannot carry the figures because it is written
+       before the read. get_pg_index_bloat is the case: its answerless rows sort FIRST by design, so a
+       capped page is 100% of them whenever they outnumber the cap.
+
+       Read through getPath and rendered as TEXT by noticeStrip, so a note is inert markup like every other
+       server value on this page (R4). */
+    const note = desc.noteKey ? getPath(res.data, desc.noteKey) : null;
+    const rendered = render(res.data, desc);
+
+    mount(body, typeof note === "string" && note.trim() ? [noticeStrip(note), rendered] : rendered);
   } catch (e) {
     mount(body, errorStrip("Could not render this panel: " + (e && e.message ? e.message : String(e))));
   }

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs
@@ -9,6 +9,7 @@
 using System;
 using PerformanceMonitor.Collectors;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
@@ -46,6 +47,14 @@ namespace PerformanceMonitor.Darling.Storage;
 /// NULL and reports 0 reclaimable — the index is measured, and what it holds is nothing. Filtering the row
 /// out instead would serve the read successfully while hiding a real index, which is the failure mode that
 /// looks most like a fix.</para>
+///
+/// <para><b>The row list cannot carry its own denominator, so a second read supplies it (#3278).</b> The
+/// unmeasured-first sort above means any <c>LIMIT</c> smaller than the suppressed population returns 100%
+/// suppressed rows — structurally, not by chance — and raising the limit does not help while the suppressed
+/// population is still larger. <see cref="GetCoverageVerdictAsync"/> answers what share of the server has an
+/// answer with its own population-level query, so no page of this read can be mistaken for a coverage claim.
+/// It reports BYTES beside every count, because on the live fleet the row ranking and the byte ranking of the
+/// suppression buckets disagree.</para>
 ///
 /// <para>Shared by the WPF tab and the MCP surface so there is one copy of this SQL, per #2530.</para>
 /// </summary>
@@ -277,6 +286,259 @@ public static class DarlingPgIndexBloatReader
                  index_bytes DESC
         LIMIT $4
         """;
+
+    /// <summary>
+    /// One group of the coverage census: whether the collector produced a run at all, and — for one
+    /// combination of stored reason and provenance — how many indexes and how many index bytes it accounts
+    /// for.
+    /// </summary>
+    /// <param name="EvidenceCollectorRan">
+    /// Whether <c>pg_index_bloat</c> recorded a SUCCEEDING run for this server in the evidence window. A run
+    /// and not a row count, and that distinction is the whole reason this field exists: a run that stored no
+    /// rows is the measurement establishing that the server has no btree index, so collapsing the two makes
+    /// "measured, and there is nothing" indistinguishable from "the collector has not run here".
+    ///
+    /// <para>Repeated on every group because the probe is a single-row relation the groups hang off, which
+    /// is what lets ONE statement carry both a scalar and a variable-length breakdown — and lets a server
+    /// with no rows at all still report whether its collector ran.</para>
+    /// </param>
+    /// <param name="SkippedReason">The collector's stored prose, or null for a trusted index.
+    /// <c>skipped_reason IS NULL</c> is the ONLY trust predicate on this collector: <c>est_tuple_bytes</c>
+    /// is populated on 100% of suppressed rows and <c>est_bloat_pct</c> on 0% of them, so a census keyed on
+    /// either <c>est_</c> column would report complete coverage over a population with none.</param>
+    /// <param name="IsEstimate">This group's PROVENANCE, not its outcome — whether the row came from the
+    /// statistics model or is an older <c>pgstatindex</c> measurement still inside retention. Read only
+    /// alongside <paramref name="SkippedReason"/>, never instead of it.</param>
+    public readonly record struct PgIndexBloatCoverageGroup(
+        bool EvidenceCollectorRan,
+        string? SkippedReason,
+        bool IsEstimate,
+        long IndexCount,
+        long IndexBytes);
+
+    /// <summary>
+    /// <see cref="EnumeratedCollectorDriver.FreshnessSuccessStatuses"/> as a SQL <c>IN</c> list. Built from
+    /// the shared list rather than retyped so the bar for "this collector produced valid evidence" is the
+    /// one the freshness reads and the self-alert evaluator already apply, and so a status added there
+    /// reaches this probe without anybody remembering to come here.
+    ///
+    /// <para>Literal-safe by construction: every element is a compile-time constant in this repo's own
+    /// source, never operator input.</para>
+    /// </summary>
+    private static readonly string EvidenceStatusList = string.Join(
+        ", ",
+        EnumeratedCollectorDriver.FreshnessSuccessStatuses.Select(status => "'" + status + "'"));
+
+    /* THE LATEST ROW PER INDEX, with the SAME tie-break the row read uses - (skipped_reason IS NULL) DESC
+       before collection_time DESC. Not a coincidence and not copied for tidiness: this census decides
+       whether an index counts as answered, and the row read decides what it displays for that index. If the
+       two disagreed about which of an index's rows is current, the census would publish a trusted count the
+       grid beside it contradicts, index by index, with nothing that fails.
+
+       DISTINCT ON is what makes it a POPULATION rather than a history. pg_index_bloat writes every btree on
+       every cycle, so a plain aggregate over a 48-hour window counts each index once per run and would
+       report double the server's index count and double its footprint - a denominator wrong in the
+       direction that makes coverage look better than it is.
+
+       database_name leads the key (#2599): this collector runs once per database and an index name is only
+       unique within one, so without it a shared schema's copies collapse into whichever collected last.
+
+       THE PROBE IS A SINGLE-ROW RELATION THE GROUPS HANG OFF, via LEFT JOIN ... ON true. That is the whole
+       reason one statement can carry a scalar and a variable-length breakdown: a server whose collector ran
+       and stored NOTHING still returns one row carrying the probe, where an inner join would drop exactly
+       the row that separates "no indexes" from "no evidence". EXISTS rather than count(*) because only the
+       zero test is read.
+
+       AND IT COUNTS ONLY RUNS THAT SUCCEEDED, which is not a detail here. Measured on a live Aurora target
+       on 2026-09-10 this collector recorded 7 runs in seven days and 3 of them ERRORED - one a 300-second
+       client-side command deadline that stored nothing at all. An unfiltered probe on a window landing on
+       such a cycle would say "it ran" over zero rows, and the classifier would answer NoCandidates,
+       "nothing to fix", on a server whose collector is timing out. That is this issue's own false innocence
+       relocated into the collector's health. The status set comes from
+       EnumeratedCollectorDriver.FreshnessSuccessStatuses rather than being retyped.
+
+       GROUPING ON THE REASON PROSE, then keying it in C#. The reason is a 250-character paragraph repeated
+       on every row - 2,954 identical copies in the fleet's largest bucket - so grouping first reduces it to
+       at most a dozen rows, and the classifier maps prose to a short stable key with an Unrecognized arm for
+       text this build does not know. Keying in SQL instead would put the marker list in two places.
+
+       $1 server_id, $2 window start, $3 window end. */
+    public static readonly string CoverageEvidenceSql = @"
+WITH latest AS (
+    SELECT DISTINCT ON (database_name, schema_name, table_name, index_name)
+           index_bytes, skipped_reason, est_tuple_bytes
+    FROM pg_index_bloat
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    AND   collection_time <= $3
+    ORDER BY database_name, schema_name, table_name, index_name,
+             (skipped_reason IS NULL) DESC, collection_time DESC
+),
+probe AS (
+    SELECT EXISTS (
+        SELECT 1
+        FROM collection_log
+        WHERE server_id = $1
+        AND   collector_name = 'pg_index_bloat'
+        AND   collection_time >= $2
+        AND   collection_time <= $3
+        AND   status IN (" + EvidenceStatusList + @")
+    ) AS evidence_collector_ran
+),
+grouped AS (
+    SELECT latest.skipped_reason                              AS skipped_reason,
+           (latest.est_tuple_bytes IS NOT NULL)               AS is_estimate,
+           count(*)::bigint                                   AS index_count,
+           COALESCE(sum(latest.index_bytes), 0)::bigint       AS index_bytes
+    FROM latest
+    GROUP BY latest.skipped_reason, (latest.est_tuple_bytes IS NOT NULL)
+)
+SELECT probe.evidence_collector_ran,
+       grouped.skipped_reason,
+       grouped.is_estimate,
+       grouped.index_count,
+       grouped.index_bytes
+FROM probe
+LEFT JOIN grouped ON true";
+
+    /// <summary>
+    /// The coverage verdict for a <c>get_pg_index_bloat</c> read — what share of this server's btree
+    /// footprint has an answer, by count AND by bytes, and the sentence saying so (#3278).
+    ///
+    /// <para>A failed evidence read answers <see cref="PgIndexBloatCoverageArm.Undetermined"/> with its own
+    /// wording rather than throwing, the same rule <c>DarlingRuntimePrecondition</c> follows: this runs to
+    /// EXPLAIN a result the caller already has, and turning that into a read error would replace an
+    /// under-described answer with no answer.</para>
+    ///
+    /// <para><b>No window START, deliberately, and the signature says so by not having one.</b> The evidence
+    /// span is <see cref="EvidenceStart"/> to <paramref name="endUtc"/> whatever window the caller read its
+    /// rows over — see that method for why. An accepted-but-ignored <c>startUtc</c> is worse than an absent
+    /// one: the caller passes a window, reasonably believes it is honoured, and neither the compiler nor the
+    /// answer tells them otherwise. Callers wanting the raw groups over a span of their own have
+    /// <see cref="GetCoverageEvidenceAsync"/>, which takes both ends BECAUSE it uses both.</para>
+    /// </summary>
+    /// <param name="endUtc">The instant the caller's read ENDS at, which the evidence window is anchored on
+    /// so an <c>as_of</c> read is explained by contemporary evidence rather than by today's.</param>
+    /// <param name="returnedRows">How many rows the caller's read returned. Reported as its own labelled
+    /// figure and never divided into a population one.</param>
+    public static async Task<PgIndexBloatCoverageVerdict> GetCoverageVerdictAsync(
+        NpgsqlDataSource postgres, int serverId, DateTime endUtc, int returnedRows,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(postgres);
+
+        try
+        {
+            var groups = await GetCoverageEvidenceAsync(
+                postgres, serverId, EvidenceStart(endUtc), endUtc, cancellationToken);
+
+            var estimated = default(PgIndexBloatTally);
+            var exactlyMeasured = default(PgIndexBloatTally);
+            var suppressed = new List<PgIndexBloatSuppressionBucket>();
+
+            foreach (var group in groups)
+            {
+                var tally = new PgIndexBloatTally(group.IndexCount, group.IndexBytes);
+
+                /* skipped_reason, and nothing else. A group's IsEstimate says where its figure CAME FROM
+                   and never whether there is one - est_tuple_bytes is populated on every suppressed row in
+                   every bucket, so splitting on provenance first would file 6,680 answerless indexes as
+                   estimates. */
+                if (group.SkippedReason is null)
+                {
+                    if (group.IsEstimate)
+                    {
+                        estimated += tally;
+                    }
+                    else
+                    {
+                        exactlyMeasured += tally;
+                    }
+
+                    continue;
+                }
+
+                suppressed.Add(new PgIndexBloatSuppressionBucket(
+                    PgIndexBloatCoverage.Bucket(group.SkippedReason),
+                    group.IndexCount,
+                    group.IndexBytes,
+                    group.SkippedReason));
+            }
+
+            return PgIndexBloatCoverage.Classify(
+                groups.Count > 0 && groups[0].EvidenceCollectorRan,
+                estimated,
+                exactlyMeasured,
+                suppressed,
+                returnedRows);
+        }
+        catch (Exception)
+        {
+            return PgIndexBloatCoverage.EvidenceUnreadable(returnedRows);
+        }
+    }
+
+    /// <summary>
+    /// The evidence lookback: a FIXED span ending where the caller's read ends, independent of how wide a
+    /// window the caller asked its rows over.
+    ///
+    /// <para><b>The read's own window is the wrong window for this, in both directions.</b> A one-hour
+    /// panel window straddles none of a daily collector's runs, so it would report "no evidence" for a
+    /// target measured every day for a week. And a wide one is no better than wasteful: the MCP tool
+    /// defaults to 168 hours, and this census runs on every call whether the result is empty or not, over a
+    /// hypertable where a wider span means more chunks for a figure that describes the present.</para>
+    ///
+    /// <para><b>Because it is not a question about history.</b> What share of this server's indexes are
+    /// modellable is a CURRENT state, and <c>CollectorRuntimePrecondition</c> settled this shape already: it
+    /// consults the LATEST run rather than a window, on the reasoning that a precondition somebody has since
+    /// satisfied must not keep being reported. Averaging a week of candidate counts would answer a question
+    /// nobody asked and cost more to do it.</para>
+    ///
+    /// <para>Anchored on <paramref name="endUtc"/>, so an <c>as_of</c> read gets the evidence contemporary
+    /// with the data it is explaining rather than today's.</para>
+    ///
+    /// <para>The span itself lives on <see cref="PgIndexBloatCoverage.EvidenceHours"/>, not here: it appears
+    /// in the census an operator reads, so the label and the query have to be the same figure and a copy in
+    /// this file is how they stop being. That constant also carries WHY it is two of the collector's
+    /// cadences rather than one.</para>
+    /// </summary>
+    internal static DateTime EvidenceStart(DateTime endUtc) =>
+        endUtc.AddHours(-PgIndexBloatCoverage.EvidenceHours);
+
+    /// <summary>The raw census groups, for callers that want the figures rather than the sentence.</summary>
+    public static async Task<List<PgIndexBloatCoverageGroup>> GetCoverageEvidenceAsync(
+        NpgsqlDataSource postgres, int serverId, DateTime startUtc, DateTime endUtc,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(postgres);
+
+        var groups = new List<PgIndexBloatCoverageGroup>();
+        await using var command = postgres.CreateCommand(CoverageEvidenceSql);
+        command.CommandTimeout = StorageCommandDeadlines.McpReadSeconds;
+        command.Parameters.AddWithValue(serverId);
+        /* SpecifyKind(Unspecified) at the bind, for the reason the row read below documents: Kind=Utc infers
+           timestamptz and the comparison against these naive columns then resolves at the store session's
+           TimeZone, which east of UTC slides the window off the data. An evidence read that silently
+           returned nothing would answer Undetermined on a server that has the evidence. */
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified));
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            groups.Add(new PgIndexBloatCoverageGroup(
+                EvidenceCollectorRan: !reader.IsDBNull(0) && reader.GetBoolean(0),
+                SkippedReason: reader.IsDBNull(1) ? null : reader.GetString(1),
+                /* NULL on the probe-only row a server with no stored rows produces, which is neither
+                   provenance - so it must not default to the estimate arm and be counted as an answer. The
+                   count and bytes are null on that row too, so it contributes nothing either way. */
+                IsEstimate: !reader.IsDBNull(2) && reader.GetBoolean(2),
+                IndexCount: reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                IndexBytes: reader.IsDBNull(4) ? 0 : reader.GetInt64(4)));
+        }
+
+        return groups;
+    }
 
     public static async Task<List<PgIndexBloatRow>> GetPgIndexBloatAsync(
         NpgsqlDataSource postgres, int serverId, DateTime startUtc, DateTime endUtc, int limit,

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs
@@ -463,8 +463,24 @@ public sealed partial class ViewerDataService
     /// <summary>Storage tab - MEASURED b-tree index bloat (#2561), latest per index. Ranked by estimated
     /// reclaimable BYTES rather than by density, because a small index at 40% density is worth nothing next
     /// to a large one at 70%. Indexes too large to measure sort to the TOP: unknown is not zero, and they
-    /// are the likeliest big win.</summary>
+    /// are the likeliest big win. This returns the ROWS only; what the row count MEANS about the server is
+    /// <see cref="GetPgIndexBloatCoverageAsync"/>, and a caller that prints one without the other is back to
+    /// letting a page of answerless rows read as a coverage claim.</summary>
     public Task<List<DarlingPgIndexBloatReader.PgIndexBloatRow>> GetPgIndexBloatAsync(
         int serverId, DateTime startUtc, DateTime endUtc, int limit = 50, CancellationToken cancellationToken = default) =>
         DarlingPgIndexBloatReader.GetPgIndexBloatAsync(_dataSource, serverId, startUtc, endUtc, limit, cancellationToken);
+
+    /// <summary>Storage tab - what share of this server's btree footprint pg_index_bloat actually has an
+    /// answer for (#3278), by count AND by bytes, with the suppressed remainder broken down by reason and
+    /// ranked by bytes. A separate population-level query, so the grid's own row cap cannot reach it: rows
+    /// with no answer sort FIRST, which makes a capped grid 100% of them whenever they outnumber the cap.
+    /// The same classifier <c>get_pg_index_bloat</c> calls, over the same evidence, so the panel and the tool
+    /// cannot give one operator two answers.
+    /// <para>Takes the window END only, mirroring the reader: coverage is a CURRENT state of the target, so
+    /// there is no start to honour and no start is accepted. A parameter passed and ignored would let the
+    /// panel look as though its own window governed this answer.</para></summary>
+    public Task<PgIndexBloatCoverageVerdict> GetPgIndexBloatCoverageAsync(
+        int serverId, DateTime endUtc, int returnedRows, CancellationToken cancellationToken = default) =>
+        DarlingPgIndexBloatReader.GetCoverageVerdictAsync(
+            _dataSource, serverId, endUtc, returnedRows, cancellationToken);
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
@@ -943,6 +943,17 @@ public partial class ViewerServerTab
     /// measures near 90 rather than 100, so the first person to read that column would otherwise conclude
     /// every index in the fleet is 10% bloated. Since #3234 those are the older exact rows still inside
     /// retention, which is why the note distinguishes them rather than describing one kind of row.</para>
+    ///
+    /// <para><b>What the grid shows is not what the server has, and the note says so with figures (#3278).</b>
+    /// Rows with no answer sort FIRST — deliberately, since the index nobody can model is the likeliest big
+    /// win — so a grid capped at <see cref="PgGridRowLimit"/> shows 100% answerless rows whenever they
+    /// outnumber the cap, structurally rather than by chance. Counting the visible ones cannot detect that.
+    /// <see cref="PgIndexBloatCoverage"/> answers it from a separate population query and this panel prints
+    /// the verdict, the same one <c>get_pg_index_bloat</c> prints (#3278).</para>
+    ///
+    /// <para><b>Printed on the POPULATED path as well.</b> A partial view is the same defect one degree
+    /// weaker — the grid ranks what it was given and cannot show what was withheld — so the coverage
+    /// sentence rides both branches rather than being an empty-state message.</para>
     /// </summary>
     private async Task LoadPgIndexBloatAsync(DateTime startUtc, DateTime endUtc)
     {
@@ -957,6 +968,13 @@ public partial class ViewerServerTab
 
         PgIndexBloatGrid.ItemsSource = rows;
 
+        /* The SAME classifier the MCP tool calls, deliberately (#3278). The panel and the tool answering
+           the same question differently is how a defect gets fixed in one surface and left in the other,
+           and every figure that makes this answer a POPULATION figure rather than a page one is in there -
+           so neither surface authors it. */
+        var coverage = await _dataService.GetPgIndexBloatCoverageAsync(
+            _server.ServerId, endUtc, rows.Count);
+
         var reclaimable = 0L;
         foreach (var r in rows)
         {
@@ -969,10 +987,13 @@ public partial class ViewerServerTab
         var exactly = rows.Count(r => r.SkippedReason is null && !r.IsEstimate);
 
         PgIndexBloatNote.Text = rows.Count == 0
-            ? "Nothing recorded. This panel needs the pg_stats column widths, which pg_monitor alone does "
-              + "not confer - see the runbook step under \u201cThe one grant pg_monitor does not cover\u201d. "
-              + "Only B-TREE indexes are covered. When it does record, it records EVERY btree at any size, "
-              + "which is why its index count exceeds the usage panel's."
+            /* The verdict rather than a guess at the cause. This note used to assert the missing pg_stats
+               grant outright, which is a diagnosis the panel had no evidence for and is wrong wherever the
+               collector simply has not run - measured on a live target, 3 of its 7 runs in a week errored,
+               one on a 300-second command deadline that stored nothing. */
+            ? "Nothing recorded in this window. That is NOT the same as no bloat. Only B-TREE indexes are "
+              + "covered, and when this does record it records EVERY btree at any size, which is why its "
+              + "index count exceeds the usage panel's. " + coverage.Message
             : $"ESTIMATED from catalog statistics - no index page is read. About {reclaimable:N0} bytes "
               + $"look reclaimable across {rows.Count:N0} index(es), and that is what the grid is ranked "
               + "by: a percentage ranks the wrong thing, since a tiny index at 20% is worth kilobytes next "
@@ -988,12 +1009,15 @@ public partial class ViewerServerTab
                     + "is not the same as a walk that found no leaf pages."
                   : string.Empty)
               + (skipped > 0
-                  ? $"  {skipped:N0} index(es) have NO answer in this window and are listed FIRST with "
-                    + "their reason: their bloat is unknown rather than zero. Read the reason - a "
-                    + "never-analyzed parent needs an ANALYZE and invisible column widths need the "
-                    + "pg_read_all_data grant, while a PARTIAL or DEDUPLICATED index cannot be modelled at "
-                    + "any grant or statistics freshness and needs the exact command instead."
-                  : string.Empty);
+                  ? $"  {skipped:N0} of the index(es) SHOWN have no answer and are listed FIRST with their "
+                    + "reason: their bloat is unknown rather than zero. That is a count of this grid, not "
+                    + "of the server - they sort first, so a grid at its row cap shows them and not the "
+                    + "answers behind them."
+                  : string.Empty)
+              /* On the POPULATED path too, and last. A grid ranking four answered indexes while six
+                 thousand are withheld reads as a ranking of the server, and the rows themselves show no
+                 difference - which is how three independent readers got this surface wrong in one night. */
+              + "  " + coverage.Message;
     }
 
     /// <summary>

--- a/PerformanceMonitor.Collectors/PgIndexBloatCoverage.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCoverage.cs
@@ -1,0 +1,693 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace PerformanceMonitor.Collectors;
+
+/// <summary>
+/// Why one <c>pg_index_bloat</c> row carries a reason instead of an answer, as a SHORT STABLE KEY (#3278).
+///
+/// <para><b>A key rather than the prose, and that is the whole reason this enum exists.</b> The collector
+/// stores its reason as a full explanatory paragraph repeated on every row — measured on the fleet, 2,954
+/// copies of the same 250-character sentence in the largest bucket alone. A summary that grouped on that
+/// text would carry a quarter of a kilobyte per bucket to say which bucket it is, and a consumer wanting
+/// to branch on the cause would be matching prose. So the bucket is keyed here and the prose travels
+/// once.</para>
+/// </summary>
+public enum PgIndexBloatSuppression
+{
+    /// <summary>
+    /// The reason text is not one this build recognises. Reachable and deliberately not an error: the store
+    /// holds 90 days of rows, so a reason written by an older or newer collector arrives here rather than
+    /// being dropped — an unrecognised bucket still counts toward the suppressed totals, because a bucket
+    /// whose bytes vanished from the census would understate the gap it exists to measure.
+    ///
+    /// <para>First rather than last so <c>default</c> lands on "we do not know which" instead of on a named
+    /// cause with a remedy attached.</para>
+    /// </summary>
+    Unrecognized,
+
+    /// <summary>
+    /// The index carries a predicate, so the model's parent <c>reltuples</c> describes a superset of the
+    /// rows the index actually holds. Structural: no grant and no <c>ANALYZE</c> reaches it. Second largest
+    /// bucket BY BYTES on the fleet at 1,385 GB, and fourth of five by rows.
+    /// </summary>
+    Partial,
+
+    /// <summary>
+    /// The parent table has never been analyzed (<c>reltuples = -1</c>), so there is no row count to model
+    /// from. Remediable with one <c>ANALYZE</c> — and the bucket the byte weighting exists to demote: second
+    /// largest of five BY ROWS on the fleet and LAST by footprint, at 22 MB of 5,970 GB.
+    /// </summary>
+    ParentNeverAnalyzed,
+
+    /// <summary>
+    /// A key column is <c>name</c>-typed, whose <c>pg_stats</c> width is the padded 64 bytes rather than the
+    /// stored text. Structural: the statistic exists and is the wrong quantity, so no grant improves it.
+    /// </summary>
+    NameTypedKey,
+
+    /// <summary>
+    /// <c>pg_stats</c> did not yield a width for every key column. Remediable, and the largest bucket by
+    /// footprint on the fleet at 4,144 GB — <c>pg_stats</c> filters on <c>has_column_privilege</c>, so the
+    /// commonest cause is a monitoring login without SELECT rather than anything about the index.
+    /// </summary>
+    ColumnWidthsNotVisible,
+
+    /// <summary>
+    /// The index occupies no pages yet, so there is nothing for it to be holding. Nothing to fix and nothing
+    /// to grant — the one suppression bucket that is a measurement rather than a gap.
+    /// </summary>
+    NoPagesYet,
+
+    /// <summary>
+    /// The model predicts more pages than the index occupies. Structural on PostgreSQL 13 and above, which
+    /// stores duplicate keys once in a posting list: real storage is denser than per-tuple arithmetic can
+    /// predict, so a CORRECT model still over-predicts and the shortfall is not an answer.
+    /// </summary>
+    NegativeBloat,
+}
+
+/// <summary>
+/// One suppression bucket: which reason, how many indexes, how many BYTES of index those hold, and the
+/// collector's own prose for it carried once rather than per row.
+/// </summary>
+/// <param name="Reason">The stable key. <see cref="PgIndexBloatSuppression.Unrecognized"/> when the stored
+/// prose matches no marker this build knows.</param>
+/// <param name="IndexCount">Indexes in this bucket.</param>
+/// <param name="IndexBytes">Their combined <c>index_bytes</c>. Not optional and not decoration: on the live
+/// fleet the row ranking and the byte ranking of these buckets DISAGREE, so a census carrying only counts
+/// points an operator at the bucket that cannot matter.</param>
+/// <param name="Detail">The collector's stored explanation, once. Null when nothing supplied one.</param>
+public readonly record struct PgIndexBloatSuppressionBucket(
+    PgIndexBloatSuppression Reason,
+    long IndexCount,
+    long IndexBytes,
+    string? Detail);
+
+/// <summary>
+/// A count and the bytes it accounts for, as one value — so a caller cannot pass or print the one without
+/// the other, which is the defect <see cref="PgIndexBloatCoverage"/> exists to close.
+/// </summary>
+public readonly record struct PgIndexBloatTally(long IndexCount, long IndexBytes)
+{
+    /// <summary>The two figures added, for composing a total out of its parts.</summary>
+    public static PgIndexBloatTally operator +(PgIndexBloatTally left, PgIndexBloatTally right) =>
+        new(left.IndexCount + right.IndexCount, left.IndexBytes + right.IndexBytes);
+}
+
+/// <summary>
+/// What a <c>get_pg_index_bloat</c> read's coverage IS, over the server rather than over the page returned
+/// (#3278). Named arms rather than a ratio, because the population figures and the rows are measured over
+/// different spans and a ratio drawn across them is not a coverage claim.
+/// </summary>
+public enum PgIndexBloatCoverageArm
+{
+    /// <summary>
+    /// No usable evidence for this server in the evidence window, so no arm can be selected. The arm that
+    /// keeps the others honest: without it a collector that errored every cycle in the window presents
+    /// as a server with no indexes, which is a confident all-clear built on no measurement.
+    /// </summary>
+    Undetermined,
+
+    /// <summary>
+    /// The collector ran and the window holds no candidate index at all. The census is correct and empty,
+    /// and there is nothing for an operator to do.
+    /// </summary>
+    NoCandidates,
+
+    /// <summary>
+    /// Candidates exist and NOT ONE of them has a trusted answer. This is the fleet's measured state on a
+    /// target whose monitoring login cannot read <c>pg_stats</c>, and it is the arm a truncated page of
+    /// all-skipped rows has been misread as ever since the estimate arm shipped.
+    /// </summary>
+    NothingTrusted,
+
+    /// <summary>
+    /// Some candidates have an answer and some do not. The ranking is over a subset of the server's index
+    /// footprint, which is the same defect as a total absence one degree weaker — the grid looks complete
+    /// and is not.
+    /// </summary>
+    PartialCoverage,
+
+    /// <summary>Every candidate index has a trusted answer. The ranking describes the whole server.</summary>
+    FullyTrusted,
+
+    /// <summary>
+    /// The read returned rows and the evidence window holds no candidate index — so the two describe
+    /// different populations and neither a coverage ratio nor an emptiness verdict can be claimed.
+    ///
+    /// <para>Reachable because the spans differ: the evidence is a fixed
+    /// <see cref="PgIndexBloatCoverage.EvidenceHoursDescription"/> lookback while the rows are over whatever
+    /// window the caller asked for, which defaults to seven days. An index dropped since, a database
+    /// removed from the enumeration, or a collector that has errored for longer than the evidence window
+    /// all leave rows behind with no candidate to match them. Without this arm that combination took
+    /// <see cref="NoCandidates"/> and printed "nothing to do" beside a non-empty result.</para>
+    /// </summary>
+    EvidenceStale,
+}
+
+/// <summary>
+/// One <see cref="PgIndexBloatCoverageArm"/>, the population figures it was decided from, the verdict
+/// sentence, and the suppression breakdown — as one value, so no surface can print the arm without its
+/// figures or the figures without the arm.
+///
+/// <para><b><see cref="Census"/> and <see cref="Cause"/> are separate on purpose.</b> The census is the
+/// figures, in one shape for every arm; the cause is the verdict and carries NO figures at all. A guard
+/// that the arms are distinguishable has to compare the CAUSE — comparing the composed message would pass
+/// on the figures differing, which they always do, and would then report discrimination this class had
+/// stopped providing.</para>
+/// </summary>
+/// <param name="Suppressed">The buckets, ranked BY BYTES descending. Carried on the verdict rather than
+/// left at the call site so the MCP payload and the WPF note rank them identically.</param>
+public readonly record struct PgIndexBloatCoverageVerdict(
+    PgIndexBloatCoverageArm Arm,
+    string Census,
+    string Cause,
+    PgIndexBloatTally Candidates,
+    PgIndexBloatTally Estimated,
+    PgIndexBloatTally ExactlyMeasured,
+    IReadOnlyList<PgIndexBloatSuppressionBucket> Suppressed)
+{
+    /// <summary>Estimated plus exactly measured, derived rather than passed — see the classifier.</summary>
+    public PgIndexBloatTally Trusted => Estimated + ExactlyMeasured;
+
+    /// <summary>The census then the cause, for the surfaces that print one string.</summary>
+    public string Message => Census + " " + Cause;
+}
+
+/// <summary>
+/// What share of a server's index footprint <c>get_pg_index_bloat</c> actually has an answer for, and the
+/// one sentence that says so (#3278).
+///
+/// <para><b>The defect this closes.</b> The reader sorts rows carrying a reason FIRST, by design — an index
+/// too large or too odd to model is the likeliest big win, so filtering it out would hide the biggest
+/// candidate. The consequence is that any <c>LIMIT</c> smaller than the suppressed population returns 100%
+/// suppressed rows, structurally rather than probabilistically, and raising the limit does not fix it while
+/// the suppressed population is still larger. Four independent sessions misread that surface in one night
+/// on 2026-09-10, three through the limit and a fourth through the store directly — and every one of them
+/// had read the "unmeasured first" design comment first. Three careful readers reaching the same wrong
+/// conclusion is a property of the surface.</para>
+///
+/// <para><b>Why bytes are mandatory rather than a refinement.</b> Measured on the fleet at 2026-09-10, 50
+/// targets and 7,597 rows over 5,970 GB of index: <see cref="PgIndexBloatSuppression.ParentNeverAnalyzed"/>
+/// is the SECOND largest bucket by rows and the LAST by footprint, at 22 MB — 0.0004% of it. Meanwhile
+/// <see cref="PgIndexBloatSuppression.Partial"/> is fourth of five by rows and second by bytes at 1,385 GB.
+/// Both orderings look defensible and only one is useful, so a census reporting counts alone would point an
+/// operator squarely at the bucket that cannot matter.</para>
+///
+/// <para><b><c>skipped_reason IS NULL</c> is the only trust predicate, and nothing in the column names says
+/// so.</b> <c>est_tuple_bytes</c> is populated on 100% of suppressed rows in every bucket — 2954/2954,
+/// 2225/2225, 803/803, 698/698 — while <c>est_bloat_pct</c> is populated on 0% of them. The intermediate is
+/// universally present and both conclusions are universally NULL, so a reader who filters on the
+/// intermediate gets every row and believes they have complete coverage. That is incident four, and it cost
+/// a reported "461 GB now covered" against a real 214 GB of 5,954.</para>
+///
+/// <para><b>Pure policy, no clock and no I/O.</b> The caller reads the tallies and passes them in, the same
+/// discipline <c>PgColumnStatsCoverage</c> follows — which is what lets the arm selection be asserted
+/// without a store, and what lets one classifier serve the MCP tool and the WPF panel so the two cannot
+/// disagree about what a page of skipped rows means.</para>
+/// </summary>
+public static class PgIndexBloatCoverage
+{
+    /// <summary>
+    /// What the census prints where a figure should be when there is no measurement to put there. A word,
+    /// never a zero: "0 candidate indexes" is a finding and "we did not look" is not, and rendering those
+    /// two identically is the whole of this defect class.
+    /// </summary>
+    public const string NotMeasured = "not measured";
+
+    /// <summary>
+    /// What the census prints where a RATIO should be when the population was measured and has no footprint
+    /// to take a share of. Distinct from <see cref="NotMeasured"/>, and the distinction is the same one this
+    /// class exists for one level down: 0 of 0 bytes is undefined arithmetic over a real measurement, and
+    /// rendering it as "we did not look" would put the no-evidence word on the one arm that has evidence.
+    /// </summary>
+    public const string NotApplicable = "not applicable";
+
+    /// <summary>
+    /// How far back the population figures are measured, and the single definition of it — the store reader
+    /// applies this rather than holding a copy, because the figure appears in operator-facing text and a
+    /// second definition is how the label stops describing the query.
+    ///
+    /// <para><b>Two of the subject collector's own cadences, not one.</b> <c>pg_index_bloat</c> runs every
+    /// 1440 minutes, so a lookback of ONE cadence straddles zero or one run and any jitter or single lost
+    /// cycle manufactures <see cref="PgIndexBloatCoverageArm.Undetermined"/> on a server holding a week of
+    /// evidence. That is not hypothetical for this collector: measured on a live Aurora target on
+    /// 2026-09-10 it recorded 7 runs in seven days and 3 of them ERRORED — a 42.9% failure rate, one of
+    /// them a 300-second client-side command deadline that stored nothing at all. A single-cadence window
+    /// landing on that cycle would have answered "coverage cannot be established" beside six days of
+    /// perfectly good census rows. Two cadences is the smallest span that survives one lost cycle, which is
+    /// the property <c>PgColumnStatsCoverage.EvidenceHours</c> gets for free by spanning twenty-four of its
+    /// evidence collector's hourly runs.</para>
+    ///
+    /// <para>It is deliberately NOT the caller's window — see the store reader's <c>EvidenceStart</c> for
+    /// why that is wrong in both directions, and <see cref="PgIndexBloatCoverageArm.EvidenceStale"/> for
+    /// what happens when the two spans disagree.</para>
+    /// </summary>
+    public const int EvidenceHours = 48;
+
+    /// <summary>
+    /// How the census labels the span its population figures are measured over, derived from
+    /// <see cref="EvidenceHours"/> rather than retyped. Spelled out beside the figures because the returned
+    /// row count is measured over a DIFFERENT span — the caller's own window, and subject to the caller's
+    /// own limit — and a reader drawing a ratio across them has to know that before doing it.
+    /// </summary>
+    public static readonly string EvidenceHoursDescription =
+        "measured over the last " + EvidenceHours.ToString(CultureInfo.InvariantCulture) + "h";
+
+    /// <summary>
+    /// The <c>GRANT</c> remedy, one copy. It names the PostgreSQL 14+ role because that is the grant
+    /// measured to restore agreement with a superuser's numbers (#2542), and the explicit GRANT beside it
+    /// because 13 has no such role.
+    /// </summary>
+    public const string PrivilegeRemedy =
+        "Remedy: grant the monitoring login read access - GRANT pg_read_all_data TO <login> on PostgreSQL 14 "
+        + "and above, or GRANT SELECT on the parent tables on 13. Row-level security empties pg_stats by the "
+        + "same filter, so check for policies on these tables if the grant is already in place.";
+
+    /// <summary>
+    /// The prose prefix the collector writes for each bucket, and the key it maps to. Prefixes rather than
+    /// substring probes, and read from the collector's own literals — a marker that has drifted from the
+    /// shipped SQL sends every row of that bucket to
+    /// <see cref="PgIndexBloatSuppression.Unrecognized"/>, which is why a pin asserts each one still appears
+    /// in the query the collector actually issues.
+    ///
+    /// <para>Sorted longest-marker-first BY CONSTRUCTION rather than by how they are typed below, so a
+    /// marker that is also the start of another cannot decide the match by declaration accident. None
+    /// currently overlap; sorting is what keeps a later addition from making the declaration order
+    /// load-bearing, and what keeps the claim in this sentence from depending on somebody counting
+    /// characters correctly.</para>
+    /// </summary>
+    public static readonly IReadOnlyList<(string Marker, PgIndexBloatSuppression Reason)> Markers =
+    [
+        .. new (string Marker, PgIndexBloatSuppression Reason)[]
+        {
+            ("partial index:", PgIndexBloatSuppression.Partial),
+            ("the parent table has never been analyzed", PgIndexBloatSuppression.ParentNeverAnalyzed),
+            ("a key column is name-typed", PgIndexBloatSuppression.NameTypedKey),
+            ("column widths are not visible for every key", PgIndexBloatSuppression.ColumnWidthsNotVisible),
+            ("the index occupies no pages yet", PgIndexBloatSuppression.NoPagesYet),
+            ("the model predicts more pages than the index occupies", PgIndexBloatSuppression.NegativeBloat),
+        }.OrderByDescending(entry => entry.Marker.Length),
+    ];
+
+    /// <summary>
+    /// Which bucket a stored <c>skipped_reason</c> belongs to. Unknown prose answers
+    /// <see cref="PgIndexBloatSuppression.Unrecognized"/> rather than throwing or guessing: the store holds
+    /// 90 days of rows and the reason text is not a contract, so failing toward "we do not know which
+    /// bucket" keeps the bytes in the census where a dropped row would take them out of it.
+    /// </summary>
+    public static PgIndexBloatSuppression Bucket(string? skippedReason)
+    {
+        if (string.IsNullOrWhiteSpace(skippedReason))
+        {
+            return PgIndexBloatSuppression.Unrecognized;
+        }
+
+        var reason = skippedReason.TrimStart();
+
+        foreach (var (marker, bucket) in Markers)
+        {
+            if (reason.StartsWith(marker, StringComparison.OrdinalIgnoreCase))
+            {
+                return bucket;
+            }
+        }
+
+        return PgIndexBloatSuppression.Unrecognized;
+    }
+
+    /// <summary>
+    /// What to DO about one bucket, and whether anything can be. Separate from the prose the collector
+    /// stores, which explains the modelling rather than naming the action.
+    /// </summary>
+    public static string Remedy(PgIndexBloatSuppression reason) =>
+        reason switch
+        {
+            PgIndexBloatSuppression.ColumnWidthsNotVisible =>
+                "pg_stats yielded no width for at least one key column, and on a managed fleet the usual "
+                + "cause is the monitoring login rather than the index: pg_stats filters on "
+                + "has_column_privilege and pg_monitor does not confer SELECT. " + PrivilegeRemedy
+                + " A never-analyzed parent empties the same view, so ANALYZE the parents that stay dark "
+                + "after the grant lands.",
+            PgIndexBloatSuppression.ParentNeverAnalyzed =>
+                "Remedy: ANALYZE the parent tables. reltuples is -1 until the first analyze, so there is no "
+                + "row count to model from and one pass makes these estimable.",
+            PgIndexBloatSuppression.Partial =>
+                "STRUCTURAL, not remediable: the model scales the parent's row count and the index holds "
+                + "only the rows matching its predicate. No grant and no ANALYZE reaches these - "
+                + "exact_measurement_command is the only route to a figure.",
+            PgIndexBloatSuppression.NegativeBloat =>
+                "STRUCTURAL, not remediable: PostgreSQL 13 and above store duplicate keys once in a posting "
+                + "list, so real storage is denser than per-tuple arithmetic predicts and a CORRECT model "
+                + "still over-predicts. exact_measurement_command is the only route to a figure.",
+            PgIndexBloatSuppression.NameTypedKey =>
+                "STRUCTURAL, not remediable: a name-typed key column's pg_stats width is the padded 64 "
+                + "bytes rather than the stored text, so the statistic exists and is the wrong quantity. "
+                + "exact_measurement_command is the only route to a figure.",
+            PgIndexBloatSuppression.NoPagesYet =>
+                "Nothing to fix: these indexes occupy no pages, so there is no space in them to reclaim. "
+                + "They are here because the trust predicate is the presence of a reason, and this is the "
+                + "one reason that is a measurement rather than a gap.",
+            _ =>
+                "UNATTRIBUTED: the stored reason text is not one this build recognises, so its bytes are "
+                + "counted in the suppressed total and its cause is not named. A collector newer or older "
+                + "than this read produces exactly this; check the collector and this read are the same "
+                + "build before reading anything else into it.",
+        };
+
+    /// <summary>
+    /// The arm this server's coverage falls in, the population figures it was decided from, and the
+    /// sentence for it.
+    ///
+    /// <para><b>The candidate total is DERIVED from the parts rather than passed in, and that is a
+    /// correctness choice.</b> Every row is either trusted or suppressed — <c>skipped_reason IS NULL</c>
+    /// partitions the population exhaustively — so a separately queried total could only ever disagree with
+    /// the breakdown printed to explain it, and a census whose parts do not add up to its total is worse
+    /// than one that omits the total.</para>
+    ///
+    /// <para>Order is load-bearing. <paramref name="evidenceCollectorRan"/> is asked FIRST because every
+    /// other arm is an inference from figures that mean nothing until the collector supplying them has
+    /// produced a run — asking it later lets an absent collector answer
+    /// <see cref="PgIndexBloatCoverageArm.NoCandidates"/>, which is a confident all-clear over no
+    /// measurement. Then the candidate count, because a server with nothing to model cannot have a coverage
+    /// gap worth reporting. Only then the arms that need the trusted tally to tell apart.</para>
+    /// </summary>
+    /// <param name="evidenceCollectorRan">
+    /// Whether <c>pg_index_bloat</c> recorded a SUCCEEDING run for this server in the evidence window.
+    /// Deliberately a run and deliberately a succeeding one: a run that hit its command deadline stores
+    /// nothing and still writes a log row, so an unfiltered probe would report "it ran" over zero rows and
+    /// this classifier would answer <see cref="PgIndexBloatCoverageArm.NoCandidates"/> — "nothing to do" —
+    /// on a target whose collector is timing out. Measured at 3 errored runs of 7 on a live target.
+    /// </param>
+    /// <param name="estimated">Candidates whose latest row in the window carries a statistics estimate.</param>
+    /// <param name="exactlyMeasured">Candidates whose latest row is an older <c>pgstatindex</c> measurement
+    /// still inside retention. Kept separate from <paramref name="estimated"/> because the two mean
+    /// different things about how much the number can be trusted, not because they rank differently.</param>
+    /// <param name="suppressed">One bucket per distinct stored reason. Merged by key and ranked by bytes
+    /// here rather than at the call site, so two surfaces cannot rank them two ways.</param>
+    /// <param name="returnedRows">Rows the caller's read actually returned — over the caller's window and
+    /// subject to the caller's limit, which is why it is labelled as such and never divided into a
+    /// population figure.</param>
+    public static PgIndexBloatCoverageVerdict Classify(
+        bool evidenceCollectorRan,
+        PgIndexBloatTally estimated,
+        PgIndexBloatTally exactlyMeasured,
+        IReadOnlyList<PgIndexBloatSuppressionBucket>? suppressed,
+        int returnedRows)
+    {
+        var buckets = Merge(suppressed);
+        var trusted = estimated + exactlyMeasured;
+        var candidates = buckets.Aggregate(
+            trusted,
+            (running, bucket) => running + new PgIndexBloatTally(bucket.IndexCount, bucket.IndexBytes));
+
+        if (!evidenceCollectorRan)
+        {
+            return new PgIndexBloatCoverageVerdict(
+                PgIndexBloatCoverageArm.Undetermined,
+                Census(null, null, null, [], returnedRows),
+                "WHAT SHARE of this server's indexes have an answer cannot be established: pg_index_bloat "
+                + "recorded no succeeding run here in this window. It collects DAILY and only off a writer, "
+                + "so a read replica, a window shorter than a cycle, and a collector erroring on every "
+                + "cycle all legitimately leave no evidence - and this read will not guess which. Do not "
+                + "read the rows beside this as a coverage claim in either direction.",
+                default,
+                default,
+                default,
+                []);
+        }
+
+        var census = Census(candidates, estimated, exactlyMeasured, buckets, returnedRows);
+
+        if (candidates.IndexCount <= 0)
+        {
+            /* The RETURNED ROW COUNT is asked before the emptiness verdict is claimed, because the two are
+               measured over different spans and can therefore disagree. Rows in hand say candidate indexes
+               DID exist when they were collected, whatever the evidence window says about now - so "there
+               is nothing here" is a statement the data printed beside it contradicts. */
+            if (returnedRows > 0)
+            {
+                return new PgIndexBloatCoverageVerdict(
+                    PgIndexBloatCoverageArm.EvidenceStale,
+                    census,
+                    "COVERAGE CANNOT BE ATTRIBUTED - the evidence and the rows describe different "
+                    + "populations. Rows were returned, so candidate indexes DID exist when they were "
+                    + "collected, yet the evidence window holds none. The two are measured over different "
+                    + "spans, so an index dropped since, a database gone from the enumeration, or a "
+                    + "collector erroring for longer than the evidence window produces exactly this. Read "
+                    + "the rows as describing indexes that may no longer exist, and do not read this as "
+                    + "full coverage or as an absence of bloat.",
+                    candidates,
+                    estimated,
+                    exactlyMeasured,
+                    buckets);
+            }
+
+            return new PgIndexBloatCoverageVerdict(
+                PgIndexBloatCoverageArm.NoCandidates,
+                census,
+                "NO CANDIDATES: the collector ran and this server has no btree index for it to model. This "
+                + "census has no size floor, so that is a genuinely empty schema rather than a floor "
+                + "filtering small indexes out. Nothing to fix.",
+                candidates,
+                estimated,
+                exactlyMeasured,
+                buckets);
+        }
+
+        if (trusted.IndexCount <= 0)
+        {
+            return new PgIndexBloatCoverageVerdict(
+                PgIndexBloatCoverageArm.NothingTrusted,
+                census,
+                "NO COVERAGE AT ALL: every candidate index on this server carries a reason instead of an "
+                + "answer, so nothing here ranks anything. A page of rows from this server is 100% "
+                + "suppressed because that is ALL there is, not because the limit truncated a ranking - and "
+                + "raising the limit cannot change it. The largest bucket by BYTES, which is the one worth "
+                + "acting on: " + Dominant(buckets),
+                candidates,
+                estimated,
+                exactlyMeasured,
+                buckets);
+        }
+
+        if (buckets.Count > 0)
+        {
+            return new PgIndexBloatCoverageVerdict(
+                PgIndexBloatCoverageArm.PartialCoverage,
+                census,
+                "PARTIAL COVERAGE, not a clean bill of health. Indexes with no answer are ABSENT from the "
+                + "ranking rather than unremarkable in it, and they sort FIRST, so a truncated read shows "
+                + "them and not the answers behind them. Judge the gap by the byte share above and never by "
+                + "the row share - the two rank these buckets differently. The largest bucket by BYTES: "
+                + Dominant(buckets),
+                candidates,
+                estimated,
+                exactlyMeasured,
+                buckets);
+        }
+
+        return new PgIndexBloatCoverageVerdict(
+            PgIndexBloatCoverageArm.FullyTrusted,
+            census,
+            "FULL COVERAGE: every candidate index on this server has an answer, with none withheld by a "
+            + "modelling limit or a missing grant. The ranking describes the whole of this server's btree "
+            + "footprint.",
+            candidates,
+            estimated,
+            exactlyMeasured,
+            buckets);
+    }
+
+    /// <summary>
+    /// The verdict when the evidence read itself failed — <see cref="PgIndexBloatCoverageArm.Undetermined"/>
+    /// with its OWN wording, because "the monitoring store could not be read" and "this collector does not
+    /// run on this target" are different situations and only one of them is the design working.
+    ///
+    /// <para>Here rather than at the call site so every operator-facing sentence about this collector's
+    /// coverage lives in one file and is pinned together. A caller composing its own would be the second
+    /// copy, and the second copy is the one that drifts.</para>
+    /// </summary>
+    public static PgIndexBloatCoverageVerdict EvidenceUnreadable(int returnedRows) =>
+        new(PgIndexBloatCoverageArm.Undetermined,
+            Census(null, null, null, [], returnedRows),
+            "WHAT SHARE of this server's indexes have an answer cannot be established: the monitoring store "
+            + "read that supplies the figures above FAILED. That is a monitoring-side fault rather than "
+            + "anything about the target, so check collection health for THIS store - and read nothing "
+            + "about the target's indexes into it either way.",
+            default,
+            default,
+            default,
+            []);
+
+    /// <summary>
+    /// The buckets merged by key and ranked by BYTES descending — the ranking the whole issue turns on.
+    /// Merged because two distinct stored prose strings can map to one key, and two entries under one key
+    /// would let a reader add a bucket to itself.
+    /// </summary>
+    private static IReadOnlyList<PgIndexBloatSuppressionBucket> Merge(
+        IReadOnlyList<PgIndexBloatSuppressionBucket>? suppressed)
+    {
+        if (suppressed is null || suppressed.Count == 0)
+        {
+            return [];
+        }
+
+        return
+        [
+            .. suppressed
+                .GroupBy(bucket => bucket.Reason)
+                .Select(group => new PgIndexBloatSuppressionBucket(
+                    group.Key,
+                    group.Sum(bucket => bucket.IndexCount),
+                    group.Sum(bucket => bucket.IndexBytes),
+                    group.Select(bucket => bucket.Detail).FirstOrDefault(detail => detail is not null)))
+                /* Bytes, then count, then the key itself - a total order, so the dominant bucket a verdict
+                   names is the same one on every call rather than whatever the grouping happened to emit. */
+                .OrderByDescending(bucket => bucket.IndexBytes)
+                .ThenByDescending(bucket => bucket.IndexCount)
+                .ThenBy(bucket => bucket.Reason),
+        ];
+    }
+
+    /// <summary>
+    /// The largest bucket by bytes, named with its remedy and no figures. Its FIGURES are in the census;
+    /// repeating them here would make the cause a function of the numbers rather than of the verdict.
+    /// </summary>
+    private static string Dominant(IReadOnlyList<PgIndexBloatSuppressionBucket> buckets) =>
+        buckets.Count == 0
+            ? string.Empty
+            : Label(buckets[0].Reason) + ". " + Remedy(buckets[0].Reason);
+
+    /// <summary>
+    /// One bucket's short operator-facing label. Distinct from the enum name, which is a programming
+    /// identifier, and from the collector's stored prose, which is a paragraph.
+    /// </summary>
+    public static string Label(PgIndexBloatSuppression reason) =>
+        reason switch
+        {
+            PgIndexBloatSuppression.ColumnWidthsNotVisible => "column widths not visible for every key",
+            PgIndexBloatSuppression.ParentNeverAnalyzed => "parent table never analyzed",
+            PgIndexBloatSuppression.Partial => "partial index",
+            PgIndexBloatSuppression.NegativeBloat => "negative bloat (deduplicated index)",
+            PgIndexBloatSuppression.NameTypedKey => "name-typed key column",
+            PgIndexBloatSuppression.NoPagesYet => "index occupies no pages",
+            _ => "reason not recognised by this build",
+        };
+
+    /// <summary>
+    /// The population figures and the returned row count, labelled, in the one format every arm uses. Nulls
+    /// render as <see cref="NotMeasured"/>.
+    ///
+    /// <para>Every figure is formatted invariantly: the viewer runs on whatever desktop the operator has and
+    /// the MCP answer is parsed by machines, so a separator that moved with the host locale would render
+    /// one reading two ways.</para>
+    /// </summary>
+    private static string Census(
+        PgIndexBloatTally? candidates,
+        PgIndexBloatTally? estimated,
+        PgIndexBloatTally? exactlyMeasured,
+        IReadOnlyList<PgIndexBloatSuppressionBucket> buckets,
+        int returnedRows)
+    {
+        var trusted = candidates is null || estimated is null || exactlyMeasured is null
+            ? (PgIndexBloatTally?)null
+            : estimated.Value + exactlyMeasured.Value;
+
+        var suppressedCount = candidates is null
+            ? (long?)null
+            : candidates.Value.IndexCount - (trusted?.IndexCount ?? 0);
+        var suppressedBytes = candidates is null
+            ? (long?)null
+            : candidates.Value.IndexBytes - (trusted?.IndexBytes ?? 0);
+
+        return "Candidate btree indexes on this server (" + EvidenceHoursDescription
+            + ", independently of your row limit): " + Tally(candidates)
+            + ". WITH a trusted answer: " + Tally(trusted) + " - " + BytePercent(trusted, candidates)
+            + " (from the statistics model: " + Tally(estimated)
+            + "; older exact measurements still in retention: " + Tally(exactlyMeasured)
+            + "). WITH NO answer: " + Count(suppressedCount) + " holding " + Bytes(suppressedBytes)
+            + ", by reason and ranked BY BYTES because the row ranking and the byte ranking disagree"
+            + Breakdown(buckets)
+            + ". Rows returned (over the window you asked for, and capped by your row limit): "
+            + Count(returnedRows) + ".";
+    }
+
+    private static string Breakdown(IReadOnlyList<PgIndexBloatSuppressionBucket> buckets) =>
+        buckets.Count == 0
+            ? string.Empty
+            : " - " + string.Join(
+                "; ",
+                buckets.Select(bucket =>
+                    Label(bucket.Reason) + " " + Count(bucket.IndexCount) + " / " + Bytes(bucket.IndexBytes)));
+
+    private static string Tally(PgIndexBloatTally? tally) =>
+        tally is { } present
+            ? Count(present.IndexCount) + " holding " + Bytes(present.IndexBytes)
+            : NotMeasured;
+
+    /// <summary>
+    /// The BYTE-weighted coverage share, which is the figure the row share gets wrong. Measured on the
+    /// fleet, 917 trusted rows of 7,597 reads as 12% by rows and is 3.84% of the footprint, because the
+    /// suppressed indexes are the big ones.
+    ///
+    /// <para>Three outcomes, not two. A zero denominator over a MEASURED population is undefined arithmetic
+    /// rather than an absent measurement, so it answers <see cref="NotApplicable"/> — putting
+    /// <see cref="NotMeasured"/> there would print the no-evidence word on the one arm that has evidence,
+    /// which is this whole defect class reappearing inside its own fix.</para>
+    /// </summary>
+    private static string BytePercent(PgIndexBloatTally? trusted, PgIndexBloatTally? candidates)
+    {
+        if (trusted is not { } part || candidates is not { } whole)
+        {
+            return NotMeasured + " as a share of the candidate footprint";
+        }
+
+        return whole.IndexBytes > 0
+            ? (100.0 * part.IndexBytes / whole.IndexBytes).ToString("0.00", CultureInfo.InvariantCulture)
+              + "% of the candidate footprint"
+            : NotApplicable + " as a share of the candidate footprint, which is zero bytes";
+    }
+
+    private static string Count(long? value) =>
+        value is { } present ? present.ToString("N0", CultureInfo.InvariantCulture) : NotMeasured;
+
+    /// <summary>
+    /// Bytes in a unit a person can read, chosen per figure. A fixed unit cannot serve both ends of this
+    /// range: the fleet's largest suppression bucket is 4,144 GB and its smallest is 22 MB, and rendering
+    /// the small one in the large one's unit prints a ZERO beside a non-zero index count — which is the
+    /// exact confusion between "none" and "a small amount" this class exists to prevent. Comparison across
+    /// buckets is served by the ORDERING, which is already done for the reader, so it does not need one
+    /// unit.
+    /// </summary>
+    private static string Bytes(long? value)
+    {
+        if (value is not { } bytes)
+        {
+            return NotMeasured;
+        }
+
+        const long Kib = 1024L;
+        const long Mib = Kib * 1024L;
+        const long Gib = Mib * 1024L;
+
+        return bytes switch
+        {
+            < Kib => bytes.ToString("N0", CultureInfo.InvariantCulture) + " B",
+            < Mib => (bytes / (double)Kib).ToString("N1", CultureInfo.InvariantCulture) + " KB",
+            < Gib => (bytes / (double)Mib).ToString("N1", CultureInfo.InvariantCulture) + " MB",
+            _ => (bytes / (double)Gib).ToString("N1", CultureInfo.InvariantCulture) + " GB",
+        };
+    }
+}


### PR DESCRIPTION
Addresses #3278.

`get_pg_index_bloat` sorts rows carrying a `skipped_reason` FIRST, by design — the index nobody can model is the likeliest big win, so filtering it out would hide the biggest candidate. The consequence is that any `LIMIT` smaller than the answerless population returns 100% answerless rows, structurally rather than by chance, and raising the limit does not fix it while that population is still larger. The row list cannot carry its own denominator, so a separate population-level read supplies one.

## Not modelled on `get_pg_table_bloat`

The issue body suggests it, and copying it would reproduce the defect: table bloat computes `trusted_estimate_count` over the rows it RETURNED, so under a limit smaller than the skipped population it still has no denominator. The model here is `get_pg_column_stats` (#3154) — a separate aggregate query, a fixed evidence lookback, and a pure classifier.

## What it returns

`PgIndexBloatCoverage` is a pure classifier over its own query: candidate btree indexes on the server, the trusted set split into statistics-model estimates and older exact `pgstatindex` measurements still inside retention, and the suppressed remainder keyed to a short stable reason. Six arms — `Undetermined`, `NoCandidates`, `NothingTrusted`, `PartialCoverage`, `FullyTrusted`, `EvidenceStale` — with `Census` (the figures, one shape for every arm) and `Cause` (the verdict, carrying no figures) as separate components.

**Every count carries its BYTES, and that is a requirement rather than a refinement.** On the fleet capture in the issue, the row ranking and the byte ranking of the suppression buckets disagree: `parent never analyzed` is second largest of five by rows and LAST by footprint at 22 MB of 5,970 GB — 0.0004% of it — while `partial index` is fourth by rows and second by bytes at 1,385 GB. A census reporting counts alone would point an operator squarely at the bucket that cannot matter. The classifier ranks buckets by bytes and the cause names the byte-dominant one with its remedy.

The candidate total is DERIVED from the trusted tallies plus the buckets rather than separately queried. `skipped_reason IS NULL` partitions the population exhaustively, so a separate total could only ever disagree with the breakdown printed to explain it.

## The evidence lookback is two of the collector's cadences, and it was measured

`pg_index_bloat` runs every 1440 minutes, so a lookback of ONE cadence straddles zero or one run and a single lost cycle manufactures `Undetermined` on a server holding a week of evidence. Measured read-only against a live Aurora target on 2026-09-10: 7 runs in seven days and **3 of them errored — a 42.9% failure rate**, one a 300-second client-side command deadline that stored nothing at all. A single-cadence window landing on that cycle would have answered "coverage cannot be established" beside six days of usable census rows. `EvidenceHours` is 48 for that reason, and the run probe counts only succeeding runs — an unfiltered probe would report "it ran" over zero rows and the classifier would answer `NoCandidates`, "nothing to fix", on a target whose collector is timing out.

## `skipped_reason IS NULL` stays the only trust predicate

`est_tuple_bytes` is populated on 100% of answerless rows in every bucket and `est_bloat_pct` on 0% of them, so the intermediate is universally present while both conclusions are universally NULL. The census reads neither conclusion column, groups on the reason, and the reader tests the reason BEFORE splitting on provenance — source order, because both orderings compile and both return a plausible number.

The census reuses the row read's `(skipped_reason IS NULL) DESC, collection_time DESC` tie-break and its `DISTINCT ON` index identity. If they differed the census would publish a trusted count the grid contradicts index by index; without `DISTINCT ON` it would count every index once per cycle and report twice the population and twice the footprint, which is wrong in the direction that flatters coverage.

## Three surfaces, not two

The MCP tool gains a structured `coverage` object (arm, evidence hours, and count-plus-bytes for candidates, trusted, estimated, exactly measured, and each suppression bucket with its label, remedy and the collector's prose carried once rather than per row) and prints the census on the empty AND the populated path. The truncation note now says why a truncated page is 100% answerless by construction and points at the coverage field instead of telling the reader to raise the limit. The tool `[Description]` carries the trap, since that is what an agent reads first.

The WPF panel prints the same verdict through the viewer data service. Its empty-state note previously asserted the missing `pg_stats` grant as the cause outright — a diagnosis it had no evidence for, and wrong wherever the collector simply has not run. That is now the classifier's answer, and the panel's own skipped count is labelled as a count of the grid rather than of the server.

**The web dashboard is the third, and it had the defect on its populated path.** `DarlingWebEndpoints` delegates straight to `DarlingMcpPgIndexTools.GetPgIndexBloat`, so the page already received the coverage object — and dropped it. Its empty envelope did reach the operator (`panels.js` mounts `emptyStrip(res.message)`, and the empty status carries the census), but the populated path rendered rows and nothing else. That is the path the caveat matters on: a page of answerless rows looks like a working read, and a client-authored subtitle cannot carry the figures because it is written before the read. `panels.js` gains an opt-in `noteKey` — a descriptor without one is untouched, which is every panel but this one — read through `getPath` and rendered by `noticeStrip`, so it is inert text like every other server value on the page.

While there, that panel's own prose was still describing the pre-#3234 census: titled "measured", subtitled "measured by walking the index", and telling the reader a missing figure meant a per-cycle budget skipped it. None of that has been true since the estimate arm shipped, and a coverage census printed under a title saying "measured" would contradict itself.

The existing `answered_count` / `estimated_count` / `exactly_measured_count` are unchanged and still withheld when truncated. Their caution was correct; this adds a true population figure beside them rather than replacing it.

## Pins

16 pins in `PgIndexBloatCoverageTests`, derived from the property's violation routes. Arms table-driven as a pure function; both surfaces asserted to CALL the shared accessor and to print it on both paths, through `CSharpSourceWalker.StripCommentsAndStrings` so a design comment cannot satisfy a call scan; neither surface may construct a verdict or re-rank the buckets; the miss answers asserted in precedence order; the verdict read asserted NOT to accept a `startUtc` it would ignore while the raw-evidence read takes both ends because it uses both; the printed hours label asserted to contain the constant the query uses; the reason markers asserted against the SHIPPED collector query; and a region sweep over 96 input combinations asserting no verdict contradicts the row set printed beside it.

Every pin was mutation-tested — 24 mutations, each turning the pin it guards red, restored and content-verified against HEAD (content compared byte-for-byte, not by diffstat). The web chain gets five of its own: reverting the title, dropping the `noteKey` from the panel, dropping it from the helper, reading the note ahead of the empty branch, and rendering the body without it. One of them earned a fix: `TheCauseCarriesNoneOfTheInputFigures` checked a fixed list of input figures, so a mutation that echoed the DERIVED candidate total passed it and was caught only by an unrelated pin. It now tests INVARIANCE — same arm, same dominant bucket, wildly different figures, identical cause — which catches any figure, raw or summed. Both variants go red against it now.

`Darling.Tests` is `net10.0-windows` and cannot run on macOS, so the actual test `.cs` was compiled into a `net10.0` console harness with an xunit shim and run: 15 passed, 0 failed. It caught two real defects before commit — two hand-typed byte sums that were wrong (5,971 and 5,742 against a real 5,969 and 5,740, now derived from the bucket constants rather than restated), and a leak where a measured zero footprint printed "not measured", putting the no-evidence word on the one arm that has evidence. That third state is now its own `NotApplicable` token with its own pin.

One pin elsewhere moved with it. `ServerPageTabsTests.EveryDataPanel_ExplainsItsOwnEmptyState` asserts `table()`'s WHOLE signature, so that `emptyText` is pinned as a declared parameter rather than something read off an options object; appending `noteKey` broke the literal. It stays spelled out rather than truncated at `emptyText`, because a prefix match would stop noticing a parameter inserted BEFORE it — which is what the full literal is for. Found by grepping every test for the exact literals of each region this diff touches, then by compiling that whole class into the local harness and running it: 17 pins there, all green.

## One pin that needs a real store, because none of the others can reach it

`GetCoverageVerdictAsync` catches every exception and answers `Undetermined`, deliberately — the census runs to EXPLAIN a result the caller already has and must not turn that into a read error. The cost of that decision is that a census which does not PARSE degrades to a polite sentence, on every server, forever, with nothing that fails. The 15 pins above are pure functions and source scans; not one of them can tell a working query from a syntactically broken one.

`DarlingPgIndexBloatCoverageLivePostgresTests` executes it against the store CI stands up, and settles the three properties only a real store can:

- **The window reduces to one row per index.** This collector writes every btree on every cycle, so the fixture seeds two cycles — twelve rows over six distinct indexes — and asserts the population is six. Twelve is the denominator error that makes coverage look better than it is.
- **The census applies the row read's measured-row-wins tie-break.** `shipments_pkey` is seeded measured on the older cycle and labelled on the newer one, and has to count as answered — the same row the grid shows. A census disagreeing with the row read about which of an index's rows is current would publish a trusted count the grid contradicts index by index.
- **The run probe separates no-indexes from no-evidence**, including the errored-run case: the same rows answer `Undetermined` with the `collection_log` row deleted, and again with only an `ERROR` run present.

The seeded buckets are weighted so the row ranking and the byte ranking disagree — one index at 300 GB against three at 4 MB — because a fixture where they agree would pass whichever ordering shipped. Every suppressed row carries `est_tuple_bytes` and no `est_bloat_pct`, which is the fleet's measured shape on 100% of suppressed rows and the exact route incident four took.

I could not run this locally — there is no Postgres on this machine and `Darling.Tests` is Windows-targeted — so the `Darling PostgreSQL tests` job is its instrument, and its result is the only evidence that the census executes. Two counts in it were typed from memory and wrong before being derived from the fixture instead; that is noted here because the same mistake produced the two bad byte sums above, in one sitting.

## Two census lists this change moves, named here because their guards ask for it

**`TsqlConventionGuardTests.KnownTruncatedRanges` gains two entries** — `PerformanceMonitor.Collectors/PgIndexBloatCoverage.cs Count` and `... Tally`. Both ARRIVED (nothing left). They are the same expression-bodied formatter shape as the `PgColumnStatsCoverage.cs Figure` entry already in that list, in the classifier beside it. What each strands is a format fragment and nothing else: `Count` strands `"N0"` and `Tally` strands `" holding "` — and that list's own comment already names `"N0"` as an example of the kind of literal these entries strand. Neither is T-SQL and neither is a tempdb label, so no census reads a site of that kind here, which is the condition the comment sets for choosing an inventory over rewriting the member to suit the walker.

**`DarlingPgReadSqlParsesLiveTests.NotQueryFields` gains `DarlingPgIndexBloatReader.EvidenceStatusList`** — the twin of the `DarlingPgColumnStatsReader` entry directly above it. It is an `IN`-list fragment built from `EnumeratedCollectorDriver.FreshnessSuccessStatuses`, so it holds `'SUCCESS', 'SKIPPED'` and not a statement. The query it splices into, `CoverageEvidenceSql`, IS in the parse-checked population and **passed parse analysis against live PostgreSQL in CI** — so the fragment is verified where it is used rather than shipped unverified.

Both were caught by CI on the first push, both messages named exactly what to do, and both were then verified locally by compiling those two test classes into the harness and running them by name.

## CHANGELOG entry text (not committed — for the coordinator to splice)

```
- `get_pg_index_bloat` now returns a population-level coverage census — candidate btree indexes, trusted versus suppressed, and each suppression reason — with BYTES beside every count, from a separate query no row limit can reach. Its answerless rows sort first by design, so any limit below the answerless population returned 100% of them and a page could not be told apart from a coverage claim. Shipped on the MCP tool and the WPF storage panel through one classifier. (#3278)
```
