### PR TITLE
Deliver the alert's detail text on every channel

### DIFF
--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -10,7 +10,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using PerformanceMonitor.Alerting;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Service;
@@ -556,4 +562,206 @@ public sealed class AlertDeliveryChannelTests
 
     private static string RepoRoot([CallerFilePath] string thisFile = "")
         => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", ".."));
+
+    /* ─────────────── #3297: the detail text reaches the WIRE, not just the payload builder ─────────────── */
+
+    /// <summary>
+    /// #3297: <see cref="AlertOutcome.DetailText"/> reached the history store, the Viewer, the MCP reader and
+    /// the triage endpoint — and no delivery channel. <c>WebhookAlertService</c> held zero references to it
+    /// across all 1,534 lines, and the email template's detail section was gated on
+    /// <see cref="AlertContext.Details"/>, a different and STRUCTURED field, which a self-alert leaves null.
+    /// So an operator whose only channel was email received a metric name, a value, a threshold and two
+    /// timestamps, with the remedy discarded — reported from the field on #3296.
+    ///
+    /// <para>This drives the WHOLE Darling path — <see cref="DarlingAlertDeliverer.DeliverAsync"/> through the
+    /// shared send core, the fan-out, and each channel's payload builder — and asserts against the bytes that
+    /// actually left the process. Deliberately not a payload-builder assertion: the defect was never in a
+    /// builder, it was that nothing passed the text TO one, and a builder-level pin is green on a fan-out
+    /// that drops the argument. There is no dogfooding path here (no email configured on any of the three
+    /// stores, and no webhook channel until one is stood up), so a test is the only instrument.</para>
+    ///
+    /// <para>Three requests: Teams, Slack and the generic channel all point at the one loopback endpoint.
+    /// PagerDuty is absent because its endpoint is the hardcoded Events v2 URL and cannot be redirected —
+    /// its builder is pinned in <c>Lite.Tests.PagerDutyWebhookTests</c> instead, and it takes the same
+    /// <c>prose</c> from the same single resolution in the fan-out as the three checked here.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheDeliverer_PutsDetailTextOnTheWire_ForEveryRedirectableWebhookChannel()
+    {
+        /* The #3296 alert's own detail, shortened. The marker is the operator action the reporter had to
+           work out for themselves because no channel delivered it. */
+        const string Prose =
+            "Store query_stats retention [1072] is HELD PAUSED by the rollup-coverage gate. Run the " +
+            "--backfill-rollups operator action, then RESTART the service.";
+
+        using var endpoint = new CapturingWebhookEndpoint();
+
+        var config = new DarlingConfig();
+        config.Webhooks.TeamsUrl = endpoint.Url;
+        config.Webhooks.SlackUrl = endpoint.Url;
+        config.Webhooks.GenericUrl = endpoint.Url;
+
+        var settings = new DarlingAlertSettings(config);
+        var history = new DiscardingHistoryStore();
+        var webhooks = new WebhookAlertService(
+            settings, DarlingAlertDeliverer.Branding, NullLogger<WebhookAlertService>.Instance, history);
+        var deliverer = new DarlingAlertDeliverer(settings, history, webhooks, NullLogger.Instance);
+
+        /* A self-alert: Context null, prose in DetailText. The shape the defect hid in. */
+        await deliverer.DeliverAsync(
+            new AlertOutcome(
+                "retentionhold:1072", "Monitor Store", "Retention Held", "9.6x its 4 days horizon", "2.0x",
+                Context: null, DetailText: Prose, NumericCurrentValue: 9.6, NumericThresholdValue: 2.0,
+                Muted: false, Severity: AlertSeverityLevel.Critical),
+            TestContext.Current.CancellationToken);
+
+        var bodies = endpoint.Bodies;
+        Assert.Equal(3, bodies.Count);
+        Assert.All(bodies, body => Assert.Contains("--backfill-rollups", body, StringComparison.Ordinal));
+        Assert.All(bodies, body => Assert.Contains("RESTART the service", body, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A loopback endpoint that records the bodies posted to it. <see cref="System.Net.Sockets.TcpListener"/>
+    /// rather than <c>HttpListener</c> on purpose: HttpListener wants a URL ACL on Windows, and the four
+    /// lines of HTTP a webhook POST needs are cheaper than that dependency. The same choice
+    /// <c>NpgsqlRootCertificateValidationTests</c> and <c>DarlingStoreUpgradeTests</c> already make.
+    /// </summary>
+    private sealed class CapturingWebhookEndpoint : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly List<string> _bodies = new();
+        private readonly CancellationTokenSource _stop = new();
+        private readonly Task _accepting;
+
+        public CapturingWebhookEndpoint()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Url = $"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/hook";
+            _accepting = Task.Run(AcceptLoopAsync);
+        }
+
+        public string Url { get; }
+
+        /// <summary>
+        /// Safe to read without synchronization once the send has been awaited: each body is appended before
+        /// its response is written, and the sender awaits every response in turn.
+        /// </summary>
+        public IReadOnlyList<string> Bodies => _bodies;
+
+        private async Task AcceptLoopAsync()
+        {
+            try
+            {
+                while (!_stop.IsCancellationRequested)
+                {
+                    using var client = await _listener.AcceptTcpClientAsync(_stop.Token);
+                    using var stream = client.GetStream();
+                    _bodies.Add(await ReadRequestBodyAsync(stream));
+
+                    var response = Encoding.ASCII.GetBytes(
+                        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+                    await stream.WriteAsync(response, _stop.Token);
+                    await stream.FlushAsync(_stop.Token);
+                }
+            }
+            catch (OperationCanceledException) { /* Dispose */ }
+            catch (System.Net.Sockets.SocketException) { /* listener stopped */ }
+            catch (ObjectDisposedException) { /* listener stopped */ }
+        }
+
+        /// <summary>Reads headers to the blank line, then exactly Content-Length bytes of body.</summary>
+        private static async Task<string> ReadRequestBodyAsync(NetworkStream stream)
+        {
+            var buffer = new byte[16 * 1024];
+            var received = new List<byte>(capacity: 16 * 1024);
+            int headerEnd;
+
+            while ((headerEnd = IndexOfHeaderEnd(received)) < 0)
+            {
+                var read = await stream.ReadAsync(buffer);
+                if (read == 0)
+                {
+                    return Encoding.UTF8.GetString(received.ToArray());
+                }
+
+                received.AddRange(new ArraySegment<byte>(buffer, 0, read));
+            }
+
+            var headers = Encoding.ASCII.GetString(received.ToArray(), 0, headerEnd);
+            var contentLength = ParseContentLength(headers);
+            var bodyStart = headerEnd + 4;
+
+            while (received.Count - bodyStart < contentLength)
+            {
+                var read = await stream.ReadAsync(buffer);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                received.AddRange(new ArraySegment<byte>(buffer, 0, read));
+            }
+
+            var body = received.ToArray();
+            var available = Math.Min(contentLength, body.Length - bodyStart);
+            return Encoding.UTF8.GetString(body, bodyStart, Math.Max(0, available));
+        }
+
+        private static int IndexOfHeaderEnd(List<byte> bytes)
+        {
+            for (int i = 0; i + 3 < bytes.Count; i++)
+            {
+                if (bytes[i] == (byte)'\r' && bytes[i + 1] == (byte)'\n' &&
+                    bytes[i + 2] == (byte)'\r' && bytes[i + 3] == (byte)'\n')
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int ParseContentLength(string headers)
+        {
+            foreach (var line in headers.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase) &&
+                    int.TryParse(line.AsSpan("Content-Length:".Length).Trim(), out var length))
+                {
+                    return length;
+                }
+            }
+
+            return 0;
+        }
+
+        public void Dispose()
+        {
+            _stop.Cancel();
+            _listener.Stop();
+            try
+            {
+                _accepting.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (AggregateException) { /* the cancellation above */ }
+
+            _stop.Dispose();
+        }
+    }
+
+    private sealed class DiscardingHistoryStore : IAlertHistoryStore
+    {
+        public Task RecordAlertAsync(AlertHistoryRecord record) => Task.CompletedTask;
+
+        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastAlertTimeAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+    }
 }

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -638,6 +638,89 @@ public sealed class AlertDeliveryChannelTests
         Assert.Equal(2, CountOccurrences(message, "--backfill-rollups"));
     }
 
+    /// <summary>
+    /// #3297 and #3303 arrived at this seam from opposite directions in the same week — the alert's prose
+    /// detail and a custom rule's human display name — and every signature from
+    /// <see cref="DarlingAlertDeliverer"/> down to each payload builder gained one parameter from each. Both
+    /// are <c>string?</c>, so nothing about losing one, or transposing the pair, is a compile error.
+    ///
+    /// <para>Each side's own suite covers its payload BUILDERS. Neither covers the three hops between the
+    /// deliverer and those builders with the OTHER field also present, because neither side had both fields
+    /// to pass. This drives the whole path once with both set and reads the bytes that left the process, so
+    /// "both survived" is measured at the hops the merge conflict was actually in rather than inferred from
+    /// the builders being intact.</para>
+    ///
+    /// <para>Bodies are identified by a channel-native marker, never by arrival order. And the generic
+    /// channel's exemption is asserted here rather than assumed: it carries the prose (alert content) but
+    /// keeps the immutable metric name, because <c>{{metric}}</c> is the key an automation correlates on and
+    /// that channel renders no title.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheDeliverer_CarriesBothTheProseAndTheDisplayName_ThroughTheOneFanOut()
+    {
+        const string Prose =
+            "Signal wait time has exceeded its ceiling for 15 minutes. Check for a runaway parallel query "
+            + "before raising MAXDOP.";
+        const string DisplayName = "Signal wait % high";
+        const string MetricKey = "Custom:42";
+
+        using var endpoint = new CapturingWebhookEndpoint();
+        using var smtp = new CapturingSmtpEndpoint();
+
+        var config = new DarlingConfig();
+        config.Webhooks.TeamsUrl = endpoint.Url;
+        config.Webhooks.SlackUrl = endpoint.Url;
+        config.Webhooks.GenericUrl = endpoint.Url;
+        config.Smtp.Host = "127.0.0.1";
+        config.Smtp.Port = smtp.Port;
+        config.Smtp.UseSsl = false;
+        config.Smtp.From = "monitor@example.invalid";
+        config.Smtp.To = "operator@example.invalid";
+
+        var settings = new DarlingAlertSettings(config);
+        var history = new DiscardingHistoryStore();
+        var webhooks = new WebhookAlertService(
+            settings, DarlingAlertDeliverer.Branding, NullLogger<WebhookAlertService>.Instance, history);
+        var deliverer = new DarlingAlertDeliverer(settings, history, webhooks, NullLogger.Instance);
+
+        /* A custom-rule fire, the shape CustomAlertEvaluator.BuildFireOutcome produces: Context null, the
+           rule's prose in DetailText, the rule's name in DisplayName, "Custom:<id>" as the metric key. */
+        await deliverer.DeliverAsync(
+            new AlertOutcome(
+                "custom:42", "PROD01", MetricKey, "1500", ">= 1000",
+                Context: null, DetailText: Prose, NumericCurrentValue: 1500, NumericThresholdValue: 1000,
+                Muted: false, Severity: AlertSeverityLevel.Warning,
+                ShortMessage: null, DisplayName: DisplayName),
+            TestContext.Current.CancellationToken);
+
+        var bodies = endpoint.Bodies;
+        Assert.Equal(3, bodies.Count);
+
+        /* The prose is alert CONTENT, so every channel carries it. */
+        Assert.All(bodies, body => Assert.Contains(Prose, body, StringComparison.Ordinal));
+
+        /* The display name is a TITLE concern, so the two card channels carry it. */
+        var teams = Assert.Single(bodies, b => b.Contains("themeColor", StringComparison.Ordinal));
+        Assert.Contains(DisplayName, teams, StringComparison.Ordinal);
+        Assert.DoesNotContain(MetricKey, teams, StringComparison.Ordinal);
+
+        var slack = Assert.Single(bodies, b => b.Contains("\"blocks\"", StringComparison.Ordinal));
+        Assert.Contains(DisplayName, slack, StringComparison.Ordinal);
+        Assert.DoesNotContain(MetricKey, slack, StringComparison.Ordinal);
+
+        /* And the generic channel keeps the machine key instead. */
+        var generic = Assert.Single(bodies, b => b.Contains("\"metric\"", StringComparison.Ordinal));
+        Assert.Contains(MetricKey, generic, StringComparison.Ordinal);
+        Assert.DoesNotContain(DisplayName, generic, StringComparison.Ordinal);
+
+        /* Email is the channel #3296 was reported from, and its subject is where #3303's name shows. Both
+           MIME parts again, so losing either body fails. */
+        var message = Assert.Single(smtp.Messages);
+        Assert.Contains(DisplayName, message, StringComparison.Ordinal);
+        Assert.Contains("before raising MAXDOP", message, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(message, "before raising MAXDOP"));
+    }
+
     private static int CountOccurrences(string haystack, string needle)
     {
         int count = 0, index = 0;

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -586,7 +586,7 @@ public sealed class AlertDeliveryChannelTests
     /// <c>prose</c> from the same single resolution in the fan-out as the three checked here.</para>
     /// </summary>
     [Fact]
-    public async Task TheDeliverer_PutsDetailTextOnTheWire_ForEveryRedirectableWebhookChannel()
+    public async Task TheDeliverer_PutsDetailTextOnTheWire_OnEmailAndEveryRedirectableWebhookChannel()
     {
         /* The #3296 alert's own detail, shortened. The marker is the operator action the reporter had to
            work out for themselves because no channel delivered it. */
@@ -595,11 +595,17 @@ public sealed class AlertDeliveryChannelTests
             "--backfill-rollups operator action, then RESTART the service.";
 
         using var endpoint = new CapturingWebhookEndpoint();
+        using var smtp = new CapturingSmtpEndpoint();
 
         var config = new DarlingConfig();
         config.Webhooks.TeamsUrl = endpoint.Url;
         config.Webhooks.SlackUrl = endpoint.Url;
         config.Webhooks.GenericUrl = endpoint.Url;
+        config.Smtp.Host = "127.0.0.1";
+        config.Smtp.Port = smtp.Port;
+        config.Smtp.UseSsl = false;
+        config.Smtp.From = "monitor@example.invalid";
+        config.Smtp.To = "operator@example.invalid";
 
         var settings = new DarlingAlertSettings(config);
         var history = new DiscardingHistoryStore();
@@ -619,6 +625,29 @@ public sealed class AlertDeliveryChannelTests
         Assert.Equal(3, bodies.Count);
         Assert.All(bodies, body => Assert.Contains("--backfill-rollups", body, StringComparison.Ordinal));
         Assert.All(bodies, body => Assert.Contains("RESTART the service", body, StringComparison.Ordinal));
+
+        /* And email, which is the channel #3296 actually reported and therefore the one that must not be
+           covered only at the payload builder. Both MIME parts: the HTML and plain-text bodies are built by
+           two different methods and a repair to one says nothing about the other. */
+        var message = Assert.Single(smtp.Messages);
+        Assert.Contains("--backfill-rollups", message, StringComparison.Ordinal);
+        Assert.Contains("RESTART the service", message, StringComparison.Ordinal);
+        /* TWICE: once in the text/plain part, once in the text/html one. A single occurrence would mean one
+           of the two bodies lost it, which the pre-#3297 code would have reported as a clean pass on the
+           other. */
+        Assert.Equal(2, CountOccurrences(message, "--backfill-rollups"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
     }
 
     /// <summary>
@@ -735,6 +764,172 @@ public sealed class AlertDeliveryChannelTests
             }
 
             return 0;
+        }
+
+        public void Dispose()
+        {
+            _stop.Cancel();
+            _listener.Stop();
+            try
+            {
+                _accepting.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (AggregateException) { /* the cancellation above */ }
+
+            _stop.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// A loopback SMTP sink that records the DATA of each message posted to it, quoted-printable soft line
+    /// breaks removed so an assertion on a phrase cannot fail because MIME wrapped it at column 76.
+    /// <para>Exists because email is the only channel with no interception point short of the protocol:
+    /// there is no builder-returns-the-payload seam between <c>EmailSendCore</c> and the wire. Without it a
+    /// mutation that drops the detail on the way to the email template alone passes every other pin — which
+    /// is exactly the defect #3296 reported, so leaving that one hop unpinned was not an option.</para>
+    /// </summary>
+    private sealed class CapturingSmtpEndpoint : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly List<string> _messages = new();
+        private readonly CancellationTokenSource _stop = new();
+        private readonly Task _accepting;
+
+        public CapturingSmtpEndpoint()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            _accepting = Task.Run(AcceptLoopAsync);
+        }
+
+        public int Port { get; }
+
+        /// <summary>Safe to read once the send has been awaited; see the webhook endpoint's note.</summary>
+        public IReadOnlyList<string> Messages => _messages;
+
+        private async Task AcceptLoopAsync()
+        {
+            try
+            {
+                while (!_stop.IsCancellationRequested)
+                {
+                    using var client = await _listener.AcceptTcpClientAsync(_stop.Token);
+                    using var stream = client.GetStream();
+                    using var reader = new StreamReader(stream, Encoding.UTF8, false, 8192, leaveOpen: true);
+                    using var writer = new StreamWriter(stream, new UTF8Encoding(false), 8192, leaveOpen: true) { AutoFlush = true, NewLine = "\r\n" };
+
+                    await writer.WriteLineAsync("220 localhost ESMTP capture");
+
+                    var data = new StringBuilder();
+                    var inData = false;
+                    string? line;
+                    while ((line = await reader.ReadLineAsync(_stop.Token)) is not null)
+                    {
+                        if (inData)
+                        {
+                            if (line == ".")
+                            {
+                                _messages.Add(DecodeMimeText(data.ToString()));
+                                data.Clear();
+                                inData = false;
+                                await writer.WriteLineAsync("250 OK queued");
+                                continue;
+                            }
+
+                            /* Transparency: a body line starting with '.' arrives doubled. CRLF explicitly,
+                               not AppendLine: MIME line endings are CRLF by the spec the parsing below
+                               depends on, and Environment.NewLine is LF on the platform this is written on. */
+                            data.Append(line.StartsWith("..", StringComparison.Ordinal) ? line.Substring(1) : line).Append("\r\n");
+                            continue;
+                        }
+
+                        if (line.StartsWith("EHLO", StringComparison.OrdinalIgnoreCase) ||
+                            line.StartsWith("HELO", StringComparison.OrdinalIgnoreCase))
+                        {
+                            /* No extensions advertised, so the client never tries STARTTLS or AUTH. */
+                            await writer.WriteLineAsync("250 localhost");
+                        }
+                        else if (line.StartsWith("DATA", StringComparison.OrdinalIgnoreCase))
+                        {
+                            inData = true;
+                            await writer.WriteLineAsync("354 End data with <CRLF>.<CRLF>");
+                        }
+                        else if (line.StartsWith("QUIT", StringComparison.OrdinalIgnoreCase))
+                        {
+                            await writer.WriteLineAsync("221 Bye");
+                            break;
+                        }
+                        else
+                        {
+                            await writer.WriteLineAsync("250 OK");
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException) { /* Dispose */ }
+            catch (IOException) { /* client went away */ }
+            catch (SocketException) { /* listener stopped */ }
+            catch (ObjectDisposedException) { /* listener stopped */ }
+        }
+
+        /// <summary>
+        /// Returns the DECODED text of every MIME part, concatenated. Both transfer encodings this message
+        /// actually uses are handled — .NET picks base64 for the utf-8 plain-text alternate view and
+        /// quoted-printable for the us-ascii HTML one — because an assertion against the raw DATA would be
+        /// asserting against an encoding choice rather than against the delivered words.
+        /// </summary>
+        private static string DecodeMimeText(string raw)
+        {
+            var boundary = System.Text.RegularExpressions.Regex.Match(raw, @"boundary=(\S+)");
+            if (!boundary.Success)
+            {
+                return DecodeQuotedPrintable(raw);
+            }
+
+            var parts = raw.Split("--" + boundary.Groups[1].Value, StringSplitOptions.None);
+            var decoded = new StringBuilder();
+
+            foreach (var part in parts.Skip(1))
+            {
+                var split = part.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+                if (split < 0)
+                {
+                    continue;
+                }
+
+                var headers = part.Substring(0, split);
+                var body = part.Substring(split + 4);
+
+                decoded.Append(headers.Contains("base64", StringComparison.OrdinalIgnoreCase)
+                    ? Encoding.UTF8.GetString(Convert.FromBase64String(
+                        new string(body.Where(c => !char.IsWhiteSpace(c)).ToArray())))
+                    : DecodeQuotedPrintable(body)).Append("\r\n");
+            }
+
+            return decoded.ToString();
+        }
+
+        /// <summary>Drops soft line breaks ("=" at end of line) and decodes "=XX" octets.</summary>
+        private static string DecodeQuotedPrintable(string raw)
+        {
+            var unfolded = raw.Replace("=\r\n", "", StringComparison.Ordinal).Replace("=\n", "", StringComparison.Ordinal);
+            var sb = new StringBuilder(unfolded.Length);
+
+            for (int i = 0; i < unfolded.Length; i++)
+            {
+                if (unfolded[i] == '=' && i + 2 < unfolded.Length &&
+                    Uri.IsHexDigit(unfolded[i + 1]) && Uri.IsHexDigit(unfolded[i + 2]))
+                {
+                    sb.Append((char)Convert.ToInt32(unfolded.Substring(i + 1, 2), 16));
+                    i += 2;
+                    continue;
+                }
+
+                sb.Append(unfolded[i]);
+            }
+
+            return sb.ToString();
         }
 
         public void Dispose()

--- a/Darling/Darling.Tests/AlertEngineTests.cs
+++ b/Darling/Darling.Tests/AlertEngineTests.cs
@@ -2137,4 +2137,42 @@ public sealed class AlertEngineTests
         Assert.Equal(PerformanceMonitor.Notifications.AlertSeverityLevel.Critical, o.Severity);
         Assert.Contains("no baseline", o.ShortMessage);
     }
+
+    /// <summary>
+    /// #3297 delivers this alert's detail block on every channel, which makes a fact stated under two
+    /// labels a thing an operator reads twice rather than a harmless internal duplication. The pending
+    /// case is where that is easy to reintroduce: <c>Expected State</c> already IS "(no baseline yet)"
+    /// whenever the baseline is missing, so a second field restating it looks like new information while
+    /// adding none.
+    ///
+    /// <para>An occurrence COUNT rather than a field-name list: a list would pass while the same fact
+    /// arrived under a label nobody thought to enumerate, which is the failure this is guarding.</para>
+    /// </summary>
+    [Fact]
+    public async Task DatabaseState_PendingCriticalFirstObservation_StatesTheMissingBaselineOnce()
+    {
+        var h = new Harness();
+        h.Settings.DatabaseStateEnabled = true;
+        h.Adapter.DatabaseStates.Add(new DatabaseStateInfo { DatabaseName = "Payments", StateDesc = "SUSPECT", ExpectedState = "" });
+        var engine = h.Build();
+
+        await engine.EvaluateServerAsync(Harness.Snapshot());
+
+        var detail = Assert.Single(h.Deliverer.Outcomes).DetailText!;
+
+        Assert.Contains("no baseline", detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, CountOccurrences(detail, "baseline"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.OrdinalIgnoreCase)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
 }

--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -2391,6 +2391,34 @@ VALUES ($1, $2, $3, $4, $5, 0, $6, NULL, 0, 0, 0)", connection);
         Assert.Contains("held at 4.5x", fired.ShortMessage, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// #3297: the detail names WHEN the policy arms. It said the policy "arms ITSELF once its consumer covers
+    /// everything raw holds" and stopped there, which is true and one step short:
+    /// <c>TimescaleSupport.EnsureRetentionPoliciesAsync</c> is the only thing that arms a held policy and it
+    /// has exactly one call site, the service startup path. So arming happens on the next service START, not
+    /// when coverage catches up. An operator following the old wording runs the backfill, watches the hourly
+    /// Critical keep firing, and concludes the backfill failed — which is what happened on #3296, where the
+    /// reporter's own sequence included the restart and ours did not. Pinned here rather than only in
+    /// <c>docs/retention-hold-runbook.md</c> because the alert is what an operator sees first, and now that
+    /// every channel delivers the detail (#3297) it is what most of them will see at all.
+    /// </summary>
+    [Fact]
+    public async Task RetentionHeld_TheDetail_NamesTheRestartAsPartOfTheRemedy()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyRetentionHoldsAsync(new[] { HeldPolicy() }, Ct);
+
+        var detail = Assert.Single(h.Deliverer.Outcomes).DetailText!;
+        Assert.Contains("--backfill-rollups", detail, StringComparison.Ordinal);
+        Assert.Contains("RESTART", detail, StringComparison.Ordinal);
+        /* The reason the restart is not optional, so a future edit cannot drop it to a bare instruction. */
+        Assert.Contains("STARTUP", detail, StringComparison.Ordinal);
+        /* And the do-not-arm warning it must never displace. */
+        Assert.Contains("Do NOT", detail, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task RetentionHeld_TheProductionIncident_ReadsCritical()
     {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
@@ -146,7 +146,7 @@ public sealed class DarlingAlertDeliverer : IAlertDeliverer
         /* Lite's EmailAlertService.cs:65-66 — muted alerts skip both channels but still record below. */
         var result = await _core.TrySendAsync(
             outcome.MetricName, outcome.ServerName, currentValue, outcome.ThresholdValue,
-            outcome.ServerKey, context, attemptChannels: !outcome.Muted);
+            outcome.ServerKey, context, attemptChannels: !outcome.Muted, detailText: detailText);
 
         /* trayChannelPresent: false — this is the HEADLESS service. It has no tray icon and no toast
            code, so the taxonomy's "tray" fallback (which is Lite's, and truthful there) would assert a UI

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingFindingAlertSender.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingFindingAlertSender.cs
@@ -80,7 +80,7 @@ public sealed class DarlingFindingAlertSender : IFindingAlertSender
                stories before they became findings (Lite passes muted: false identically). */
             var result = await _core.TrySendAsync(
                 alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue,
-                alert.ServerId, alert.Context, attemptChannels: true);
+                alert.ServerId, alert.Context, attemptChannels: true, detailText: alert.DetailText);
 
             /* trayChannelPresent: false — the headless service has no tray; see DarlingAlertDeliverer. */
             var delivery = AlertDelivery.FromFanout(result, muted: false, trayChannelPresent: false);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -1885,11 +1885,15 @@ internal sealed class DarlingSelfAlertEvaluator
                                 : "The gate is working as designed - it will not let retention drop history a " +
                                   "rollup has never materialized - but the hold has lasted long enough to cost " +
                                   "real disk. ") +
-                            "The policy arms ITSELF once its consumer covers everything raw holds; what is " +
-                            "missing is the backfill, which is the --backfill-rollups operator action. Do NOT " +
-                            "arm the policy by hand: the history it holds exists nowhere else, so arming drops " +
-                            "the only copy, which is precisely what the gate prevents. Check the service log at " +
-                            "startup for the 'HELD PAUSED' line naming which consumer is short.",
+                            "The policy arms ITSELF once its consumer covers everything raw holds, but it " +
+                            "arms at STARTUP rather than the moment coverage catches up - EnsureRetentionPoliciesAsync " +
+                            "runs on the service start path and nowhere else. So the remedy is two steps, and the " +
+                            "second is not optional: run the --backfill-rollups operator action, then RESTART the " +
+                            "service. Skip the restart and the backfill will have worked while this alert keeps " +
+                            "firing, which reads like the backfill failed. Do NOT arm the policy by hand: the " +
+                            "history it holds exists nowhere else, so arming drops the only copy, which is " +
+                            "precisely what the gate prevents. Check the service log at startup for the " +
+                            "'HELD PAUSED' line naming which consumer is short.",
                         severity: critical ? AlertSeverityLevel.Critical : AlertSeverityLevel.Warning,
                         shortMessage: $"{label} held at {ratio:F1}x its {policy.DropAfter} horizon",
                         numericCurrentValue: Math.Round(ratio, 2),

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
@@ -816,7 +816,7 @@
                 </Grid>
                 <TextBlock Margin="20,8,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
                     <Run Text="Placeholders (each is JSON-escaped when substituted): "/>
-                    <Run FontFamily="Consolas" Text="{}{{metric}} {{server}} {{value}} {{threshold}} {{severity}} {{context}} {{timestamp}}"/>
+                    <Run FontFamily="Consolas" Text="{}{{metric}} {{server}} {{value}} {{threshold}} {{severity}} {{context}} {{detail}} {{timestamp}}"/>
                 </TextBlock>
                 <TextBlock Margin="20,4,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
                     <Run Text="Automation placeholders — the first two substitute RAW JSON values (use them unquoted, e.g. &quot;context&quot;: {{context_json}}): "/>

--- a/Lite.Tests/AlertContextBuildersTests.cs
+++ b/Lite.Tests/AlertContextBuildersTests.cs
@@ -446,6 +446,43 @@ public class AlertContextBuildersTests
 
         var expected = string.Join(Environment.NewLine, "H1", "  A: 1", "", "H2", "  B: 2");
         Assert.Equal(expected, AlertContextBuilders.ContextToDetailText(context));
+
+        /* #3297: the implementation moved to the Notifications project, because the delivery channels there
+           decide whether an alert's prose adds anything over its structured context by comparing against
+           this exact text — and they cannot reference this project. One implementation, so the comparison
+           cannot drift away from the text it compares to. */
+        Assert.Equal(expected, AlertDetailText.Flatten(context));
+    }
+
+    /// <summary>
+    /// #3297's gate, which is what keeps the fix from printing every engine alert twice. Every engine
+    /// alert's detail text IS <see cref="AlertDetailText.Flatten"/> of its own context —
+    /// <c>AlertEngine</c> builds it that way at every fire site — so the channels suppress prose on that
+    /// equality and the alerts that already read correctly (blocking, deadlocks) are unchanged.
+    /// </summary>
+    [Fact]
+    public void ProseForDelivery_SuppressesAFlattenedContext_AndKeepsIndependentProse()
+    {
+        var context = new AlertContext();
+        context.Details.Add(new AlertDetailItem { Heading = "H1", Fields = new() { ("A", "1") } });
+
+        /* The engine path: detail text derived from the context. Nothing to add. */
+        var flattened = AlertContextBuilders.ContextToDetailText(context)!;
+        Assert.Null(AlertDetailText.ProseForDelivery(flattened, context));
+        Assert.Null(AlertDetailText.ProseForDelivery(flattened + "\r\n  ", context));
+
+        /* The #2109 AG-database path: a structured context AND hand-written prose naming the remedy.
+           Suppressing whenever a context is present would drop exactly this. */
+        Assert.Equal(
+            "Resume it with ALTER DATABASE SET HADR RESUME.",
+            AlertDetailText.ProseForDelivery("Resume it with ALTER DATABASE SET HADR RESUME.", context));
+
+        /* The self-alert path: prose, no context at all. */
+        Assert.Equal("do the thing", AlertDetailText.ProseForDelivery("do the thing", null));
+
+        /* Nothing is nothing, however it is spelled. */
+        Assert.Null(AlertDetailText.ProseForDelivery(null, context));
+        Assert.Null(AlertDetailText.ProseForDelivery("   ", context));
     }
 
     [Fact]

--- a/Lite.Tests/AlertIncidentRenderTests.cs
+++ b/Lite.Tests/AlertIncidentRenderTests.cs
@@ -181,4 +181,74 @@ public class AlertIncidentRenderTests
         var teams = WebhookAlertService.BuildTeamsPayload("Low Disk Space", "S1", "5%", "10%", Branding, context: ctx);
         Assert.DoesNotContain("\"name\":\"Resource\"", teams);
     }
+
+    /// <summary>
+    /// #3297, the constraint the fix had to satisfy to be safe: an ENGINE alert's detail text is
+    /// <see cref="AlertDetailText.Flatten"/> of its own context, built that way at every
+    /// <c>AlertEngine</c> fire site. So carrying the detail text on top of the structured render would
+    /// print the same content twice on every channel — a regression in precisely the alerts that already
+    /// read correctly (blocking, deadlocks), which are the ones populating a structured context.
+    /// <para>Asserted by counting a marker from the flattened text rather than comparing whole payloads,
+    /// because every builder stamps <c>DateTime.UtcNow</c> and a byte comparison would be a clock race.
+    /// One marker in, one marker out, on all four channels and both email bodies.</para>
+    /// </summary>
+    [Fact]
+    public void AnEngineAlertsFlattenedDetail_IsNotRenderedTwice_OnAnyChannel()
+    {
+        const string Marker = "SalesDB.dbo.Orders";
+        var ctx = new AlertContext();
+        AlertIncidentRenderer.Apply(ctx, new[] { new AlertIncident("fingerprint-abc", new[] { Marker }) });
+        var flattened = AlertDetailText.Flatten(ctx)!;
+        Assert.Contains(Marker, flattened, StringComparison.Ordinal);
+
+        static int Count(string haystack, string needle)
+        {
+            int n = 0, i = 0;
+            while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { n++; i += needle.Length; }
+            return n;
+        }
+
+        var teamsWithout = WebhookAlertService.BuildTeamsPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx);
+        var teamsWith = WebhookAlertService.BuildTeamsPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx, detailText: flattened);
+        Assert.Equal(Count(teamsWithout, Marker), Count(teamsWith, Marker));
+
+        var slackWithout = WebhookAlertService.BuildSlackPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx);
+        var slackWith = WebhookAlertService.BuildSlackPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx, detailText: flattened);
+        Assert.Equal(Count(slackWithout, Marker), Count(slackWith, Marker));
+
+        var pdWithout = WebhookAlertService.BuildPagerDutyPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, "rk", context: ctx);
+        var pdWith = WebhookAlertService.BuildPagerDutyPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, "rk", context: ctx, detailText: flattened);
+        Assert.Equal(Count(pdWithout, Marker), Count(pdWith, Marker));
+
+        var genericWithout = WebhookAlertService.BuildGenericPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx);
+        var genericWith = WebhookAlertService.BuildGenericPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx, detailText: flattened);
+        Assert.Equal(Count(genericWithout, Marker), Count(genericWith, Marker));
+
+        var (htmlWithout, plainWithout) = EmailTemplateBuilder.BuildAlertEmail("Deadlocks Detected", "S1", "2", "n/a", 15, Branding, ctx);
+        var (htmlWith, plainWith) = EmailTemplateBuilder.BuildAlertEmail("Deadlocks Detected", "S1", "2", "n/a", 15, Branding, ctx, flattened);
+        Assert.Equal(Count(htmlWithout, Marker), Count(htmlWith, Marker));
+        Assert.Equal(Count(plainWithout, Marker), Count(plainWith, Marker));
+    }
+
+    /// <summary>
+    /// The complement, so the pin above cannot be satisfied by a channel that simply ignores the detail
+    /// text: an alert carrying prose the context does NOT already say adds that prose on every channel.
+    /// A pin that only ever asserts an absence is green whether the feature exists or not.
+    /// </summary>
+    [Fact]
+    public void IndependentProse_IsAdded_OnEveryChannel()
+    {
+        const string Prose = "Run the --backfill-rollups operator action, then RESTART the service.";
+        var ctx = new AlertContext();
+        AlertIncidentRenderer.Apply(ctx, new[] { new AlertIncident("fingerprint-abc", new[] { "SalesDB.dbo.Orders" }) });
+
+        Assert.Contains(Prose, WebhookAlertService.BuildTeamsPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx, detailText: Prose), StringComparison.Ordinal);
+        Assert.Contains(Prose, WebhookAlertService.BuildSlackPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx, detailText: Prose), StringComparison.Ordinal);
+        Assert.Contains(Prose, WebhookAlertService.BuildPagerDutyPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, "rk", context: ctx, detailText: Prose), StringComparison.Ordinal);
+        Assert.Contains(Prose, WebhookAlertService.BuildGenericPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx, detailText: Prose), StringComparison.Ordinal);
+
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail("Deadlocks Detected", "S1", "2", "n/a", 15, Branding, ctx, Prose);
+        Assert.Contains(System.Net.WebUtility.HtmlEncode(Prose), html, StringComparison.Ordinal);
+        Assert.Contains(Prose, plain, StringComparison.Ordinal);
+    }
 }

