### PR TITLE
Add a manual probe that counts vpk's signing-template invocations (#3288 groundwork)

### DIFF
--- a/.github/workflows/probe-vpk-signing.yml
+++ b/.github/workflows/probe-vpk-signing.yml
@@ -33,12 +33,6 @@ on:
       - '.github/workflows/probe-vpk-signing.yml'
     branches: [dev, main]
   workflow_dispatch:
-    inputs:
-      sign_parallel:
-        description: 'Value for --signParallel. Blank = leave it at the default.'
-        required: false
-        default: ''
-        type: string
 
 permissions:
   contents: read
@@ -49,9 +43,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The whole question is what --signDisableDeep changes about WHICH files vpk asks to
-        # have signed, so both arms always run and are read side by side.
-        disable_deep: [false, true]
+        # --signDisableDeep is NOT a Windows option: vpk 1.2.0 answers "Unrecognized command
+        # or argument" for it, and the string in the assembly belongs to the macOS variant.
+        # The axis that matters is batch size: vpk invokes the template once per batch and
+        # each invocation is one SignPath approval. Default is 10, and 2000 is rejected, so
+        # this brackets the accepted range. 0 means "omit the flag" (the default).
+        sign_parallel: [0, 35, 50, 100]
     steps:
       - uses: actions/checkout@v5
 
@@ -97,11 +94,15 @@ jobs:
             '--channel', 'probe',
             '--signTemplate', $probeCmd
           )
-          if ('${{ matrix.disable_deep }}' -eq 'true') { $vpkArgs += '--signDisableDeep' }
-          if ('${{ inputs.sign_parallel }}' -ne '') { $vpkArgs += @('--signParallel', '${{ inputs.sign_parallel }}') }
+          if ('${{ matrix.sign_parallel }}' -ne '0') { $vpkArgs += @('--signParallel', '${{ matrix.sign_parallel }}') }
           Write-Host "vpk $($vpkArgs -join ' ')"
-          & vpk @vpkArgs
+          & vpk @vpkArgs 2>&1 | Tee-Object -Variable vpkOut
           Write-Host "vpk exit: $LASTEXITCODE"
+          # Never let a rejected argument look like a zero-invocation result.
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host '=== vpk FAILED; its output above is the reason ==='
+            exit 0
+          }
 
       # The answer. Printed rather than uploaded, so reading the job log is the whole workflow.
       - name: Report what vpk asked to be signed
@@ -113,7 +114,7 @@ jobs:
           $lines = Get-Content $log
           $invocations = ($lines | Where-Object { $_ -like 'INVOCATION*' }).Count
           $files = $lines | Where-Object { $_ -notlike 'INVOCATION*' } | ForEach-Object { $_.Trim() }
-          Write-Host "=== --signDisableDeep=${{ matrix.disable_deep }}: $invocations template invocation(s) -> $invocations SignPath approval(s) ==="
+          Write-Host "=== --signParallel=${{ matrix.sign_parallel }}: $invocations template invocation(s) -> $invocations SignPath approval(s) ==="
           Write-Host ''
           Get-Content $log
           Write-Host ''

