### PR TITLE
Show the rule name in custom-alert notification titles (#3303)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertDisplayNameTests.cs
+++ b/Darling/Darling.Tests/CustomAlertDisplayNameTests.cs
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Alerting;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3303: a custom rule's human name reaches the delivered <see cref="AlertOutcome"/> (so notification
+/// titles show the name, not "Custom:&lt;id&gt;"), the detail_text separator is a plain " - " not an em dash,
+/// and, the security half, the user-authored name/description are newline-stripped + length-capped before
+/// they enter detail_text so a crafted name cannot forge a mute-context label line that the viewer's
+/// mute-from-history pre-fill (<see cref="AlertMuteContext.PopulateFromDetailText"/>) would parse.
+/// </summary>
+public class CustomAlertDisplayNameTests
+{
+    /// <summary>A valid Scalar metric over a real catalog measure (mirrors CustomAlertRuleDefinitionTests).</summary>
+    private const string DefinitionJson =
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
+        "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1000}}";
+
+    private static CustomAlertRuleDefinition Definition()
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(DefinitionJson);
+        Assert.Null(error);
+        Assert.NotNull(def);
+        return def!;
+    }
+
+    private static CustomAlertRule Rule(long id, string name, string? description = null) =>
+        new(id, name, DefinitionJson, description, Enabled: true, Version: 1,
+            CreatedAt: DateTime.UtcNow, UpdatedAt: DateTime.UtcNow, UpdatedBy: null);
+
+    // ─────────────────────────── SanitizeDisplayText ───────────────────────────
+
+    [Fact]
+    public void Sanitize_StripsEveryLineBreak_ToSingleLine()
+    {
+        var result = CustomAlertEvaluator.SanitizeDisplayText("a\nb\r\nc\rd\te", 200);
+
+        Assert.DoesNotContain('\n', result);
+        Assert.DoesNotContain('\r', result);
+        Assert.DoesNotContain('\t', result);
+        Assert.Equal("a b c d e", result);
+    }
+
+    [Fact]
+    public void Sanitize_CollapsesWhitespace_AndTrims()
+    {
+        Assert.Equal("Hello World", CustomAlertEvaluator.SanitizeDisplayText("   Hello    World   ", 200));
+    }
+
+    [Fact]
+    public void Sanitize_CapsLength()
+    {
+        var result = CustomAlertEvaluator.SanitizeDisplayText(new string('x', 500), 200);
+        Assert.Equal(200, result.Length);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\n\r\t")]
+    public void Sanitize_NullOrAllWhitespaceOrControl_ReturnsEmpty(string? input)
+    {
+        Assert.Equal(string.Empty, CustomAlertEvaluator.SanitizeDisplayText(input, 200));
+    }
+
+    [Fact]
+    public void Sanitize_LeavesOrdinaryNameUnchanged()
+    {
+        Assert.Equal("Signal wait % high", CustomAlertEvaluator.SanitizeDisplayText("Signal wait % high", 200));
+    }
+
+    // ─────────────────────── the mute-pre-fill spoof guard ───────────────────────
+
+    /// <summary>
+    /// Proves the attack the guard defends: an UNSANITIZED detail_text carrying newline-led label lines
+    /// makes PopulateFromDetailText harvest attacker-chosen mute-context fields. (The seam test — if this
+    /// ever stops extracting, the guarded test below would pass vacuously.)
+    /// </summary>
+    [Fact]
+    public void RawNewlineBearingText_WouldSpoofTheMutePreFill()
+    {
+        var ctx = new AlertMuteContext();
+        ctx.PopulateFromDetailText("Innocent\nDatabase: master\nWait Type: PAGEIOLATCH_SH\nQuery: DROP TABLE x");
+
+        Assert.Equal("master", ctx.DatabaseName);
+        Assert.Equal("PAGEIOLATCH_SH", ctx.WaitType);
+        Assert.Equal("DROP TABLE x", ctx.QueryText);
+    }
+
+    /// <summary>
+    /// The mandated test: a malicious newline-bearing rule name + description, once they flow through
+    /// <see cref="CustomAlertEvaluator.BuildFireOutcome"/> into the persisted detail_text, extract NOTHING
+    /// when the viewer re-parses that detail_text for the mute-from-history pre-fill.
+    /// </summary>
+    [Fact]
+    public void BuildFireOutcome_NewlineBearingName_DefeatsMutePreFillSpoof()
+    {
+        var row = Rule(
+            42,
+            name: "Innocent\nDatabase: master\nWait Type: PAGEIOLATCH_SH",
+            description: "looks fine\nJob Name: sa_nightly_backup\nQuery: DROP TABLE dbo.Orders");
+
+        var outcome = CustomAlertEvaluator.BuildFireOutcome(
+            row, Definition(), serverKey: "7", serverDisplayName: "PROD01",
+            value: 1500, severity: AlertSeverityLevel.Warning, muted: false);
+
+        // The detail_text (and display name) are single-line.
+        Assert.DoesNotContain('\n', outcome.DetailText!);
+        Assert.DoesNotContain('\r', outcome.DetailText!);
+        Assert.DoesNotContain('\n', outcome.DisplayName!);
+
+        // Re-parsing the persisted detail_text harvests no attacker-controlled mute-context field.
+        var ctx = new AlertMuteContext();
+        ctx.PopulateFromDetailText(outcome.DetailText);
+        Assert.Null(ctx.DatabaseName);
+        Assert.Null(ctx.WaitType);
+        Assert.Null(ctx.JobName);
+        Assert.Null(ctx.QueryText);
+    }
+
+    // ─────────────────────── display name + separator wiring ───────────────────────
+
+    [Fact]
+    public void BuildFireOutcome_SetsDisplayNameToRuleName_AndKeepsImmutableMetricKey()
+    {
+        var outcome = CustomAlertEvaluator.BuildFireOutcome(
+            Rule(42, "Signal wait % too high"), Definition(),
+            serverKey: "7", serverDisplayName: "PROD01",
+            value: 1500, severity: AlertSeverityLevel.Warning, muted: false);
+
+        Assert.Equal("Signal wait % too high", outcome.DisplayName);
+        // The dedup/mute/history key stays the immutable id, never the name.
+        Assert.Equal("Custom:42", outcome.MetricName);
+    }
+
+    [Fact]
+    public void BuildFireOutcome_DetailText_UsesPlainSeparator_NotEmDash()
+    {
+        var outcome = CustomAlertEvaluator.BuildFireOutcome(
+            Rule(42, "CPU pressure", description: "watch the schedulers"), Definition(),
+            serverKey: "7", serverDisplayName: "PROD01",
+            value: 1500, severity: AlertSeverityLevel.Warning, muted: false);
+
+        Assert.Equal("CPU pressure - watch the schedulers", outcome.DetailText);
+        Assert.DoesNotContain('\u2014', outcome.DetailText!); // em dash
+        Assert.DoesNotContain('\u2013', outcome.DetailText!); // en dash
+    }
+
+    [Fact]
+    public void BuildFireOutcome_NoDescription_DetailTextIsJustTheName()
+    {
+        var outcome = CustomAlertEvaluator.BuildFireOutcome(
+            Rule(42, "CPU pressure"), Definition(),
+            serverKey: "7", serverDisplayName: "PROD01",
+            value: 1500, severity: AlertSeverityLevel.Warning, muted: false);
+
+        Assert.Equal("CPU pressure", outcome.DetailText);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -82,6 +83,65 @@ public sealed class CustomAlertEvaluator
     /// name, so a rename does not orphan history or break mute rules.</summary>
     public static string MetricNameFor(long ruleId) =>
         "Custom:" + ruleId.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>An abuse bound on the description portion of the rendered <c>detail_text</c> (the column is
+    /// unbounded text; the name has its own <see cref="CustomAlertRuleStore.MaxNameLength"/> bound).</summary>
+    private const int MaxDetailDescriptionLength = 500;
+
+    /// <summary>
+    /// Makes a user-authored rule name/description safe to render in a notification title and to write into
+    /// the <c>detail_text</c> that the viewer's mute-from-history pre-fill
+    /// (<see cref="AlertMuteContext.PopulateFromDetailText"/>) later parses. That parser splits
+    /// <c>detail_text</c> on <c>'\n'</c> and reads any line beginning with a <c>"Database: "</c> /
+    /// <c>"Query: "</c> / <c>"Wait Type: "</c> / <c>"Job Name: "</c> label into a mute pattern, so a crafted
+    /// name carrying <c>"\nDatabase: master"</c> could forge a mute-context field and spoof the pre-fill.
+    /// Collapsing every line break and control character (CR/LF/TAB/NEL and the Unicode line/paragraph
+    /// separators) to a single space guarantees the value stays one line that cannot begin a forged label
+    /// line, and the length cap bounds the other half of the problem. Runs of whitespace collapse and the
+    /// result is trimmed; returns "" for null/blank input so a render site falls back to the metric name.
+    /// </summary>
+    public static string SanitizeDisplayText(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value) || maxLength <= 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(Math.Min(value.Length, maxLength));
+        var pendingSpace = false;
+        foreach (var ch in value)
+        {
+            var isBreakOrControl =
+                ch < ' ' || ch == (char)0x7F || ch == (char)0x85 || ch == '\u2028' || ch == '\u2029';
+
+            if (isBreakOrControl || ch == ' ')
+            {
+                // Defer whitespace: emitted only before the next real char (drops leading + trailing runs).
+                pendingSpace = builder.Length > 0;
+                continue;
+            }
+
+            if (pendingSpace)
+            {
+                if (builder.Length >= maxLength)
+                {
+                    break;
+                }
+
+                builder.Append(' ');
+                pendingSpace = false;
+            }
+
+            if (builder.Length >= maxLength)
+            {
+                break;
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString();
+    }
 
     /// <summary>Evaluates every enabled rule applicable to one server. Failure-isolated per rule.</summary>
     public async Task EvaluateServerAsync(int serverId, string storageName, string displayName, CancellationToken cancellationToken)
@@ -233,39 +293,69 @@ public sealed class CustomAlertEvaluator
         var serverKey = serverId.ToString(CultureInfo.InvariantCulture);
         var muted = _isAlertMuted?.Invoke(new AlertMuteContext { ServerName = displayName, MetricName = metricName }) ?? false;
 
+        await _deliverer.DeliverAsync(
+            BuildFireOutcome(row, def, serverKey, displayName, value, severity, muted),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds the <see cref="AlertOutcome"/> for one custom-rule fire — pure (no I/O), so the display-name
+    /// wiring, the detail_text sanitization/separator, and the metric key are unit-testable without a store.
+    /// The user-authored name/description are newline-stripped + length-capped (<see cref="SanitizeDisplayText"/>);
+    /// the sanitized name rides <see cref="AlertOutcome.DisplayName"/> (rendered in titles/subjects) while
+    /// <c>metric_name = "Custom:&lt;id&gt;"</c> stays the immutable history / mute / cooldown key.
+    /// </summary>
+    /// <param name="serverDisplayName">The monitored server's display name (<see cref="AlertOutcome.ServerName"/>).</param>
+    public static AlertOutcome BuildFireOutcome(
+        CustomAlertRule row, CustomAlertRuleDefinition def, string serverKey, string serverDisplayName,
+        double value, AlertSeverityLevel severity, bool muted)
+    {
+        var metricName = MetricNameFor(row.Id);
         var currentText = value.ToString("0.###", CultureInfo.InvariantCulture);
         var thresholdValue = severity == AlertSeverityLevel.Critical && def.CriticalThreshold is double critical
             ? critical
             : def.WarnThreshold;
         var thresholdText = string.Create(CultureInfo.InvariantCulture, $"{def.OpSymbol} {thresholdValue:0.###}");
-        var shortMessage = string.Create(CultureInfo.InvariantCulture,
-            $"{row.Name}: {def.MeasureDisplayName} {currentText} (threshold {thresholdText})");
-        var detail = string.IsNullOrWhiteSpace(row.Description) ? row.Name : $"{row.Name} — {row.Description}";
 
-        await _deliverer.DeliverAsync(
-            new AlertOutcome(
-                serverKey,
-                displayName,
-                metricName,
-                currentText,
-                thresholdText,
-                Context: null,
-                DetailText: detail,
-                NumericCurrentValue: value,
-                NumericThresholdValue: thresholdValue,
-                Muted: muted,
-                Severity: severity,
-                ShortMessage: shortMessage),
-            cancellationToken);
+        /* Sanitize the user-authored name/description before they enter any rendered string or the persisted
+           detail_text: strip every line break + control char and cap the length so a crafted name cannot
+           forge a "Database:"/"Query:" label line that the mute-from-history pre-fill would parse
+           (AlertMuteContext.PopulateFromDetailText). safeName also rides AlertOutcome.DisplayName so the
+           delivery layer renders the human name instead of the "Custom:<id>" metric key. */
+        var safeName = SanitizeDisplayText(row.Name, CustomAlertRuleStore.MaxNameLength);
+        var safeDescription = SanitizeDisplayText(row.Description, MaxDetailDescriptionLength);
+        var shortMessage = string.Create(CultureInfo.InvariantCulture,
+            $"{safeName}: {def.MeasureDisplayName} {currentText} (threshold {thresholdText})");
+        /* Plain " - " separator (never an em dash — a style tell to keep out of delivered text). */
+        var detail = safeDescription.Length == 0 ? safeName : $"{safeName} - {safeDescription}";
+
+        return new AlertOutcome(
+            serverKey,
+            serverDisplayName,
+            metricName,
+            currentText,
+            thresholdText,
+            Context: null,
+            DetailText: detail,
+            NumericCurrentValue: value,
+            NumericThresholdValue: thresholdValue,
+            Muted: muted,
+            Severity: severity,
+            ShortMessage: shortMessage,
+            DisplayName: safeName);
     }
 
     private async Task DeliverResolveAsync(CustomAlertRule row, int serverId, string displayName, double value)
     {
         var metricName = MetricNameFor(row.Id);
         var serverKey = serverId.ToString(CultureInfo.InvariantCulture);
-        var title = row.Name + " Resolved";
+        /* Same sanitization as the fire path: the resolution's Title becomes the history row's metric_name
+           and its Message becomes detail_text, so a crafted rule name must be newline-stripped + capped here
+           too or it re-opens the mute-pre-fill spoof on the recovery row. */
+        var safeName = SanitizeDisplayText(row.Name, CustomAlertRuleStore.MaxNameLength);
+        var title = safeName + " Resolved";
         var message = string.Create(CultureInfo.InvariantCulture,
-            $"{displayName}: {row.Name} back within threshold (now {value:0.###})");
+            $"{displayName}: {safeName} back within threshold (now {value:0.###})");
 
         _logger.LogInformation("{Line}", AlertFiringLog.Resolved(displayName, title, message));
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
@@ -143,10 +143,13 @@ public sealed class DarlingAlertDeliverer : IAlertDeliverer
             context.SeverityOverride ??= outcome.Severity;
         }
 
-        /* Lite's EmailAlertService.cs:65-66 — muted alerts skip both channels but still record below. */
+        /* Lite's EmailAlertService.cs:65-66 — muted alerts skip both channels but still record below.
+           outcome.DisplayName (a custom rule's human name, or null for built-ins) renders in the
+           subject/body/webhook titles in place of the "Custom:<id>" metric name; the metric name stays the
+           cooldown/history/mute key. */
         var result = await _core.TrySendAsync(
             outcome.MetricName, outcome.ServerName, currentValue, outcome.ThresholdValue,
-            outcome.ServerKey, context, attemptChannels: !outcome.Muted);
+            outcome.ServerKey, context, attemptChannels: !outcome.Muted, displayName: outcome.DisplayName);
 
         /* trayChannelPresent: false — this is the HEADLESS service. It has no tray icon and no toast
            code, so the taxonomy's "tray" fallback (which is Lite's, and truthful there) would assert a UI

--- a/Lite.Tests/CustomAlertRenderTests.cs
+++ b/Lite.Tests/CustomAlertRenderTests.cs
@@ -1,0 +1,120 @@
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #3303: the shared email/webhook render builders take an optional human display name (a custom alert
+/// rule's name) that replaces the metric name in the VISIBLE subject/title/heading, while severity, dedup,
+/// and cooldown keep keying on the metric name. A null/empty display name renders the metric name exactly as
+/// before, so built-in alerts (which never pass one) are unchanged — the existing WebhookPayloadBranding /
+/// AlertSeverity / EmailTemplateBranding suites pin that byte-for-byte; these add the present/absent cases.
+/// </summary>
+public class CustomAlertRenderTests
+{
+    private static AlertBranding Branding => EmailAlertService.Branding;
+
+    /* A custom fire arrives with metric_name "Custom:<id>" plus a SeverityOverride context (the deliverer
+       folds AlertOutcome.Severity into it), so ForMetric still resolves a real badge from the override. */
+    private static AlertContext Warn => new() { SeverityOverride = AlertSeverityLevel.Warning };
+
+    // ─────────────────────────── email ───────────────────────────
+
+    [Fact]
+    public void EmailBody_WithDisplayName_ShowsHumanName_NotTheCustomKey()
+    {
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail(
+            "Custom:42", "PROD01", "1500", ">= 1000", 15, Branding, Warn, displayName: "Signal wait % high");
+
+        Assert.Contains("Signal wait % high", html);
+        Assert.DoesNotContain("Custom:42", html);
+        Assert.Contains("Signal wait % high", plain);
+        Assert.DoesNotContain("Custom:42", plain);
+    }
+
+    [Fact]
+    public void EmailBody_NoDisplayName_FallsBackToMetricName()
+    {
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail(
+            "High CPU", "PROD01", "95%", "90%", 15, Branding);
+
+        Assert.Contains("High CPU", html);
+        Assert.Contains("High CPU", plain);
+    }
+
+    [Fact]
+    public void EmailBody_EmptyDisplayName_FallsBackToMetricName()
+    {
+        var (html, _) = EmailTemplateBuilder.BuildAlertEmail(
+            "High CPU", "PROD01", "95%", "90%", 15, Branding, context: null, displayName: "");
+
+        Assert.Contains("High CPU", html);
+    }
+
+    // ─────────────────────────── Teams ───────────────────────────
+
+    [Fact]
+    public void TeamsPayload_WithDisplayName_TitleShowsHumanName_NotTheCustomKey()
+    {
+        var payload = WebhookAlertService.BuildTeamsPayload(
+            "Custom:42", "PROD01", "1500", ">= 1000", Branding, context: Warn, displayName: "Signal wait % high");
+
+        Assert.Contains("Signal wait % high", payload);
+        Assert.DoesNotContain("Custom:42", payload);
+    }
+
+    [Fact]
+    public void TeamsPayload_NoDisplayName_TitleShowsMetricName()
+    {
+        var payload = WebhookAlertService.BuildTeamsPayload(
+            "High CPU", "PROD01", "95%", "90%", Branding);
+
+        Assert.Contains("High CPU", payload);
+    }
+
+    // ─────────────────────────── Slack ───────────────────────────
+
+    [Fact]
+    public void SlackPayload_WithDisplayName_TitleShowsHumanName_NotTheCustomKey()
+    {
+        var payload = WebhookAlertService.BuildSlackPayload(
+            "Custom:42", "PROD01", "1500", ">= 1000", Branding, context: Warn, displayName: "Signal wait % high");
+
+        Assert.Contains("Signal wait % high", payload);
+        Assert.DoesNotContain("Custom:42", payload);
+    }
+
+    [Fact]
+    public void SlackPayload_NoDisplayName_TitleShowsMetricName()
+    {
+        var payload = WebhookAlertService.BuildSlackPayload(
+            "High CPU", "PROD01", "95%", "90%", Branding);
+
+        Assert.Contains("High CPU", payload);
+    }
+
+    // ─────────────────────────── PagerDuty ───────────────────────────
+
+    [Fact]
+    public void PagerDutyPayload_WithDisplayName_SummaryShowsHumanName_ButDedupKeepsTheCustomKey()
+    {
+        var payload = WebhookAlertService.BuildPagerDutyPayload(
+            "Custom:42", "PROD01", "1500", ">= 1000", Branding, "routing-key",
+            context: Warn, displayName: "Signal wait % high");
+
+        // The human-facing summary carries the name...
+        Assert.Contains("Signal wait % high", payload);
+        // ...but the dedup_key stays the immutable metric key so PagerDuty correlation is rename-safe.
+        Assert.Contains("Custom:42", payload);
+    }
+
+    [Fact]
+    public void PagerDutyPayload_NoDisplayName_SummaryShowsMetricName()
+    {
+        var payload = WebhookAlertService.BuildPagerDutyPayload(
+            "High CPU", "PROD01", "95%", "90%", Branding, "routing-key");
+
+        Assert.Contains("High CPU", payload);
+    }
+}

--- a/PerformanceMonitor.Alerting/IAlertDeliverer.cs
+++ b/PerformanceMonitor.Alerting/IAlertDeliverer.cs
@@ -37,6 +37,15 @@ namespace PerformanceMonitor.Alerting;
 /// that the other display fields don't carry; interactive hosts render it as
 /// <c>$"{ServerName}: {ShortMessage}"</c>, headless hosts may log or ignore it.
 /// </param>
+/// <param name="DisplayName">
+/// Human-facing name rendered in notification titles/subjects INSTEAD of <paramref name="MetricName"/>,
+/// or null/empty for built-in alerts — which keep rendering <paramref name="MetricName"/> unchanged
+/// (byte-identical to before this field existed). Custom alert rules key history / mute / cooldown on the
+/// immutable <paramref name="MetricName"/> (<c>"Custom:&lt;id&gt;"</c>, rename-safe) but set this to the
+/// rule's (newline-stripped, length-capped) name so a human sees the name, not <c>Custom:42</c>. Every
+/// render site falls back to <paramref name="MetricName"/> whenever this is null or empty; the metric name
+/// stays the severity / cooldown / dedup key everywhere.
+/// </param>
 public sealed record AlertOutcome(
     string ServerKey,
     string ServerName,
@@ -49,7 +58,8 @@ public sealed record AlertOutcome(
     double? NumericThresholdValue,
     bool Muted,
     AlertSeverityLevel? Severity,
-    string? ShortMessage = null);
+    string? ShortMessage = null,
+    string? DisplayName = null);
 
 /// <summary>
 /// The record-and-send seam for the Phase-5 shared alert engine: the engine evaluates conditions

--- a/PerformanceMonitor.Notifications/EmailSendCore.cs
+++ b/PerformanceMonitor.Notifications/EmailSendCore.cs
@@ -70,6 +70,12 @@ public sealed class EmailSendCore
     /// When false (Lite's muted case) neither email nor webhook is attempted; the caller
     /// still records its row from the all-false result.
     /// </param>
+    /// <param name="displayName">
+    /// Human-facing name to render in the subject/body/webhook titles in place of
+    /// <paramref name="metricName"/> (a custom alert rule's name). Null/empty keeps
+    /// <paramref name="metricName"/> — built-in alerts render exactly as before. The cooldown key,
+    /// severity, and dedup all stay on <paramref name="metricName"/>.
+    /// </param>
     public async Task<EmailFanoutResult> TrySendAsync(
         string metricName,
         string serverName,
@@ -77,7 +83,8 @@ public sealed class EmailSendCore
         string thresholdValue,
         string serverId,
         AlertContext? context,
-        bool attemptChannels)
+        bool attemptChannels,
+        string? displayName = null)
     {
         bool emailAttempted = false;
         bool emailSent = false;
@@ -109,9 +116,10 @@ public sealed class EmailSendCore
             {
                 emailAttempted = true;
 
-                var subject = $"[SQL Monitor Alert] {metricName} on {serverName}";
+                var titleName = string.IsNullOrEmpty(displayName) ? metricName : displayName;
+                var subject = $"[SQL Monitor Alert] {titleName} on {serverName}";
                 var (htmlBody, plainTextBody) = EmailTemplateBuilder.BuildAlertEmail(
-                    metricName, serverName, currentValue, thresholdValue, _settings.EmailCooldownMinutes, _branding, context);
+                    metricName, serverName, currentValue, thresholdValue, _settings.EmailCooldownMinutes, _branding, context, displayName);
 
                 try
                 {
@@ -151,7 +159,7 @@ public sealed class EmailSendCore
         if (attemptChannels)
         {
             webhookSent = await _webhookAlertService.TrySendWebhookAlertsAsync(
-                metricName, serverName, currentValue, thresholdValue, serverId, context);
+                metricName, serverName, currentValue, thresholdValue, serverId, context, displayName);
         }
 
         return new EmailFanoutResult(emailAttempted, emailSent, sendError, webhookSent, anyChannelConfigured);

--- a/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
+++ b/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
@@ -24,6 +24,11 @@ internal static class EmailTemplateBuilder
     /// <summary>
     /// Builds both HTML and plain-text bodies for an alert email.
     /// </summary>
+    /// <param name="displayName">
+    /// Human-facing name to show in place of <paramref name="metricName"/> in the visible heading/subject
+    /// (a custom alert rule's name). Null or empty renders <paramref name="metricName"/> unchanged, so
+    /// built-in alerts are byte-identical. Severity/color still derive from <paramref name="metricName"/>.
+    /// </param>
     public static (string HtmlBody, string PlainTextBody) BuildAlertEmail(
         string metricName,
         string serverName,
@@ -31,16 +36,20 @@ internal static class EmailTemplateBuilder
         string thresholdValue,
         int emailCooldownMinutes,
         AlertBranding branding,
-        AlertContext? context = null)
+        AlertContext? context = null,
+        string? displayName = null)
     {
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
+        /* Severity/color map on the immutable metric name (AlertSeverity's key); a custom rule's human name
+           only replaces the metric name in the VISIBLE heading, never in ForMetric. */
         var (accentColor, badgeText, _) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
+        var titleName = string.IsNullOrEmpty(displayName) ? metricName : displayName;
 
-        var html = BuildHtmlBody(metricName, serverName, currentValue,
+        var html = BuildHtmlBody(titleName, serverName, currentValue,
             thresholdValue, utcNow, localNow, accentColor, badgeText, branding, context: context, emailCooldownMinutes: emailCooldownMinutes);
 
-        var plain = BuildPlainTextBody(metricName, serverName, currentValue,
+        var plain = BuildPlainTextBody(titleName, serverName, currentValue,
             thresholdValue, utcNow, localNow, emailCooldownMinutes, branding, context);
 
         return (html, plain);

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -141,7 +141,8 @@ public class WebhookAlertService
         string currentValue,
         string thresholdValue,
         string serverId = "",
-        AlertContext? context = null)
+        AlertContext? context = null,
+        string? displayName = null)
     {
         try
         {
@@ -173,22 +174,24 @@ public class WebhookAlertService
 
             if (TeamsConfigured)
             {
-                sent |= await TrySendTeamsAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl);
+                sent |= await TrySendTeamsAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl, displayName);
             }
 
             if (SlackConfigured)
             {
-                sent |= await TrySendSlackAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl);
+                sent |= await TrySendSlackAlertAsync(metricName, serverName, currentValue, thresholdValue, context, triageUrl, displayName);
             }
 
             if (GenericConfigured)
             {
+                /* Generic webhook: the payload's "metric" field is a machine key an automation correlates on,
+                   so it stays the immutable metric name — the display name is a human-title concern only. */
                 sent |= await TrySendGenericAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, context, triageUrl);
             }
 
             if (PagerDutyConfigured)
             {
-                sent |= await TrySendPagerDutyAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, context, triageUrl);
+                sent |= await TrySendPagerDutyAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, context, triageUrl, displayName);
             }
 
             if (sent)