--- a/Lite.Tests/AnalysisNotificationTests.cs
+++ b/Lite.Tests/AnalysisNotificationTests.cs
@@ -361,6 +361,40 @@ public class AnalysisNotificationTests : IClassFixture<SharedDuckDbFixture>, IDi
         Assert.Equal("Regressed Queries", context.Details[3].Heading);
     }
 
+    /// <summary>
+    /// The boundary the webhook redaction rule depends on, asserted rather than assumed
+    /// (review catch on #3297): a GENERATED remediation command only ever lands in an
+    /// <see cref="AlertDetailItem"/> flagged <c>IsCodeBlock</c> — which every webhook channel replaces
+    /// with <c>TsqlWebhookHint</c> before anything leaves the process — and NEVER in the flat prose
+    /// <c>detailText</c>, which since #3297 rides out to those same channels verbatim.
+    /// <para>Fold the command into the detail text and it would bypass the redaction with no other test
+    /// noticing, because both surfaces render "correctly" either way. This is the PLAN_REGRESSION finding,
+    /// which is the case that actually has a generated command.</para>
+    /// </summary>
+    [Fact]
+    public void TheGeneratedRemediationCommand_RidesOnlyInTheCodeBlockItem_NeverInTheProseDetailText()
+    {
+        var finding = MakeFinding("planreg000000001", rootFactKey: "PLAN_REGRESSION",
+            drillDown: RegressedQueriesDrillDown());
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+        var detailText = FindingMessageFormatter.DetailText(finding, notifyThreshold: 1.5);
+
+        /* The command exists, and it is in the redacted item. */
+        var codeBlock = Assert.Single(context.Details, d => d.IsCodeBlock);
+        Assert.Contains("sp_query_store_force_plan", codeBlock.Body);
+
+        /* And nowhere in the prose that now reaches a webhook. */
+        Assert.DoesNotContain("sp_query_store_force_plan", detailText, StringComparison.Ordinal);
+        Assert.DoesNotContain("DBCC", detailText, StringComparison.Ordinal);
+        Assert.DoesNotContain("ALTER DATABASE", detailText, StringComparison.Ordinal);
+
+        /* The prose is finding METADATA, which is what makes the boundary hold by construction rather
+           than by each author remembering it. */
+        Assert.Contains("Story:", detailText, StringComparison.Ordinal);
+        Assert.Contains("Severity:", detailText, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void BuildContext_UnknownFactKey_OmitsAdviceAndTsql()
     {

--- a/Lite.Tests/EmailTemplateBrandingTests.cs
+++ b/Lite.Tests/EmailTemplateBrandingTests.cs
@@ -31,4 +31,69 @@ public class EmailTemplateBrandingTests
         Assert.Contains(WebUtility.HtmlEncode(branding.SnoozeHint), html);
         Assert.Contains(branding.SnoozeHint!, plain);
     }
+
+    /* ---------------- #3297: the alert's prose detail reaches both bodies ---------------- */
+
+    /// <summary>The #3296 alert, shortened: a self-alert's prose detail with no structured context at all.</summary>
+    private const string Prose =
+        "Store query_stats retention [1072] is HELD PAUSED by the rollup-coverage gate. The policy arms " +
+        "ITSELF once its consumer covers everything raw holds, but it arms at STARTUP: run the " +
+        "--backfill-rollups operator action, then RESTART the service.";
+
+    /// <summary>
+    /// #3297, the defect itself. A self-alert fires with <c>context: null</c>, so the Details section — which
+    /// was gated on <see cref="AlertContext.Details"/>, a STRUCTURED collection — never rendered, and the
+    /// delivered email was a metric name, a current value, a threshold and two timestamps with the remedy
+    /// discarded. Reported from the field on #3296 by the only operator who has ever had email configured;
+    /// there is no dogfooding path to this, so this assertion is the whole guard.
+    /// <para>Both bodies, separately: they are built by two different methods
+    /// (<c>BuildHtmlBody</c> / <c>BuildPlainTextBody</c>) and a repair to one says nothing about the other.</para>
+    /// </summary>
+    [Fact]
+    public void BuildAlertEmail_ProseDetail_ReachesBothBodies_OnAContextFreeSelfAlert()
+    {
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail(
+            "Retention Held", "Monitor Store", "9.6x its 4 days horizon", "2.0x", 15,
+            EmailAlertService.Branding, context: null, detailText: Prose);
+
+        Assert.Contains("DETAILS", html);
+        Assert.Contains(WebUtility.HtmlEncode(Prose), html);
+
+        Assert.Contains("--- Details ---", plain);
+        Assert.Contains(Prose, plain);
+    }
+
+    /// <summary>
+    /// The other half of the same gate: an alert with neither prose nor structured detail must still render
+    /// no Details section, so the pre-#3297 email is unchanged wherever there was nothing to add.
+    /// </summary>
+    [Fact]
+    public void BuildAlertEmail_NoProseAndNoContext_RendersNoDetailsSection()
+    {
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail(
+            "High CPU", "TestServer", "95%", "90%", 15, EmailAlertService.Branding);
+
+        Assert.DoesNotContain("DETAILS", html);
+        Assert.DoesNotContain("--- Details ---", plain);
+    }
+
+    /// <summary>
+    /// The #2109 AG-database shape: a structured context AND independent prose naming the remedy. Suppressing
+    /// the prose whenever a context is present would have dropped exactly this, which is why the gate compares
+    /// the prose against the context's own flattening instead.
+    /// </summary>
+    [Fact]
+    public void BuildAlertEmail_StructuredContextAndIndependentProse_RendersBoth()
+    {
+        var context = AgAlertContexts.ForDatabase("SalesDB", "ag-primary", "replica-1");
+
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail(
+            "AG Database Suspended", "SRV", "Suspended", "Online", 15,
+            EmailAlertService.Branding, context: context, detailText: "Resume it with ALTER DATABASE SET HADR RESUME.");
+
+        Assert.Contains("SET HADR RESUME", html);
+        Assert.Contains("Availability Group", html);
+        Assert.Contains("SET HADR RESUME", plain);
+        Assert.Contains("Availability Group", plain);
+    }
 }

--- a/Lite.Tests/GenericWebhookTests.cs
+++ b/Lite.Tests/GenericWebhookTests.cs
@@ -457,4 +457,64 @@ public class GenericWebhookTests
         Assert.DoesNotContain("incidents_json", WebhookAlertService.DefaultGenericBodyTemplate, System.StringComparison.Ordinal);
         Assert.DoesNotContain("dedup_key", WebhookAlertService.DefaultGenericBodyTemplate, System.StringComparison.Ordinal);
     }
