### PR TITLE
Force-resolve + reconcile custom-alert state on disable/delete (#3305)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertTeardownLiveTests.cs
+++ b/Darling/Darling.Tests/CustomAlertTeardownLiveTests.cs
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using PerformanceMonitor.Alerting;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3305 gated live round-trips (DARLING_TEST_PG): force-resolve + reconcile custom-alert state on rule
+/// disable/delete. Deleting a rule cascades its <c>custom_alert_state</c> rows away silently, so the delete path
+/// must resolve any open incident (write the recovery row) BEFORE the cascade; disabling neither deletes nor
+/// cascades, so a sweep reconcile force-resolves the orphaned incident and cleans its state. These prove both
+/// against a real store (the JOIN queries and the FK cascade cannot be exercised without Postgres).
+/// </summary>
+[Collection("live-postgres")]
+public sealed class CustomAlertTeardownLiveTests
+{
+    private const string SampleDefinition =
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":0.25},\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1}}";
+
+    private sealed class NoopDeliverer : IAlertDeliverer
+    {
+        public Task DeliverAsync(AlertOutcome outcome, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private static string RequireLivePostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string (owner/superuser) to run the custom-alert teardown live tests.");
+        return connectionString!;
+    }
+
+    private static async Task<NpgsqlDataSource> MigrateAndOpenAsync(string connectionString, CancellationToken ct)
+    {
+        await using (var migrate = new NpgsqlConnection(connectionString))
+        {
+            await migrate.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(migrate, ct);
+        }
+
+        var dataSourceConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            SearchPath = "collect,config,public",
+        }.ConnectionString;
+
+        return NpgsqlDataSource.Create(dataSourceConnectionString);
+    }
+
+    private static async Task<int> CountAlertLogAsync(NpgsqlDataSource dataSource, string metricName, int serverId, CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand(
+            "SELECT COUNT(*) FROM config_alert_log WHERE metric_name = $1 AND server_id = $2");
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = metricName });
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        return Convert.ToInt32(await command.ExecuteScalarAsync(ct));
+    }
+
+    private static CustomAlertRuleState Firing(int ruleVersion)
+    {
+        var evaluatedAt = new DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc);
+        return new CustomAlertRuleState(
+            new PersistenceState(ConsecutiveBreaches: 3, ConsecutiveClears: 0, Firing: true),
+            ruleVersion, "Critical", evaluatedAt, evaluatedAt.AddSeconds(60));
+    }
+
+    [Fact]
+    public async Task Delete_FiringRule_WritesRecoveryRow_ThenCascadesStateAway()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = await MigrateAndOpenAsync(connectionString, ct);
+
+        var rules = new CustomAlertRuleStore(dataSource);
+        var state = new CustomAlertStateStore(dataSource);
+
+        var ruleName = "car_del_" + Guid.NewGuid().ToString("N");
+        const int serverId = 990101;
+        var bodySucceeded = false;
+        try
+        {
+            var created = Assert.IsType<CustomAlertRuleResult.Ok>(
+                await rules.CreateAsync(ruleName, null, SampleDefinition, true, "test", ct));
+            var ruleId = created.Rule!.Id;
+            await state.SaveAsync(ruleId, serverId, Firing(created.Rule!.Version), ct);
+
+            // The delete path force-resolves the open incident, then deletes (cascade drops the state).
+            Assert.IsType<CustomAlertRuleResult.Ok>(
+                await CustomAlertEvaluator.ResolveAndDeleteRuleAsync(dataSource, ruleId, logger: null, ct));
+
+            // A recovery row was written for the firing subject BEFORE the cascade removed its state.
+            Assert.Equal(1, await CountAlertLogAsync(dataSource, ruleName + " Resolved", serverId, ct));
+            // State is gone (FK cascade) and so is the rule.
+            Assert.Empty(await state.ListForRuleAsync(ruleId, ct));
+            Assert.IsType<CustomAlertRuleResult.NotFound>(await rules.GetAsync(ruleId, ct));
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DeleteTestRowsAsync(cleanup, ruleName, serverId, cleanupCt);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task Reconcile_DisabledFiringRule_ResolvesAndClearsState_KeepingTheRuleRow()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = await MigrateAndOpenAsync(connectionString, ct);
+
+        var rules = new CustomAlertRuleStore(dataSource);
+        var state = new CustomAlertStateStore(dataSource);
+
+        var ruleName = "car_dis_" + Guid.NewGuid().ToString("N");
+        const int serverId = 990202;
+        var bodySucceeded = false;
+        try
+        {
+            var created = Assert.IsType<CustomAlertRuleResult.Ok>(
+                await rules.CreateAsync(ruleName, null, SampleDefinition, true, "test", ct));
+            var ruleId = created.Rule!.Id;
+            await state.SaveAsync(ruleId, serverId, Firing(created.Rule!.Version), ct);
+
+            // Disable the rule (does NOT delete or cascade — the firing state row persists, orphaned).
+            var disabled = Assert.IsType<CustomAlertRuleResult.Ok>(
+                await rules.UpdateAsync(ruleId, ruleName, null, SampleDefinition, enabled: false, created.Rule!.Version, "test", ct));
+            Assert.False(disabled.Rule!.Enabled);
+
+            // Build the monitored map from the real registry PLUS this test's synthetic server, so a real
+            // enabled rule on the store is left in scope (kept) — only the disabled rule is torn down, and by the
+            // "disabled" reason rather than "out of scope".
+            var monitored = await BuildMonitoredMapAsync(dataSource, ct);
+            monitored[serverId] = ("syn_storage", "SynServer");
+
+            var evaluator = new CustomAlertEvaluator(
+                rules, state, dataSource /* viewer: unused by reconcile */, new NoopDeliverer(),
+                isAlertMuted: null, new PgAlertHistoryStore(dataSource), defaultIntervalSeconds: 60,
+                cacheTtl: TimeSpan.Zero /* force a fresh rule read */, NullLogger.Instance);
+
+            await evaluator.ReconcileStateAsync(monitored, ct);
+
+            // The orphaned incident was force-resolved and its state cleaned, but the (disabled) rule row remains.
+            Assert.Equal(1, await CountAlertLogAsync(dataSource, ruleName + " Resolved", serverId, ct));
+            Assert.Empty(await state.ListForRuleAsync(ruleId, ct));
+            Assert.IsType<CustomAlertRuleResult.Ok>(await rules.GetAsync(ruleId, ct));
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DeleteTestRowsAsync(cleanup, ruleName, serverId, cleanupCt);
+            });
+        }
+    }
+
+    private static async Task<Dictionary<int, (string StorageName, string DisplayName)>> BuildMonitoredMapAsync(
+        NpgsqlDataSource dataSource, CancellationToken ct)
+    {
+        var map = new Dictionary<int, (string, string)>();
+        await using var command = dataSource.CreateCommand(
+            "SELECT server_id, COALESCE(name, server_id::text) FROM config_monitored_servers");
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var name = reader.GetString(1);
+            map[reader.GetInt32(0)] = (name, name);
+        }
+
+        return map;
+    }
+
+    private static async Task DeleteTestRowsAsync(NpgsqlConnection cleanup, string ruleName, int serverId, CancellationToken ct)
+    {
+        using (var rule = new NpgsqlCommand("DELETE FROM config.custom_alert_rules WHERE name = $1", cleanup))
+        {
+            rule.Parameters.AddWithValue(ruleName);
+            await rule.ExecuteNonQueryAsync(ct);
+        }
+
+        // config_alert_log has no FK to the rule, so the recovery rows this test wrote must be cleaned explicitly.
+        using var log = new NpgsqlCommand("DELETE FROM config.config_alert_log WHERE server_id = $1", cleanup);
+        log.Parameters.AddWithValue(serverId);
+        await log.ExecuteNonQueryAsync(ct);
+    }
+}