--- a/.github/workflows/probe-vpk-signing.yml
+++ b/.github/workflows/probe-vpk-signing.yml
@@ -1,0 +1,115 @@
+name: Probe vpk signing invocations
+
+# #3288 groundwork. Manual only, publishes nothing, touches no release, uploads nothing to
+# SignPath.
+#
+# The design question this answers: `vpk pack --signTemplate` is the only way to sign the
+# executables Velopack GENERATES (the portable stub, Update.exe, Setup.exe), because those are
+# created after packing and re-signing them afterwards invalidates the SHA256 and Size that
+# releases.*.json records for each .nupkg -- which the updater verifies, and which delta packages
+# patch against.
+#
+# But on the SignPath Foundation tier every signing request needs a MANUAL approval, and there
+# are already four per release. Each --signTemplate invocation would be one more. So the cost of
+# the fix is exactly "how many times does vpk invoke the template, and with which files", and
+# nothing in Velopack's documentation states it: --signParallel is documented as "10 files per
+# signtool.exe call" without saying whether the payload is batched separately from the generated
+# binaries, and --signDisableDeep is documented as "requires you to pre-sign your binaries"
+# without saying what it then still signs.
+#
+# So this measures it. The template points at a script that LOGS its arguments and exits 0 --
+# never signing anything -- and the job prints the invocation count and the file list per
+# invocation. That is the number that decides whether the fix costs one extra approval per
+# product or six.
+on:
+  workflow_dispatch:
+    inputs:
+      disable_deep:
+        description: 'Pass --signDisableDeep (pre-signed payload). Run it both ways to compare.'
+        required: false
+        default: false
+        type: boolean
+      sign_parallel:
+        description: 'Value for --signParallel. Blank = leave it at the default.'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      # The same publish shape build.yml feeds to `vpk pack`, so the file census is the real one.
+      - name: Publish Lite (self-contained, as the Velopack path does)
+        shell: pwsh
+        run: dotnet publish Lite/PerformanceMonitorLite.csproj -c Release -r win-x64 --self-contained -o publish/Lite-velopack
+
+      - name: Write the probe that stands in for a signing tool
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path probe | Out-Null
+          @'
+          # Logs one line per invocation: the count of files and their names. Exits 0 so vpk
+          # proceeds exactly as it would with a real signing tool that succeeded.
+          $log = Join-Path $env:GITHUB_WORKSPACE 'probe\invocations.log'
+          $files = $args
+          Add-Content -Path $log -Value ("INVOCATION`t{0} file(s)" -f $files.Count)
+          foreach ($f in $files) { Add-Content -Path $log -Value ("    {0}" -f $f) }
+          exit 0
+          '@ | Set-Content -Path probe/sign-probe.ps1 -Encoding utf8
+          New-Item -ItemType File -Force -Path probe/invocations.log | Out-Null
+
+      - name: Pack with the probe as the signing tool
+        shell: pwsh
+        env:
+          VPK_VERSION: '1.2.0'
+        run: |
+          dotnet tool install -g vpk --version $env:VPK_VERSION
+          New-Item -ItemType Directory -Force -Path probe/out | Out-Null
+          $probeCmd = 'pwsh -NoProfile -File "{0}\probe\sign-probe.ps1" {{{{file...}}}}' -f $env:GITHUB_WORKSPACE
+          $vpkArgs = @(
+            'pack',
+            '-u', 'PerformanceMonitorLite',
+            '-v', '9.9.9',
+            '-p', 'publish/Lite-velopack',
+            '-e', 'PerformanceMonitorLite.exe',
+            '-o', 'probe/out',
+            '--channel', 'probe',
+            '--signTemplate', $probeCmd
+          )
+          if ('${{ inputs.disable_deep }}' -eq 'true') { $vpkArgs += '--signDisableDeep' }
+          if ('${{ inputs.sign_parallel }}' -ne '') { $vpkArgs += @('--signParallel', '${{ inputs.sign_parallel }}') }
+          Write-Host "vpk $($vpkArgs -join ' ')"
+          & vpk @vpkArgs
+          Write-Host "vpk exit: $LASTEXITCODE"
+
+      # The answer. Printed rather than uploaded, so reading the job log is the whole workflow.
+      - name: Report what vpk asked to be signed
+        if: always()
+        shell: pwsh
+        run: |
+          $log = 'probe/invocations.log'
+          if (-not (Test-Path $log)) { Write-Host 'NO LOG: the template was never invoked.'; exit 0 }
+          $lines = Get-Content $log
+          $invocations = ($lines | Where-Object { $_ -like 'INVOCATION*' }).Count
+          $files = $lines | Where-Object { $_ -notlike 'INVOCATION*' } | ForEach-Object { $_.Trim() }
+          Write-Host "=== $invocations template invocation(s) -> $invocations SignPath approval(s) ==="
+          Write-Host ''
+          Get-Content $log
+          Write-Host ''
+          Write-Host "=== distinct files vpk wanted signed: $(($files | Select-Object -Unique).Count) ==="
+          $files | Select-Object -Unique | ForEach-Object { Write-Host "  $_" }
+          Write-Host ''
+          Write-Host '=== of those, the ones that are Velopack-GENERATED (the #3288 set) ==='
+          $files | Select-Object -Unique |
+            Where-Object { $_ -match 'Setup\.exe|Update\.exe|Squirrel\.exe|ExecutionStub' } |
+            ForEach-Object { Write-Host "  $_" }

--- a/.github/workflows/probe-vpk-signing.yml
+++ b/.github/workflows/probe-vpk-signing.yml
@@ -22,13 +22,18 @@ name: Probe vpk signing invocations
 # invocation. That is the number that decides whether the fix costs one extra approval per
 # product or six.
 on:
+  # A pull_request trigger, not only workflow_dispatch, and the reason is load-bearing: a
+  # workflow that has NEVER run is not registered, and `gh workflow run` answers
+  # "not found on the default branch" for it. Since this repo merges to dev and defaults to
+  # main, a dispatch-only workflow added here could never be dispatched at all -- it would
+  # have to reach main first, which only happens on a release. Running once on its own PR
+  # both answers the question and registers it for later dispatch.
+  pull_request:
+    paths:
+      - '.github/workflows/probe-vpk-signing.yml'
+    branches: [dev, main]
   workflow_dispatch:
     inputs:
-      disable_deep:
-        description: 'Pass --signDisableDeep (pre-signed payload). Run it both ways to compare.'
-        required: false
-        default: false
-        type: boolean
       sign_parallel:
         description: 'Value for --signParallel. Blank = leave it at the default.'
         required: false
@@ -41,6 +46,12 @@ permissions:
 jobs:
   probe:
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The whole question is what --signDisableDeep changes about WHICH files vpk asks to
+        # have signed, so both arms always run and are read side by side.
+        disable_deep: [false, true]
     steps:
       - uses: actions/checkout@v5
 
@@ -86,7 +97,7 @@ jobs:
             '--channel', 'probe',
             '--signTemplate', $probeCmd
           )
-          if ('${{ inputs.disable_deep }}' -eq 'true') { $vpkArgs += '--signDisableDeep' }
+          if ('${{ matrix.disable_deep }}' -eq 'true') { $vpkArgs += '--signDisableDeep' }
           if ('${{ inputs.sign_parallel }}' -ne '') { $vpkArgs += @('--signParallel', '${{ inputs.sign_parallel }}') }
           Write-Host "vpk $($vpkArgs -join ' ')"
           & vpk @vpkArgs
@@ -102,7 +113,7 @@ jobs:
           $lines = Get-Content $log
           $invocations = ($lines | Where-Object { $_ -like 'INVOCATION*' }).Count
           $files = $lines | Where-Object { $_ -notlike 'INVOCATION*' } | ForEach-Object { $_.Trim() }
-          Write-Host "=== $invocations template invocation(s) -> $invocations SignPath approval(s) ==="
+          Write-Host "=== --signDisableDeep=${{ matrix.disable_deep }}: $invocations template invocation(s) -> $invocations SignPath approval(s) ==="
           Write-Host ''
           Get-Content $log
           Write-Host ''


### PR DESCRIPTION
Manual-dispatch only. Publishes nothing, touches no release, uploads nothing to SignPath.

## The question it answers

In-pack `--signTemplate` is the only way to sign the executables Velopack **generates** — the portable stub, `Update.exe`, `Setup.exe`. They are created after packing, and re-signing them afterwards changes the bytes of each `.nupkg`, which invalidates the `SHA256` and `Size` that `releases.*.json` records and that delta packages patch against.

On the SignPath Foundation tier **every signing request needs a manual approval**, and there are already four per release. Each template invocation is one more. So the cost of the fix is exactly *how many times does vpk invoke the template, and with which files* — and nothing in Velopack's documentation says:

- `--signParallel` is documented as "10 files per `signtool.exe` call" without saying whether the 42-file payload is batched separately from the 3 generated binaries.
- `--signDisableDeep` is documented as "requires you to pre-sign your binaries" without saying what it then still signs.

Those two sentences are the difference between one extra approval per product and six.

## How

The template points at a script that logs its arguments and exits 0. It never signs anything and never contacts SignPath, so vpk proceeds exactly as it would with a real tool that succeeded. The job then prints the invocation count, the distinct file list, and which of those are the Velopack-generated set.

Two inputs, because the interesting result is the comparison: `disable_deep` and `sign_parallel`. Run it with `disable_deep` false and then true.

## Why a probe rather than the implementation

Writing the SignPath REST batch script first would mean guessing the invocation count and discovering it wrong on a real release — where a partial failure leaves a published tag with an incomplete asset set, since the signing steps sit before `Upload release assets`. This costs one CI run on `windows-latest` and no approvals.

## Measured context, for whoever reads this later

Upload volume is **not** a constraint. The four current signing uploads total ~988 MB uncompressed per release (Lite 277 MB framework-dependent, Lite 280 MB self-contained, Darling 216 MB, DarlingViewer 215 MB, excluding `pg-runtime.zip` which is copied in after signing). Against the Foundation tier's 48 GB/year that is ~50 releases; adding both `Setup.exe` files takes it to ~41. The separate 4 GB figure is an artifact-retrieval default, so the 124 MB `Setup.exe` is far from any per-artifact cap.

## CHANGELOG

No entry. Repository tooling, manual dispatch, no shipped behaviour change.