### PR TITLE
Resolve the Proc [Database Id = N Object Id = M] placeholder to schema.object (#3307)

### DIFF
--- a/Lite.Tests/ProcPlaceholderResolutionTests.cs
+++ b/Lite.Tests/ProcPlaceholderResolutionTests.cs
@@ -201,7 +201,7 @@ public sealed class ProcPlaceholderResolutionTests
     }
 
     [Fact]
-    public async Task ReadResolutionsAsync_DropsAPairMissingEitherHalf()
+    public async Task ReadResolutionsAsync_DropsAPairMissingAnyPart()
     {
         /* The blanking guard, exercised on every route a partial answer can arrive by — one row per part,
            NULL and empty. Both references concatenate server-side, so each of these rows would have
@@ -308,7 +308,7 @@ public sealed class ProcPlaceholderResolutionTests
     }
 
     [Fact]
-    public async Task Deadlocks_ResolveTheVictimProcedure_SchemaQualified()
+    public async Task Deadlocks_ResolveTheVictimProcedure_FullyQualified()
     {
         var context = MakeContext();
         using var reader = new FakeCollectorDataReader(

--- a/Lite.Tests/ProcPlaceholderResolutionTests.cs
+++ b/Lite.Tests/ProcPlaceholderResolutionTests.cs
@@ -1,0 +1,445 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Lite.Tests.Helpers;
+using PerformanceMonitor.Collectors;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// #3307: a deadlock or a blocked-process report whose statement sits inside a stored procedure showed
+/// SQL Server's own <c>Proc [Database Id = N Object Id = M]</c> placeholder, because nothing in the tree
+/// parsed it — the resolution was never attempted rather than attempted and failed.
+///
+/// <para><b>Two of the three details fail SILENTLY</b>, which is what these fixtures are shaped around.
+/// The T-SQL references (<c>sp_HumanEventsBlockViewer</c>, <c>sp_BlitzLock</c>) need
+/// <c>ESCAPE N'|'</c> because <c>[</c> opens a <c>LIKE</c> character class, and they prepend
+/// <c>@inputbuf_bom</c> because the text can be led by one; omit either and the predicate matches nothing
+/// without erroring. The port here is C#, so the <c>ESCAPE</c> failure mode does not exist — nothing
+/// treats <c>[</c> as a metacharacter — and what remains load-bearing is the bracket AS A LITERAL and the
+/// leading-noise skip. <see cref="TheBom_SurvivesTheTrimBothCallersAlreadyApply"/> establishes that the
+/// BOM fixture is reachable rather than hypothetical, which is the assertion that stops the BOM case from
+/// being a pin over an impossible input.</para>
+///
+/// <para>The third detail is the regression risk: <c>NULL + N'.' + NULL</c> is NULL in T-SQL, so a
+/// reference-faithful server-side concatenation BLANKS the field for a procedure the monitoring login
+/// cannot see. This port projects the two names separately and drops any pair missing either, so
+/// <see cref="Resolve_KeepsTheRawPlaceholder_WhenTheLookupCannotAnswer"/> can require the object id to
+/// survive.</para>
+/// </summary>
+public sealed class ProcPlaceholderResolutionTests
+{
+    private static readonly RecordingCollectorDeltaCalculator s_deltas = new();
+
+    /// <summary>#3307's reported text, anonymized there and here.</summary>
+    private const string Placeholder = "Proc [Database Id = 7 Object Id = 1790404501]";
+
+    /// <summary>
+    /// A real byte-order mark, spelled by code point. Written as a literal it is INVISIBLE in the source
+    /// and a reader cannot tell it from an accident, which is how a fixture for a silent failure mode
+    /// stops being read as one.
+    /// </summary>
+    private const string Bom = "\uFEFF";
+
+    private static CollectorContext MakeContext(bool isAzureSqlDb = false)
+        => new()
+        {
+            ServerId = 42,
+            ServerName = "test-server",
+            CollectionTime = new DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc),
+            Deltas = s_deltas,
+            Target = new CollectorTargetInfo { IsAzureSqlDb = isAzureSqlDb },
+        };
+
+    [Fact]
+    public void TryParse_TakesBothIdsOutOfTheReportedText()
+    {
+        Assert.True(ProcPlaceholder.TryParse(Placeholder, out var id));
+        Assert.Equal(7, id.DatabaseId);
+        Assert.Equal(1790404501, id.ObjectId);
+    }
+
+    [Fact]
+    public void TryParse_ToleratesTheLeadingNoiseThatLeadsInputbufText()
+    {
+        /* The references' @inputbuf_bom is CONVERT(nvarchar(1), 0x0a00, 0) — UTF-16LE 0x000A, a line
+           feed, which is what SQL Server puts in front of <inputbuf> element text. A real byte-order
+           mark can lead it too. Both arms, because dropping either from the skip set is a silent
+           no-op on exactly the rows it drops. */
+        Assert.True(ProcPlaceholder.TryParse("\n" + Placeholder, out var afterLineFeed));
+        Assert.Equal(new ProcPlaceholderId(7, 1790404501), afterLineFeed);
+
+        Assert.True(ProcPlaceholder.TryParse(Bom + Placeholder, out var afterBom));
+        Assert.Equal(new ProcPlaceholderId(7, 1790404501), afterBom);
+
+        Assert.True(ProcPlaceholder.TryParse(Bom + "\n   " + Placeholder, out var afterBoth));
+        Assert.Equal(new ProcPlaceholderId(7, 1790404501), afterBoth);
+    }
+
+    [Fact]
+    public void TheBom_SurvivesTheTrimBothCallersAlreadyApply()
+    {
+        /* Why the BOM arm is not a pin over an impossible input. Both collectors store
+           Element("inputbuf")?.Value?.Trim(), and .NET does NOT treat U+FEFF as whitespace — it is a
+           format character — so the BOM reaches the predicate while the line feed does not. If this
+           ever stops holding, the BOM arm above has become decoration and should be read as such
+           rather than trusted. */
+        Assert.StartsWith(Bom, (Bom + Placeholder + "   ").Trim(), StringComparison.Ordinal);
+        Assert.False(char.IsWhiteSpace('\uFEFF'));
+
+        /* And the line feed genuinely does not survive it, so the whitespace half of the skip earns its
+           keep on untrimmed text rather than on this path. */
+        Assert.Equal(Placeholder, ("\n" + Placeholder + "   ").Trim());
+    }
+
+    [Fact]
+    public void TryParse_ReadsANegativeObjectId()
+    {
+        /* System objects carry negative ids, and a deadlock can name one. */
+        Assert.True(ProcPlaceholder.TryParse("Proc [Database Id = 2 Object Id = -1073624922]", out var id));
+        Assert.Equal(new ProcPlaceholderId(2, -1073624922), id);
+    }
+
+    [Theory]
+    /* Ordinary captured statements, which is the overwhelming majority of rows. */
+    [InlineData("UPDATE dbo.Orders SET Total = 1 WHERE OrderId = 5;")]
+    [InlineData("EXEC dbo.OrderInsert @OrderId = 5;")]
+    /* The bracket, whose literal presence is the only thing left of the references' ESCAPE trap. */
+    [InlineData("Proc Database Id = 7 Object Id = 1790404501]")]
+    /* Shapes that open like the placeholder and are not it — the references match on the prefix alone
+       and then let an implicit int conversion decide, which errors rather than declining. */
+    [InlineData("Proc [Database Id = seven Object Id = 1790404501]")]
+    [InlineData("Proc [Database Id = 7]")]
+    [InlineData("Proc [Database Id = 7 Object Identifier = 1790404501]")]
+    [InlineData("Proc [Database Id =  7 Object Id = 1790404501]")]
+    [InlineData("proc [database id = 7 object id = 1790404501]")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryParse_DeclinesAnythingThatIsNotTheShape(string? text)
+    {
+        Assert.False(ProcPlaceholder.TryParse(text, out var id));
+        Assert.Equal(default, id);
+    }
+
+    [Fact]
+    public void Register_IsDistinct_OrderPreserving_AndCapped()
+    {
+        var ids = new List<ProcPlaceholderId>();
+
+        ProcPlaceholder.Register(Placeholder, ids);
+        ProcPlaceholder.Register(Bom + Placeholder, ids);         /* same pair, different leading noise */
+        ProcPlaceholder.Register("Proc [Database Id = 9 Object Id = 4]", ids);
+        ProcPlaceholder.Register("SELECT 1;", ids);                    /* not a placeholder at all */
+        ProcPlaceholder.Register(null, ids);
+
+        Assert.Equal(
+            new[] { new ProcPlaceholderId(7, 1790404501), new ProcPlaceholderId(9, 4) },
+            ids);
+
+        /* The cap bounds the VALUES list a pathological sweep can build; the overflow degrades exactly
+           like a failed lookup, which the resolve pins cover. */
+        var many = new List<ProcPlaceholderId>();
+        for (var i = 0; i < ProcPlaceholder.MaxLookupsPerCycle + 25; i++)
+        {
+            ProcPlaceholder.Register($"Proc [Database Id = 7 Object Id = {i}]", many);
+        }
+
+        Assert.Equal(ProcPlaceholder.MaxLookupsPerCycle, many.Count);
+    }
+
+    [Fact]
+    public void BuildResolutionQuery_IsNullWhenNothingNeedsResolving()
+    {
+        /* The common case, and the reason this costs nothing: a server whose captured statements never
+           came from a procedure pays no extra round trip. */
+        Assert.Null(ProcPlaceholder.BuildResolutionQuery(new List<ProcPlaceholderId>()));
+    }
+
+    [Fact]
+    public void BuildResolutionQuery_BatchesEveryPairIntoOneLookup()
+    {
+        var query = ProcPlaceholder.BuildResolutionQuery(
+            new List<ProcPlaceholderId> { new(7, 1790404501), new(9, -4) });
+
+        Assert.NotNull(query);
+        Assert.Empty(query!.Parameters);
+
+        /* Schema-qualified, and the two names projected SEPARATELY — never concatenated on the server,
+           where a NULL from either would blank the whole field. */
+        Assert.Contains("schema_name = OBJECT_SCHEMA_NAME(ids.object_id, ids.database_id)", query.Text, StringComparison.Ordinal);
+        Assert.Contains("object_name = OBJECT_NAME(ids.object_id, ids.database_id)", query.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("+ N'.' +", query.Text, StringComparison.Ordinal);
+
+        /* One batch, both pairs, and no leftover marker. */
+        Assert.Contains("(7, 1790404501), (9, -4)", query.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("PROC_ID_PAIRS", query.Text, StringComparison.Ordinal);
+
+        /* House conventions the tree's own guard enforces, asserted here at the site that builds it:
+           block comments, spaces, and the RECOMPILE that keeps a variable-length literal list from
+           interning a plan per distinct pair count. */
+        Assert.Contains("OPTION(RECOMPILE);", query.Text, StringComparison.Ordinal);
+        Assert.Contains(") AS ids", query.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("--", query.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("\t", query.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReadResolutionsAsync_DropsAPairMissingEitherHalf()
+    {
+        /* The blanking guard, exercised on every route a half-answer can arrive by. Both references
+           concatenate server-side, so each of these rows would have produced NULL there and emptied the
+           field the on-call engineer reads first. */
+        using var reader = new FakeCollectorDataReader(
+            new object[] { 7, 1790404501, "dbo", "OrderInsert" },
+            new object[] { 8, 11, DBNull.Value, "Orphan" },
+            new object[] { 8, 12, "dbo", DBNull.Value },
+            new object[] { 8, 13, "", "Empty" },
+            new object[] { 8, 14, "dbo", "" },
+            new object[] { DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value });
+
+        var resolved = await ProcPlaceholder.ReadResolutionsAsync(reader, CancellationToken.None);
+
+        Assert.Equal(new[] { new ProcPlaceholderId(7, 1790404501) }, resolved.Keys.ToArray());
+        Assert.Equal("dbo.OrderInsert", resolved[new ProcPlaceholderId(7, 1790404501)]);
+    }
+
+    [Fact]
+    public void Resolve_RewritesThePlaceholder_SchemaQualified()
+    {
+        var resolved = new Dictionary<ProcPlaceholderId, string>
+        {
+            [new ProcPlaceholderId(7, 1790404501)] = "dbo.OrderInsert",
+        };
+
+        Assert.Equal("dbo.OrderInsert", ProcPlaceholder.Resolve(Placeholder, resolved));
+        Assert.Equal("dbo.OrderInsert", ProcPlaceholder.Resolve(Bom + Placeholder, resolved));
+    }
+
+    [Fact]
+    public void Resolve_KeepsTheRawPlaceholder_WhenTheLookupCannotAnswer()
+    {
+        /* Resolution legitimately fails: the object was dropped between the event and the lookup, or the
+           monitoring login cannot read that database on a tenant fleet. An object id is a worse answer
+           than a name and a much better one than nothing — never blank, and never "unknown". */
+        var empty = new Dictionary<ProcPlaceholderId, string>();
+
+        Assert.Equal(Placeholder, ProcPlaceholder.Resolve(Placeholder, empty));
+        Assert.Equal(Bom + Placeholder, ProcPlaceholder.Resolve(Bom + Placeholder, empty));
+
+        /* A different pair answered is not this pair answered. */
+        var other = new Dictionary<ProcPlaceholderId, string>
+        {
+            [new ProcPlaceholderId(9, 4)] = "dbo.SomethingElse",
+        };
+        Assert.Equal(Placeholder, ProcPlaceholder.Resolve(Placeholder, other));
+
+        /* And a statement that was never a placeholder comes back untouched. */
+        Assert.Equal("UPDATE t SET x = 1;", ProcPlaceholder.Resolve("UPDATE t SET x = 1;", other));
+        Assert.Null(ProcPlaceholder.Resolve(null, other));
+    }
+
+    /* ───────────────────────── deadlocks, end to end ───────────────────────── */
+
+    private static string DeadlockGraph(string victimInputbuf) => $@"<deadlock>
+ <victim-list><victimProcess id=""process123""/></victim-list>
+ <process-list>
+  <process id=""process123"" currentdbname=""salesdb""><inputbuf>{victimInputbuf}</inputbuf></process>
+  <process id=""process456"" currentdbname=""salesdb""><inputbuf> SELECT 1; </inputbuf></process>
+ </process-list>
+</deadlock>";
+
+    [Fact]
+    public void Deadlocks_NoArmProjectsTheVictimText_SoTheFixCannotBeArmSpecific()
+    {
+        /* Worth pinning because it is the premise the whole design rests on. All THREE capture arms —
+           the server-scoped ring buffer, Azure's database-scoped ring buffer and Azure's telemetry blob —
+           project the deadlock GRAPH and let one C# shred find the victim's inputbuf. So resolving in C#
+           reaches every arm at once, and there is no per-arm T-SQL that could be fixed on one capture
+           path and left broken on another. */
+        foreach (var context in new[] { MakeContext(), MakeContext(isAzureSqlDb: true) })
+        {
+            var plan = DeadlocksCollector.Instance.BuildQuery(context);
+
+            Assert.Contains("deadlock_graph_xml =", plan.Text, StringComparison.Ordinal);
+            Assert.DoesNotContain("victim_sql_text", plan.Text, StringComparison.Ordinal);
+            Assert.DoesNotContain("inputbuf", plan.Text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public async Task Deadlocks_ResolveTheVictimProcedure_SchemaQualified()
+    {
+        var context = MakeContext();
+        using var reader = new FakeCollectorDataReader(
+            new object[] { new DateTime(2026, 9, 11, 11, 58, 0, DateTimeKind.Utc), "process123", DeadlockGraph("\n" + Placeholder + "   ") });
+
+        var rows = await DeadlocksCollector.Instance.ReadAsync(reader, context, CancellationToken.None);
+        var row = Assert.Single(rows);
+
+        /* The read notes the pair; the supplemental asks for it. */
+        Assert.Equal(new[] { new ProcPlaceholderId(7, 1790404501) }, context.ProcPlaceholderIds);
+        var supplemental = DeadlocksCollector.Instance.BuildSupplementalQuery(context);
+        Assert.NotNull(supplemental);
+        Assert.Contains("(7, 1790404501)", supplemental!.Text, StringComparison.Ordinal);
+
+        using var lookup = new FakeCollectorDataReader(new object[] { 7, 1790404501, "dbo", "OrderInsert" });
+        await DeadlocksCollector.Instance.ApplySupplementalAsync(rows, lookup, context, CancellationToken.None);
+
+        Assert.Equal("dbo.OrderInsert", row.VictimSqlText);
+
+        /* And it is what gets STORED — victim_sql_text is payload ordinal 2, which is the field the
+           alert renders. */
+        var writer = new RecordingCollectorRowWriter();
+        DeadlocksCollector.Instance.WritePayload(row, writer, context);
+        Assert.Equal("dbo.OrderInsert", writer.Values[2]);
+    }
+
+    [Fact]
+    public async Task Deadlocks_UnresolvableVictim_KeepsTheObjectId()
+    {
+        var context = MakeContext();
+        using var reader = new FakeCollectorDataReader(
+            new object[] { new DateTime(2026, 9, 11, 11, 58, 0, DateTimeKind.Utc), "process123", DeadlockGraph(Placeholder) });
+
+        var rows = await DeadlocksCollector.Instance.ReadAsync(reader, context, CancellationToken.None);
+
+        /* The target answered, and answered NULL — the object is gone or the login cannot see it. */
+        using var lookup = new FakeCollectorDataReader(new object[] { 7, 1790404501, DBNull.Value, DBNull.Value });
+        await DeadlocksCollector.Instance.ApplySupplementalAsync(rows, lookup, context, CancellationToken.None);
+
+        var writer = new RecordingCollectorRowWriter();
+        DeadlocksCollector.Instance.WritePayload(Assert.Single(rows), writer, context);
+        Assert.Equal(Placeholder, writer.Values[2]);
+    }
+
+    [Fact]
+    public async Task Deadlocks_OrdinaryStatement_AsksForNoLookupAtAll()
+    {
+        var context = MakeContext();
+        using var reader = new FakeCollectorDataReader(
+            new object[] { new DateTime(2026, 9, 11, 11, 58, 0, DateTimeKind.Utc), "process123", DeadlockGraph(" UPDATE t SET x = 1; ") });
+
+        var rows = await DeadlocksCollector.Instance.ReadAsync(reader, context, CancellationToken.None);
+
+        Assert.Empty(context.ProcPlaceholderIds);
+        Assert.Null(DeadlocksCollector.Instance.BuildSupplementalQuery(context));
+        Assert.Equal("UPDATE t SET x = 1;", Assert.Single(rows).VictimSqlText);
+    }
+
+    [Fact]
+    public async Task Deadlocks_SeveralVictimsAcrossOneCycle_ShareTheOneLookup()
+    {
+        /* A cycle is not one event. Two deadlocks in different procedures and a third in ad-hoc SQL:
+           two pairs, one batch, and the ad-hoc row untouched. */
+        var context = MakeContext();
+        var when = new DateTime(2026, 9, 11, 11, 58, 0, DateTimeKind.Utc);
+        using var reader = new FakeCollectorDataReader(
+            new object[] { when, "process123", DeadlockGraph("\n" + Placeholder + "   ") },
+            new object[] { when, "process123", DeadlockGraph("\nProc [Database Id = 7 Object Id = 42]   ") },
+            new object[] { when, "process123", DeadlockGraph(" DELETE dbo.t; ") },
+            new object[] { when, "process123", DeadlockGraph(Bom + Placeholder) });
+
+        var rows = await DeadlocksCollector.Instance.ReadAsync(reader, context, CancellationToken.None);
+
+        Assert.Equal(
+            new[] { new ProcPlaceholderId(7, 1790404501), new ProcPlaceholderId(7, 42) },
+            context.ProcPlaceholderIds);
+
+        using var lookup = new FakeCollectorDataReader(
+            new object[] { 7, 1790404501, "dbo", "OrderInsert" },
+            new object[] { 7, 42, "sales", "Reprice" });
+        await DeadlocksCollector.Instance.ApplySupplementalAsync(rows, lookup, context, CancellationToken.None);
+
+        Assert.Equal(
+            new[] { "dbo.OrderInsert", "sales.Reprice", "DELETE dbo.t;", "dbo.OrderInsert" },
+            rows.Select(r => r.VictimSqlText).ToArray());
+    }
+
+    /* ──────────────────── blocked process reports, end to end ──────────────────── */
+
+    private static string BlockedReport(string blockedInputbuf, string blockingInputbuf) => $@"<blocked-process-report monitorLoop=""7"">
+ <blocked-process>
+  <process id=""processa"" spid=""251"" currentdbname=""salesdb""><inputbuf>{blockedInputbuf}</inputbuf></process>
+ </blocked-process>
+ <blocking-process>
+  <process id=""processb"" spid=""256"" currentdbname=""salesdb""><inputbuf>{blockingInputbuf}</inputbuf></process>
+ </blocking-process>
+</blocked-process-report>";
+
+    [Fact]
+    public async Task BlockedProcessReports_ResolveBothSides_AndKeepWhatTheLookupCouldNot()
+    {
+        var context = MakeContext();
+
+        /* Ordinals 2-4 are the #1140 server-resolved object fields, 0-1 the event time and report XML. */
+        using var reader = new FakeCollectorDataReader(
+            new object[]
+            {
+                new DateTime(2026, 9, 11, 11, 58, 0, DateTimeKind.Utc),
+                BlockedReport("\n" + Placeholder + "   ", "\nProc [Database Id = 7 Object Id = 42]   "),
+                DBNull.Value, DBNull.Value, DBNull.Value,
+            });
+
+        var rows = await BlockedProcessReportCollector.Instance.ReadAsync(reader, context, CancellationToken.None);
+        var row = Assert.Single(rows);
+
+        Assert.Equal(
+            new[] { new ProcPlaceholderId(7, 1790404501), new ProcPlaceholderId(7, 42) },
+            context.ProcPlaceholderIds);
+        Assert.NotNull(BlockedProcessReportCollector.Instance.BuildSupplementalQuery(context));
+
+        /* The blocker resolves; the blocked side's object is one the login cannot see. */
+        using var lookup = new FakeCollectorDataReader(
+            new object[] { 7, 1790404501, DBNull.Value, DBNull.Value },
+            new object[] { 7, 42, "sales", "Reprice" });
+        await BlockedProcessReportCollector.Instance.ApplySupplementalAsync(rows, lookup, context, CancellationToken.None);
+
+        Assert.Equal(Placeholder, row.BlockedSqlText);
+        Assert.Equal("sales.Reprice", row.BlockingSqlText);
+    }
+
+    [Fact]
+    public async Task BlockedProcessReports_OrdinaryStatements_AskForNoLookupAtAll()
+    {
+        var context = MakeContext();
+        using var reader = new FakeCollectorDataReader(
+            new object[]
+            {
+                new DateTime(2026, 9, 11, 11, 58, 0, DateTimeKind.Utc),
+                BlockedReport(" SELECT 1; ", " UPDATE t SET x = 1; "),
+                DBNull.Value, DBNull.Value, DBNull.Value,
+            });
+
+        await BlockedProcessReportCollector.Instance.ReadAsync(reader, context, CancellationToken.None);
+
+        Assert.Empty(context.ProcPlaceholderIds);
+        Assert.Null(BlockedProcessReportCollector.Instance.BuildSupplementalQuery(context));
+    }
+
+    [Fact]
+    public void BothSurfaces_ShareOneResolutionQuery()
+    {
+        /* #3307's third comment argued one helper serves both surfaces, and on THIS design it does —
+           both shred <inputbuf> client-side, so neither needs a shape of its own. Pinned by text
+           equality rather than by prose, because a second copy is what would drift. */
+        var deadlocks = MakeContext();
+        var blocking = MakeContext();
+        ProcPlaceholder.Register(Placeholder, deadlocks.ProcPlaceholderIds);
+        ProcPlaceholder.Register(Placeholder, blocking.ProcPlaceholderIds);
+
+        Assert.Equal(
+            DeadlocksCollector.Instance.BuildSupplementalQuery(deadlocks)!.Text,
+            BlockedProcessReportCollector.Instance.BuildSupplementalQuery(blocking)!.Text);
+    }
+}

--- a/Lite.Tests/ProcPlaceholderResolutionTests.cs
+++ b/Lite.Tests/ProcPlaceholderResolutionTests.cs
@@ -129,6 +129,10 @@ public sealed class ProcPlaceholderResolutionTests
     [InlineData("Proc [Database Id = 7 Object Identifier = 1790404501]")]
     [InlineData("Proc [Database Id =  7 Object Id = 1790404501]")]
     [InlineData("proc [database id = 7 object id = 1790404501]")]
+    /* Text that merely OPENS with the placeholder. Resolve replaces the WHOLE input, so over-matching
+       here would silently discard whatever followed instead of declining. */
+    [InlineData("Proc [Database Id = 7 Object Id = 1790404501] and then some")]
+    [InlineData("Proc [Database Id = 7 Object Id = 1790404501x")]
     [InlineData("")]
     [InlineData(null)]
     public void TryParse_DeclinesAnythingThatIsNotTheShape(string? text)

--- a/Lite.Tests/ProcPlaceholderResolutionTests.cs
+++ b/Lite.Tests/ProcPlaceholderResolutionTests.cs
@@ -34,9 +34,14 @@ namespace Lite.Tests;
 ///
 /// <para>The third detail is the regression risk: <c>NULL + N'.' + NULL</c> is NULL in T-SQL, so a
 /// reference-faithful server-side concatenation BLANKS the field for a procedure the monitoring login
-/// cannot see. This port projects the two names separately and drops any pair missing either, so
+/// cannot see. This port projects the parts separately and drops any pair missing one, so
 /// <see cref="Resolve_KeepsTheRawPlaceholder_WhenTheLookupCannotAnswer"/> can require the object id to
 /// survive.</para>
+///
+/// <para>The resolved name is THREE-part, where both references produce two. Those two procedures report
+/// on the database they run in; this reports on a fleet, and
+/// <see cref="TheQualificationMatchesEveryOtherObjectNameInTheSameAlert"/> pins the comparison that
+/// decides it.</para>
 /// </summary>
 public sealed class ProcPlaceholderResolutionTests
 {
@@ -175,8 +180,9 @@ public sealed class ProcPlaceholderResolutionTests
         Assert.NotNull(query);
         Assert.Empty(query!.Parameters);
 
-        /* Schema-qualified, and the two names projected SEPARATELY — never concatenated on the server,
-           where a NULL from either would blank the whole field. */
+        /* All three parts projected SEPARATELY — never concatenated on the server, where a NULL from any
+           of them would blank the whole field. */
+        Assert.Contains("database_name = DB_NAME(ids.database_id)", query.Text, StringComparison.Ordinal);
         Assert.Contains("schema_name = OBJECT_SCHEMA_NAME(ids.object_id, ids.database_id)", query.Text, StringComparison.Ordinal);
         Assert.Contains("object_name = OBJECT_NAME(ids.object_id, ids.database_id)", query.Text, StringComparison.Ordinal);
         Assert.DoesNotContain("+ N'.' +", query.Text, StringComparison.Ordinal);
@@ -197,33 +203,57 @@ public sealed class ProcPlaceholderResolutionTests
     [Fact]
     public async Task ReadResolutionsAsync_DropsAPairMissingEitherHalf()
     {
-        /* The blanking guard, exercised on every route a half-answer can arrive by. Both references
-           concatenate server-side, so each of these rows would have produced NULL there and emptied the
-           field the on-call engineer reads first. */
+        /* The blanking guard, exercised on every route a partial answer can arrive by — one row per part,
+           NULL and empty. Both references concatenate server-side, so each of these rows would have
+           produced NULL there and emptied the field the on-call engineer reads first. */
         using var reader = new FakeCollectorDataReader(
-            new object[] { 7, 1790404501, "dbo", "OrderInsert" },
-            new object[] { 8, 11, DBNull.Value, "Orphan" },
-            new object[] { 8, 12, "dbo", DBNull.Value },
-            new object[] { 8, 13, "", "Empty" },
-            new object[] { 8, 14, "dbo", "" },
-            new object[] { DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value });
+            new object[] { 7, 1790404501, "salesdb", "dbo", "OrderInsert" },
+            new object[] { 8, 10, DBNull.Value, "dbo", "NoDatabase" },
+            new object[] { 8, 11, "salesdb", DBNull.Value, "NoSchema" },
+            new object[] { 8, 12, "salesdb", "dbo", DBNull.Value },
+            new object[] { 8, 13, "", "dbo", "EmptyDatabase" },
+            new object[] { 8, 14, "salesdb", "", "EmptySchema" },
+            new object[] { 8, 15, "salesdb", "dbo", "" },
+            new object[] { DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value });
 
         var resolved = await ProcPlaceholder.ReadResolutionsAsync(reader, CancellationToken.None);
 
         Assert.Equal(new[] { new ProcPlaceholderId(7, 1790404501) }, resolved.Keys.ToArray());
-        Assert.Equal("dbo.OrderInsert", resolved[new ProcPlaceholderId(7, 1790404501)]);
+        Assert.Equal("salesdb.dbo.OrderInsert", resolved[new ProcPlaceholderId(7, 1790404501)]);
     }
 
     [Fact]
-    public void Resolve_RewritesThePlaceholder_SchemaQualified()
+    public void Resolve_RewritesThePlaceholder_FullyQualified()
     {
         var resolved = new Dictionary<ProcPlaceholderId, string>
         {
-            [new ProcPlaceholderId(7, 1790404501)] = "dbo.OrderInsert",
+            [new ProcPlaceholderId(7, 1790404501)] = "salesdb.dbo.OrderInsert",
         };
 
-        Assert.Equal("dbo.OrderInsert", ProcPlaceholder.Resolve(Placeholder, resolved));
-        Assert.Equal("dbo.OrderInsert", ProcPlaceholder.Resolve(Bom + Placeholder, resolved));
+        Assert.Equal("salesdb.dbo.OrderInsert", ProcPlaceholder.Resolve(Placeholder, resolved));
+        Assert.Equal("salesdb.dbo.OrderInsert", ProcPlaceholder.Resolve(Bom + Placeholder, resolved));
+    }
+
+    [Fact]
+    public async Task TheQualificationMatchesEveryOtherObjectNameInTheSameAlert()
+    {
+        /* WHY three parts rather than the references' two, stated as a comparison rather than a
+           preference. An incident's Involved Objects field is three-part — AlertIncidentRenderTests pins
+           "SalesDB.dbo.Orders" — and it is built from the deadlock graph's own keylock/@objectname, which
+           the engine writes three-part. The graph writes a PROCEDURE three-part too, in
+           frame/@procname. So a two-part Victim SQL is what would make this field the odd one out in its
+           own message, which is the thing the references' qualification was for.
+
+           If this is ever reduced to two parts, it should be because the alert's other object names were
+           reduced too — and then this pin is the thing that says so. */
+        using var reader = new FakeCollectorDataReader(
+            new object[] { 7, 1790404501, "salesdb", "dbo", "OrderInsert" });
+        var resolved = await ProcPlaceholder.ReadResolutionsAsync(reader, CancellationToken.None);
+
+        var name = ProcPlaceholder.Resolve(Placeholder, resolved);
+
+        Assert.Equal(3, name!.Split('.').Length);
+        Assert.Equal("salesdb.dbo.OrderInsert", name);
     }
 
     [Fact]
@@ -293,16 +323,16 @@ public sealed class ProcPlaceholderResolutionTests
         Assert.NotNull(supplemental);
         Assert.Contains("(7, 1790404501)", supplemental!.Text, StringComparison.Ordinal);
 
-        using var lookup = new FakeCollectorDataReader(new object[] { 7, 1790404501, "dbo", "OrderInsert" });
+        using var lookup = new FakeCollectorDataReader(new object[] { 7, 1790404501, "salesdb", "dbo", "OrderInsert" });
         await DeadlocksCollector.Instance.ApplySupplementalAsync(rows, lookup, context, CancellationToken.None);
 
-        Assert.Equal("dbo.OrderInsert", row.VictimSqlText);
+        Assert.Equal("salesdb.dbo.OrderInsert", row.VictimSqlText);
 
         /* And it is what gets STORED — victim_sql_text is payload ordinal 2, which is the field the
            alert renders. */
         var writer = new RecordingCollectorRowWriter();
         DeadlocksCollector.Instance.WritePayload(row, writer, context);
-        Assert.Equal("dbo.OrderInsert", writer.Values[2]);
+        Assert.Equal("salesdb.dbo.OrderInsert", writer.Values[2]);
     }
 
     [Fact]
@@ -315,7 +345,7 @@ public sealed class ProcPlaceholderResolutionTests
         var rows = await DeadlocksCollector.Instance.ReadAsync(reader, context, CancellationToken.None);
 
         /* The target answered, and answered NULL — the object is gone or the login cannot see it. */
-        using var lookup = new FakeCollectorDataReader(new object[] { 7, 1790404501, DBNull.Value, DBNull.Value });
+        using var lookup = new FakeCollectorDataReader(new object[] { 7, 1790404501, DBNull.Value, DBNull.Value, DBNull.Value });
         await DeadlocksCollector.Instance.ApplySupplementalAsync(rows, lookup, context, CancellationToken.None);
 
         var writer = new RecordingCollectorRowWriter();
@@ -357,12 +387,12 @@ public sealed class ProcPlaceholderResolutionTests
             context.ProcPlaceholderIds);
 
         using var lookup = new FakeCollectorDataReader(
-            new object[] { 7, 1790404501, "dbo", "OrderInsert" },
-            new object[] { 7, 42, "sales", "Reprice" });
+            new object[] { 7, 1790404501, "salesdb", "dbo", "OrderInsert" },
+            new object[] { 7, 42, "salesdb", "sales", "Reprice" });
         await DeadlocksCollector.Instance.ApplySupplementalAsync(rows, lookup, context, CancellationToken.None);
 
         Assert.Equal(
-            new[] { "dbo.OrderInsert", "sales.Reprice", "DELETE dbo.t;", "dbo.OrderInsert" },
+            new[] { "salesdb.dbo.OrderInsert", "salesdb.sales.Reprice", "DELETE dbo.t;", "salesdb.dbo.OrderInsert" },
             rows.Select(r => r.VictimSqlText).ToArray());
     }
 
@@ -401,12 +431,12 @@ public sealed class ProcPlaceholderResolutionTests
 
         /* The blocker resolves; the blocked side's object is one the login cannot see. */
         using var lookup = new FakeCollectorDataReader(
-            new object[] { 7, 1790404501, DBNull.Value, DBNull.Value },
-            new object[] { 7, 42, "sales", "Reprice" });
+            new object[] { 7, 1790404501, DBNull.Value, DBNull.Value, DBNull.Value },
+            new object[] { 7, 42, "salesdb", "sales", "Reprice" });
         await BlockedProcessReportCollector.Instance.ApplySupplementalAsync(rows, lookup, context, CancellationToken.None);
 
         Assert.Equal(Placeholder, row.BlockedSqlText);
-        Assert.Equal("sales.Reprice", row.BlockingSqlText);
+        Assert.Equal("salesdb.sales.Reprice", row.BlockingSqlText);
     }
 
     [Fact]

--- a/PerformanceMonitor.Collectors/BlockedProcessReportCollector.cs
+++ b/PerformanceMonitor.Collectors/BlockedProcessReportCollector.cs
@@ -27,6 +27,11 @@ namespace PerformanceMonitor.Collectors;
 /// reallocated page reported once through the payload probe-failure channel. Session lifecycle — including the
 /// blocked-process-threshold sp_configure bootstrap — stays host-side; the session name lives
 /// here so the reader and the lifecycle can never disagree on it.
+///
+/// <para>#3307: either side's statement can arrive as <c>Proc [Database Id = N Object Id = M]</c> — SQL
+/// Server has no batch text to write for an RPC — and the read notes the ids so
+/// <see cref="BuildSupplementalQuery"/> can resolve them to <c>schema.object</c> in one lookup per cycle,
+/// through the same <see cref="ProcPlaceholder"/> helper <c>deadlocks</c> uses.</para>
 /// </summary>
 public sealed class BlockedProcessReportCollector : CollectorDefinitionBase<BlockedProcessReportCollector.Row>
 {
@@ -874,6 +879,12 @@ OUTER APPLY
                advance that database's watermark, re-inserting every cycle. Server-scoped
                platforms keep the parsed currentdbname (CurrentDatabaseName is null there). */
             parsed.DatabaseName = context.CurrentDatabaseName ?? parsed.DatabaseName;
+            /* #3307: either side's statement can have come from a procedure invoked as an RPC, which
+               SQL Server renders as "Proc [Database Id = N Object Id = M]" because there is no batch
+               text. Note both pairs here and the supplemental below resolves every one the cycle
+               produced in a single lookup. */
+            ProcPlaceholder.Register(parsed.BlockedSqlText, context.ProcPlaceholderIds);
+            ProcPlaceholder.Register(parsed.BlockingSqlText, context.ProcPlaceholderIds);
             rows.Add(parsed);
         }
 
@@ -886,6 +897,36 @@ OUTER APPLY
         context.Measure(EventsStoredMeasurement, rows.Count);
 
         return rows;
+    }
+
+    /// <summary>
+    /// One batched <c>OBJECT_SCHEMA_NAME</c>/<c>OBJECT_NAME</c> lookup for every
+    /// <c>Proc [Database Id = N Object Id = M]</c> this cycle's reports carried on either side (#3307), or
+    /// null when none did. Shares <see cref="ProcPlaceholder"/> with <c>deadlocks</c>: both surfaces shred
+    /// <c>&lt;inputbuf&gt;</c> client-side, so one helper genuinely serves both.
+    /// </summary>
+    public override CollectorQuery? BuildSupplementalQuery(CollectorContext context)
+        => ProcPlaceholder.BuildResolutionQuery(context.ProcPlaceholderIds);
+
+    /// <summary>
+    /// Rewrites the placeholder to <c>schema.object</c> on both sides of every report the lookup answered
+    /// for, and leaves the rest alone. A pair the target could not resolve is absent from the map, so its
+    /// raw placeholder survives rather than the field going blank.
+    /// </summary>
+    public override async ValueTask ApplySupplementalAsync(List<Row> rows, DbDataReader reader, CollectorContext context, CancellationToken cancellationToken)
+    {
+        var resolved = await ProcPlaceholder.ReadResolutionsAsync(reader, cancellationToken);
+
+        if (resolved.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var row in rows)
+        {
+            row.BlockedSqlText = ProcPlaceholder.Resolve(row.BlockedSqlText, resolved);
+            row.BlockingSqlText = ProcPlaceholder.Resolve(row.BlockingSqlText, resolved);
+        }
     }
 
     public override void WritePayload(Row row, ICollectorRowWriter writer, CollectorContext context)

--- a/PerformanceMonitor.Collectors/CollectorContext.cs
+++ b/PerformanceMonitor.Collectors/CollectorContext.cs
@@ -303,6 +303,24 @@ public sealed class CollectorContext
     public bool PerItemTextBudgetExceeded { get; set; }
 
     /// <summary>
+    /// <c>Proc [Database Id = N Object Id = M]</c> pairs this cycle's events turned out to need resolved
+    /// (#3307), filled by a definition's read method and read back by its
+    /// <see cref="ICollectorDefinition{TRow}.BuildSupplementalQuery"/>. Those two run against THIS object,
+    /// in that order, on the single-connection path — which is what lets one batched lookup serve every
+    /// event a cycle produced without the definition holding state of its own.
+    ///
+    /// <para>Empty in the common case: only <c>deadlocks</c> and <c>blocked_process_report</c> fill it, and
+    /// only when a captured statement actually came from a procedure invoked as an RPC. An empty list means
+    /// <c>BuildSupplementalQuery</c> returns null and the cycle costs no extra round trip.</para>
+    ///
+    /// <para>The Azure SQL DB per-database path fills it and never drains it — the host runs no
+    /// supplemental there — so those rows keep the raw placeholder. That is the documented degradation
+    /// rather than a separate outcome: <c>OBJECT_NAME</c> cannot read another database's metadata on Azure
+    /// SQL DB anyway, so the lookup would return NULL for exactly the rows the placeholder survives on.</para>
+    /// </summary>
+    public List<ProcPlaceholderId> ProcPlaceholderIds { get; } = new();
+
+    /// <summary>
     /// Milliseconds spent waiting for <c>ExecuteReaderAsync</c> to return for the item just read (#2164),
     /// set by the host around the open. Splits a batch's server time into the part the client cannot
     /// influence and the part it can:

--- a/PerformanceMonitor.Collectors/DeadlocksCollector.cs
+++ b/PerformanceMonitor.Collectors/DeadlocksCollector.cs
@@ -26,6 +26,12 @@ namespace PerformanceMonitor.Collectors;
 /// graph XML (parsed in the SQL/read phase — XElement.Parse is expensive and was previously
 /// misattributed as storage time). Session lifecycle (create/start/ensure) stays host-side; the
 /// session name lives here so the reader and the lifecycle can never disagree on it.
+///
+/// <para>#3307: a victim inside a stored procedure arrives as
+/// <c>Proc [Database Id = N Object Id = M]</c> — SQL Server has no batch text to write for an RPC — and
+/// the read notes the ids so <see cref="BuildSupplementalQuery"/> can resolve them to
+/// <c>schema.object</c> in one lookup per cycle. See <see cref="ProcPlaceholder"/> for why the parse is
+/// client-side and what happens when the lookup cannot answer.</para>
 /// </summary>
 public sealed class DeadlocksCollector : CollectorDefinitionBase<DeadlocksCollector.Row>
 {
@@ -316,6 +322,12 @@ OUTER APPLY
             var graphXml = reader.IsDBNull(2) ? null : reader.GetString(2);
             var victim = ExtractVictimFields(graphXml, victimProcessId);
 
+            /* #3307: a victim whose statement came from a procedure invoked as an RPC carries
+               "Proc [Database Id = N Object Id = M]" instead of the procedure name — SQL Server writes
+               the ids because there is no batch text to write. Note the pair here, in the read, and the
+               supplemental below resolves every one the cycle produced in a single lookup. */
+            ProcPlaceholder.Register(victim.SqlText, context.ProcPlaceholderIds);
+
             rows.Add(new Row
             {
                 DeadlockTime = reader.IsDBNull(0) ? null : reader.GetDateTime(0),
@@ -338,6 +350,40 @@ OUTER APPLY
         }
 
         return rows;
+    }
+
+    /// <summary>
+    /// One batched <c>OBJECT_SCHEMA_NAME</c>/<c>OBJECT_NAME</c> lookup for every
+    /// <c>Proc [Database Id = N Object Id = M]</c> the cycle's victims turned out to carry (#3307), or null
+    /// when none did — which is most cycles, so the common case pays nothing.
+    ///
+    /// <para>The seam fits the job exactly: the host runs it on the SAME connection right after
+    /// <see cref="ReadAsync"/>, skips it on an empty primary, and isolates its failure — so a monitoring
+    /// login that cannot read the victim's database costs the cycle a debug line and leaves every
+    /// <c>victim_sql_text</c> exactly as the graph wrote it.</para>
+    /// </summary>
+    public override CollectorQuery? BuildSupplementalQuery(CollectorContext context)
+        => ProcPlaceholder.BuildResolutionQuery(context.ProcPlaceholderIds);
+
+    /// <summary>
+    /// Rewrites the placeholder to <c>schema.object</c> for every victim the lookup answered for, and
+    /// leaves the rest alone. A dropped object, or one in a database the monitoring login cannot see,
+    /// comes back NULL and is absent from the map, so the raw placeholder survives — it still names an
+    /// object id someone can resolve by hand, which a blank field or the word "unknown" does not.
+    /// </summary>
+    public override async ValueTask ApplySupplementalAsync(List<Row> rows, DbDataReader reader, CollectorContext context, CancellationToken cancellationToken)
+    {
+        var resolved = await ProcPlaceholder.ReadResolutionsAsync(reader, cancellationToken);
+
+        if (resolved.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var row in rows)
+        {
+            row.VictimSqlText = ProcPlaceholder.Resolve(row.VictimSqlText, resolved);
+        }
     }
 
     /// <summary>

--- a/PerformanceMonitor.Collectors/ProcPlaceholder.cs
+++ b/PerformanceMonitor.Collectors/ProcPlaceholder.cs
@@ -21,7 +21,7 @@ public readonly record struct ProcPlaceholderId(int DatabaseId, int ObjectId);
 
 /// <summary>
 /// Resolution of SQL Server's <c>Proc [Database Id = N Object Id = M]</c> placeholder to
-/// <c>schema.object</c> (#3307).
+/// <c>database.schema.object</c> (#3307).
 ///
 /// <para>SQL Server writes that placeholder into a process's <c>&lt;inputbuf&gt;</c> whenever the batch it
 /// is running is a stored procedure invoked as an RPC rather than submitted as text — so a deadlock or a
@@ -33,8 +33,15 @@ public readonly record struct ProcPlaceholderId(int DatabaseId, int ObjectId);
 ///
 /// <para><b>The technique is ported from <c>sp_HumanEventsBlockViewer</c> and <c>sp_BlitzLock</c></b>, which
 /// resolve it identically: match the placeholder, take the two ids out of the text, and project
-/// <c>OBJECT_SCHEMA_NAME</c> + <c>'.'</c> + <c>OBJECT_NAME</c>. Two deliberate departures, both because
-/// this is the C# side of the same idea rather than the T-SQL one:</para>
+/// <c>OBJECT_SCHEMA_NAME</c> + <c>'.'</c> + <c>OBJECT_NAME</c>. Three deliberate departures:</para>
+///
+/// <para><b>The name is three-part, not two.</b> Those two procedures each report on the database they
+/// run in, where a database prefix would be noise. This reports on a fleet, and everything else in the
+/// same alert names an object in three parts: the incident's Involved Objects field
+/// (<c>AlertIncidentRenderTests</c> pins <c>SalesDB.dbo.Orders</c>), the deadlock graph's own
+/// <c>keylock/@objectname</c>, and — on a live production graph for exactly this defect — the graph's own
+/// <c>frame/@procname</c>. So two parts is what would make this field the odd one out, which is the thing
+/// the references' qualification was for.</para>
 ///
 /// <para>The references' <c>LIKE N'Proc |[Database Id = %' ESCAPE N'|'</c> needs the <c>ESCAPE</c> because
 /// <c>[</c> opens a character class in <c>LIKE</c> — without it the predicate is a range expression that
@@ -87,6 +94,7 @@ public static class ProcPlaceholder
 SELECT
     database_id = ids.database_id,
     object_id = ids.object_id,
+    database_name = DB_NAME(ids.database_id),
     schema_name = OBJECT_SCHEMA_NAME(ids.object_id, ids.database_id),
     object_name = OBJECT_NAME(ids.object_id, ids.database_id)
 FROM
@@ -211,13 +219,15 @@ OPTION(RECOMPILE);";
     }
 
     /// <summary>
-    /// Reads the lookup's result set into a pair-to-<c>schema.object</c> map, positionally — the reader
-    /// contract on this seam is by ordinal, and the collectors' test fake throws from <c>GetName</c>
-    /// deliberately.
+    /// Reads the lookup's result set into a pair-to-<c>database.schema.object</c> map, positionally — the
+    /// reader contract on this seam is by ordinal, and the collectors' test fake throws from
+    /// <c>GetName</c> deliberately.
     ///
-    /// <para>A pair whose schema or object name came back NULL or empty is simply ABSENT from the map, so
-    /// there is no partial name for <see cref="Resolve"/> to fall for. This is the one place a NULL could
-    /// have been concatenated into a blanked field.</para>
+    /// <para>A pair missing ANY of the three parts is simply ABSENT from the map, so there is no partial
+    /// name for <see cref="Resolve"/> to fall for. This is the one place a NULL could have been
+    /// concatenated into a blanked field. All three fail together in practice — naming a database, its
+    /// schema and its object all need the same access to it — so the all-or-nothing rule costs no
+    /// coverage and leaves exactly one outcome to reason about.</para>
     /// </summary>
     public static async ValueTask<Dictionary<ProcPlaceholderId, string>> ReadResolutionsAsync(
         DbDataReader reader,
@@ -229,31 +239,33 @@ OPTION(RECOMPILE);";
 
         while (await reader.ReadAsync(cancellationToken))
         {
-            if (reader.IsDBNull(0) || reader.IsDBNull(1) || reader.IsDBNull(2) || reader.IsDBNull(3))
+            if (reader.IsDBNull(0) || reader.IsDBNull(1)
+                || reader.IsDBNull(2) || reader.IsDBNull(3) || reader.IsDBNull(4))
             {
                 continue;
             }
 
-            var schemaName = reader.GetString(2);
-            var objectName = reader.GetString(3);
+            var databaseName = reader.GetString(2);
+            var schemaName = reader.GetString(3);
+            var objectName = reader.GetString(4);
 
-            if (schemaName.Length == 0 || objectName.Length == 0)
+            if (databaseName.Length == 0 || schemaName.Length == 0 || objectName.Length == 0)
             {
                 continue;
             }
 
             resolved[new ProcPlaceholderId(reader.GetInt32(0), reader.GetInt32(1))] =
-                schemaName + "." + objectName;
+                databaseName + "." + schemaName + "." + objectName;
         }
 
         return resolved;
     }
 
     /// <summary>
-    /// The resolved <c>schema.object</c> when <paramref name="text"/> is a placeholder the lookup answered
-    /// for, and <paramref name="text"/> UNCHANGED otherwise — not blank, and never "unknown". Schema
-    /// qualified because the same alert's Involved Objects field already renders that way, so an
-    /// unqualified procedure would be the odd field out in its own message.
+    /// The resolved <c>database.schema.object</c> when <paramref name="text"/> is a placeholder the lookup
+    /// answered for, and <paramref name="text"/> UNCHANGED otherwise — not blank, and never "unknown".
+    /// Three-part because that is how every other object name in the same alert renders (see the class
+    /// remarks), so anything shorter would be the odd field out in its own message.
     /// </summary>
     public static string? Resolve(string? text, IReadOnlyDictionary<ProcPlaceholderId, string> resolved)
     {

--- a/PerformanceMonitor.Collectors/ProcPlaceholder.cs
+++ b/PerformanceMonitor.Collectors/ProcPlaceholder.cs
@@ -121,7 +121,8 @@ OPTION(RECOMPILE);";
     /// complaining. Both arms carry a fixture.</para>
     ///
     /// <para>The object id may be negative (system objects), the database id never is. Anything that is not
-    /// the full shape returns false and leaves the text alone, rather than the references' behaviour of
+    /// the full shape — INCLUDING text that merely opens with it and carries something after the closing
+    /// bracket — returns false and leaves the text alone, rather than the references' behaviour of
     /// matching on the prefix and then letting an implicit int conversion decide.</para>
     /// </summary>
     public static bool TryParse(string? text, out ProcPlaceholderId id)
@@ -135,7 +136,7 @@ OPTION(RECOMPILE);";
 
         var rest = text.AsSpan();
         var lead = 0;
-        while (lead < rest.Length && IsLeadingNoise(rest[lead]))
+        while (lead < rest.Length && IsIgnorablePadding(rest[lead]))
         {
             lead++;
         }
@@ -164,6 +165,31 @@ OPTION(RECOMPILE);";
         if (!TakeInteger(ref rest, allowSign: true, out var objectId))
         {
             return false;
+        }
+
+        /* The closing bracket AND nothing but padding after it, which is what the doc comment's "full
+           shape" claim needs to be true. Without this the parse returns true for any text that merely
+           OPENS with the placeholder — and Resolve replaces the WHOLE input, so whatever followed would
+           be silently discarded rather than declined. SQL Server writes the placeholder as the entire
+           inputbuf value (space-padded: "]   "), so requiring it costs no coverage. A value truncated
+           before the bracket is still accepted: the ids are the thing being read, and declining would
+           throw away the only answer available. */
+        if (!rest.IsEmpty)
+        {
+            if (rest[0] != ']')
+            {
+                return false;
+            }
+
+            rest = rest[1..];
+
+            for (var i = 0; i < rest.Length; i++)
+            {
+                if (!IsIgnorablePadding(rest[i]))
+                {
+                    return false;
+                }
+            }
         }
 
         id = new ProcPlaceholderId(databaseId, objectId);
@@ -277,10 +303,11 @@ OPTION(RECOMPILE);";
     }
 
     /// <summary>
-    /// What may precede the placeholder: the references' <c>@inputbuf_bom</c> line feed and any other
-    /// whitespace, plus a real byte-order mark, which trimming leaves behind.
+    /// What may surround the placeholder without changing it: the references' <c>@inputbuf_bom</c> line
+    /// feed and any other whitespace, plus a real byte-order mark, which trimming leaves behind. Used on
+    /// both ends — SQL Server leads the value with a newline and pads it with spaces.
     /// </summary>
-    private static bool IsLeadingNoise(char c) => c == '\uFEFF' || char.IsWhiteSpace(c);
+    private static bool IsIgnorablePadding(char c) => c == '\uFEFF' || char.IsWhiteSpace(c);
 
     /// <summary>Consumes the digits (and optional sign) at the head of <paramref name="rest"/>.</summary>
     private static bool TakeInteger(ref ReadOnlySpan<char> rest, bool allowSign, out int value)

--- a/PerformanceMonitor.Collectors/ProcPlaceholder.cs
+++ b/PerformanceMonitor.Collectors/ProcPlaceholder.cs
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Collectors;
+
+/// <summary>The database and object a <c>Proc [Database Id = N Object Id = M]</c> placeholder names.</summary>
+public readonly record struct ProcPlaceholderId(int DatabaseId, int ObjectId);
+
+/// <summary>
+/// Resolution of SQL Server's <c>Proc [Database Id = N Object Id = M]</c> placeholder to
+/// <c>schema.object</c> (#3307).
+///
+/// <para>SQL Server writes that placeholder into a process's <c>&lt;inputbuf&gt;</c> whenever the batch it
+/// is running is a stored procedure invoked as an RPC rather than submitted as text — so a deadlock or a
+/// blocked-process report whose statement sits inside a procedure names an object id where an on-call
+/// engineer needs a procedure name. Both surfaces shred <c>&lt;inputbuf&gt;</c> CLIENT-side
+/// (<c>DeadlocksCollector.ExtractVictimFields</c>, <c>BlockedProcessReportCollector.ParseReportXml</c>), so
+/// the parse lives here in C# and only the id-to-name lookup goes to the target, batched once per cycle
+/// through the definitions' supplemental-query seam.</para>
+///
+/// <para><b>The technique is ported from <c>sp_HumanEventsBlockViewer</c> and <c>sp_BlitzLock</c></b>, which
+/// resolve it identically: match the placeholder, take the two ids out of the text, and project
+/// <c>OBJECT_SCHEMA_NAME</c> + <c>'.'</c> + <c>OBJECT_NAME</c>. Two deliberate departures, both because
+/// this is the C# side of the same idea rather than the T-SQL one:</para>
+///
+/// <para>The references' <c>LIKE N'Proc |[Database Id = %' ESCAPE N'|'</c> needs the <c>ESCAPE</c> because
+/// <c>[</c> opens a character class in <c>LIKE</c> — without it the predicate is a range expression that
+/// matches nothing and does not error. A C# ordinal comparison has no such metacharacter, so that failure
+/// mode does not exist on this path; the bracket is load-bearing only as a literal, which
+/// <c>ProcPlaceholderResolutionTests</c> pins by mutating it out.</para>
+///
+/// <para>The references concatenate the two names server-side, so a procedure the monitoring login cannot
+/// see resolves as <c>NULL + N'.' + NULL</c> — NULL — and BLANKS the field. Here the target projects the
+/// two names separately and <see cref="Resolve"/> keeps the raw placeholder unless BOTH came back. An
+/// object id is a worse answer than a name and a much better one than nothing: it is still resolvable by
+/// hand.</para>
+/// </summary>
+public static class ProcPlaceholder
+{
+    /// <summary>
+    /// The placeholder's literal opening, matched ordinally. Exactly the references' <c>LIKE</c> pattern
+    /// with the <c>ESCAPE</c> removed, because nothing here treats <c>[</c> as a metacharacter.
+    /// </summary>
+    private const string Prefix = "Proc [Database Id = ";
+
+    /// <summary>What separates the two ids. The references' <c>CHARINDEX(N'Object Id = ', …) + 12</c>.</summary>
+    private const string ObjectIdMarker = " Object Id = ";
+
+    /// <summary>
+    /// Distinct pairs one cycle will ask the target to resolve. A cycle whose events name more procedures
+    /// than this resolves the first <see cref="MaxLookupsPerCycle"/> and leaves the rest showing their
+    /// object ids — the same degradation as a failed lookup, and it keeps one pathological sweep from
+    /// building an unbounded <c>VALUES</c> list. blocked_process_report is the surface that can produce
+    /// hundreds of events in a cycle; the DISTINCT procedures behind them are normally a handful.
+    /// </summary>
+    public const int MaxLookupsPerCycle = 500;
+
+    /// <summary>
+    /// One batched lookup for every pair a cycle turned up. Text held apart from
+    /// <see cref="BuildResolutionQuery"/> so the T-SQL is one literal a reader (and the convention guard)
+    /// can see whole; the pairs splice in at the marker, exactly as the collectors' own plan fragments do.
+    ///
+    /// <para>The ids are bound as literals rather than parameters BECAUSE they are already integers — they
+    /// came out of <see cref="TryParse"/> as <c>int</c>, so there is no string to inject through, and a
+    /// per-pair parameter list would cap the batch far below what one sweep can produce.
+    /// <c>OPTION(RECOMPILE)</c> is what keeps that variable-length literal list from interning a plan per
+    /// distinct pair count.</para>
+    ///
+    /// <para><c>OBJECT_SCHEMA_NAME</c> and <c>OBJECT_NAME</c> return NULL rather than erroring when the
+    /// monitoring login has no access to that database or the object has been dropped since the event, so
+    /// the whole batch survives a pair it cannot resolve.</para>
+    /// </summary>
+    private const string ResolutionQueryText = @"
+SELECT
+    database_id = ids.database_id,
+    object_id = ids.object_id,
+    schema_name = OBJECT_SCHEMA_NAME(ids.object_id, ids.database_id),
+    object_name = OBJECT_NAME(ids.object_id, ids.database_id)
+FROM
+(
+    VALUES
+        /*PROC_ID_PAIRS*/
+) AS ids
+(
+    database_id,
+    object_id
+)
+OPTION(RECOMPILE);";
+
+    /// <summary>
+    /// True when <paramref name="text"/> is the unresolved placeholder, yielding the ids it names.
+    ///
+    /// <para><b>The leading-noise skip is load-bearing and fails silently without a fixture for it.</b> The
+    /// references prepend <c>@inputbuf_bom</c> to their pattern, built as
+    /// <c>CONVERT(nvarchar(1), 0x0a00, 0)</c> — UTF-16LE <c>0x000A</c>, a line feed, which is what SQL
+    /// Server actually puts in front of <c>&lt;inputbuf&gt;</c> element text. A real byte-order mark
+    /// (U+FEFF) can lead it too, and <c>string.Trim()</c> — which both callers already apply — does NOT
+    /// remove U+FEFF, because .NET classifies it as a format character and not whitespace. So the BOM
+    /// survives trimming and a prefix test without this skip misses every BOM-prefixed row without
+    /// complaining. Both arms carry a fixture.</para>
+    ///
+    /// <para>The object id may be negative (system objects), the database id never is. Anything that is not
+    /// the full shape returns false and leaves the text alone, rather than the references' behaviour of
+    /// matching on the prefix and then letting an implicit int conversion decide.</para>
+    /// </summary>
+    public static bool TryParse(string? text, out ProcPlaceholderId id)
+    {
+        id = default;
+
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        var rest = text.AsSpan();
+        var lead = 0;
+        while (lead < rest.Length && IsLeadingNoise(rest[lead]))
+        {
+            lead++;
+        }
+
+        rest = rest[lead..];
+
+        if (!rest.StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        rest = rest[Prefix.Length..];
+
+        if (!TakeInteger(ref rest, allowSign: false, out var databaseId))
+        {
+            return false;
+        }
+
+        if (!rest.StartsWith(ObjectIdMarker, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        rest = rest[ObjectIdMarker.Length..];
+
+        if (!TakeInteger(ref rest, allowSign: true, out var objectId))
+        {
+            return false;
+        }
+
+        id = new ProcPlaceholderId(databaseId, objectId);
+        return true;
+    }
+
+    /// <summary>
+    /// Records the pair <paramref name="text"/> names, if it is a placeholder at all, for the cycle's one
+    /// batched lookup. Distinct, capped, and order-preserving so the query text is deterministic.
+    /// </summary>
+    public static void Register(string? text, IList<ProcPlaceholderId> ids)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+
+        if (!TryParse(text, out var id) || ids.Contains(id) || ids.Count >= MaxLookupsPerCycle)
+        {
+            return;
+        }
+
+        ids.Add(id);
+    }
+
+    /// <summary>
+    /// The cycle's lookup, or null when nothing needs resolving — which is the common case, so a server
+    /// whose deadlocks never sit inside a procedure pays no extra round trip at all.
+    /// </summary>
+    public static CollectorQuery? BuildResolutionQuery(IReadOnlyList<ProcPlaceholderId> ids)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+
+        if (ids.Count == 0)
+        {
+            return null;
+        }
+
+        /* One line, separator spelled out rather than Environment.NewLine: the query text a definition
+           builds has to be identical on the Linux build and the Windows test job, and a platform newline
+           spliced into it is exactly the kind of difference a text pin cannot see but a diff of two runs
+           can. */
+        var pairs = new StringBuilder();
+        for (var i = 0; i < ids.Count; i++)
+        {
+            if (i > 0)
+            {
+                pairs.Append(", ");
+            }
+
+            pairs.Append(CultureInfo.InvariantCulture, $"({ids[i].DatabaseId}, {ids[i].ObjectId})");
+        }
+
+        return new CollectorQuery(
+            ResolutionQueryText.Replace("/*PROC_ID_PAIRS*/", pairs.ToString(), StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Reads the lookup's result set into a pair-to-<c>schema.object</c> map, positionally — the reader
+    /// contract on this seam is by ordinal, and the collectors' test fake throws from <c>GetName</c>
+    /// deliberately.
+    ///
+    /// <para>A pair whose schema or object name came back NULL or empty is simply ABSENT from the map, so
+    /// there is no partial name for <see cref="Resolve"/> to fall for. This is the one place a NULL could
+    /// have been concatenated into a blanked field.</para>
+    /// </summary>
+    public static async ValueTask<Dictionary<ProcPlaceholderId, string>> ReadResolutionsAsync(
+        DbDataReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        var resolved = new Dictionary<ProcPlaceholderId, string>();
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            if (reader.IsDBNull(0) || reader.IsDBNull(1) || reader.IsDBNull(2) || reader.IsDBNull(3))
+            {
+                continue;
+            }
+
+            var schemaName = reader.GetString(2);
+            var objectName = reader.GetString(3);
+
+            if (schemaName.Length == 0 || objectName.Length == 0)
+            {
+                continue;
+            }
+
+            resolved[new ProcPlaceholderId(reader.GetInt32(0), reader.GetInt32(1))] =
+                schemaName + "." + objectName;
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// The resolved <c>schema.object</c> when <paramref name="text"/> is a placeholder the lookup answered
+    /// for, and <paramref name="text"/> UNCHANGED otherwise — not blank, and never "unknown". Schema
+    /// qualified because the same alert's Involved Objects field already renders that way, so an
+    /// unqualified procedure would be the odd field out in its own message.
+    /// </summary>
+    public static string? Resolve(string? text, IReadOnlyDictionary<ProcPlaceholderId, string> resolved)
+    {
+        ArgumentNullException.ThrowIfNull(resolved);
+
+        return TryParse(text, out var id) && resolved.TryGetValue(id, out var name)
+            ? name
+            : text;
+    }
+
+    /// <summary>
+    /// What may precede the placeholder: the references' <c>@inputbuf_bom</c> line feed and any other
+    /// whitespace, plus a real byte-order mark, which trimming leaves behind.
+    /// </summary>
+    private static bool IsLeadingNoise(char c) => c == '\uFEFF' || char.IsWhiteSpace(c);
+
+    /// <summary>Consumes the digits (and optional sign) at the head of <paramref name="rest"/>.</summary>
+    private static bool TakeInteger(ref ReadOnlySpan<char> rest, bool allowSign, out int value)
+    {
+        value = 0;
+
+        var length = 0;
+        if (allowSign && rest.Length > 0 && rest[0] == '-')
+        {
+            length++;
+        }
+
+        var digits = 0;
+        while (length < rest.Length && char.IsAsciiDigit(rest[length]))
+        {
+            length++;
+            digits++;
+        }
+
+        if (digits == 0 || !int.TryParse(rest[..length], NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out value))
+        {
+            return false;
+        }
+
+        rest = rest[length..];
+        return true;
+    }
+}


### PR DESCRIPTION
A deadlock or blocked-process report whose statement sits inside a stored procedure stored SQL Server's own `Proc [Database Id = N Object Id = M]` where the procedure name belongs. Nothing in the tree parsed it, so this was a resolution never attempted rather than one that failed. Fixes #3307.

The technique is ported from `sp_HumanEventsBlockViewer` and `sp_BlitzLock`, which resolve it identically: match the placeholder, take the two ids out of the text, look them up with `OBJECT_SCHEMA_NAME` / `OBJECT_NAME`, and fall back to the text when it is not a placeholder.

This is not a rare shape. On one monitored server, all 20 of the most recent deadlocks in a 72-hour window stored the placeholder — every single victim, because the workload is entirely procedure-driven. The field an on-call engineer reads first was an object id on all of them.

## Where the resolution lives, and why it is C#

#3307 assumes the deadlock collector extracts the victim's statement in T-SQL, in three query variants. It does not. All three capture arms — the server-scoped ring buffer, Azure's database-scoped ring buffer and Azure's telemetry blob — project the deadlock GRAPH, and `DeadlocksCollector.ExtractVictimFields` shreds `<inputbuf>` client-side, exactly as `BlockedProcessReportCollector.ParseReportXml` does. The two surfaces are symmetric after all, so #3307's "one helper serves both" is literally true here.

The parse therefore lives in C# in `ProcPlaceholder`, and only the id-to-name lookup goes to the target — one batched `VALUES` join per cycle, through the definitions' existing supplemental-query seam, which runs on the same connection right after the read, is skipped on an empty primary, and isolates its own failure. `BuildSupplementalQuery` returns null when nothing needs resolving, so a server whose captured statements never came from a procedure pays no extra round trip at all.

Resolving in C# also means the predicate can be tested. Neither of the references' silent failure modes can be exercised from macOS if it lives in a query string, and an `Assert.Contains` on query text cannot see either of them.

## The three details, and what happened to each

**`ESCAPE N'|'` on the `[`.** In T-SQL this is load-bearing: `[` opens a `LIKE` character class, so the predicate without it is a range expression that matches nothing and does not error. A C# ordinal comparison has no metacharacter, so that failure mode does not exist on this path. What remains load-bearing is the bracket as a literal, and a mutation removing it from the prefix reds eleven tests.

**The `@inputbuf_bom` allowance.** The references build it as `CONVERT(nvarchar(1), 0x0a00, 0)` — UTF-16LE `0x000A`, a line feed. A production graph confirms that is exactly right: the victim's element content is `"\nProc [Database Id = N Object Id = M]   "`, leading line feed and trailing spaces. Both collectors already `.Trim()` that, so the line feed is gone before the predicate sees it — but a real byte-order mark is not, because .NET classifies U+FEFF as a format character rather than whitespace. `TheBom_SurvivesTheTrimBothCallersAlreadyApply` asserts that survival, so the BOM fixture is a pin over a reachable input rather than a hypothetical one, and the end-to-end deadlock fixtures include a BOM-prefixed graph that goes through the real XML parse and the real trim.

**Qualified output — and this one departs from #3307 on purpose.** #3307 asks for `OBJECT_SCHEMA_NAME + '.' + OBJECT_NAME`, justified as "matching how Involved Objects already renders". The justification is checkable and it measures the other way: `Involved Objects` is three-part. `AlertIncidentRenderTests` pins `SalesDB.dbo.Orders`, and it is built from the deadlock graph's own `keylock/@objectname`, which the engine writes three-part. The same production graph writes a PROCEDURE three-part too, in `frame/@procname`. So two parts is what would have made this field the odd one out — the exact thing qualifying it was for. The resolution is `database.schema.object`, the database name is projected as its own column and required with the other two, and `TheQualificationMatchesEveryOtherObjectNameInTheSameAlert` pins the comparison rather than the preference. Reducing it to two parts is a one-line change and that pin is what names the decision.

## The regression this avoids by construction

`NULL + N'.' + NULL` is NULL in T-SQL, so a reference-faithful server-side concatenation blanks the field for exactly the cases where resolution legitimately fails: the object dropped between the event and the lookup, or a monitoring login without access to that database. This projects the parts separately and drops any pair missing one, so the raw placeholder survives. An object id is a worse answer than a name and a much better one than nothing — never blank, never "unknown".

## Scope

Both surfaces are fixed: `deadlocks` (`victim_sql_text`) and `blocked_process_report` (`blocked_sql_text` and `blocking_sql_text`). No store column, no migration rung, no viewer change — the resolved name replaces the placeholder in the value that was already being stored, upstream of `AlertContextBuilders`.

#3307 also asks whether the `sys.dm_exec_requests`-derived surfaces carry the same placeholder. They do not, and this was checked rather than assumed: the four collectors that read query text (`DmvBlockingSnapshotCollector`, `QuerySnapshotsCollector`, `QueryStatsCollector`, `ProcedureStatsCollector`) all go through `sys.dm_exec_sql_text`, which returns a procedure's BODY. Nothing in the tree reads `sys.dm_exec_input_buffer` or `DBCC INPUTBUFFER`, and the placeholder is an input-buffer rendering — so `<inputbuf>` in the two XE graphs is the whole population.

One documented gap: the supplemental seam does not run on the Azure SQL DB per-database path, so those rows keep the raw placeholder. That is the same degradation as a failed lookup rather than a separate outcome — `OBJECT_NAME` cannot read another database's metadata on Azure SQL DB anyway, so the lookup would return NULL for the rows the placeholder survives on.

## Verification

`Lite.Tests` and `Darling.Tests` cannot run on macOS, so the actual test sources were compiled into a `net10.0` console harness with an xunit shim and run: 57 pass, 0 fail, 14 of them `async Task` tests genuinely awaited. Separately, 97 whole-tree guard tests (`TsqlConventionGuardTests`, `DocCommentHygieneTests`, `DarlingPathFilterGateTests`) were compiled and run the same way — all pass, including the T-SQL convention detector over the new query literal and the frozen enumeration of T-SQL its marker set cannot see.

Sixteen mutations against the committed pins, each restored and hash-verified byte-for-byte, all red:

| mutation | tests red |
|---|---|
| drop the BOM from the leading-noise skip | 3, incl. the end-to-end graph |
| drop whitespace from the leading-noise skip | 1 |
| drop the literal `[` from the prefix | 11 |
| concatenate an empty part instead of dropping it | 1 |
| accept a NULL part and concatenate it | 3 |
| stop requiring the database name specifically | 1 |
| blank the field when the lookup could not answer | 2 |
| build a lookup even when nothing needs resolving | 3 |
| return the bare object name | 5 |
| return the references' two-part name | 5 |
| drop the `DB_NAME` column from the lookup | 1 |
| stop requiring the closing bracket at all | 2 |
| require the bracket but allow anything after it | 1 |
| drop `OPTION(RECOMPILE)` from the lookup | 1 |
| never register the deadlock victim's placeholder | 2 |
| never register the blocked-process placeholders | 1 |

The harness itself was mutated too, because a pin is only as good as the thing reporting it: with the runner's `await` crippled, the same broken product reported 0 failures. With it restored, three tests red. So the await is what catches an async failure, not the pass counter.

## Review

`claude[bot]` found one real thing and it is fixed: `TryParse` accepted anything whose *prefix* matched the placeholder, while `Resolve` replaces the whole input — so trailing content would have been silently discarded rather than declined, and the doc comment's "full shape" claim was not what the code enforced. The closing bracket plus a padding-only tail are now part of the matched shape, with two fixtures (`…] and then some`, `…1790404501x`) and two mutations covering it. A value truncated *before* the bracket still parses: the ids are what is being read, and declining would throw away the only answer available.

## Follow-up worth a decision, not carried here

The graph already contains the answer. `frame/@procname` on the victim's execution stack is the resolved three-part procedure name, written by the engine, needing no round trip and no metadata access — so it would cover precisely the rows this lookup cannot: a dropped object, or a database the monitoring login cannot read.

It is not a drop-in replacement, which is why it is not in this change. The `<inputbuf>` placeholder names the OUTERMOST procedure — the one invoked as an RPC — while `executionStack` lists frames innermost-first, so with nested procedures the first frame's `procname` is a different object than the id in the inputbuf. Taking it would mean relying on frame order to identify the outermost frame, where `OBJECT_NAME` resolves the exact id the placeholder names. The measurement that would decide: across captured graphs, how often does a placeholder-carrying process have more than one execution-stack frame, and does the last frame's `procname` agree with what `OBJECT_NAME` returns for the inputbuf's id.

## CHANGELOG entry text

Not applied here — every lane appends to the same `[Unreleased]` block. Under `### Fixed`:

```
- A deadlock or blocked-process report whose statement sat inside a stored procedure showed SQL Server's unresolved `Proc [Database Id = N Object Id = M]` placeholder instead of the procedure name. Both collectors now resolve it to `database.schema.object` with one batched lookup per collection cycle, matching how the rest of the alert qualifies object names, and keep the raw placeholder when the object has been dropped or the monitoring login cannot see its database (#3307).
```
