### PR TITLE
Rename the release-signature job so its check name is unambiguous

### DIFF
--- a/.github/workflows/release-signatures.yml
+++ b/.github/workflows/release-signatures.yml
@@ -29,7 +29,7 @@ permissions:
   contents: read
 
 jobs:
-  verify:
+  signatures:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
#3290 named its job `verify`. So does `claude-review-guard.yml`. A check's displayed name is its JOB id, so a pull request touching the signature reader produced **two checks both called `verify`** — one of them a review guard — with no way to tell which reported what.

Renamed to `signatures`. Job ids are now distinct across all nine workflows: `build`, `darling-pg`, `darling-linux`, `darling-tree-guards`, `check-branches`, `check-version`, `verify`, `review`, `description-drift`, `signatures`, `validate-sql`, and nightly's own set.

Found while confirming the new workflow had actually run. It had — but the check list showed a single `verify` line, which is precisely the ambiguity this removes.