--- a/Darling/Darling.Tests/CustomAlertTeardownTests.cs
+++ b/Darling/Darling.Tests/CustomAlertTeardownTests.cs
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Darling.Service;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3305: the pure teardown-decision the state reconcile runs per persisted (rule, server) row. A DISABLED
+/// rule's state is orphaned (the evaluator's enabled-only sweep skips it, so its open incident never resolves
+/// on its own); an ENABLED rule's state for a server that has left its scope — or left monitoring entirely — is
+/// stale. Both are torn down (force-resolved if firing, then deleted). The DB orchestration is covered live in
+/// <c>CustomAlertTeardownLiveTests</c>; this pins the branch logic.
+/// </summary>
+public class CustomAlertTeardownTests
+{
+    private static CustomAlertRuleDefinition AllScope() => Parse(
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1},\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1000}}");
+
+    private static CustomAlertRuleDefinition ServersScope(string server) => Parse(
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
+        "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1000},\"scope\":{\"mode\":\"servers\",\"servers\":[\"" + server + "\"]}}");
+
+    private static CustomAlertRuleDefinition Parse(string json)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(json);
+        Assert.Null(error);
+        Assert.NotNull(def);
+        return def!;
+    }
+
+    [Fact]
+    public void DisabledRule_IsAlwaysTornDown_EvenWithNoDefinition()
+    {
+        // A disabled rule is not in the enabled cache, so the reconcile passes a null definition; disabled wins.
+        Assert.Equal(
+            CustomAlertEvaluator.TeardownReasonDisabled,
+            CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: false, definition: null, serverStorageName: "PROD01"));
+    }
+
+    [Fact]
+    public void EnabledRule_WithNoCachedDefinition_IsLeftAlone()
+    {
+        // Just-enabled or a stale cache: don't tear down on uncertainty.
+        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, definition: null, serverStorageName: "PROD01"));
+    }
+
+    [Fact]
+    public void EnabledAllScopeRule_WithAMonitoredServer_IsKept()
+    {
+        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, AllScope(), serverStorageName: "PROD01"));
+    }
+
+    [Fact]
+    public void EnabledServersScopeRule_ServerInScope_IsKept()
+    {
+        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, ServersScope("PROD01"), serverStorageName: "PROD01"));
+    }
+
+    [Fact]
+    public void EnabledServersScopeRule_ServerOutOfScope_IsTornDown()
+    {
+        Assert.Equal(
+            CustomAlertEvaluator.TeardownReasonOutOfScope,
+            CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, ServersScope("PROD01"), serverStorageName: "PROD02"));
+    }
+
+    [Fact]
+    public void EnabledRule_ServerLeftMonitoring_IsTornDown_EvenForAllScope()
+    {
+        // A null storage name means the server_id is not in the monitored map any more — it was removed. Its
+        // firing state can never resolve on its own (the evaluator never sweeps a gone server), so tear it down
+        // even though an "all"-scoped rule would otherwise apply to it.
+        Assert.Equal(
+            CustomAlertEvaluator.TeardownReasonOutOfScope,
+            CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, AllScope(), serverStorageName: null));
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
@@ -409,6 +409,80 @@ public sealed class CustomAlertEvaluator
         }
     }
 