+
+    /* ---------------- #3297: the alert's prose detail ---------------- */
+
+    private const string Prose =
+        "Store query_stats retention [1072] is HELD PAUSED by the rollup-coverage gate. Run the " +
+        "--backfill-rollups operator action, then RESTART the service.";
+
+    /// <summary>
+    /// #3297: the discrete <c>{{detail}}</c> token, for a template that needs the prose on its own —
+    /// mapped into a ticket body field rather than mixed in with the flattened structure.
+    /// </summary>
+    [Fact]
+    public void DetailToken_SubstitutesTheProse_AndIsEmptyWhenTheAlertHasNone()
+    {
+        const string template = """{"detail": "{{detail}}"}""";
+
+        var withProse = WebhookAlertService.BuildGenericPayload(
+            "Retention Held", "Monitor Store", "9.6x", "2.0x", Branding, bodyTemplate: template, detailText: Prose);
+        Assert.Equal(Prose, JsonDocument.Parse(withProse).RootElement.GetProperty("detail").GetString());
+
+        /* No prose ⇒ the token renders empty and the template stays well-formed, the {{triage_url}} shape. */
+        var without = WebhookAlertService.BuildGenericPayload(
+            "Retention Held", "Monitor Store", "9.6x", "2.0x", Branding, bodyTemplate: template);
+        Assert.Equal("", JsonDocument.Parse(without).RootElement.GetProperty("detail").GetString());
+    }
+
+    /// <summary>
+    /// The load-bearing half for this channel: <c>{{context}}</c> leads with the prose. A new token alone
+    /// would have fixed nothing for anyone — the shipped default template carries <c>{{context}}</c> and so
+    /// does every template an operator has already saved, and none of them can reference a token that did
+    /// not exist when they were written. This is what makes the fix arrive with no operator action.
+    /// <para>A prose-only self-alert used to render <c>{{context}}</c> as the bare "Sent by ..."
+    /// boilerplate: the whole alert body reduced to a signature.</para>
+    /// </summary>
+    [Fact]
+    public void ContextToken_LeadsWithTheProse_SoTheDefaultTemplateCarriesIt()
+    {
+        var payload = WebhookAlertService.BuildGenericPayload(
+            "Retention Held", "Monitor Store", "9.6x", "2.0x", Branding, detailText: Prose);
+
+        var context = JsonDocument.Parse(payload).RootElement.GetProperty("context").GetString()!;
+        Assert.StartsWith(Prose, context, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Sent by", context, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The prose goes through the same JSON escaping every other string token does — it is alert data, and
+    /// a quote in it would otherwise terminate the literal early exactly as a server name would.
+    /// </summary>
+    [Fact]
+    public void DetailWithAQuote_DoesNotBreakOutOfTheJsonStringLiteral()
+    {
+        const string template = """{"detail": "{{detail}}"}""";
+        const string hostile = """Run --backfill-rollups"; DROP TABLE x; --""";
+
+        var payload = WebhookAlertService.BuildGenericPayload(
+            "Retention Held", "Monitor Store", "9.6x", "2.0x", Branding, bodyTemplate: template, detailText: hostile);
+
+        Assert.Equal(hostile, JsonDocument.Parse(payload).RootElement.GetProperty("detail").GetString());
+    }
 }

--- a/Lite.Tests/GenericWebhookTests.cs
+++ b/Lite.Tests/GenericWebhookTests.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using PerformanceMonitor.Analysis;
 using PerformanceMonitor.Notifications;
@@ -500,6 +503,43 @@ public class GenericWebhookTests
         var context = JsonDocument.Parse(payload).RootElement.GetProperty("context").GetString()!;
         Assert.StartsWith(Prose, context, System.StringComparison.Ordinal);
         Assert.DoesNotContain("Sent by", context, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <b>Every substitutable token is offered to the operator in BOTH apps' Settings help text.</b>
+    /// A token nobody is told about is a token nobody can map into a template, so the help text is part of
+    /// the feature rather than decoration — and it has drifted twice: #2710 added <c>{{triage_url}}</c> to
+    /// Darling's list and not Lite's, and #3297 added <c>{{detail}}</c> to neither. Both were found by
+    /// reading, which is exactly what this replaces.
+    /// <para>Derived from <c>WebhookAlertService.GenericBodyTokens</c>, the same list the matcher is built
+    /// from, so adding a token to the engine and not to the windows fails here. A second hardcoded copy of
+    /// the token names in this test would be free to go stale in the same way the help text did.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("Lite/Windows/SettingsWindow.xaml")]
+    [InlineData("Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml")]
+    public void EverySubstitutableToken_IsListedInTheSettingsHelpText(string relativePath)
+    {
+        var xaml = File.ReadAllText(Path.Combine(RepoRoot(), relativePath));
+
+        var missing = WebhookAlertService.GenericBodyTokens
+            .Where(token => !xaml.Contains("{{" + token + "}}", System.StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Empty(missing);
+    }
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        /* Locate the repo from this file, the AlertFiringLogTests idiom — no build-output copying. */
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !Directory.Exists(Path.Combine(dir, "PerformanceMonitor.Notifications")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
     }
 
     /// <summary>

--- a/Lite.Tests/PagerDutyWebhookTests.cs
+++ b/Lite.Tests/PagerDutyWebhookTests.cs
@@ -241,6 +241,47 @@ public class PagerDutyWebhookTests
         Assert.NotNull(payload);
     }
 
+    /* ---------------- #3297: the alert's prose detail ---------------- */
+
+    /// <summary>
+    /// #3297: <c>BuildPagerDutyCustomDetails</c> already flattened <see cref="AlertContext.Details"/> — the
+    /// STRUCTURED collection — which is why this channel looked like it might already carry the detail. It
+    /// did not: an alert's <c>DetailText</c> is a separate field, and a prose-only self-alert took the
+    /// empty-Details branch that reduces custom_details to <c>{"Sent by": ...}</c>.
+    /// <para>custom_details rather than <c>summary</c>: PD-CEF caps summary at 1024 characters and it is the
+    /// one-line headline PD pages on, while custom_details is the table view and what most downstream
+    /// integrations read — the placement #2710 already chose for the triage link.</para>
+    /// </summary>
+    [Fact]
+    public void BuildPagerDutyPayload_ProseDetail_RidesInCustomDetails()
+    {
+        const string prose =
+            "Store query_stats retention [1072] is HELD PAUSED by the rollup-coverage gate. Run the " +
+            "--backfill-rollups operator action, then RESTART the service.";
+
+        var payload = WebhookAlertService.BuildPagerDutyPayload(
+            "Retention Held", "Monitor Store", "9.6x its 4 days horizon", "2.0x", Branding, "rk",
+            detailText: prose);
+
+        var customDetails = JsonDocument.Parse(payload).RootElement
+            .GetProperty("payload").GetProperty("custom_details");
+
+        Assert.Equal(prose, customDetails.GetProperty("Details").GetString());
+    }
+
+    /// <summary>A prose-free alert keeps the pre-#3297 custom_details shape — no empty key is ever sent.</summary>
+    [Fact]
+    public void BuildPagerDutyPayload_OmitsTheDetailsKey_WhenTheAlertCarriesNoProse()
+    {
+        var payload = WebhookAlertService.BuildPagerDutyPayload(
+            "High CPU", "SRV1", "95%", "90%", Branding, "rk");
+
+        var customDetails = JsonDocument.Parse(payload).RootElement
+            .GetProperty("payload").GetProperty("custom_details");
+
+        Assert.False(customDetails.TryGetProperty("Details", out _));
+    }
+
     /* ---------------- Fan-out (TrySendWebhookAlertsAsync) ---------------- */
 
     [Fact]

--- a/Lite.Tests/WebhookPayloadBrandingTests.cs
+++ b/Lite.Tests/WebhookPayloadBrandingTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using System.Text.Json;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitorLite.Services;
 using Xunit;
@@ -51,5 +54,73 @@ public class WebhookPayloadBrandingTests
         // The snooze section is alert-only; test notifications never render it.
         Assert.DoesNotContain("Manage Mute Rules", teams);
         Assert.DoesNotContain("Manage Mute Rules", slack);
+    }
+
+    /* ---------------- #3297: the alert's prose detail reaches the webhook payloads ---------------- */
+
+    private const string Prose =
+        "Store query_stats retention [1072] is HELD PAUSED by the rollup-coverage gate. Run the " +
+        "--backfill-rollups operator action, then RESTART the service.";
+
+    /// <summary>
+    /// #3297: <c>WebhookAlertService</c> held ZERO references to the alert's detail text across all of its
+    /// channels, so a Teams card carried a metric name, a value and a threshold with the remedy discarded —
+    /// the same defect #3296 reported by email. A MessageCard section with <c>text</c> rather than a fact,
+    /// because a multi-paragraph remedy in a label/value fact renders as an unreadable column.
+    /// </summary>
+    [Fact]
+    public void BuildTeamsPayload_ProseDetail_BecomesItsOwnSection()
+    {
+        var payload = WebhookAlertService.BuildTeamsPayload(
+            "Retention Held", "Monitor Store", "9.6x its 4 days horizon", "2.0x",
+            EmailAlertService.Branding, detailText: Prose);
+
+        using var doc = JsonDocument.Parse(payload);
+        var section = Assert.Single(
+            doc.RootElement.GetProperty("sections").EnumerateArray().ToList(),
+            s => s.TryGetProperty("activityTitle", out var t) && t.GetString() == "Details");
+
+        Assert.Equal(Prose, section.GetProperty("text").GetString());
+    }
+
+    /// <summary>
+    /// #3297 for Slack — the channel being stood up, and therefore the one where the first alert an operator
+    /// ever sees would otherwise have had its remedy thrown away. A Block Kit <c>section</c> with mrkdwn text
+    /// is the prose affordance; it sits under the field block and above the per-incident dividers.
+    /// </summary>
+    [Fact]
+    public void BuildSlackPayload_ProseDetail_BecomesAMrkdwnSection()
+    {
+        var payload = WebhookAlertService.BuildSlackPayload(
+            "Retention Held", "Monitor Store", "9.6x its 4 days horizon", "2.0x",
+            EmailAlertService.Branding, detailText: Prose);
+
+        using var doc = JsonDocument.Parse(payload);
+        var carried = doc.RootElement.GetProperty("attachments")[0].GetProperty("blocks")
+            .EnumerateArray()
+            .Any(b => b.GetProperty("type").GetString() == "section" &&
+                      b.TryGetProperty("text", out var t) &&
+                      t.GetProperty("type").GetString() == "mrkdwn" &&
+                      t.GetProperty("text").GetString()!.Contains(Prose, StringComparison.Ordinal));
+
+        Assert.True(carried, "no mrkdwn section carried the alert's detail text");
+    }
+
+    /// <summary>
+    /// Prose-free alerts keep the pre-#3297 payloads: no Details section on Teams, and no section block on
+    /// Slack beyond the ones the structured context already produced.
+    /// </summary>
+    [Fact]
+    public void ChannelPayloads_OmitTheDetailSection_WhenTheAlertCarriesNoProse()
+    {
+        var teams = WebhookAlertService.BuildTeamsPayload(
+            "High CPU", "SRV", "97%", "90%", EmailAlertService.Branding);
+        Assert.DoesNotContain(
+            JsonDocument.Parse(teams).RootElement.GetProperty("sections").EnumerateArray().ToList(),
+            s => s.TryGetProperty("activityTitle", out var t) && t.GetString() == "Details");
+
+        var slack = WebhookAlertService.BuildSlackPayload(
+            "High CPU", "SRV", "97%", "90%", EmailAlertService.Branding);
+        Assert.DoesNotContain("*Details*", slack, StringComparison.Ordinal);
     }
 }

--- a/Lite/Services/EmailAlertService.cs
+++ b/Lite/Services/EmailAlertService.cs
@@ -63,7 +63,8 @@ public class EmailAlertService : IFindingAlertSender
         try
         {
             var result = await _core.TrySendAsync(
-                metricName, serverName, currentValue, thresholdValue, serverId.ToString(), context, attemptChannels: !muted);
+                metricName, serverName, currentValue, thresholdValue, serverId.ToString(), context, attemptChannels: !muted,
+                detailText: detailText);
 
             /* trayChannelPresent: true — LiteAlertDeliverer.DeliverAsync shows a styled balloon for every
                non-muted alert on the same call that reaches here, so a stored "tray" really does mean a

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -645,11 +645,11 @@
                 </Grid>
                 <TextBlock Margin="20,8,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
                     <Run Text="Placeholders (each is JSON-escaped when substituted): "/>
-                    <Run FontFamily="Consolas" Text="{}{{metric}} {{server}} {{value}} {{threshold}} {{severity}} {{context}} {{timestamp}}"/>
+                    <Run FontFamily="Consolas" Text="{}{{metric}} {{server}} {{value}} {{threshold}} {{severity}} {{context}} {{detail}} {{timestamp}}"/>
                 </TextBlock>
                 <TextBlock Margin="20,4,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
                     <Run Text="Automation placeholders — the first two substitute RAW JSON values (use them unquoted, e.g. &quot;context&quot;: {{context_json}}): "/>
-                    <Run FontFamily="Consolas" Text="{}{{context_json}} {{incidents_json}} {{dedup_key}} {{resource_name}} {{database}}"/>
+                    <Run FontFamily="Consolas" Text="{}{{context_json}} {{incidents_json}} {{dedup_key}} {{resource_name}} {{database}} {{triage_url}}"/>
                 </TextBlock>
                 <TextBlock Margin="20,6,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
                     <Run FontWeight="SemiBold" Text="Example — re-run a GitHub Actions workflow when an alert fires:"/>

--- a/PerformanceMonitor.Alerting/AlertContextBuilders.cs
+++ b/PerformanceMonitor.Alerting/AlertContextBuilders.cs
@@ -773,20 +773,13 @@ public static class AlertContextBuilders
     /// <summary>
     /// Flattens an <see cref="AlertContext"/> into the plain-text detail block persisted in alert
     /// history and rendered in plain-text notification bodies. Null when there is nothing to render.
+    /// <para>The implementation lives in <see cref="AlertDetailText.Flatten"/>, in the Notifications
+    /// project, because the delivery channels there decide whether an alert's prose detail adds anything
+    /// over its structured context by comparing against this exact text — and that project cannot
+    /// reference this one. Kept as the name every fire site already calls.</para>
     /// </summary>
-    public static string? ContextToDetailText(AlertContext? context)
-    {
-        if (context == null || context.Details.Count == 0) return null;
-        var sb = new System.Text.StringBuilder();
-        foreach (var detail in context.Details)
-        {
-            if (sb.Length > 0) sb.AppendLine();
-            sb.AppendLine(detail.Heading);
-            foreach (var (label, value) in detail.Fields)
-                sb.AppendLine($"  {label}: {value}");
-        }
-        return sb.ToString().TrimEnd();
-    }
+    public static string? ContextToDetailText(AlertContext? context) =>
+        AlertDetailText.Flatten(context);
 
     /// <summary>
     /// Collapses newlines to spaces, trims, and truncates to <paramref name="maxLength"/> with a

--- a/PerformanceMonitor.Alerting/AlertEngine.cs
+++ b/PerformanceMonitor.Alerting/AlertEngine.cs
@@ -1736,27 +1736,23 @@ public sealed class AlertEngine
                     ? $"{dbName} first observed {stateText} (no baseline yet)"
                     : $"{dbName} changed to {stateText} (expected {expectedText})";
 
-                /* #2109: the same fields the prose carries, as discrete facts — this alert fired with
-                   Context: null, which left the database name reachable only by parsing the title.
-                   #3297: the structured fields are now the ONLY carrier, and the detail text is their
-                   flattening, as at every other engine fire site. The prose used to restate them under
-                   different labels, which since #3297 delivers every channel the same facts twice — the
-                   fields are the canonical copy per #2109, so the restatement is what goes. The one thing
-                   the prose said that the fields did not (no baseline yet) is a field now. */
-                var stateFields = new List<(string Label, string Value)>
-                {
-                    ("Database", dbName),
-                    ("Current State", stateText),
-                    ("Expected State", expectedText)
-                };
-
-                if (pending)
-                {
-                    stateFields.Add(("Baseline", "none — first observed in a critical state"));
-                }
-
+                /* #2109: the same facts as discrete fields — this alert fired with Context: null, which
+                   left the database name reachable only by parsing the title. These three fields are the
+                   canonical copy and the detail text is their flattening, as at every other engine fire
+                   site, so no channel receives the same fact under two labels. The no-baseline case needs
+                   no field of its own: expectedText above IS "(no baseline yet)" whenever pending, and
+                   ShortMessage says it too. */
                 var stateContext = new AlertContext();
-                stateContext.Details.Add(new AlertDetailItem { Heading = dbName, Fields = stateFields });
+                stateContext.Details.Add(new AlertDetailItem
+                {
+                    Heading = dbName,
+                    Fields = new()
+                    {
+                        ("Database", dbName),
+                        ("Current State", stateText),
+                        ("Expected State", expectedText)
+                    }
+                });
 
                 var detailText = AlertContextBuilders.ContextToDetailText(stateContext);
 

--- a/PerformanceMonitor.Alerting/AlertEngine.cs
+++ b/PerformanceMonitor.Alerting/AlertEngine.cs
@@ -1732,26 +1732,38 @@ public sealed class AlertEngine
                 bool isMuted = _isAlertMuted(muteCtx);
                 _lastDatabaseStateAlert[cooldownKey] = now; /* stamped even when muted, like the others */
 
-                var detailText = pending
-                    ? $"  Database: {dbName}\n  Current: {stateText}\n  First observed in a critical state — no baseline established yet."
-                    : $"  Database: {dbName}\n  Expected: {expectedText}\n  Current: {stateText}";
                 var shortMessage = pending
                     ? $"{dbName} first observed {stateText} (no baseline yet)"
                     : $"{dbName} changed to {stateText} (expected {expectedText})";
 
                 /* #2109: the same fields the prose carries, as discrete facts — this alert fired with
-                   Context: null, which left the database name reachable only by parsing the title. */
+                   Context: null, which left the database name reachable only by parsing the title.
+                   #3297: the structured fields are now the ONLY carrier, and the detail text is their
+                   flattening, as at every other engine fire site. The prose used to restate them under
+                   different labels, which since #3297 delivers every channel the same facts twice — the
+                   fields are the canonical copy per #2109, so the restatement is what goes. The one thing
+                   the prose said that the fields did not (no baseline yet) is a field now. */
                 var stateContext = new AlertContext();
                 stateContext.Details.Add(new AlertDetailItem
                 {
                     Heading = dbName,
-                    Fields = new()
-                    {
-                        ("Database", dbName),
-                        ("Current State", stateText),
-                        ("Expected State", expectedText)
-                    }
+                    Fields = pending
+                        ? new()
+                        {
+                            ("Database", dbName),
+                            ("Current State", stateText),
+                            ("Expected State", expectedText),
+                            ("Baseline", "none — first observed in a critical state")
+                        }
+                        : new()
+                        {
+                            ("Database", dbName),
+                            ("Current State", stateText),
+                            ("Expected State", expectedText)
+                        }
                 });
+
+                var detailText = AlertContextBuilders.ContextToDetailText(stateContext);
 
                 await FireAsync(new AlertOutcome(
                     key, serverName, DatabaseStateTokens.MetricName,
@@ -1916,16 +1928,12 @@ public sealed class AlertEngine
                 bool isMuted = _isAlertMuted(muteCtx);
                 _lastForcePlanAlert[cooldownKey] = now; /* stamped even when muted, like the others */
 
-                var detailText =
-                    $"  Database: {failure.DatabaseName}\n" +
-                    $"  Query / Plan: {failure.QueryId} / {failure.PlanId}\n" +
-                    $"  Forcing: {forcingText}\n" +
-                    $"  Reason: {reasonText}\n" +
-                    $"  New failures since last collection: {failure.FailureDelta} (total {failure.TotalFailures})\n" +
-                    "  The query is running on the optimizer's plan, not the forced one.";
-
                 /* #2109 discipline: the same facts the prose carries, as discrete fields, so a consumer
-                   never has to parse the title to learn which plan this is about. */
+                   never has to parse the title to learn which plan this is about.
+                   #3297: and the fields are now the only carrier — the detail text is their flattening, as
+                   at every other engine fire site, rather than a hand-authored restatement that would
+                   deliver the same facts twice on every channel. The consequence the prose stated and the
+                   fields did not is a field now. */
                 var context = new AlertContext();
                 context.Details.Add(new AlertDetailItem
                 {
@@ -1938,9 +1946,12 @@ public sealed class AlertEngine
                         ("Forcing Type", forcingText),
                         ("Failure Reason", reasonText),
                         ("New Failures", failure.FailureDelta.ToString(CultureInfo.InvariantCulture)),
-                        ("Total Failures", failure.TotalFailures.ToString(CultureInfo.InvariantCulture))
+                        ("Total Failures", failure.TotalFailures.ToString(CultureInfo.InvariantCulture)),
+                        ("Effect", "the query is running on the optimizer's plan, not the forced one")
                     }
                 });
+
+                var detailText = AlertContextBuilders.ContextToDetailText(context);
 
                 await FireAsync(new AlertOutcome(
                     key, serverName, ForcePlanTokens.MetricName,

--- a/PerformanceMonitor.Alerting/AlertEngine.cs
+++ b/PerformanceMonitor.Alerting/AlertEngine.cs
@@ -1743,25 +1743,20 @@ public sealed class AlertEngine
                    different labels, which since #3297 delivers every channel the same facts twice — the
                    fields are the canonical copy per #2109, so the restatement is what goes. The one thing
                    the prose said that the fields did not (no baseline yet) is a field now. */
-                var stateContext = new AlertContext();
-                stateContext.Details.Add(new AlertDetailItem
+                var stateFields = new List<(string Label, string Value)>
                 {
-                    Heading = dbName,
-                    Fields = pending
-                        ? new()
-                        {
-                            ("Database", dbName),
-                            ("Current State", stateText),
-                            ("Expected State", expectedText),
-                            ("Baseline", "none — first observed in a critical state")
-                        }
-                        : new()
-                        {
-                            ("Database", dbName),
-                            ("Current State", stateText),
-                            ("Expected State", expectedText)
-                        }
-                });
+                    ("Database", dbName),
+                    ("Current State", stateText),
+                    ("Expected State", expectedText)
+                };
+
+                if (pending)
+                {
+                    stateFields.Add(("Baseline", "none — first observed in a critical state"));
+                }
+
+                var stateContext = new AlertContext();
+                stateContext.Details.Add(new AlertDetailItem { Heading = dbName, Fields = stateFields });
 
                 var detailText = AlertContextBuilders.ContextToDetailText(stateContext);
 

--- a/PerformanceMonitor.Alerting/IAlertDeliverer.cs
+++ b/PerformanceMonitor.Alerting/IAlertDeliverer.cs
@@ -24,7 +24,14 @@ namespace PerformanceMonitor.Alerting;
 /// <param name="CurrentValue">Human-readable current value (e.g. "3 deadlock(s) in the last hour").</param>
 /// <param name="ThresholdValue">Human-readable threshold it breached (e.g. "1", "80%").</param>
 /// <param name="Context">Structured detail context (built by <see cref="AlertContextBuilders"/>), or null when no detail was resolvable.</param>
-/// <param name="DetailText">Flat plain-text rendering of <paramref name="Context"/> (the engine emits <see cref="AlertContextBuilders.ContextToDetailText"/> output), or null.</param>
+/// <param name="DetailText">
+/// The alert's flat plain-text detail, or null. For an engine alert this is a rendering of
+/// <paramref name="Context"/> (<see cref="AlertContextBuilders.ContextToDetailText"/>), but it is NOT only
+/// that: a self-alert fires with <c>Context: null</c> and carries independent prose here — what happened,
+/// what it costs, and the operator action that clears it — which is the ONLY place that text exists. Every
+/// delivery channel renders it (#3297), suppressed on the engine case so the same content is not printed
+/// twice.
+/// </param>
 /// <param name="NumericCurrentValue">Numeric current value for history charting/thresholding, when the metric has one.</param>
 /// <param name="NumericThresholdValue">Numeric threshold twin of <paramref name="NumericCurrentValue"/>.</param>
 /// <param name="Muted">True when a mute rule matched — the host records the alert but must not toast/send it.</param>

--- a/PerformanceMonitor.Notifications/AlertDetailText.cs
+++ b/PerformanceMonitor.Notifications/AlertDetailText.cs
@@ -20,6 +20,20 @@ namespace PerformanceMonitor.Notifications;
 /// retention held) carry only the prose and fire with <c>context: null</c>, so a channel that renders only
 /// the structured collection delivers a metric name, a value and a threshold with the remedy discarded.
 /// </para>
+/// <para>
+/// <b>Scope against the never-on-a-webhook T-SQL rule.</b> That rule
+/// (<c>WebhookAlertService.RedactForWebhook</c>, and the per-channel <c>IsCodeBlock</c> substitution) targets
+/// GENERATED remediation payloads: <see cref="AlertDetailItem.IsCodeBlock"/> bodies and
+/// <see cref="AlertDetailItem.Remediation"/> actions built by <c>FactRemediation</c> — multi-statement
+/// scripts, two of the seven shapes destructive, carrying a two-sided risk-disclosure header that has to be
+/// read before the script is run. The prose here is none of those: it is authored per alert, and where it
+/// names a command at all (the #2109 AG alerts' <c>SET HADR RESUME</c>) the command IS the recovery action
+/// and the sentence IS the alert. Redacting it would deliver "see email or the in-app dialog" to an operator
+/// whose only channel is the one being redacted, which is the #3296 defect over again.
+/// <para>A generated command never reaches this text, which is what makes the boundary hold. That is a
+/// checked fact, not an author's habit — see
+/// <c>Lite.Tests.AnalysisNotificationTests.TheGeneratedRemediationCommand_RidesOnlyInTheCodeBlockItem_NeverInTheProseDetailText</c>.</para>
+/// </para>
 /// </summary>
 public static class AlertDetailText
 {

--- a/PerformanceMonitor.Notifications/AlertDetailText.cs
+++ b/PerformanceMonitor.Notifications/AlertDetailText.cs
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Notifications;
+
+/// <summary>
+/// The alert's flat detail block, and the one rule every delivery channel applies before rendering it.
+/// <para>
+/// Two different things arrive at a channel builder under the name "detail". <see cref="AlertContext.Details"/>
+/// is STRUCTURED — headings, labelled fields, code blocks — and every channel here has always rendered it.
+/// An alert record's <c>DetailText</c> is PROSE: what happened, what it costs, and the operator action that
+/// clears it. Self-alerts (store disk pressure, capture down, agent not running, collection health,
+/// retention held) carry only the prose and fire with <c>context: null</c>, so a channel that renders only
+/// the structured collection delivers a metric name, a value and a threshold with the remedy discarded.
+/// </para>
+/// </summary>
+public static class AlertDetailText
+{
+    /// <summary>
+    /// Flattens an <see cref="AlertContext"/> into the plain-text detail block persisted in alert history
+    /// and rendered in plain-text notification bodies. Null when there is nothing to render.
+    /// <para>Lives here rather than beside the context builders because
+    /// <see cref="ProseForDelivery"/> has to compare against it and this project cannot see the Alerting
+    /// project. <c>AlertContextBuilders.ContextToDetailText</c> forwards to it, so there is exactly one
+    /// implementation and the comparison cannot drift away from the text it is comparing to.</para>
+    /// </summary>
+    public static string? Flatten(AlertContext? context)
+    {
+        if (context == null || context.Details.Count == 0)
+        {
+            return null;
+        }
+
+        var sb = new System.Text.StringBuilder();
+        foreach (var detail in context.Details)
+        {
+            if (sb.Length > 0)
+            {
+                sb.AppendLine();
+            }
+
+            sb.AppendLine(detail.Heading);
+            foreach (var (label, value) in detail.Fields)
+            {
+                sb.AppendLine($"  {label}: {value}");
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// The prose a channel should render, or null when there is none to add.
+    /// <para>
+    /// Every engine alert's detail text IS <see cref="Flatten"/> of its own context — <c>AlertEngine</c>
+    /// builds it that way at eleven fire sites — so rendering both would print the same content twice in
+    /// the alerts that already read correctly (blocking, deadlocks, long-running queries, low disk, jobs).
+    /// Suppressing on that equality keeps those deliveries byte-for-byte unchanged while the prose-only
+    /// alerts gain their detail. It is not the same as suppressing whenever a context is present: the
+    /// #2109 AG database alerts carry BOTH a structured context and independent prose naming the
+    /// <c>SET HADR RESUME</c> remedy, and that prose must still be delivered.
+    /// </para>
+    /// <para>
+    /// Compared against the shared <see cref="Flatten"/> rather than a local reimplementation, so the two
+    /// texts are equal by construction. Should they ever disagree anyway, the alert is delivered twice —
+    /// visible and harmless — rather than having its remedy dropped again, which is the failure this whole
+    /// path exists to stop.
+    /// </para>
+    /// </summary>
+    public static string? ProseForDelivery(string? detailText, AlertContext? context)
+    {
+        if (string.IsNullOrWhiteSpace(detailText))
+        {
+            return null;
+        }
+
+        var trimmed = detailText.Trim();
+        var flattened = Flatten(context);
+
+        return string.Equals(trimmed, flattened?.Trim(), StringComparison.Ordinal) ? null : trimmed;
+    }
+}

--- a/PerformanceMonitor.Notifications/EmailSendCore.cs
+++ b/PerformanceMonitor.Notifications/EmailSendCore.cs
@@ -70,6 +70,13 @@ public sealed class EmailSendCore
     /// When false (Lite's muted case) neither email nor webhook is attempted; the caller
     /// still records its row from the all-false result.
     /// </param>
+    /// <param name="detailText">
+    /// #3297: the alert's flat prose detail — the same text the caller records as the history row's
+    /// <c>detail_text</c> and the viewer, the MCP reader and the triage page all show. Passed on to the
+    /// email template and the webhook fan-out so the channels carry the alert's remedy and not only its
+    /// number. Optional so the deprecated Dashboard shell, which has no detail text to give, keeps
+    /// compiling; every live caller has one.
+    /// </param>
     public async Task<EmailFanoutResult> TrySendAsync(
         string metricName,
         string serverName,
@@ -77,7 +84,8 @@ public sealed class EmailSendCore
         string thresholdValue,
         string serverId,
         AlertContext? context,
-        bool attemptChannels)
+        bool attemptChannels,
+        string? detailText = null)
     {
         bool emailAttempted = false;
         bool emailSent = false;
@@ -111,7 +119,8 @@ public sealed class EmailSendCore
 
                 var subject = $"[SQL Monitor Alert] {metricName} on {serverName}";
                 var (htmlBody, plainTextBody) = EmailTemplateBuilder.BuildAlertEmail(
-                    metricName, serverName, currentValue, thresholdValue, _settings.EmailCooldownMinutes, _branding, context);
+                    metricName, serverName, currentValue, thresholdValue, _settings.EmailCooldownMinutes, _branding, context,
+                    detailText);
 
                 try
                 {
@@ -151,7 +160,7 @@ public sealed class EmailSendCore
         if (attemptChannels)
         {
             webhookSent = await _webhookAlertService.TrySendWebhookAlertsAsync(
-                metricName, serverName, currentValue, thresholdValue, serverId, context);
+                metricName, serverName, currentValue, thresholdValue, serverId, context, detailText);
         }
 
         return new EmailFanoutResult(emailAttempted, emailSent, sendError, webhookSent, anyChannelConfigured);

--- a/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
+++ b/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
@@ -21,9 +21,20 @@ internal static class EmailTemplateBuilder
 {
     private const string FontStack = "-apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
 
+    /* An alert can now open the Details section on its prose alone, with no structured items behind it,
+       so the plain-text builder's item loop needs something to iterate when there is no context at all. */
+    private static readonly System.Collections.Generic.List<AlertDetailItem> EmptyDetails = new();
+
     /// <summary>
     /// Builds both HTML and plain-text bodies for an alert email.
     /// </summary>
+    /// <param name="detailText">
+    /// #3297: the alert's flat prose detail — what happened, what it costs, and the operator action that
+    /// clears it. Rendered into BOTH bodies, as the lead of the Details section. Gated through
+    /// <see cref="AlertDetailText.ProseForDelivery"/> so an engine alert whose detail text is just a
+    /// flattening of <paramref name="context"/> is not printed twice; null (and a prose-free alert) renders
+    /// exactly the pre-#3297 email.
+    /// </param>
     public static (string HtmlBody, string PlainTextBody) BuildAlertEmail(
         string metricName,
         string serverName,
@@ -31,17 +42,20 @@ internal static class EmailTemplateBuilder
         string thresholdValue,
         int emailCooldownMinutes,
         AlertBranding branding,
-        AlertContext? context = null)
+        AlertContext? context = null,
+        string? detailText = null)
     {
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
         var (accentColor, badgeText, _) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
+        var prose = AlertDetailText.ProseForDelivery(detailText, context);
 
         var html = BuildHtmlBody(metricName, serverName, currentValue,
-            thresholdValue, utcNow, localNow, accentColor, badgeText, branding, context: context, emailCooldownMinutes: emailCooldownMinutes);
+            thresholdValue, utcNow, localNow, accentColor, badgeText, branding, context: context, emailCooldownMinutes: emailCooldownMinutes,
+            prose: prose);
 
         var plain = BuildPlainTextBody(metricName, serverName, currentValue,
-            thresholdValue, utcNow, localNow, emailCooldownMinutes, branding, context);
+            thresholdValue, utcNow, localNow, emailCooldownMinutes, branding, context, prose);
 
         return (html, plain);
     }
@@ -78,7 +92,8 @@ internal static class EmailTemplateBuilder
         AlertBranding branding,
         bool isTest = false,
         AlertContext? context = null,
-        int emailCooldownMinutes = 15)
+        int emailCooldownMinutes = 15,
+        string? prose = null)
     {
         var sb = new StringBuilder(2048);
 
@@ -137,10 +152,12 @@ internal static class EmailTemplateBuilder
         sb.Append("</table>");
         sb.Append("</td></tr>");
 
-        /* Detail section (blocking chains, deadlock participants) */
-        if (context?.Details?.Count > 0)
+        /* Detail section: the alert's prose detail (#3297) leads, then the structured items (blocking
+           chains, deadlock participants). Either can be absent — a self-alert has only the prose, an
+           engine alert only the structure — so the section renders when EITHER is present. */
+        if (prose is not null || context?.Details?.Count > 0)
         {
-            AppendDetailSection(sb, context);
+            AppendDetailSection(sb, context, prose);
         }
 
         /* Attachment note */
@@ -186,13 +203,30 @@ internal static class EmailTemplateBuilder
         sb.Append("</tr>");
     }
 
-    private static void AppendDetailSection(StringBuilder sb, AlertContext context)
+    private static void AppendDetailSection(StringBuilder sb, AlertContext? context, string? prose)
     {
         /* Separator + heading */
         sb.Append("<tr><td style=\"padding:0 24px;\"><table role=\"presentation\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" width=\"100%\"><tr><td style=\"height:1px;background-color:#404040;font-size:0;line-height:0;\">&nbsp;</td></tr></table></td></tr>");
         sb.Append("<tr><td style=\"padding:12px 24px 4px 24px;\">");
         sb.Append($"<span style=\"font-family:{FontStack};font-size:13px;font-weight:600;color:#E4E6EB;letter-spacing:0.5px;\">DETAILS</span>");
         sb.Append("</td></tr>");
+
+        /* #3297: the prose first, in the same paragraph treatment the advice items below get. It is the
+           actionable half of the alert, so it reads before the drill-down rather than after it. */
+        if (prose is not null)
+        {
+            sb.Append("<tr><td style=\"padding:2px 24px 8px 24px;\">");
+            foreach (var para in prose.Replace("\r\n", "\n", StringComparison.Ordinal).Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
+            {
+                sb.Append($"<p style=\"margin:0 0 8px 0;font-family:{FontStack};font-size:13px;color:#E0E0E0;line-height:1.5;\">{WebUtility.HtmlEncode(para)}</p>");
+            }
+            sb.Append("</td></tr>");
+        }
+
+        if (context?.Details is null)
+        {
+            return;
+        }
 
         foreach (var item in context.Details)
         {
@@ -267,7 +301,8 @@ internal static class EmailTemplateBuilder
         DateTime localNow,
         int emailCooldownMinutes,
         AlertBranding branding,
-        AlertContext? context = null)
+        AlertContext? context = null,
+        string? prose = null)
     {
         var sb = new StringBuilder();
         sb.Append($"{branding.EditionName} Alert\r\n");
@@ -279,10 +314,22 @@ internal static class EmailTemplateBuilder
         sb.Append($"Time (UTC): {utcNow:yyyy-MM-dd HH:mm:ss}\r\n");
         sb.Append($"Time (Local): {localNow:yyyy-MM-dd HH:mm:ss}\r\n");
 
-        if (context?.Details?.Count > 0)
+        /* The HTML body's Details section, in parallel (BuildHtmlBody / AppendDetailSection): the #3297
+           prose leads, the structured items follow, and either half alone still opens the section. The two
+           bodies are maintained together — a change to one must touch the other. */
+        if (prose is not null || context?.Details?.Count > 0)
         {
             sb.Append($"\r\n--- Details ---\r\n");
-            foreach (var item in context.Details)
+
+            if (prose is not null)
+            {
+                foreach (var para in prose.Replace("\r\n", "\n", StringComparison.Ordinal).Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
+                {
+                    sb.Append($"\r\n  {para}\r\n");
+                }
+            }
+
+            foreach (var item in context?.Details ?? EmptyDetails)
             {
                 sb.Append($"\r\n  {item.Heading}\r\n");
 

--- a/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
+++ b/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
@@ -22,8 +22,11 @@ internal static class EmailTemplateBuilder
     private const string FontStack = "-apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
 
     /* An alert can now open the Details section on its prose alone, with no structured items behind it,
-       so the plain-text builder's item loop needs something to iterate when there is no context at all. */
-    private static readonly System.Collections.Generic.List<AlertDetailItem> EmptyDetails = new();
+       so the plain-text builder's item loop needs something to iterate when there is no context at all.
+       An array rather than an empty List: a process-wide static that anything could Add to is a hazard
+       for the sake of nothing, since this is only ever read. */
+    private static readonly System.Collections.Generic.IReadOnlyList<AlertDetailItem> EmptyDetails =
+        System.Array.Empty<AlertDetailItem>();
 
     /// <summary>
     /// Builds both HTML and plain-text bodies for an alert email.

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -135,13 +135,19 @@ public class WebhookAlertService
     /// Sends webhook alerts to all configured channels (Teams and/or Slack).
     /// Respects the email cooldown setting for throttling. Never throws.
     /// </summary>
+    /// <param name="detailText">
+    /// #3297: the alert's flat prose detail. Resolved ONCE here, the same way <c>triageUrl</c> below is
+    /// and for the same reason — all four channels must carry the same text for the same firing, and a
+    /// per-channel resolution would be four places for one of them to drift or be forgotten.
+    /// </param>
     public async Task<bool> TrySendWebhookAlertsAsync(
         string metricName,
         string serverName,
         string currentValue,
         string thresholdValue,
         string serverId = "",
-        AlertContext? context = null)
+        AlertContext? context = null,
+        string? detailText = null)
     {
         try
         {
@@ -171,24 +177,28 @@ public class WebhookAlertService
                 _settings.TriageBaseUrl, serverName, metricName, DateTime.UtcNow,
                 DerivePagerDutyDedupKey(string.IsNullOrEmpty(serverId) ? serverName : serverId, metricName, context));
 
+            /* #3297: null when the alert carries no prose, or when its prose is only a flattening of the
+               structured context every channel below already renders. */
+            var prose = AlertDetailText.ProseForDelivery(detailText, context);
+
             if (TeamsConfigured)
             {
-                sent |= await TrySendTeamsAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl);
+                sent |= await TrySendTeamsAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl, prose);
             }
 
             if (SlackConfigured)
             {
-                sent |= await TrySendSlackAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl);
+                sent |= await TrySendSlackAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl, prose);
             }
 
             if (GenericConfigured)
             {
-                sent |= await TrySendGenericAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, context, triageUrl);
+                sent |= await TrySendGenericAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, context, triageUrl, prose);
             }
 
             if (PagerDutyConfigured)
             {
-                sent |= await TrySendPagerDutyAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, context, triageUrl);
+                sent |= await TrySendPagerDutyAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, context, triageUrl, prose);
             }
 
             if (sent)
