### PR TITLE
Sign the executables Velopack generates, during packing (#3288)

### DIFF
--- a/.github/scripts/sign-batch.ps1
+++ b/.github/scripts/sign-batch.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+  Signs a batch of files through SignPath. Written to be called BY `vpk pack --signTemplate` (#3288).
+
+.DESCRIPTION
+  Velopack generates the portable launcher stub, Update.exe and Setup.exe AFTER packing, so they
+  cannot be signed by the pre-pack rounds and cannot be signed afterwards either: re-signing a
+  file inside a .nupkg changes that package's bytes, which invalidates the SHA256 and Size that
+  releases.<channel>.json records and that delta packages patch against. Signing therefore has to
+  happen inside packing, which is what `--signTemplate` is for.
+
+  Measured behaviour of `vpk pack` 1.2.0 that this script depends on:
+
+    * It offers 35 files for the Lite payload, not ~700, because it SKIPS files that already
+      carry a signature -- Microsoft's framework binaries never reach here.
+    * With `--signParallel 50` it invokes this script exactly twice per product: once with the
+      34 pack-directory files, once with Setup.exe alone in its own later phase.
+    * It does NOT check that this script actually signed anything. A template that exits 0
+      without signing leaves packing to complete and the release to publish unsigned binaries,
+      which is precisely how #3288 shipped on two releases. So this script verifies its own
+      outcome before returning success, and that verification is the point of it.
+
+.PARAMETER Files
+  The files to sign, passed positionally by vpk in place of {{file...}}.
+
+.NOTES
+  Required environment:
+    SIGNPATH_API_TOKEN     CI user token
+    SIGNPATH_ORG_ID        organization id
+    SIGNPATH_PROJECT_SLUG  project slug
+    SIGNPATH_POLICY_SLUG   signing policy slug
+    SIGNPATH_CONFIG_SLUG   artifact configuration slug for a flat batch of PE files
+  Optional:
+    SIGNPATH_TIMEOUT_SECONDS  default 3600. Submit-SigningRequest's own default is 600, which
+                              is not enough when a human has to approve the request -- every
+                              Foundation-tier request does.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $Files
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Fail([string] $message) {
+    Write-Host "sign-batch: FAIL: $message"
+    exit 1
+}
+
+# The artifact configuration for this batch declares min-matches="0" on both suffixes, because a
+# batch may be all-exe (the Setup.exe invocation) or mixed (the pack directory). That removes the
+# loud failure the per-product configurations get from min-matches="1", so an EMPTY submission
+# would succeed and sign nothing. Refusing it here is the only thing standing in for that.
+if (-not $Files -or $Files.Count -eq 0) {
+    Fail 'no files were passed. An empty batch would be signed successfully and sign nothing.'
+}
+
+$missing = $Files | Where-Object { -not (Test-Path -LiteralPath $_ -PathType Leaf) }
+if ($missing) { Fail "these paths do not exist: $($missing -join ', ')" }
+
+foreach ($name in 'SIGNPATH_API_TOKEN', 'SIGNPATH_ORG_ID', 'SIGNPATH_PROJECT_SLUG',
+                  'SIGNPATH_POLICY_SLUG', 'SIGNPATH_CONFIG_SLUG') {
+    if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+        Fail "$name is not set."
+    }
+}
+
+$timeout = 3600
+if (-not [string]::IsNullOrWhiteSpace($env:SIGNPATH_TIMEOUT_SECONDS)) {
+    $timeout = [int] $env:SIGNPATH_TIMEOUT_SECONDS
+}
+
+Write-Host "sign-batch: $($Files.Count) file(s)"
+foreach ($f in $Files) { Write-Host "  $(Split-Path -Leaf $f)" }
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("signbatch-" + [guid]::NewGuid().ToString('N'))
+# A subdirectory, not the zip root: the artifact configuration matches `**/*.exe`, and whether
+# `**/` also matches zero path segments is not documented. One segment removes the question.
+$staged = Join-Path $work 'batch'
+New-Item -ItemType Directory -Force -Path $staged | Out-Null
+
+# vpk passes one directory's files per invocation so base names are unique in practice, but a
+# collision would silently drop a file from the batch and leave it unsigned, so it is checked
+# rather than assumed.
+$map = @{}
+foreach ($f in $Files) {
+    $leaf = Split-Path -Leaf $f
+    if ($map.ContainsKey($leaf)) {
+        Fail "two files in one batch share the name '$leaf': '$($map[$leaf])' and '$f'."
+    }
+    $map[$leaf] = (Resolve-Path -LiteralPath $f).Path
+    Copy-Item -LiteralPath $f -Destination (Join-Path $staged $leaf) -Force
+}
+
+$inputZip  = Join-Path $work 'batch.zip'
+$outputZip = Join-Path $work 'batch-signed.zip'
+Compress-Archive -Path (Join-Path $staged '*') -DestinationPath $inputZip -Force
+
+if (-not (Get-Module -ListAvailable -Name SignPath)) {
+    Install-Module -Name SignPath -Force -Scope CurrentUser -AllowClobber | Out-Null
+}
+Import-Module SignPath
+
+Write-Host "sign-batch: submitting to SignPath (timeout ${timeout}s; a Foundation-tier request waits for manual approval)"
+Submit-SigningRequest `
+    -InputArtifactPath $inputZip `
+    -OutputArtifactPath $outputZip `
+    -OrganizationId $env:SIGNPATH_ORG_ID `
+    -ApiToken $env:SIGNPATH_API_TOKEN `
+    -ProjectSlug $env:SIGNPATH_PROJECT_SLUG `
+    -SigningPolicySlug $env:SIGNPATH_POLICY_SLUG `
+    -ArtifactConfigurationSlug $env:SIGNPATH_CONFIG_SLUG `
+    -WaitForCompletion `
+    -WaitForCompletionTimeoutInSeconds $timeout
+
+if (-not (Test-Path -LiteralPath $outputZip)) { Fail 'SignPath returned no signed artifact.' }
+
+$expanded = Join-Path $work 'signed'
+Expand-Archive -LiteralPath $outputZip -DestinationPath $expanded -Force
+
+# Copy back over the ORIGINAL paths, because those are what vpk goes on to package.
+$restored = @()
+foreach ($leaf in $map.Keys) {
+    $signed = Get-ChildItem -LiteralPath $expanded -Recurse -File |
+              Where-Object { $_.Name -eq $leaf } | Select-Object -First 1
+    if (-not $signed) { Fail "SignPath's response does not contain '$leaf'." }
+    Copy-Item -LiteralPath $signed.FullName -Destination $map[$leaf] -Force
+    $restored += $map[$leaf]
+}
+
+# THE POST-CONDITION, and the reason this script cannot just trust its own exit code: vpk does
+# not check, so if this is wrong nothing downstream notices until a user is blocked by Windows.
+# Delegated to the reader that found #3288, whose PE parse is covered by six mutations.
+$verifier = Join-Path $PSScriptRoot 'verify_release_signatures.py'
+if (-not (Test-Path -LiteralPath $verifier)) { Fail "verifier not found beside this script: $verifier" }
+& python3 $verifier --verify-files @restored
+if ($LASTEXITCODE -ne 0) {
+    Fail "signing reported success but $($restored.Count) file(s) did not all come back signed."
+}
+
+Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
+Write-Host "sign-batch: $($restored.Count) file(s) signed and verified"
+exit 0

--- a/.github/scripts/verify_release_signatures.py
+++ b/.github/scripts/verify_release_signatures.py
@@ -196,6 +196,90 @@ def check_archive(url: str, name: str, size: int, include_dlls: bool) -> tuple[l
     return findings, errors
 
 
+def verify_local_files(paths: list[str]) -> int:
+    """Assert every named local file carries a signature. Used as the post-condition of signing.
+
+    This exists because `vpk pack` does NOT verify that its `--signTemplate` actually signed
+    anything: a template that exits 0 without signing leaves packing to complete normally and
+    the release to publish unsigned binaries, which is exactly how #3288 shipped twice. So the
+    signing script asserts the outcome here rather than trusting its own success.
+    """
+    failures, checked = [], 0
+    for path in paths:
+        try:
+            with open(path, "rb") as handle:
+                head = handle.read(HEADER_BYTES)
+            off, length = certificate_table(head)
+        except (OSError, ReadError, struct.error) as exc:
+            failures.append(f"{path}: unreadable as a PE image ({exc})")
+            continue
+        checked += 1
+        if off == 0 or length == 0:
+            failures.append(f"{path}: NO SIGNATURE after signing")
+    for f in failures:
+        print(f"VERIFY FAIL: {f}", file=sys.stderr)
+    if not checked:
+        print("VERIFY FAIL: nothing was checked", file=sys.stderr)
+        return 2
+    if failures:
+        return 1
+    print(f"verified: {checked} file(s) carry a signature")
+    return 0
+
+
+def verify_local_dir(directory: str) -> int:
+    """Assert every executable under `directory`, including inside zips and nupkgs, is signed.
+
+    This is the release guard. It runs on the artifacts as they sit on disk BEFORE upload, so it
+    needs no network and no published release -- the difference between this and the tag mode is
+    only where the bytes come from.
+    """
+    import glob
+    import os
+    import zipfile
+
+    findings: list[Finding] = []
+    for path in sorted(glob.glob(os.path.join(directory, "**", "*"), recursive=True)):
+        if not os.path.isfile(path):
+            continue
+        lower = path.lower()
+        rel = os.path.relpath(path, directory)
+        if lower.endswith(".exe"):
+            try:
+                with open(path, "rb") as handle:
+                    off, length = certificate_table(handle.read(HEADER_BYTES))
+                findings.append(Finding(rel, "", os.path.getsize(path), off != 0 and length != 0))
+            except (OSError, ReadError, struct.error) as exc:
+                print(f"GUARD: cannot read {rel}: {exc}", file=sys.stderr)
+                return 2
+        elif lower.endswith(ARCHIVE_SUFFIXES):
+            try:
+                with zipfile.ZipFile(path) as zf:
+                    for info in zf.infolist():
+                        if not info.filename.lower().endswith(".exe"):
+                            continue
+                        blob = zf.read(info)
+                        off, length = certificate_table(blob)
+                        findings.append(
+                            Finding(rel, info.filename, info.file_size, off != 0 and length != 0)
+                        )
+            except (OSError, zipfile.BadZipFile, ReadError, struct.error) as exc:
+                print(f"GUARD: cannot read {rel}: {exc}", file=sys.stderr)
+                return 2
+
+    if not findings:
+        print(f"GUARD FAIL: no executables found under {directory}", file=sys.stderr)
+        return 2
+    unsigned = [f for f in findings if not f.signed]
+    for f in sorted(findings, key=lambda x: (x.signed, x.label)):
+        print(f"  {'signed  ' if f.signed else 'UNSIGNED'}  {f.label}")
+    print(f"\n{len(findings)} executable(s) checked, {len(unsigned)} unsigned")
+    if unsigned:
+        print(f"GUARD FAIL: {len(unsigned)} unsigned executable(s). See #3288.", file=sys.stderr)
+        return 1
+    return 0
+
+
 def release_assets(tag: str, repo: str, gh: str) -> list[dict]:
     proc = subprocess.run(
         [gh, "api", f"repos/{repo}/releases/tags/{tag}"], capture_output=True, text=True
@@ -294,6 +378,17 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("tag", nargs="?", help="release tag, e.g. v3.7.0")
     parser.add_argument("--self-test", action="store_true", dest="self_test")
+    parser.add_argument(
+        "--verify-files",
+        nargs="+",
+        metavar="PATH",
+        help="verify local files carry a signature (the signing script's post-condition)",
+    )
+    parser.add_argument(
+        "--verify-dir",
+        metavar="DIR",
+        help="release guard: every .exe under DIR, including inside zips/nupkgs, must be signed",
+    )
     parser.add_argument("--repo", default="erikdarlingdata/PerformanceMonitor")
     parser.add_argument("--gh", default="gh", help="gh executable (use the identity wrapper)")
     parser.add_argument(
@@ -306,8 +401,12 @@ def main() -> int:
 
     if args.self_test:
         return self_test()
+    if args.verify_files:
+        return verify_local_files(args.verify_files)
+    if args.verify_dir:
+        return verify_local_dir(args.verify_dir)
     if not args.tag:
-        parser.error("a release tag is required unless --self-test is given")
+        parser.error("a release tag is required unless --self-test or --verify-files is given")
 
     try:
         report = build_report(args.tag, args.repo, args.gh, args.include_dlls)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -576,14 +576,12 @@ jobs:
           SIGNPATH_ORG_ID: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
           SIGNPATH_PROJECT_SLUG: 'PerformanceMonitor'
           SIGNPATH_POLICY_SLUG: 'release-signing'
-          # A repository variable rather than a literal: the artifact configuration for a flat
-          # batch of PE files is created on signpath.io, and a step naming a slug that does not
-          # exist fails the release -- the standing lesson from the DarlingViewer slug.
-          SIGNPATH_CONFIG_SLUG: ${{ vars.SIGNPATH_CONFIG_SLUG }}
+          # The artifact configuration for a flat batch of PE files, declared on signpath.io as
+          # `**/*.exe` and `**/*.dll` with min-matches="0" on both -- a batch is all-exe for the
+          # Setup.exe invocation and mixed for the pack directory, so neither suffix can be
+          # required. sign-batch.ps1 refuses an empty batch for exactly that reason.
+          SIGNPATH_CONFIG_SLUG: 'SignTemplate'
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:SIGNPATH_CONFIG_SLUG)) {
-            throw 'SIGNPATH_CONFIG_SLUG repository variable is not set; set it to the batch artifact configuration slug before cutting a release.'
-          }
           # Pin vpk to the Velopack library version (keep in sync with the Velopack
           # PackageReference in PerformanceMonitorLite.csproj).
           dotnet tool install -g vpk --version 1.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -558,68 +558,32 @@ jobs:
           Remove-Item "releases/PerformanceMonitorDarling-$version.zip" -ErrorAction SilentlyContinue
           Compress-Archive -Path 'signed/Darling/*' -DestinationPath "releases/PerformanceMonitorDarling-$version.zip" -Force
 
-      # The Velopack (Setup.exe) path publishes a SEPARATE self-contained build
-      # (publish/Dashboard-velopack, publish/Lite-velopack -- see the "self-contained
-      # for Velopack" steps above) that previously went straight into `vpk pack`
-      # without ever being uploaded to SignPath. Only the framework-dependent trees
-      # used for the legacy ZIPs were signed, so every Setup.exe shipped unsigned
-      # since Velopack packaging was introduced. These steps close that gap by
-      # mirroring the exact upload/sign pattern used for Dashboard/Lite/Installer
-      # above, and vpk pack below now reads from the signed output.
-      - name: Upload Lite (Velopack) for signing
-        if: github.event_name == 'release'
-        id: upload-lite-velopack
-        uses: actions/upload-artifact@v6
-        with:
-          name: Lite-Velopack-unsigned
-          path: publish/Lite-velopack/
-
-      - name: Upload Darling Viewer (Velopack) for signing
-        if: github.event_name == 'release'
-        id: upload-darlingviewer-velopack
-        uses: actions/upload-artifact@v6
-        with:
-          name: DarlingViewer-Velopack-unsigned
-          path: publish/DarlingViewer-velopack/
-
-      - name: Sign Lite (Velopack)
-        if: github.event_name == 'release'
-        uses: signpath/github-action-submit-signing-request@v2
-        with:
-          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
-          project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'release-signing'
-          artifact-configuration-slug: 'Lite'
-          github-artifact-id: '${{ steps.upload-lite-velopack.outputs.artifact-id }}'
-          wait-for-completion: true
-          output-artifact-directory: 'signed/Lite-Velopack'
-
-      # The remote-seat viewer Setup.exe (#1555) is signed with its OWN 'DarlingViewer' artifact
-      # configuration — the co-located-zip 'Darling' slug signs a service+viewer\ tree layout, which
-      # does not match this self-contained viewer-at-root publish. Like the 'Darling' slug, the
-      # 'DarlingViewer' config (which files get signed) lives outside this repo on signpath.io; until
-      # Erik creates the slug this step fails the release — the standing #1340 SignPath prerequisite.
-      - name: Sign Darling Viewer (Velopack)
-        if: github.event_name == 'release'
-        uses: signpath/github-action-submit-signing-request@v2
-        with:
-          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
-          project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'release-signing'
-          artifact-configuration-slug: 'DarlingViewer'
-          github-artifact-id: '${{ steps.upload-darlingviewer-velopack.outputs.artifact-id }}'
-          wait-for-completion: true
-          output-artifact-directory: 'signed/DarlingViewer-Velopack'
-
+      # #3288: the Velopack payload is no longer signed here. `vpk pack` signs it itself via
+      # --signTemplate, which is the ONLY way to reach the three executables Velopack GENERATES
+      # after packing -- the portable launcher stub, Update.exe and Setup.exe. Those cannot be
+      # signed afterwards: re-signing a file inside a .nupkg changes that package's bytes, which
+      # invalidates the SHA256 and Size recorded in releases.<channel>.json and patched against
+      # by delta packages. Two pre-pack rounds were removed here; --signParallel 50 makes the
+      # in-pack signing two invocations per product, so the release goes from 4 approvals to 6.
       - name: Create Velopack releases (Lite + Darling Viewer)
         if: github.event_name == 'release'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.VERSION }}
+          # Consumed by .github/scripts/sign-batch.ps1, which vpk invokes per batch.
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+          SIGNPATH_ORG_ID: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
+          SIGNPATH_PROJECT_SLUG: 'PerformanceMonitor'
+          SIGNPATH_POLICY_SLUG: 'release-signing'
+          # A repository variable rather than a literal: the artifact configuration for a flat
+          # batch of PE files is created on signpath.io, and a step naming a slug that does not
+          # exist fails the release -- the standing lesson from the DarlingViewer slug.
+          SIGNPATH_CONFIG_SLUG: ${{ vars.SIGNPATH_CONFIG_SLUG }}
         run: |
+          if ([string]::IsNullOrWhiteSpace($env:SIGNPATH_CONFIG_SLUG)) {
+            throw 'SIGNPATH_CONFIG_SLUG repository variable is not set; set it to the batch artifact configuration slug before cutting a release.'
+          }
           # Pin vpk to the Velopack library version (keep in sync with the Velopack
           # PackageReference in PerformanceMonitorLite.csproj).
           dotnet tool install -g vpk --version 1.2.0
@@ -628,13 +592,13 @@ jobs:
 
           # Lite: download previous + pack (from the SIGNED velopack output, not the raw publish dir)
           vpk download github --repoUrl https://github.com/${{ github.repository }} --channel lite -o releases/velopack-lite --token $env:GH_TOKEN
-          vpk pack -u PerformanceMonitorLite -v $env:VERSION -p signed/Lite-Velopack -e PerformanceMonitorLite.exe -o releases/velopack-lite --channel lite
+          vpk pack -u PerformanceMonitorLite -v $env:VERSION -p publish/Lite-velopack -e PerformanceMonitorLite.exe -o releases/velopack-lite --channel lite --signParallel 50 --signTemplate "pwsh -NoProfile -File $env:GITHUB_WORKSPACE\.github\scripts\sign-batch.ps1 {{file...}}"
 
           # Darling Viewer remote-seat installer (#1555): download previous + pack (from the SIGNED
           # velopack output). Its own 'darlingviewer' channel/delta feed, separate from the co-located
           # viewer inside PerformanceMonitorDarling-*.zip (which stays plain-zip only).
           vpk download github --repoUrl https://github.com/${{ github.repository }} --channel darlingviewer -o releases/velopack-darlingviewer --token $env:GH_TOKEN
-          vpk pack -u PerformanceMonitorDarlingViewer -v $env:VERSION -p signed/DarlingViewer-Velopack -e PerformanceMonitor.Darling.Viewer.exe -o releases/velopack-darlingviewer --channel darlingviewer
+          vpk pack -u PerformanceMonitorDarlingViewer -v $env:VERSION -p publish/DarlingViewer-velopack -e PerformanceMonitor.Darling.Viewer.exe -o releases/velopack-darlingviewer --channel darlingviewer --signParallel 50 --signTemplate "pwsh -NoProfile -File $env:GITHUB_WORKSPACE\.github\scripts\sign-batch.ps1 {{file...}}"
 
       - name: Generate checksums
         if: github.event_name == 'release'
@@ -659,6 +623,17 @@ jobs:
             [Text.UTF8Encoding]::new($false))
           Write-Host "Checksums:"
           $checksums | ForEach-Object { Write-Host $_ }
+
+      # #3288's guard, and it lands WITH the fix rather than before it: on the pre-fix tree it
+      # fails immediately, because ten executables per release were unsigned. It walks the
+      # artifacts on disk -- including the executables INSIDE the zips and nupkgs, which is
+      # where the launcher stub and Update.exe live -- so it needs no network and no published
+      # release. `vpk pack` does not check that --signTemplate signed anything, so without this
+      # a template that silently declined would publish exactly what #3288 published twice.
+      - name: Assert every published executable is signed
+        if: github.event_name == 'release'
+        shell: pwsh
+        run: python3 .github/scripts/verify_release_signatures.py --verify-dir releases
 
       - name: Upload release assets
         if: github.event_name == 'release'


### PR DESCRIPTION
Closes the #3288 gap: the portable launcher stub, `Update.exe` and `Setup.exe` ship unsigned on every release, for both Lite and the Darling remote-seat Viewer — ten executables per release, while the app payload is signed.

Nothing needs configuring before this merges: the batch artifact configuration slug is `SignTemplate`, named directly in `build.yml` alongside `Lite`, `Darling` and `DarlingViewer`. Every new step is gated on `github.event_name == 'release'`, so merging to `dev` changes nothing until a release is cut.

## Why signing has to happen during packing

Velopack creates those three executables *after* packing. They cannot be signed afterwards, because re-signing a file inside a `.nupkg` changes that package's bytes, which invalidates the `SHA256` and `Size` recorded in `releases.<channel>.json` and patched against by delta packages. Velopack's own documentation says signing "needs to be performed by Velopack itself".

## What the probe (#3292) established, so none of this is inferred

- `vpk pack` offers **35 files, not ~700** — it skips files that already carry a signature, so Microsoft's framework binaries never reach the template.
- It offers exactly the three targets: `PerformanceMonitorLite_ExecutionStub.exe`, `Squirrel.exe` (Update.exe's internal name), `Setup.exe`.
- With `--signParallel 50` it invokes the template **twice per product** — 34 pack-directory files, then `Setup.exe` in its own later phase. At the default of 10 it is five.
- **It does not verify that the template signed anything.** A no-op template returned exit 0 and packing completed normally. That is how #3288 shipped twice, and it is why this change verifies its own outcome in two places.
- `--signDisableDeep` does **not** exist on the Windows command, despite the string appearing in the tool's assemblies.

## Approvals: 4 today, 6 after

The two pre-pack Velopack rounds are **deleted** — vpk signs that payload itself now, and keeping both would sign it twice and cost two more approvals. `Sign Lite` (flat zip) and `Sign Darling` (service + `viewer/`) are unchanged.

## Two verification points, because the packer provides none

`sign-batch.ps1` refuses an empty batch, refuses duplicate base names within a batch, and after copying the signed files back over the originals it **asserts each one now carries a certificate table** before returning success.

The release guard then re-checks the whole `releases/` directory before upload, including executables inside the zips and nupkgs. Both reuse the PE parse from `verify_release_signatures.py`, whose six mutations are each confirmed to turn its self-test red.

Guard behaviour is tested locally in all three directions: an unsigned exe **hidden inside a zip** fails it, an all-signed directory passes, and an empty directory fails with a distinct status — finding nothing to check is a broken run, not a clean one.

## What is NOT tested, stated plainly

No SignPath call has been made. `Submit-SigningRequest`'s invocation, the batch artifact configuration matching `**/*.exe` and `**/*.dll` inside a `batch/` subdirectory, and the copy-back are all unexercised against the real service. `.ps1` cannot run on the machine this was written on. The throwaway pre-release tag is the gate, not this PR's CI.

Two specifics to watch there:
- Files are staged into a **`batch/` subdirectory** rather than the zip root, because whether `**/` also matches zero path segments is undocumented. One segment removes the question.
- `-WaitForCompletionTimeoutInSeconds` is set to **3600**. The cmdlet's own default is 600, which will not survive waiting for a human to approve — and every Foundation-tier request needs one.

## CHANGELOG

```
- **Every executable in a release is signed, including the ones Velopack generates** ([#3288]) - the portable launcher stub, `Update.exe` and `Setup.exe` shipped unsigned on both products while the app payload was signed, so the file a user double-clicks in the portable zip was a 399 kB unsigned launcher rather than the signed 182 kB app - which is what an "unknown publisher" policy blocks. They are created after packing and cannot be signed afterwards without invalidating the package hashes the updater verifies, so `vpk pack` now signs them during packing, and a release-time guard refuses to publish an executable without a signature.
```