@@ -300,11 +303,12 @@ public class WebhookAlertService
         string currentValue,
         string thresholdValue,
         AlertContext? context,
-        string? triageUrl)
+        string? triageUrl,
+        string? displayName = null)
     {
         try
         {
-            var payload = BuildTeamsPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl);
+            var payload = BuildTeamsPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl, displayName: displayName);
             var error = await PostWebhookAsync(_settings.TeamsWebhookUrl, payload, _settings.TeamsProxyAddress);
 
             if (error != null)
@@ -391,9 +395,13 @@ public class WebhookAlertService
         AlertBranding branding,
         bool isTest = false,
         AlertContext? context = null,
-        string? triageUrl = null)
+        string? triageUrl = null,
+        string? displayName = null)
     {
         var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
+        /* Title/summary show the human name when present; ForMetric above stays on the immutable metric
+           name (the severity key), and a null/empty display name renders the metric name unchanged. */
+        var titleName = string.IsNullOrEmpty(displayName) ? metricName : displayName;
         var themeColor = hexColor.TrimStart('#');
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
@@ -469,7 +477,7 @@ public class WebhookAlertService
 
         var title = isTest
             ? $"{emoji} TEST — {metricName}"
-            : $"{emoji} {badgeText} — {metricName}";
+            : $"{emoji} {badgeText} — {titleName}";
 
         var sections = new List<object>
         {
@@ -490,7 +498,7 @@ public class WebhookAlertService
 
         var summary = isTest
             ? "[SQL Monitor] Test Notification"
-            : $"[SQL Monitor] {badgeText}: {metricName} on {serverName}";
+            : $"[SQL Monitor] {badgeText}: {titleName} on {serverName}";
 
         /* #2710: the OpenUri action carries its schema keys as REAL "@type" (a Dictionary, because a C#
            @-identifier only escapes the keyword — the existing card's `@type` serializes as "type", a
@@ -537,11 +545,12 @@ public class WebhookAlertService
         string currentValue,
         string thresholdValue,
         AlertContext? context,
-        string? triageUrl)
+        string? triageUrl,
+        string? displayName = null)
     {
         try
         {
-            var payload = BuildSlackPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl);
+            var payload = BuildSlackPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl, displayName: displayName);
             var error = await PostWebhookAsync(_settings.SlackWebhookUrl, payload, _settings.SlackProxyAddress);
 
             if (error != null)
@@ -589,15 +598,18 @@ public class WebhookAlertService
         AlertBranding branding,
         bool isTest = false,
         AlertContext? context = null,
-        string? triageUrl = null)
+        string? triageUrl = null,
+        string? displayName = null)
     {
         var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
+        /* Human name in the header when present; ForMetric above keeps the immutable metric-name key. */
+        var titleName = string.IsNullOrEmpty(displayName) ? metricName : displayName;
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
 
         var title = isTest
             ? $"{emoji} TEST — {metricName}"
-            : $"{emoji} {badgeText} — {metricName}";
+            : $"{emoji} {badgeText} — {titleName}";
 
         var blocks = new List<object>
         {
@@ -1171,7 +1183,8 @@ public class WebhookAlertService
         string thresholdValue,
         string serverId,
         AlertContext? context,
-        string? triageUrl)
+        string? triageUrl,
+        string? displayName = null)
     {
         try
         {
@@ -1182,7 +1195,7 @@ public class WebhookAlertService
 
             var payload = BuildPagerDutyPayload(
                 metricName, serverName, currentValue, thresholdValue, _branding,
-                _settings.PagerDutyRoutingKey, context: context, dedupKey: dedupKey, triageUrl: triageUrl);
+                _settings.PagerDutyRoutingKey, context: context, dedupKey: dedupKey, triageUrl: triageUrl, displayName: displayName);
 
             var endpoint = PagerDutyEndpoint(_settings.PagerDutyUseEuRegion);
             var error = await PostWebhookAsync(endpoint, payload, _settings.PagerDutyProxyAddress);
@@ -1237,17 +1250,21 @@ public class WebhookAlertService
         AlertContext? context = null,
         string? dedupKey = null,
         string? serverId = null,
-        string? triageUrl = null)
+        string? triageUrl = null,
+        string? displayName = null)
     {
         var (_, badgeText, _) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
         var severity = MapToPagerDutySeverity(badgeText);
+        /* The PD summary (the incident title) shows the human name when present; severity above and the
+           dedup_key below stay on the immutable metric name so correlation/dedup are rename-safe. */
+        var titleName = string.IsNullOrEmpty(displayName) ? metricName : displayName;
         var utcNow = DateTime.UtcNow;
 
         /* PD-CEF caps summary at 1024 chars — no truncation needed given the source strings, but document
            the constraint matching this codebase's habit of documenting limits even when unreachable. */
         var summary = isTest
             ? "Webhook configuration verified"
-            : $"{metricName} on {serverName}: {currentValue} (threshold {thresholdValue})";
+            : $"{titleName} on {serverName}: {currentValue} (threshold {thresholdValue})";
 
         var source = isTest
             ? branding.EditionName


### PR DESCRIPTION
## What & why

Custom alert rules key history / mute / cooldown on the immutable `metric_name = "Custom:<rule_id>"` (rename-safe, per the design plan Decision 1 — **unchanged here**). But the delivery layer rendered `metric_name` directly, so a human saw `Custom:42` instead of the rule's name in email subjects and Teams / Slack / PagerDuty titles.

This is the delivery slice of that fix. Built-in alerts are untouched — they render byte-identically.

## Changes

- **`AlertOutcome.DisplayName`** (new, optional/nullable). Null/empty for built-in alerts → every render site falls back to `metric_name`, so built-ins are byte-identical to before.
- **Threaded through the render sites**, each falling back to `metric_name`:
  - email **subject** and body heading (`EmailSendCore` / `EmailTemplateBuilder`)
  - Teams / Slack / PagerDuty **titles + summaries** (`WebhookAlertService`)
  - `AlertSeverity.ForMetric` (severity/color), the email/webhook **cooldown key**, and the PagerDuty **dedup_key** all keep keying on `metric_name`. The **generic** webhook's `"metric"` field also stays the immutable key (automation correlates on it) — display name is a human-title concern only.
- **`CustomAlertEvaluator`** sets `DisplayName` to the rule name on fire.
- **Persistence: `detail_text` (no schema change).** The rule name already rides `detail_text`, which `get_alert_history` and the viewer already return, so history / MCP / viewer resolve the name after the fact and it survives a rename/delete (captured at fire time). Chosen over a dedicated `config_alert_log` column to keep this slice focused and avoid the cross-app `AlertHistoryRecord` + migration-ladder-fixture blast radius; the issue explicitly sanctions `detail_text`.
- **Security guard.** `SanitizeDisplayText` strips every line break / control char and length-caps the name + description **before they enter `detail_text`**, so a crafted name (e.g. `Innocent\nDatabase: master`) can no longer forge a `Database:`/`Query:`/`Wait Type:`/`Job Name:` label line that `MuteRule.PopulateFromDetailText` would parse into the viewer's mute-from-history pre-fill. That parser splits on `\n` and reads line-leading labels; a single-line value cannot introduce one. Applied on **both** the fire and the resolve paths (the resolve row's message also becomes `detail_text`).
- **Em dash → plain `" - "`** in the fire `detail_text` separator.

## Tests

- `Darling.Tests/CustomAlertDisplayNameTests` (13 cases): `SanitizeDisplayText` (line-break strip, whitespace-collapse, length-cap, empty fallback); a **seam test** proving raw newline-bearing text *would* spoof the mute pre-fill, then the guarded end-to-end assertion that the built fire outcome's `detail_text` extracts **nothing**; display-name wiring + the plain separator; `metric_name` stays `Custom:<id>`.
- `Lite.Tests/CustomAlertRenderTests` (9 cases): email/Teams/Slack/PagerDuty show the human name when present and fall back to `metric_name` when absent; PagerDuty summary shows the name while its dedup_key keeps `Custom:42`.

Full local suites (run from a worktree): **Darling.Tests 8600 total / 3 failed** and **Lite.Tests 3646 total / 4 failed** — all 7 failures are pre-existing environmental artifacts unrelated to this diff (source-tree-scan guards that resolve 0 files when run from a `.claude/worktrees/` checkout, plus one TLS-cert platform test). Every pinned built-in render suite (WebhookPayloadBranding / AlertSeverity / PagerDutyWebhook / GenericWebhook / EmailTemplateBranding) passed. Build: **0 Warning(s) / 0 Error(s)**.

Part of #3285. Addresses #3303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
