### PR TITLE
Fix dev red: the #3278 census test teardown ran bare SQL on a connection with no search_path

### DIFF
--- a/Darling/Darling.Tests/DarlingPgIndexBloatCoverageLivePostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingPgIndexBloatCoverageLivePostgresTests.cs
@@ -212,14 +212,13 @@ public sealed class DarlingPgIndexBloatCoverageLivePostgresTests
         }
         finally
         {
-            await LiveStoreCleanup.RunOwnedAsync(
-                bodySucceeded,
-                async () =>
-                {
-                    await using var cleanup = new NpgsqlConnection(connectionString);
-                    await cleanup.OpenAsync(CancellationToken.None);
-                    await DeleteRowsAsync(cleanup, CancellationToken.None);
-                });
+            /* RunAsync, not RunOwnedAsync: this cleanup's statements use unqualified table names, and a
+               connection Npgsql hands back from the pool can predate the store's first migration - it
+               then keeps the pre-ALTER default search_path for its whole life and every bare name
+               resolves to nothing (42P01). RunAsync opens the connection AND sets the search_path, which
+               is the whole reason it exists. Owning the connection here skipped that and made the
+               teardown depend on which physical session the pool happened to return. */
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, DeleteRowsAsync);
         }
     }
 


### PR DESCRIPTION
`dev` is red at `132b7ee1`. `Darling PostgreSQL tests` fails with `42P01: relation "pg_index_bloat" does not exist`, thrown from the #3278 census test's `finally`, not from any assertion. `Total: 8497, Failed: 1`. The preceding dev commit was green and the PR was green on its own head, so this appeared only after the merge.

## Cause

The test body resolves unqualified table names because `PgMigrations.MigrateAsync` runs on its connection first and the migrate session leaves `search_path` set. The teardown then called `LiveStoreCleanup.RunOwnedAsync` and opened a **second, fresh** connection by hand — which never migrates and never sets `search_path`, so every bare name in `DeleteRowsAsync` resolves against the default `"$user", public`.

It passed pre-merge because Npgsql pools physical sessions: whether that fresh connection happens to receive a session that was already migrated decides the outcome. An order-dependent teardown, not a deterministic break — which is also why it reproduces locally only sometimes.

`LiveStoreCleanup.RunAsync` exists for precisely this, and its own comment names the failure mode: *"SET, never inherit: Npgsql pools physical sessions, and one opened before the store's first migration keeps the pre-ALTER default `"$user", public` for its whole life — bare table names then resolve to nothing (42P01)."* The ratchet's guidance says the same thing in one clause: **opening a connection by hand is not enough.**

`RunOwnedAsync` is the right choice only when the cleanup must use connections the test already holds (#1902/#1896). This cleanup does not — it opens its own. `DeleteRowsAsync` already matches `RunAsync`'s delegate shape, so the conversion is the call site and nothing else.

## Verified

Reproduced the mechanism against real PostgreSQL 17, both directions:

| session | result |
|---|---|
| default `search_path` (`"$user", public`), bare name | `ERROR: relation "pg_index_bloat" does not exist` — identical to CI |
| `SET search_path = collect, config, public`, same statement | `DELETE 0` |

`Darling.Tests` compiles clean with `-p:EnableWindowsTargeting=true` (0 warnings, 0 errors). `LiveCleanupConversionRatchetTests.AConvertedTeardownIsNotAnOffender` accepts both entry points, so the conversion does not trip the ratchet, and no census names this file.

Swept the other four `RunOwnedAsync` callers: each documents a real reason (#1902/#1896) and none runs bare SQL on a connection it opened inside the cleanup. This was the only instance.

## Worth a separate decision

The ratchet catches a teardown that bypasses `LiveStoreCleanup` entirely, but not one that goes through `RunOwnedAsync` and then hand-opens a connection anyway — which is the case that broke `dev`. Its error text already asserts that rule, so the intent is there and the scan is one clause short of it. Not bundled here, because `dev` is red and this change is deliberately one call site.

## CHANGELOG

No entry. Test-only teardown correctness, no shipped behaviour change.