@@ -300,11 +310,12 @@ public class WebhookAlertService
         string currentValue,
         string thresholdValue,
         AlertContext? context,
-        string? triageUrl)
+        string? triageUrl,
+        string? detailText)
     {
         try
         {
-            var payload = BuildTeamsPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl);
+            var payload = BuildTeamsPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl, detailText: detailText);
             var error = await PostWebhookAsync(_settings.TeamsWebhookUrl, payload, _settings.TeamsProxyAddress);
 
             if (error != null)
@@ -382,6 +393,10 @@ public class WebhookAlertService
     /// <para>#2710: a non-null <paramref name="triageUrl"/> adds a <c>potentialAction</c> OpenUri button —
     /// the MessageCard-native link affordance — pointing at the computed triage page. Null (base URL unset,
     /// or a test send) renders exactly the pre-#2710 card.</para>
+    /// <para>#3297: <paramref name="detailText"/> is the alert's flat prose detail. It becomes its own
+    /// <c>Details</c> section ahead of the per-incident ones, because a multi-paragraph remedy in a
+    /// label/value fact renders as an unreadable column — <c>text</c> is the MessageCard-native place for
+    /// prose, and the snooze footer already uses it.</para>
     /// </summary>
     internal static string BuildTeamsPayload(
         string metricName,
@@ -391,9 +406,11 @@ public class WebhookAlertService
         AlertBranding branding,
         bool isTest = false,
         AlertContext? context = null,
-        string? triageUrl = null)
+        string? triageUrl = null,
+        string? detailText = null)
     {
         var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
+        var prose = AlertDetailText.ProseForDelivery(detailText, context);
         var themeColor = hexColor.TrimStart('#');
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
@@ -426,6 +443,13 @@ public class WebhookAlertService
            remediation-T-SQL items stay folded into the lead section's facts — they are commentary
            on the whole alert, not incidents. */
         var itemSections = new List<object>();
+
+        /* #3297: ahead of the per-incident sections — it is the actionable half of the alert. */
+        if (prose is not null)
+        {
+            itemSections.Add(new { activityTitle = "Details", text = prose, markdown = true });
+        }
+
         if (context?.Details != null)
         {
             foreach (var detail in context.Details)
@@ -537,11 +561,12 @@ public class WebhookAlertService
         string currentValue,
         string thresholdValue,
         AlertContext? context,
-        string? triageUrl)
+        string? triageUrl,
+        string? detailText)
     {
         try
         {
-            var payload = BuildSlackPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl);
+            var payload = BuildSlackPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl, detailText: detailText);
             var error = await PostWebhookAsync(_settings.SlackWebhookUrl, payload, _settings.SlackProxyAddress);
 
             if (error != null)