+    /// <summary>The reason a firing (rule, server) subject is force-resolved when its rule is disabled (#3305).</summary>
+    internal const string TeardownReasonDisabled = "the rule was disabled";
+
+    /// <summary>The reason a firing (rule, server) subject is force-resolved when the server has left the rule's
+    /// scope, or has been removed from monitoring entirely (#3305).</summary>
+    internal const string TeardownReasonOutOfScope = "the server is no longer in the rule's scope";
+
+    /// <summary>The reason a firing (rule, server) subject is force-resolved when the rule is deleted (#3305).</summary>
+    internal const string TeardownReasonDeleted = "the rule was deleted";
+
+    /// <summary>
+    /// Writes ONE recovery/resolution row for a teardown (#3305) — the SAME resolve idiom
+    /// <see cref="DeliverResolveAsync"/> uses (<c>BuildResolutionRecord</c> + <c>AlertFiringLog.Resolved</c>),
+    /// but keyed off an already-known (rule, server) rather than a live evaluation, and stating WHY (deleted /
+    /// disabled / out of scope) rather than a threshold recovery. Static so both the delete path and the sweep
+    /// reconcile can call it. The rule name is newline-stripped + length-capped before it reaches
+    /// <c>detail_text</c>, so a crafted name cannot re-open the mute-from-history spoof on the recovery row.
+    /// Failure-isolated: an audit-row write must never break a delete or a sweep.
+    /// </summary>
+    public static async Task WriteTeardownResolutionAsync(
+        IAlertHistoryStore historyStore, ILogger? logger,
+        long ruleId, string ruleName, int serverId, string serverName, string reason)
+    {
+        var safeName = SanitizeDisplayText(ruleName, CustomAlertRuleStore.MaxNameLength);
+        var metricName = MetricNameFor(ruleId);
+        var title = safeName + " Resolved";
+        var message = string.Create(CultureInfo.InvariantCulture, $"{serverName}: {safeName} resolved because {reason}");
+
+        logger?.LogInformation("{Line}", AlertFiringLog.Resolved(serverName, title, message));
+
+        try
+        {
+            await historyStore.RecordAlertAsync(DarlingSelfAlertEvaluator.BuildResolutionRecord(
+                new AlertResolution(serverId.ToString(CultureInfo.InvariantCulture), serverName, metricName, title, message)));
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning("Could not record custom alert teardown resolution for rule {Rule} on {Server}: {Message}",
+                ruleId, serverName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Force-resolves any OPEN incident of a rule and then deletes the rule (#3305). Reads the rule (for its
+    /// name) and its firing subjects and writes a recovery row for each BEFORE calling
+    /// <see cref="CustomAlertRuleStore.DeleteAsync"/> — because that delete's FK cascade drops the
+    /// <c>custom_alert_state</c> rows that say which (rule, server) pairs were firing, so the resolve must read
+    /// them first. Static (the MCP delete tool holds only the owner pool, not the singleton evaluator); the
+    /// evaluator's in-memory no-data map is pruned lazily on its next cache refresh. The resolve is best-effort
+    /// (its own failure isolation) so a resolve blip never blocks the delete the operator asked for.
+    /// </summary>
+    public static async Task<CustomAlertRuleResult> ResolveAndDeleteRuleAsync(
+        NpgsqlDataSource postgres, long ruleId, ILogger? logger, CancellationToken cancellationToken)
+    {
+        var ruleStore = new CustomAlertRuleStore(postgres);
+
+        var current = await ruleStore.GetAsync(ruleId, cancellationToken);
+        if (current is CustomAlertRuleResult.Ok ok && ok.Rule is not null)
+        {
+            var stateStore = new CustomAlertStateStore(postgres);
+            var firing = await stateStore.ListFiringWithNamesAsync(ruleId, cancellationToken);
+            if (firing.Count > 0)
+            {
+                var historyStore = new PgAlertHistoryStore(postgres, logger);
+                foreach (var (serverId, serverName) in firing)
+                {
+                    await WriteTeardownResolutionAsync(historyStore, logger, ruleId, ok.Rule.Name, serverId, serverName, TeardownReasonDeleted);
+                }
+            }
+        }
+
+        return await ruleStore.DeleteAsync(ruleId, cancellationToken);
+    }
+
     private async Task<IReadOnlyList<ParsedRule>> GetEnabledRulesAsync(CancellationToken cancellationToken)
     {
         // Lock-free by design: the refresh is an idempotent read of a tiny table, so a rare duplicate
@@ -557,6 +631,119 @@ public sealed class CustomAlertEvaluator
         }
 
         return new CustomAlertHealthReport(_brokenRules, neverFiring);
+    }
+
+    /// <summary>
+    /// Decides whether one persisted (rule, server) state row should be TORN DOWN (#3305): a disabled rule's
+    /// state is orphaned (the evaluator's <c>ListEnabledAsync</c> skips it, so its incident never resolves on its
+    /// own), and an enabled rule's state for a server that has left its scope — or left monitoring entirely
+    /// (<paramref name="serverStorageName"/> null) — is stale. Returns the teardown reason, or null to KEEP the
+    /// row. Conservative on uncertainty: an enabled rule whose definition is not currently in the cache
+    /// (<paramref name="definition"/> null — just enabled, or a stale cache) is left alone rather than torn down.
+    /// Pure so both teardown cases are unit-testable without a store.
+    /// </summary>
+    internal static string? ClassifyStateTeardown(
+        bool ruleEnabled, CustomAlertRuleDefinition? definition, string? serverStorageName)
+    {
+        if (!ruleEnabled)
+        {
+            return TeardownReasonDisabled;
+        }
+
+        if (definition is null)
+        {
+            // Enabled but its definition is not in the cache this pass — don't tear down on uncertainty.
+            return null;
+        }
+
+        if (serverStorageName is null || !definition.AppliesTo(serverStorageName))
+        {
+            return TeardownReasonOutOfScope;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reconciles <c>custom_alert_state</c> against the live rules + monitored fleet (#3305): force-resolves and
+    /// cleans the state of DISABLED rules and of servers that have left a rule's scope. Deleted rules need no
+    /// handling here — their state cascaded away and their open incidents were resolved on the delete path
+    /// (<see cref="ResolveAndDeleteRuleAsync"/>). Runs on the fleet-global health cadence. Failure-isolated per
+    /// row and at each load, so a bad row or a store blip never stops the sweep (it only ever propagates
+    /// cancellation).
+    /// </summary>
+    /// <param name="monitoredServers">The current fleet: server id → (storage name for the scope check, display
+    /// name for the resolution row). A server absent from this map has left monitoring.</param>
+    public async Task ReconcileStateAsync(
+        IReadOnlyDictionary<int, (string StorageName, string DisplayName)> monitoredServers,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<ParsedRule> parsed;
+        try
+        {
+            parsed = await GetEnabledRulesAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Custom alert reconcile: rule load failed: {Message}", ex.Message);
+            return;
+        }
+
+        var definitionsById = parsed.ToDictionary(p => p.Row.Id, p => p.Definition);
+
+        IReadOnlyList<CustomAlertStateRow> rows;
+        try
+        {
+            rows = await _stateStore.ListAllWithRuleAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Custom alert reconcile: state load failed: {Message}", ex.Message);
+            return;
+        }
+
+        foreach (var row in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var storageName = monitoredServers.TryGetValue(row.ServerId, out var server) ? server.StorageName : null;
+            var definition = definitionsById.TryGetValue(row.RuleId, out var def) ? def : null;
+            var reason = ClassifyStateTeardown(row.RuleEnabled, definition, storageName);
+            if (reason is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                if (row.Firing)
+                {
+                    var serverName = monitoredServers.TryGetValue(row.ServerId, out var s)
+                        ? s.DisplayName
+                        : row.ServerId.ToString(CultureInfo.InvariantCulture);
+                    await WriteTeardownResolutionAsync(_historyStore, _logger, row.RuleId, row.RuleName, row.ServerId, serverName, reason);
+                }
+
+                await _stateStore.DeleteAsync(row.RuleId, row.ServerId, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Custom alert reconcile: teardown of rule {Rule} on server {Server} failed: {Message}",
+                    row.RuleId, row.ServerId, ex.Message);
+            }
+        }
     }
 }
 

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertStateStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertStateStore.cs
@@ -71,6 +71,23 @@ SELECT server_id, firing FROM custom_alert_state WHERE rule_id = $1";
     /// $1 rule_id, $2 server_id.</summary>
     public const string DeleteSql = "DELETE FROM custom_alert_state WHERE rule_id = $1 AND server_id = $2";
 
+    /// <summary>The FIRING (server_id, resolved server name) subjects of one rule (#3305), for force-resolving an
+    /// open incident on the delete path BEFORE the FK cascade drops the state. The name is the monitored-server
+    /// registry's, falling back to the id when the server itself is already gone. $1 rule_id.</summary>
+    public const string ListFiringWithNamesSql = @"
+SELECT s.server_id, COALESCE(m.name, s.server_id::text)
+FROM custom_alert_state s
+LEFT JOIN config_monitored_servers m ON m.server_id = s.server_id
+WHERE s.rule_id = $1 AND s.firing = TRUE";
+
+    /// <summary>Every state row joined to its rule's name + enabled flag (#3305 reconcile). Rows of a DELETED
+    /// rule are absent (the FK cascade already dropped them), so this reaches only DISABLED rules (to force-resolve
+    /// + clean) and enabled rules whose servers may have left scope.</summary>
+    public const string ListAllWithRuleSql = @"
+SELECT s.rule_id, s.server_id, s.firing, r.name, r.enabled
+FROM custom_alert_state s
+JOIN custom_alert_rules r ON r.id = s.rule_id";
+
     /// <summary>
     /// Loads one subject's state for the rule at <paramref name="currentRuleVersion"/>. Returns
     /// <see cref="CustomAlertRuleState.Fresh"/> when no row exists. When the stored <c>rule_version</c> differs
@@ -158,6 +175,39 @@ SELECT server_id, firing FROM custom_alert_state WHERE rule_id = $1";
         await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
+    /// <summary>Lists the FIRING subjects of one rule with a resolved server name (#3305 delete path). $1 rule_id.</summary>
+    public async Task<IReadOnlyList<(int ServerId, string ServerName)>> ListFiringWithNamesAsync(
+        long ruleId, CancellationToken cancellationToken = default)
+    {
+        var rows = new List<(int, string)>();
+        await using var command = _dataSource.CreateCommand(ListFiringWithNamesSql);
+        command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
+        command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = ruleId });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add((reader.GetInt32(0), reader.GetString(1)));
+        }
+
+        return rows;
+    }
+
+    /// <summary>Lists every state row joined to its rule's name + enabled flag (#3305 reconcile).</summary>
+    public async Task<IReadOnlyList<CustomAlertStateRow>> ListAllWithRuleAsync(CancellationToken cancellationToken = default)
+    {
+        var rows = new List<CustomAlertStateRow>();
+        await using var command = _dataSource.CreateCommand(ListAllWithRuleSql);
+        command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new CustomAlertStateRow(
+                reader.GetInt64(0), reader.GetInt32(1), reader.GetBoolean(2), reader.GetString(3), reader.GetBoolean(4)));
+        }
+
+        return rows;
+    }
+
     private static void AddNullableTimestamp(NpgsqlCommand command, DateTime? value) =>
         command.Parameters.Add(new NpgsqlParameter
         {
@@ -189,3 +239,8 @@ public sealed record CustomAlertRuleState(
     public static CustomAlertRuleState Fresh(int ruleVersion) =>
         new(PersistenceState.Initial, ruleVersion, null, null, null);
 }
+
+/// <summary>One <c>custom_alert_state</c> row joined to its rule's name + enabled flag — the #3305 reconcile's
+/// unit of work: whether this (rule, server) subject should be torn down (rule disabled, or server out of scope)
+/// and, if it is <see cref="Firing"/>, force-resolved first.</summary>
+public sealed record CustomAlertStateRow(long RuleId, int ServerId, bool Firing, string RuleName, bool RuleEnabled);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1945,6 +1945,11 @@ public sealed class DarlingWorker : BackgroundService
             {
                 _nextCustomAlertHealthCheckUtc = DateTime.UtcNow.Add(s_customAlertHealthInterval);
                 await EvaluateCustomAlertRuleHealthAsync(servers, stoppingToken);
+
+                /* #3305: on the same cadence, reconcile persisted state — force-resolve + clean the state of
+                   disabled rules (which the enabled-only sweep would orphan) and of servers that have left a
+                   rule's scope. Deleted rules are resolved on the delete path (their state cascades away). */
+                await ReconcileCustomAlertStateAsync(servers, stoppingToken);
             }
 
             /* #1581: the compression-job self-heal backstop. TimescaleDB compression policy jobs can silently
@@ -4510,10 +4515,10 @@ LIMIT 1";
     /// re-parse the enabled rules against the live catalog and flag broken / never-firing ones (the current
     /// monitored-storage-name set feeds the 0-server-scope case), then hands the report to
     /// <see cref="DarlingSelfAlertEvaluator.EvaluateCustomRuleHealthAsync"/>, which raises ONE aggregated
-    /// self-health alert. Both halves are failure-isolated internally (BuildHealthReportAsync returns an empty
-    /// report on a load error rather than resolving a standing alert; the Evaluate* wrapper contains a throwing
-    /// mute seam), matching the disk-pressure posture — this sweep-loop body has no catch-all of its own. Only
-    /// called when both evaluators are non-null (guarded at the call site).
+    /// self-health alert. Both halves are failure-isolated internally (BuildHealthReportAsync returns null on a
+    /// load error and this method then HOLDS the standing alert rather than resolving it; the Evaluate* wrapper
+    /// contains a throwing mute seam), matching the disk-pressure posture — this sweep-loop body has no catch-all
+    /// of its own. Only called when both evaluators are non-null (guarded at the call site).
     /// </summary>
     private async Task EvaluateCustomAlertRuleHealthAsync(List<ServerLoopState> servers, CancellationToken cancellationToken)
     {
@@ -4529,6 +4534,24 @@ LIMIT 1";
         {
             await _selfAlerts!.EvaluateCustomRuleHealthAsync(report, cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// #3305: the fleet-level custom-alert-state reconcile. Force-resolves and cleans the persisted state of
+    /// DISABLED rules (whose open incidents the evaluator's enabled-only sweep would otherwise orphan forever)
+    /// and of servers that have left a rule's scope. Deleted rules are handled on the delete path instead
+    /// (their state cascades away). Hands the evaluator the current fleet — server id → (storage name for the
+    /// scope check, display name for the recovery row); a server absent from it has left monitoring. Runs on
+    /// the fleet-global health cadence; the evaluator's method is failure-isolated per row so this never stops
+    /// the sweep. Only called when the custom-alert evaluator is non-null (guarded at the call site).
+    /// </summary>
+    private async Task ReconcileCustomAlertStateAsync(List<ServerLoopState> servers, CancellationToken cancellationToken)
+    {
+        var monitored = servers
+            .Where(s => !s.Retired)
+            .ToDictionary(s => s.Config.ServerId, s => (s.Config.StorageName, s.Config.DisplayName));
+
+        await _customAlertEvaluator!.ReconcileStateAsync(monitored, cancellationToken);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 using ModelContextProtocol.Server;
 using Npgsql;
@@ -234,16 +235,19 @@ public sealed class DarlingMcpCustomAlertTools
     [McpServerTool(Name = "delete_custom_alert_rule"), Description(
         "Deletes a saved custom alert rule by id. Returns {status:\"deleted\", rule_id:N} on success, or " +
         "{status:\"not_found\", ...} when no rule has that id. This is permanent, and it also drops the rule's " +
-        "accumulated per-server alert state (an open incident is torn down without delivering a resolve; " +
-        "disable the rule instead with update_custom_alert_rule enabled=false to keep its state).")]
+        "accumulated per-server alert state. Any OPEN incident for the rule is force-resolved first (a recovery " +
+        "row is written to alert history) so nothing is left showing as firing forever. To pause a rule without " +
+        "deleting it, set enabled=false with update_custom_alert_rule (its open incidents are resolved too).")]
     public static async Task<string> DeleteCustomAlertRule(
         NpgsqlDataSource postgres,
         [Description("The id of the rule to delete (from list_custom_alert_rules).")] long rule_id)
     {
         try
         {
-            var store = new CustomAlertRuleStore(postgres);
-            var result = await store.DeleteAsync(rule_id);
+            // #3305: resolve any open incident (write the recovery row) BEFORE the delete's FK cascade drops the
+            // state that says which (rule, server) pairs were firing. No logger on the MCP surface — the recovery
+            // row still writes; only the (optional) service-log line is skipped.
+            var result = await CustomAlertEvaluator.ResolveAndDeleteRuleAsync(postgres, rule_id, logger: null, CancellationToken.None);
             return result is CustomAlertRuleResult.Ok
                 ? JsonSerializer.Serialize(new { status = "deleted", rule_id }, McpHelpers.JsonOptions)
                 : Outcome("not_found", $"No custom alert rule with id {rule_id}.");


### PR DESCRIPTION
## What & why

Disabling or deleting a custom alert rule with an OPEN incident left it firing forever and orphaned its `config.custom_alert_state` row. Two distinct causes:

- **Delete** cascades the state rows away (`ON DELETE CASCADE`) *without* writing a recovery row — the incident just vanishes from state but stays "open" in history.
- **Disable** neither deletes nor cascades: the `firing=true` state persists, but the evaluator's enabled-only sweep skips the rule, so nothing ever resolves it.

## Changes

- **Delete path — `CustomAlertEvaluator.ResolveAndDeleteRuleAsync`** (static, works from the MCP surface that holds only the owner pool): reads the rule's firing subjects and writes ONE recovery row for each **before** calling the store's delete, because that delete's FK cascade drops the very state that says which `(rule, server)` pairs were firing. The MCP `delete_custom_alert_rule` tool routes through it; its description no longer claims an open incident is torn down without a resolve.
- **Disable + out-of-scope — `CustomAlertEvaluator.ReconcileStateAsync`**, run on the fleet-global health cadence: force-resolves and cleans the state of disabled rules and of servers that have left a rule's scope (or left monitoring entirely). The pure `ClassifyStateTeardown` decides per row; `DarlingWorker` builds the current fleet map and calls it after the health check.
- **`CustomAlertStateStore`**: `ListFiringWithNamesAsync` (delete path, firing rows + server name via `LEFT JOIN config_monitored_servers`) and `ListAllWithRuleAsync` (reconcile, all state joined to `name`/`enabled`) + a `CustomAlertStateRow` record.
- **`WriteTeardownResolutionAsync`** is the shared resolve idiom — mirrors `DeliverResolveAsync` (`BuildResolutionRecord` + `AlertFiringLog.Resolved`) — and reuses `SanitizeDisplayText` so a crafted rule name cannot re-open the mute-from-history spoof on the recovery row.
- **Stale-comment fix** (slice-2 review catch): `EvaluateCustomAlertRuleHealthAsync`'s doc now says `BuildHealthReportAsync` returns **null** on a load error and the worker HOLDS the standing alert — not "an empty report".

## Delete/resolve coordination decision

Resolve **before** delete, matching the store's own `DeleteAsync` contract (its doc already says *"the cascade drops the state rows, so the resolve delivery must happen first"*). The recovery write and the delete are separate statements (the history write opens its own connection), **not** one transaction — the resolve is best-effort audit, failure-isolated. The failure modes are benign: a resolve failure logs and the delete still proceeds (no orphaned incident, no worse than today); a delete-failure-after-resolve leaves only a premature recovery row that the incident's normal resolve later supersedes. Making it transactional would mean inlining/threading the history INSERT through the delete's connection for an audit row that the codebase already treats as best-effort everywhere else — not worth the coupling. The in-memory no-data map is cleaned lazily by the slice-2 cache-refresh prune; the delivery-layer cooldown is keyed by the now-gone `metric_name` and simply never recurs.

Deleted rules are intentionally NOT handled by the reconcile (their state has already cascaded away and their incidents were resolved on the delete path); the reconcile only reaches disabled + out-of-scope, which is why it's a separate mechanism.

## Tests

- `Darling.Tests/CustomAlertTeardownTests` (6, no DB): every `ClassifyStateTeardown` branch — disabled always torn down (even with no cached definition), enabled+uncached left alone, all-scope/in-scope kept, servers-scope out-of-scope torn down, and a server that left monitoring torn down even for an all-scope rule.
- `Darling.Tests/CustomAlertTeardownLiveTests` (2, gated on `DARLING_TEST_PG`): delete a firing rule -> recovery row written + state gone via FK cascade + rule gone; disable a firing rule -> reconcile writes the recovery row + clears the state, keeping the (disabled) rule row. Both build a monitored map from the real registry so a real enabled rule on the store stays in scope.

Full local suites (from a worktree): **Darling.Tests 8624 total / 3 failed**, **Lite.Tests 3646 total / 4 failed** — all 7 are the same pre-existing environmental artifacts as slices 1-2 (source-tree-scan guards that resolve 0 files from a `.claude/worktrees/` checkout, plus one TLS-cert platform test); my +8 tests pass (the 2 live ones skip without `DARLING_TEST_PG` and run in CI's `darling-pg` gate). The #3013 swallowed-read census stays green (the new catches all live in `CustomAlertEvaluator.cs`, outside its scope). Build: **0 Warning(s) / 0 Error(s)**.

Part of #3285. Addresses #3305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