@@ -580,6 +605,9 @@ public class WebhookAlertService
     /// <para>#2710: a non-null <paramref name="triageUrl"/> adds an actions block with a LINK button (a url
     /// button needs no interactivity config on the webhook, unlike an action_id button) pointing at the
     /// computed triage page, placed above the "Sent by" context footer. Null renders the pre-#2710 payload.</para>
+    /// <para>#3297: <paramref name="detailText"/> is the alert's flat prose detail, rendered as its own
+    /// mrkdwn <c>section</c> block directly under the field block — Block Kit's home for prose, and above
+    /// the per-incident dividers so the remedy reads before the drill-down.</para>
     /// </summary>
     internal static string BuildSlackPayload(
         string metricName,
@@ -589,9 +617,11 @@ public class WebhookAlertService
         AlertBranding branding,
         bool isTest = false,
         AlertContext? context = null,
-        string? triageUrl = null)
+        string? triageUrl = null,
+        string? detailText = null)
     {
         var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
+        var prose = AlertDetailText.ProseForDelivery(detailText, context);
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
 
@@ -631,6 +661,12 @@ public class WebhookAlertService
         }
 
         blocks.Add(new { type = "section", fields });
+
+        /* #3297: the prose detail, before the per-incident dividers. */
+        if (prose is not null)
+        {
+            blocks.Add(new { type = "section", text = new { type = "mrkdwn", text = $"*Details*\n{prose}" } });
+        }
 
         if (context?.Details != null)
         {
@@ -721,7 +757,8 @@ public class WebhookAlertService
         string thresholdValue,
         string serverId,
         AlertContext? context,
-        string? triageUrl)
+        string? triageUrl,
+        string? detailText)
     {
         try
         {
@@ -737,7 +774,7 @@ public class WebhookAlertService
             var payload = BuildGenericPayload(
                 metricName, serverName, currentValue, thresholdValue, _branding,
                 context: context, bodyTemplate: _settings.GenericWebhookBodyTemplate, serverId: serverId,
-                triageUrl: triageUrl);
+                triageUrl: triageUrl, detailText: detailText);
 
             if (!IsWellFormedJson(payload, out var bodyError))
             {
@@ -816,6 +853,16 @@ public class WebhookAlertService
     /// channels carry (<see cref="TriageLink.Build"/>), empty when no <see cref="IAlertSettings.TriageBaseUrl"/>
     /// is configured, so a template using it stays well-formed either way.
     /// </para>
+    /// <para>
+    /// #3297: <c>{{detail}}</c> is the alert's flat prose detail — what happened and the operator action
+    /// that clears it — as an ordinary escaped string, empty when the alert carries no prose over and above
+    /// its structured context. It ALSO leads <c>{{context}}</c>: the default template and every template an
+    /// operator already saved carry <c>{{context}}</c> and none of them can carry a token that did not
+    /// exist when they were written, so a token alone would have left every existing generic-channel
+    /// deployment still dropping the detail. <c>{{detail}}</c> exists on top of that for a template that
+    /// needs the prose on its own — mapped into a ticket body field, say — rather than mixed with the
+    /// flattened structure.
+    /// </para>
     /// </summary>
     internal static string BuildGenericPayload(
         string metricName,
@@ -827,14 +874,17 @@ public class WebhookAlertService
         AlertContext? context = null,
         string? bodyTemplate = null,
         string serverId = "",
-        string? triageUrl = null)
+        string? triageUrl = null,
+        string? detailText = null)
     {
         var (_, badgeText, _) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
         var template = string.IsNullOrWhiteSpace(bodyTemplate) ? DefaultGenericBodyTemplate : bodyTemplate!;
 
+        var prose = AlertDetailText.ProseForDelivery(detailText, context);
+
         var contextText = isTest
             ? $"Webhook configuration is working correctly. Sent by {branding.EditionName}."
-            : RenderContextForTemplate(context, branding);
+            : RenderContextForTemplate(context, branding, prose);
 
         /* Keyed on the numeric serverId the fan-out passes — the same identity the LIVE PagerDuty path
            feeds DerivePagerDutyDedupKey — so the two channels' keys are equal for the same alert. The
@@ -863,6 +913,10 @@ public class WebhookAlertService
             ["resource_name"] = EscapeForJson(DeriveResourceName(context) ?? ""),
             ["database"] = EscapeForJson(DeriveResourceDatabase(context) ?? ""),
             ["triage_url"] = EscapeForJson(triageUrl ?? ""),
+            /* The test send substitutes the same canned line {{context}} gets, so a template that maps
+               {{detail}} into a required field is exercised with a value rather than validating against an
+               empty string and only failing on the first real alert. */
+            ["detail"] = EscapeForJson(isTest ? $"Webhook configuration is working correctly. Sent by {branding.EditionName}." : prose ?? ""),
         };
 
         /* Single pass: a MatchEvaluator's output is NOT re-scanned, so a value that itself contains the
@@ -875,22 +929,30 @@ public class WebhookAlertService
     /* context_json before context: alternation is ordered, and while the closing \}\} would force a
        backtrack to the right answer anyway, longest-first means correctness never leans on it. */
     private static readonly System.Text.RegularExpressions.Regex s_genericPlaceholders =
-        new(@"\{\{(metric|server|value|threshold|severity|context_json|incidents_json|dedup_key|resource_name|database|triage_url|context|timestamp)\}\}",
+        new(@"\{\{(metric|server|value|threshold|severity|context_json|incidents_json|dedup_key|resource_name|database|triage_url|context|timestamp|detail)\}\}",
             System.Text.RegularExpressions.RegexOptions.Compiled);
 
     /// <summary>
     /// Flattens the structured alert context into one plain-text line for <c>{{context}}</c> — the generic
     /// endpoint has no card schema to render into. Follows the Teams/Slack rule: remediation T-SQL is never
     /// inlined, it points at the email / in-app dialog.
+    /// <para>#3297: <paramref name="prose"/>, the alert's flat detail, leads the line when present. A
+    /// prose-only alert used to render this as the bare "Sent by ..." boilerplate — the whole alert body
+    /// reduced to a signature.</para>
     /// </summary>
-    private static string RenderContextForTemplate(AlertContext? context, AlertBranding branding)
+    private static string RenderContextForTemplate(AlertContext? context, AlertBranding branding, string? prose = null)
     {
-        if (context?.Details is not { Count: > 0 })
+        var parts = new List<string>();
+
+        if (prose is not null)
         {
-            return $"Sent by {branding.EditionName}";
+            parts.Add(prose.Replace("\r\n", " ", StringComparison.Ordinal).Replace("\n", " ", StringComparison.Ordinal));
         }
 
-        var parts = new List<string>();
+        if (context?.Details is not { Count: > 0 })
+        {
+            return parts.Count == 0 ? $"Sent by {branding.EditionName}" : string.Join(" | ", parts);
+        }
 
         foreach (var detail in context.Details)
         {
@@ -1171,7 +1233,8 @@ public class WebhookAlertService
         string thresholdValue,
         string serverId,
         AlertContext? context,
-        string? triageUrl)
+        string? triageUrl,
+        string? detailText)
     {
         try
         {
@@ -1182,7 +1245,8 @@ public class WebhookAlertService
 
             var payload = BuildPagerDutyPayload(
                 metricName, serverName, currentValue, thresholdValue, _branding,
-                _settings.PagerDutyRoutingKey, context: context, dedupKey: dedupKey, triageUrl: triageUrl);
+                _settings.PagerDutyRoutingKey, context: context, dedupKey: dedupKey, triageUrl: triageUrl,
+                detailText: detailText);
 
             var endpoint = PagerDutyEndpoint(_settings.PagerDutyUseEuRegion);
             var error = await PostWebhookAsync(endpoint, payload, _settings.PagerDutyProxyAddress);
@@ -1225,6 +1289,10 @@ public class WebhookAlertService
     /// (which PD renders as a first-class link on the alert) and <c>custom_details["Triage"]</c> (so an
     /// integration reading only the details table still gets it). Null renders the pre-#2710 payload — no
     /// empty <c>links</c> key is ever sent.</para>
+    /// <para>#3297: <paramref name="detailText"/>, the alert's flat prose detail, rides in
+    /// <c>custom_details["Details"]</c>. Not in <c>summary</c>: PD-CEF caps that at 1024 characters and it
+    /// is the one-line headline PD pages on, while custom_details is the table view and what most
+    /// downstream integrations read — the same reasoning that put the triage link there.</para>
     /// </summary>
     internal static string BuildPagerDutyPayload(
         string metricName,
@@ -1237,7 +1305,8 @@ public class WebhookAlertService
         AlertContext? context = null,
         string? dedupKey = null,
         string? serverId = null,
-        string? triageUrl = null)
+        string? triageUrl = null,
+        string? detailText = null)
     {
         var (_, badgeText, _) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
         var severity = MapToPagerDutySeverity(badgeText);
@@ -1253,7 +1322,8 @@ public class WebhookAlertService
             ? branding.EditionName
             : serverName;
 
-        var customDetails = BuildPagerDutyCustomDetails(isTest, branding, context, triageUrl);
+        var customDetails = BuildPagerDutyCustomDetails(
+            isTest, branding, context, triageUrl, AlertDetailText.ProseForDelivery(detailText, context));
 
         /* Derive dedup_key from the incident fingerprint when not explicitly provided, falling back to a
            stable metric+server key. This ensures PagerDuty correlates repeated alerts for the same incident. */
@@ -1312,7 +1382,8 @@ public class WebhookAlertService
         bool isTest,
         AlertBranding branding,
         AlertContext? context,
-        string? triageUrl = null)
+        string? triageUrl = null,
+        string? prose = null)
     {
         var details = new Dictionary<string, object>();
 
@@ -1336,6 +1407,11 @@ public class WebhookAlertService
             details["Database"] = database;
         if (triageUrl is not null)
             details["Triage"] = triageUrl;
+
+        /* #3297: before the per-incident keys and before the empty-Details return, which is the branch a
+           prose-only self-alert takes — the branch that used to reduce the whole alert to "Sent by". */
+        if (prose is not null)
+            details["Details"] = prose;
 
         if (context?.Details is null || context.Details.Count == 0)
         {

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -985,6 +985,10 @@ public class WebhookAlertService
     /// can see a remediation EXISTS) but carry the hint as their body and no <c>Remediation</c> payload; the
     /// typed payload is likewise stripped from every item defensively. Returns a COPY — the same context
     /// instance flows on to the other channels, and mutating it here would redact their email too.
+    /// <para>#3297: this covers the STRUCTURED context, which is the whole of what it has ever protected —
+    /// generated <c>FactRemediation</c> payloads. An alert's flat prose detail is delivered verbatim and
+    /// deliberately; see <see cref="AlertDetailText"/> for why, and for the pin that keeps a generated
+    /// command out of it.</para>
     /// </summary>
     private static AlertContext RedactForWebhook(AlertContext context)
     {

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -926,10 +926,25 @@ public class WebhookAlertService
         return s_genericPlaceholders.Replace(template, m => values[m.Groups[1].Value]);
     }
 
-    /* context_json before context: alternation is ordered, and while the closing \}\} would force a
-       backtrack to the right answer anyway, longest-first means correctness never leans on it. */
+    /// <summary>
+    /// Every token <see cref="BuildGenericPayload"/> substitutes, in the order the matcher tries them.
+    /// <para>context_json before context: alternation is ordered, and while the closing <c>}}</c> would
+    /// force a backtrack to the right answer anyway, longest-first means correctness never leans on it.</para>
+    /// <para>A LIST, and the matcher is built from it, because both apps' Settings windows print the token
+    /// set as help text and an operator cannot use a token they never learn exists. That help text has now
+    /// drifted twice — #2710 added <c>triage_url</c> to Darling's list and not Lite's, and #3297 added
+    /// <c>detail</c> to neither — so <c>Lite.Tests.GenericWebhookTests</c> checks both windows against this
+    /// list rather than against a second copy of it that would be free to drift the same way.</para>
+    /// </summary>
+    internal static readonly string[] GenericBodyTokens =
+    {
+        "metric", "server", "value", "threshold", "severity",
+        "context_json", "incidents_json", "dedup_key", "resource_name", "database", "triage_url",
+        "context", "timestamp", "detail"
+    };
+
     private static readonly System.Text.RegularExpressions.Regex s_genericPlaceholders =
-        new(@"\{\{(metric|server|value|threshold|severity|context_json|incidents_json|dedup_key|resource_name|database|triage_url|context|timestamp|detail)\}\}",
+        new(@"\{\{(" + string.Join("|", GenericBodyTokens) + @")\}\}",
             System.Text.RegularExpressions.RegexOptions.Compiled);
 
     /// <summary>

--- a/docs/retention-hold-runbook.md
+++ b/docs/retention-hold-runbook.md
@@ -70,9 +70,5 @@ That output is the authority, and it is generated from the parser that actually 
 
 ## Known rough edges
 
-- **The alert's email does not carry any of the above.** The alert writes a detail block naming the
-  `--backfill-rollups` remedy and the do-not-arm warning; the viewer and the MCP surface show it and the
-  email template never receives it. #3297.
 - **The 2.0x and 4.0x thresholds are not tunable.** They are compile-time constants rather than
-  `config_alert_settings` rows, which makes this the one alert that cannot be adjusted in Settings. Also
-  #3297.
+  `config_alert_settings` rows, which makes this the one alert that cannot be adjusted in Settings. #3297.


### PR DESCRIPTION
An alert's `DetailText` — the block that says what happened, what it costs, and what to do about it — reached the history store, the WPF viewer, the MCP reader and the triage endpoint, and **no delivery channel**. `WebhookAlertService` held zero references to it across all 1,534 lines. The email template does have a detail section, but it is gated on `AlertContext.Details`, a separate and *structured* collection; self-alerts fire with `context: null`, so it never rendered and the detail had no path to the message at all. Reported from the field on #3296, where the operator received a metric name, a current value, a threshold and two timestamps, and had to open an issue to find out what the alert meant.

## Which surfaces were broken

All five, and PagerDuty only looked like an exception.

| surface | before | now |
|---|---|---|
| Email HTML | dropped | leads the `DETAILS` section |
| Email plain text | dropped | leads `--- Details ---` |
| Teams | dropped | its own `Details` MessageCard section, `text` not a fact |
| Slack | dropped | an mrkdwn `section` block under the fields |
| Generic | dropped | leads `{{context}}`, plus a new discrete `{{detail}}` token |
| PagerDuty | dropped | `custom_details["Details"]` |

`BuildPagerDutyCustomDetails` already flattened `AlertContext.Details`, which is why #2710's note reads as though the channel carried the detail. It carried the *structured* collection; a prose-only self-alert took the empty-`Details` branch that reduces `custom_details` to `{"Sent by": …}`.

The generic channel was a token question, and a new token alone would have fixed nothing for anyone: the shipped default template carries `{{context}}`, so does every template an operator has already saved, and none of them can reference a token that did not exist when they were written. So the prose leads `{{context}}` — which is what makes the fix arrive with no operator action — and `{{detail}}` exists on top of that for a template that wants the prose on its own, mapped into a ticket body field rather than mixed with the flattened structure.

## What keeps engine alerts unchanged

Every engine alert's `DetailText` *is* `ContextToDetailText` of its own context — `AlertEngine` builds it that way at eleven fire sites — so carrying it on top of the structured render would print the same content twice in exactly the alerts that already read correctly. `AlertDetailText.ProseForDelivery` suppresses on that equality, resolved once per firing in the fan-out the way `triageUrl` already is.

It is deliberately not "suppress whenever a context is present": the #2109 AG-database alerts carry **both** a structured context and independent prose naming the `SET HADR RESUME` remedy, and that prose must still be delivered. The comparison is against the shared `AlertDetailText.Flatten`, so the two texts are equal by construction — `AlertContextBuilders.ContextToDetailText` now forwards to it rather than holding a second copy. Should they ever disagree anyway the alert is delivered twice, which is visible and harmless, rather than having its remedy dropped again.

## The wording fix

The #2813 Retention Held detail said the policy "arms ITSELF once its consumer covers everything raw holds" and stopped there. True and one step short: `TimescaleSupport.EnsureRetentionPoliciesAsync` is the only thing that arms a held policy and it has exactly one call site, the service startup path. An operator following the old wording runs `--backfill-rollups`, watches the hourly Critical keep firing, and concludes the backfill failed. The detail now names the restart and says why it is not optional — the wording `docs/retention-hold-runbook.md` already uses. That runbook's "the alert's email does not carry any of the above" rough edge is now stale and is removed; the untunable-thresholds one stays.

`IAlertDeliverer`'s doc comment for `DetailText` said it was a rendering of `Context`, which is the statement that makes delivering it look redundant. It now says what a self-alert actually puts there.

## Verification

There is no dogfooding path to this defect. No email is configured on any of the three stores and there is no webhook channel yet, so it can only ever be found by a user filing an issue, which is how it was found. The pins are the whole guard, and every one of them was mutation-tested: the detail deleted from the payload, red confirmed, restored, and the restore verified by blob hash rather than by diffstat.

`TheDeliverer_PutsDetailTextOnTheWire_OnEmailAndEveryRedirectableWebhookChannel` drives the whole Darling path — `DeliverAsync`, the send core, the fan-out, each builder — and asserts against the bytes that left the process, via a loopback sink per channel. Deliberately not a payload-builder assertion: the defect was never in a builder, it was that nothing passed the text to one, and a builder-level pin is green on a fan-out that drops the argument. Mutation testing proved that: dropping `prose` in the fan-out kills only this test, and every builder pin stays green.

It also found the one hop that no pin covered — the send core handing the email template the detail. Email has no interception point short of the protocol, and that hop is the channel #3296 actually reported, so the sink now speaks enough SMTP to capture the DATA and decode both transfer encodings (.NET picks base64 for the utf-8 plain part and quoted-printable for the us-ascii HTML one). The assertion is that the phrase appears **twice**, once per MIME part, so losing either body fails.

PagerDuty's endpoint is the hardcoded Events v2 URL and cannot be redirected at a sink; its builder is pinned separately and takes its prose from the same single resolution in the fan-out as the three that are checked on the wire.

Full solution builds clean with zero warnings. The Windows-only suites were run on macOS by compiling the actual committed test `.cs` files into `net10.0` console harnesses over an xunit shim, in three scopes: the eight Lite render/payload classes (111/111), the two Darling delivery classes (44 pass, 1 skip), and `AlertEngineTests` (69/69, 66 async tests confirmed awaited rather than reported as hollow passes). The shim has a `--self-check` mode with two control classes — six that must pass, five that must fail, including a failure raised after an `await` and structural equality on two distinct-but-equal `List<T>` — so a hollow pass and a red that belongs to the harness are both ruled out by measurement rather than by care. A shimmed subject reports SKIP and is never counted as a pass: `TheViewerRow_RendersThroughTheSharedDescriber`'s subject is the WPF `ViewerAlertRow`, so it skips here and CI runs it for real.

The new tests are confirmed to have RUN, by count rather than by name — MTP prints no per-test `Passed` lines, so the grep that used to confirm this returns nothing. Against `dev` at `a220d210`, `Lite.Tests` goes 3646 to 3663, exactly the 17 cases added here (15 facts plus a two-case theory), and `Darling.Tests` 8600 to 8604, exactly the 4 (2 here, plus the merged-seam wire pin and the no-duplicate-fact pin below). `Skipped` is unchanged — 338 in the Windows job, 6 in the Postgres one — and none of the touched classes appears in either skip list. The `Darling whole-tree guards` job reports in seconds because its gate saw the `build` job run the full Darling suite on this commit and says so; that is its documented skip path, not an empty run.

One mutation survived, and it is not a gap in this change: passing `null` instead of the per-event split's detail text in `DarlingAlertDeliverer`. That path's detail text is by construction the flattening of its own split context, so the gate suppresses it on either branch and no channel's output moves. It does reach the history row, which no test asserts — that is #1236/#1141's coverage, untouched here.

## Two things review found, and what changed for each

**The prose bypasses the never-on-a-webhook T-SQL redaction.** The premise is right — the #2109 AG alert's `DetailText` really does contain `ALTER DATABASE [db] SET HADR RESUME`, and it now rides out unredacted. Declined, with the reason recorded in the code. That rule's subject is the GENERATED payload: `IsCodeBlock` bodies and `RemediationAction` built by `FactRemediation`, multi-statement, two of the seven shapes destructive, carrying a two-sided risk-disclosure header that has to be read before the script is run. Prose is authored per alert, and where it names a command at all that command IS the recovery action and the sentence IS the alert; replacing it with "see email or the in-app dialog" delivers nothing to an operator whose only channel is the one being redacted, which is #3296 over again. It is also not a disclosure control — the payload already carries `resource_name`, `database` and `{{incidents_json}}` with the same object names.

What the finding got right underneath that is the drift risk: nothing stopped a generated command from being folded into the prose, at which point it really would bypass the rule with no test noticing. `FindingMessageFormatter.DetailText` is finding metadata and the command rides only in the code-block item, so that is now asserted rather than assumed, and both docs say which surface the rule covers.

**Two engine alerts would have delivered their facts twice.** Correct, and fixed. Database-State-Changed and Force-Plan-Failing hand-author a detail text restating their own structured fields under different labels, so the suppression gate never fired for them. Per #2109 the fields are the canonical copy, so the restatement goes and the detail text is their flattening, as at the other eleven fire sites; the one thing each prose said that its fields did not — no baseline yet, and that the query is running on the optimizer's plan — is a field now. All thirteen `detailText` locals in `AlertEngine` now come from `ContextToDetailText`.

**And the new token was in neither app's Settings help text**, so nothing told an operator it exists. Both lists carry it, and Lite's automation list picks up the `{{triage_url}}` it never got when #2710 added it to Darling's. That is the second drift of the same kind, so the token set is now one list the matcher is built from and the help text is checked against that list — not against a second copy free to go stale the same way. Adding a token to the engine and not to the windows fails.

## Merged with #3303's display name, which landed on the same seam first

#3308 threaded a custom rule's human display name through the same five-channel delivery seam this branch threads the alert's prose detail through, and landed on `dev` first. Every signature between `DarlingAlertDeliverer` and the payload builders had gained one parameter from each side, so four files conflicted. Both are kept, `detailText` ahead of `displayName` so this branch's positional call sites in `AlertIncidentRenderTests` stay valid while #3308's named `displayName:` sites are unaffected.

The two intents compose per channel rather than collapsing into one rule, because they are different kinds of thing. The prose is alert CONTENT, so every channel carries it. The display name is a TITLE concern, so it reaches the Teams card title and summary, the Slack header, the PagerDuty summary and the email subject and heading — and deliberately not the generic channel, which renders no title and whose `{{metric}}` field is the machine key an automation correlates on. That exemption was #3308's decision and is preserved; it is now asserted rather than left as a comment.

Neither side's severity, cooldown, dedup or mute key moves: `AlertSeverity.ForMetric`, `DerivePagerDutyDedupKey` and the history row all still key on the immutable metric name.

### The hops the conflict was in had no pin, measured rather than assumed

`detailText` and `displayName` are both `string?`. Dropping one, or transposing the pair, at any of the three hops between the deliverer and the builders is not a compile error — and against the pre-merge code it was not a test failure either. Dropping `displayName` in `DarlingAlertDeliverer`, and again in `EmailSendCore`'s webhook fan-out, each left every suite green: #3308's tests cover its payload BUILDERS, and neither side could cover a hop with the other side's field also present, because neither side had both fields.

That is the same asymmetry this branch already found and closed on the prose side, so it is closed the same way. `TheDeliverer_CarriesBothTheProseAndTheDisplayName_ThroughTheOneFanOut` drives the whole Darling path once with both fields set and reads the bytes that left the process. Bodies are identified by a channel-native marker rather than by arrival order. Four mutations confirm it discriminates: dropping `displayName` at either hop, transposing the pair at the merged call, and handing the generic channel the display name in place of the machine key all turn it red.

## One more duplicated fact, found by the review pass on the merged head

The pending database-state alert carried a `Baseline: none — first observed in a critical state` field alongside an `Expected State` that already renders `(no baseline yet)` — computed from the same `pending` flag, and present since #2109. So it stated one fact under two labels, and now that the detail block is delivered that is something an operator reads twice rather than an internal duplication. It is the same defect class this PR exists to prevent, so it is fixed here rather than noted: the three canonical fields stand alone again, and the commit comment claiming the no-baseline fact was not already a field is corrected.

`DatabaseState_PendingCriticalFirstObservation_StatesTheMissingBaselineOnce` counts occurrences rather than enumerating field names, because a name list would pass while the fact arrived under a label nobody thought to enumerate — which is the failure being guarded. Re-adding the field turns it red.

## Open, and not fixed here: analysis-finding alerts deliver their Diagnosis facts twice

`FindingMessageFormatter` is a third producer of `(Context, DetailText)` pairs, after the two `AlertEngine` sites above, and this PR does not touch it. `BuildContext` puts Story / Severity / Notify threshold / Confidence / Facts / Database / Window into a `Diagnosis` item; `DetailText` independently formats the same seven values with different labels (`Facts in chain` vs `Facts`, one combined severity line vs two fields, `-` vs `→` in the window). The two are therefore never string-equal, the suppression gate treats the prose as independent, and every channel renders both. Reproduced against the real formatter and the real email template: `ProseForDelivery` returns the prose, and the plain-text body carries all six facts twice, adjacent.

It is not fixed here because `FindingMessageFormatter.DetailText` is not only a delivery string — it is the persisted `config_alert_log.detail_text` for every analysis row, what the MCP reader and the triage page read, the Dashboard's no-channel tray-row text, and the input `AlertMuteContext.PopulateFromDetailText` parses. Making it `AlertDetailText.Flatten(BuildContext(...))`, which is the #2109 rule the two `AlertEngine` sites follow and the right direction, changes what that column holds for the largest alert category: it gains the `Diagnosis` heading, a separate `Notify threshold` field, the advice headline, the remediation-T-SQL heading and every drill-down field. That belongs in its own change with its own review.

Widening the gate is the wrong direction: any "suppress when the context's facts all appear in the prose" rule also drops the #2109 AG alerts' `SET HADR RESUME` remedy, which is the case the gate exists not to drop.

The review thread on `AlertDetailText.cs` is left unresolved for this reason.

## CHANGELOG

The `[Unreleased]` entry text, for whoever is batching them:

```
- **Alert detail text now reaches every delivery channel** (#3297): an alert's detail block — what happened, what it costs, and the operator action that clears it — was stored and shown in the viewer, the MCP reader and the triage page, but delivered by no channel. Email (both the HTML and plain-text bodies), Teams, Slack, PagerDuty's `custom_details` and the generic webhook now all carry it; the generic channel's `{{context}}` token leads with it, so existing templates and the shipped default get it with no operator change, and a new `{{detail}}` token carries it alone. Engine alerts whose detail text is only a flattening of their structured context are unchanged. The Retention Held detail (#2813) also now names the service restart, which is what actually arms a held retention policy.
```

