### PR TITLE
Stop analysis-finding alerts delivering their Diagnosis facts twice

### DIFF
--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -722,7 +722,7 @@ public sealed class AlertDeliveryChannelTests
         Assert.Equal(2, CountOccurrences(message, "before raising MAXDOP"));
     }
 
-    /* ─────────── #3313: an analysis finding's Diagnosis facts, delivered once and stored in full ─────────── */
+    /* ────── #3302 regression: a finding's Diagnosis facts, delivered once and stored in full ────── */
 
     /// <summary>
     /// The counting marker for the two tests below. It appears exactly ONCE per rendering of the Diagnosis
@@ -773,7 +773,7 @@ public sealed class AlertDeliveryChannelTests
     };
 
     /// <summary>
-    /// #3313, on the wire. <c>FindingMessageFormatter</c> is a third producer of
+    /// The regression, on the wire. <c>FindingMessageFormatter</c> is a third producer of
     /// <c>(Context, DetailText)</c> pairs that #3297 never touched: <c>BuildContext</c> puts story /
     /// severity / notify threshold / confidence / fact count / database / window into a <c>Diagnosis</c>
     /// item, and <c>DetailText</c> formats the same values with different labels and a different window
@@ -872,7 +872,7 @@ public sealed class AlertDeliveryChannelTests
         var body = Assert.Single(endpoint.Bodies);
         Assert.Equal(1, CountOccurrences(body, FindingDatabaseMarker));
 
-        /* And the row kept the prose whole, byte for byte what it held before #3313. */
+        /* And the row kept the prose whole, byte for byte what it held before this change. */
         var record = Assert.Single(history.Records);
         Assert.Equal(PersistedFindingDetailText, record.DetailText);
         Assert.NotNull(record.ContextJson);

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -18,6 +18,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using PerformanceMonitor.Alerting;
+using PerformanceMonitor.Analysis;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Viewer;
@@ -721,6 +722,211 @@ public sealed class AlertDeliveryChannelTests
         Assert.Equal(2, CountOccurrences(message, "before raising MAXDOP"));
     }
 
+    /* ─────────── #3313: an analysis finding's Diagnosis facts, delivered once and stored in full ─────────── */
+
+    /// <summary>
+    /// The counting marker for the two tests below. It appears exactly ONCE per rendering of the Diagnosis
+    /// facts — as the <c>Database</c> field of the structured item, and as the <c>Database:</c> line of the
+    /// prose — and nowhere else in any payload: not in the metric name (category + hash), not in the
+    /// current value (root fact key + value), not in the thresholds, not in the static advice prose, and
+    /// not in the email subject. So an occurrence count over a delivered body IS the number of times those
+    /// facts arrived.
+    /// </summary>
+    private const string FindingDatabaseMarker = "LedgerArchive_7731";
+
+    /// <summary>
+    /// What <c>config_alert_log.detail_text</c> holds for an analysis row. A frozen list of lines, not a
+    /// re-derivation from <c>FindingMessageFormatter</c> — which this assembly cannot see anyway, the
+    /// Notifications project granting <c>InternalsVisibleTo</c> to Lite and Dashboard but not here. That
+    /// limitation is useful: the expectation cannot follow the code it pins.
+    /// </summary>
+    private static string PersistedFindingDetailText => string.Join(Environment.NewLine, new[]
+    {
+        "  Story: CPU_SPIKE → PLAN_REGRESSION",
+        "  Severity: 1.80 (notify threshold 1.5)",
+        "  Confidence: 0.67",
+        "  Facts in chain: 2",
+        "  Database: " + FindingDatabaseMarker,
+        "  Window: 2026-09-11 01:00:00Z - 2026-09-11 02:00:00Z"
+    });
+
+    /// <summary>
+    /// A realistic <c>cpu_pressure</c> finding with every Diagnosis field populated and a FIXED window, so
+    /// the expected detail text above can be a literal.
+    /// </summary>
+    private static AnalysisFinding CpuFinding() => new()
+    {
+        ServerId = 1,
+        ServerName = "PROD01",
+        Category = "cpu_pressure",
+        StoryPath = "CPU_SPIKE → PLAN_REGRESSION",
+        StoryPathHash = "diag000000000001",
+        IncidentId = string.Empty,
+        Severity = 1.8,
+        Confidence = 0.67,
+        FactCount = 2,
+        RootFactKey = "CPU_SPIKE",
+        RootFactValue = 92.5,
+        DatabaseName = FindingDatabaseMarker,
+        TimeRangeStart = new DateTime(2026, 9, 11, 1, 0, 0, DateTimeKind.Utc),
+        TimeRangeEnd = new DateTime(2026, 9, 11, 2, 0, 0, DateTimeKind.Utc)
+    };
+
+    /// <summary>
+    /// #3313, on the wire. <c>FindingMessageFormatter</c> is a third producer of
+    /// <c>(Context, DetailText)</c> pairs that #3297 never touched: <c>BuildContext</c> puts story /
+    /// severity / notify threshold / confidence / fact count / database / window into a <c>Diagnosis</c>
+    /// item, and <c>DetailText</c> formats the same values with different labels and a different window
+    /// separator. Different text, so <c>AlertDetailText.ProseForDelivery</c>'s equality never fires, so
+    /// every channel rendered those facts twice — on the largest alert category there is.
+    ///
+    /// <para>Driven through the REAL producer rather than a hand-built <c>FindingAlert</c>: the
+    /// declaration under test belongs to <c>AnalysisNotificationService</c>, and a hand-built record
+    /// would assert the arrangement instead of the behaviour. From there it is the whole Darling path —
+    /// <see cref="DarlingFindingAlertSender"/> through the shared send core, the fan-out and each payload
+    /// builder — read off the bytes that left the process.</para>
+    ///
+    /// <para>An occurrence COUNT rather than an absence. Asserting only that the prose is gone would pass
+    /// just as well if the structured context had been dropped instead, which is the opposite defect and
+    /// the more expensive one: the context carries the advice, the remediation T-SQL and the drill-down
+    /// that the prose does not.</para>
+    /// </summary>
+    [Fact]
+    public async Task AnAnalysisFinding_DeliversItsDiagnosisFactsOnce_OnEveryRedirectableChannel()
+    {
+        using var endpoint = new CapturingWebhookEndpoint();
+        using var smtp = new CapturingSmtpEndpoint();
+
+        var config = new DarlingConfig();
+        config.Webhooks.TeamsUrl = endpoint.Url;
+        config.Webhooks.SlackUrl = endpoint.Url;
+        config.Webhooks.GenericUrl = endpoint.Url;
+        config.Smtp.Host = "127.0.0.1";
+        config.Smtp.Port = smtp.Port;
+        config.Smtp.UseSsl = false;
+        config.Smtp.From = "monitor@example.invalid";
+        config.Smtp.To = "operator@example.invalid";
+
+        var settings = new DarlingAlertSettings(config);
+        var sender = new DarlingFindingAlertSender(
+            settings, new DiscardingHistoryStore(),
+            new WebhookAlertService(settings, DarlingAlertDeliverer.Branding,
+                NullLogger<WebhookAlertService>.Instance, new DiscardingHistoryStore()),
+            NullLogger.Instance);
+
+        var notifier = new AnalysisNotificationService(
+            sender, settings, f => f.ServerId.ToString(),
+            NullLogger<AnalysisNotificationService>.Instance);
+
+        await notifier.NotifyAsync(new[] { CpuFinding() });
+
+        var bodies = endpoint.Bodies;
+        Assert.Equal(3, bodies.Count);
+        Assert.All(bodies, body => Assert.Equal(1, CountOccurrences(body, FindingDatabaseMarker)));
+
+        /* Email, and both MIME parts: one occurrence per body, built by two different methods. */
+        var message = Assert.Single(smtp.Messages);
+        Assert.Equal(2, CountOccurrences(message, FindingDatabaseMarker));
+
+        /* The rendering that survived is the STRUCTURED one, which is the copy that carries the advice
+           and the remediation T-SQL. Its own labels, not the prose's, on every channel. */
+        Assert.All(bodies, body => Assert.Contains("Diagnosis", body, StringComparison.Ordinal));
+        Assert.All(bodies, body => Assert.DoesNotContain("Facts in chain", body, StringComparison.Ordinal));
+        Assert.Contains("Diagnosis", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Facts in chain", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The constraint the whole approach rests on. The obvious repair — make
+    /// <c>FindingMessageFormatter.DetailText</c> the flattening of its own context, as the thirteen
+    /// <c>AlertEngine</c> fire sites do — would change <c>config_alert_log.detail_text</c> for every
+    /// analysis row, and that column is read by the MCP alert reader, the triage endpoint and the Viewer's
+    /// detail pane, and PARSED by <c>AlertMuteContext.PopulateFromDetailText</c> for the mute pre-fill.
+    /// So the suppression is at delivery only, and that this is true of the STORED value is asserted here
+    /// rather than intended: same dispatch, channels configured, the row read off
+    /// <see cref="IAlertHistoryStore"/>.
+    /// </summary>
+    [Fact]
+    public async Task AnAnalysisFinding_PersistsItsProseDetailTextInFull_WhileTheChannelsRenderTheContext()
+    {
+        using var endpoint = new CapturingWebhookEndpoint();
+
+        var config = new DarlingConfig();
+        config.Webhooks.GenericUrl = endpoint.Url;
+
+        var settings = new DarlingAlertSettings(config);
+        var history = new CapturingHistoryStore();
+        var sender = new DarlingFindingAlertSender(
+            settings, history,
+            new WebhookAlertService(settings, DarlingAlertDeliverer.Branding,
+                NullLogger<WebhookAlertService>.Instance, history),
+            NullLogger.Instance);
+
+        var notifier = new AnalysisNotificationService(
+            sender, settings, f => f.ServerId.ToString(),
+            NullLogger<AnalysisNotificationService>.Instance);
+
+        await notifier.NotifyAsync(new[] { CpuFinding() });
+
+        /* The channel saw the facts once. */
+        var body = Assert.Single(endpoint.Bodies);
+        Assert.Equal(1, CountOccurrences(body, FindingDatabaseMarker));
+
+        /* And the row kept the prose whole, byte for byte what it held before #3313. */
+        var record = Assert.Single(history.Records);
+        Assert.Equal(PersistedFindingDetailText, record.DetailText);
+        Assert.NotNull(record.ContextJson);
+    }
+
+    /// <summary>
+    /// The other direction, without which the fix is indistinguishable from reverting #3297 for this seam:
+    /// "never deliver a finding's prose" satisfies both tests above. The suppression is the PRODUCER's
+    /// declaration, read off the record, so a producer whose prose carries something its context does not
+    /// still has it delivered — the #2109 AG alerts' <c>SET HADR RESUME</c> being the standing example,
+    /// and the one case <c>AlertDetailText.ProseForDelivery</c> was deliberately built not to drop.
+    ///
+    /// <para>Hand-built here, because no producer in the tree answers <c>true</c> today. That is the point
+    /// of putting the question on the record rather than hardcoding the answer in each sender: the next
+    /// producer gets to answer it, and this is what proves the answer is still read.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFindingWhoseProseIsNotARestatement_IsStillDelivered()
+    {
+        const string Remedy = "Fix the underlying cause, then resume it with ALTER DATABASE [Sales] SET HADR RESUME.";
+
+        using var endpoint = new CapturingWebhookEndpoint();
+
+        var config = new DarlingConfig();
+        config.Webhooks.GenericUrl = endpoint.Url;
+
+        var settings = new DarlingAlertSettings(config);
+        var history = new CapturingHistoryStore();
+        var sender = new DarlingFindingAlertSender(
+            settings, history,
+            new WebhookAlertService(settings, DarlingAlertDeliverer.Branding,
+                NullLogger<WebhookAlertService>.Instance, history),
+            NullLogger.Instance);
+
+        var independent = new FindingAlert(
+            "Analysis: ag_health [indep000]", "PROD01", "AG_DATABASE_SUSPENDED", "1.5", "1",
+            new AlertContext(), 1.8, 1.5, Remedy, DeliverDetailText: true);
+
+        await sender.SendFindingAlertAsync(independent);
+        Assert.Contains("SET HADR RESUME", Assert.Single(endpoint.Bodies), StringComparison.Ordinal);
+
+        /* The same alert declared a restatement: nothing on the wire, everything on the row. */
+        await sender.SendFindingAlertAsync(independent with
+        {
+            MetricName = "Analysis: ag_health [suppress]",
+            DeliverDetailText = false
+        });
+
+        Assert.Equal(2, endpoint.Bodies.Count);
+        Assert.DoesNotContain("SET HADR RESUME", endpoint.Bodies[1], StringComparison.Ordinal);
+        Assert.Equal(2, history.Records.Count);
+        Assert.All(history.Records, r => Assert.Equal(Remedy, r.DetailText));
+    }
+
     private static int CountOccurrences(string haystack, string needle)
     {
         int count = 0, index = 0;
@@ -1027,6 +1233,31 @@ public sealed class AlertDeliveryChannelTests
 
             _stop.Dispose();
         }
+    }
+
+    /// <summary>
+    /// <see cref="DiscardingHistoryStore"/> with the records kept, so a test can read what the row would
+    /// have held. Safe to read after the send has been awaited: <c>SendFindingAlertAsync</c> awaits its
+    /// own <c>RecordAlertAsync</c>.
+    /// </summary>
+    private sealed class CapturingHistoryStore : IAlertHistoryStore
+    {
+        public List<AlertHistoryRecord> Records { get; } = new();
+
+        public Task RecordAlertAsync(AlertHistoryRecord record)
+        {
+            Records.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastAlertTimeAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
     }
 
     private sealed class DiscardingHistoryStore : IAlertHistoryStore

--- a/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
+++ b/Darling/Darling.Tests/AlertDeliveryChannelTests.cs
@@ -838,8 +838,8 @@ public sealed class AlertDeliveryChannelTests
 
     /// <summary>
     /// The constraint the whole approach rests on. The obvious repair — make
-    /// <c>FindingMessageFormatter.DetailText</c> the flattening of its own context, as the thirteen
-    /// <c>AlertEngine</c> fire sites do — would change <c>config_alert_log.detail_text</c> for every
+    /// <c>FindingMessageFormatter.DetailText</c> the flattening of its own context, as every
+    /// <c>AlertEngine</c> fire site does — would change <c>config_alert_log.detail_text</c> for every
     /// analysis row, and that column is read by the MCP alert reader, the triage endpoint and the Viewer's
     /// detail pane, and PARSED by <c>AlertMuteContext.PopulateFromDetailText</c> for the mute pre-fill.
     /// So the suppression is at delivery only, and that this is true of the STORED value is asserted here

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingFindingAlertSender.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingFindingAlertSender.cs
@@ -66,6 +66,8 @@ public sealed class DarlingFindingAlertSender : IFindingAlertSender
     /// <see cref="IFindingAlertSender"/>: dispatches a composed analysis-finding alert.
     /// Lite's cadence — one combined alert-history row written unconditionally, carrying the
     /// numeric severity/threshold and the detail text — so no separate fallback row is needed.
+    /// <para>The channels get <see cref="FindingAlert.DeliveredProse"/> and the row gets
+    /// <c>DetailText</c>: two destinations, two values. See <see cref="FindingAlert"/>.</para>
     /// </summary>
     public async Task SendFindingAlertAsync(FindingAlert alert)
     {
@@ -77,17 +79,22 @@ public sealed class DarlingFindingAlertSender : IFindingAlertSender
         try
         {
             /* Findings are never muted here — the pipeline's mute filter dropped muted
-               stories before they became findings (Lite passes muted: false identically). */
+               stories before they became findings (Lite passes muted: false identically).
+               DeliveredProse, not DetailText: an analysis finding's prose restates the structured
+               context the channels already render, so delivering both prints the Diagnosis facts
+               twice. The persisted value below is unaffected. */
             var result = await _core.TrySendAsync(
                 alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue,
-                alert.ServerId, alert.Context, attemptChannels: true, detailText: alert.DetailText);
+                alert.ServerId, alert.Context, attemptChannels: true, detailText: alert.DeliveredProse);
 
             /* trayChannelPresent: false — the headless service has no tray; see DarlingAlertDeliverer. */
             var delivery = AlertDelivery.FromFanout(result, muted: false, trayChannelPresent: false);
 
             /* Always log the alert, regardless of channel status — the structured context
                persists as JSON alongside the flat detail_text, the numeric severity/threshold
-               in the double columns (Lite's shape). */
+               in the double columns (Lite's shape). DetailText in full here whatever the channels
+               were handed: this column is what the MCP reader, the triage endpoint and the Viewer's
+               detail pane render, and what the mute pre-fill parses. */
             string? contextJson = alert.Context is not null ? AlertContextSerializer.Serialize(alert.Context) : null;
             await _historyStore.RecordAlertAsync(new AlertHistoryRecord(
                 alert.ServerId, alert.ServerName, alert.MetricName,

--- a/Lite.Tests/AnalysisProseDeliveryTests.cs
+++ b/Lite.Tests/AnalysisProseDeliveryTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 namespace PerformanceMonitorLite.Tests;
 
 /// <summary>
-/// #3313: an analysis finding's Diagnosis facts reached every channel TWICE.
+/// A regression #3302 shipped: an analysis finding's Diagnosis facts reach every channel TWICE.
 ///
 /// <para>#3297 threaded each alert's prose <c>DetailText</c> through to all five delivery channels, gated
 /// on <c>AlertDetailText.ProseForDelivery</c> — which suppresses the prose when it is textually equal to
@@ -202,7 +202,7 @@ public class AnalysisProseDeliveryTests
     /// <summary>
     /// The constraint the whole approach rests on: suppressing at delivery must not change what is
     /// stored. Asserted on the record Lite's real <c>EmailAlertService</c> handed its history store,
-    /// against a frozen literal — the same text, byte for byte, that the pre-#3313 row held.
+    /// against a frozen literal — the same text, byte for byte, that the row held before this change.
     /// </summary>
     [Fact]
     public async Task ThePersistedDetailText_IsUnchanged_ByTheDeliverySuppression()

--- a/Lite.Tests/AnalysisProseDeliveryTests.cs
+++ b/Lite.Tests/AnalysisProseDeliveryTests.cs
@@ -1,0 +1,525 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #3313: an analysis finding's Diagnosis facts reached every channel TWICE.
+///
+/// <para>#3297 threaded each alert's prose <c>DetailText</c> through to all five delivery channels, gated
+/// on <c>AlertDetailText.ProseForDelivery</c> — which suppresses the prose when it is textually equal to
+/// the flattening of the alert's own structured context. <c>FindingMessageFormatter</c> is a third
+/// producer of <c>(Context, DetailText)</c> pairs and nothing in #3297 touched it: <c>BuildContext</c>
+/// puts story / severity / notify threshold / confidence / fact count / database / window into a
+/// <c>Diagnosis</c> item, and <c>DetailText</c> formats the SAME values with different labels
+/// ("Facts in chain" vs "Facts", one combined severity line vs two fields) and a different window
+/// separator. Different text, so the equality gate never fires, so both are delivered — on the largest
+/// alert category there is (CPU spikes, plan regressions, index and RCSI findings), on both SKUs.</para>
+///
+/// <para>The fix suppresses the prose at DELIVERY and leaves the PERSISTED value alone, because
+/// <c>FindingMessageFormatter.DetailText</c> is also <c>config_alert_log.detail_text</c> — read by the MCP
+/// alert reader, the triage endpoint and the Viewer's detail pane, and parsed by
+/// <c>AlertMuteContext.PopulateFromDetailText</c> for the mute pre-fill. Both halves are asserted here:
+/// what the channels render, and what the row keeps.</para>
+/// </summary>
+public class AnalysisProseDeliveryTests
+{
+    /// <summary>
+    /// The counting marker. It appears exactly ONCE per rendering of the Diagnosis facts — as the
+    /// <c>Database</c> field of the structured item, and as the <c>Database:</c> line of the prose — and
+    /// nowhere else in any payload: not in the metric name (category + hash), not in the current value
+    /// (root fact key + value), not in the thresholds, not in the static advice prose, and not in the
+    /// email subject. So an occurrence count over a delivered body IS the number of times those facts
+    /// arrived, which is the quantity in question.
+    /// </summary>
+    private const string DatabaseMarker = "LedgerArchive_7731";
+
+    private const double NotifyThreshold = 1.5;
+
+    /// <summary>
+    /// A realistic <c>cpu_pressure</c> finding with every Diagnosis field populated and a FIXED window, so
+    /// the persisted detail text below can be a frozen literal rather than a re-derivation of the code
+    /// under test.
+    /// </summary>
+    private static AnalysisFinding Finding() => new()
+    {
+        ServerId = 1,
+        ServerName = "TestServer",
+        Category = "cpu_pressure",
+        StoryPath = "CPU_SPIKE → PLAN_REGRESSION",
+        StoryPathHash = "diag000000000001",
+        IncidentId = string.Empty,
+        Severity = 1.8,
+        Confidence = 0.67,
+        FactCount = 2,
+        RootFactKey = "CPU_SPIKE",
+        RootFactValue = 92.5,
+        DatabaseName = DatabaseMarker,
+        TimeRangeStart = new DateTime(2026, 9, 11, 1, 0, 0, DateTimeKind.Utc),
+        TimeRangeEnd = new DateTime(2026, 9, 11, 2, 0, 0, DateTimeKind.Utc)
+    };
+
+    /// <summary>
+    /// What <c>config_alert_log.detail_text</c> holds for an analysis row — stated as a frozen list of
+    /// lines rather than computed from <c>FindingMessageFormatter</c>, so it cannot follow the code it is
+    /// pinning. Joined with <c>Environment.NewLine</c> because <c>StringBuilder.AppendLine</c>
+    /// emits that, and this suite runs on Windows in CI.
+    /// </summary>
+    private static string PersistedDetailText => string.Join(Environment.NewLine, new[]
+    {
+        "  Story: CPU_SPIKE → PLAN_REGRESSION",
+        "  Severity: 1.80 (notify threshold 1.5)",
+        "  Confidence: 0.67",
+        "  Facts in chain: 2",
+        "  Database: " + DatabaseMarker,
+        "  Window: 2026-09-11 01:00:00Z - 2026-09-11 02:00:00Z"
+    });
+
+    /// <summary>
+    /// Runs the REAL producer and returns the composed alert it dispatched. Driving
+    /// <c>AnalysisNotificationService</c> rather than hand-building a <c>FindingAlert</c> is the point:
+    /// the declaration under test is the producer's, and a hand-built record would assert the
+    /// arrangement instead of the behaviour.
+    /// </summary>
+    private static async Task<FindingAlert> ComposedAlertAsync()
+    {
+        var sender = new CapturingSender();
+        var notifier = new AnalysisNotificationService(
+            sender,
+            new FixedThresholdSettings(),
+            f => f.ServerId.ToString(),
+            new AppLoggerAdapter<AnalysisNotificationService>());
+
+        await notifier.NotifyAsync(new[] { Finding() });
+
+        return Assert.Single(sender.Sent);
+    }
+
+    /* ─────────────── what the channels render ─────────────── */
+
+    /// <summary>
+    /// The regression, on every channel that renders the facts at all, measured as an occurrence count.
+    ///
+    /// <para>Each assertion is paired with the SAME builder fed <c>DetailText</c> — the argument #3297
+    /// shipped — which must come back with the facts twice. Without that control the test would pass just
+    /// as well if the structured context were dropped instead of the prose, which is the opposite defect
+    /// and the more expensive one: the context carries the advice, the remediation T-SQL and the
+    /// drill-down that the prose does not.</para>
+    /// </summary>
+    [Fact]
+    public async Task AnAnalysisFinding_RendersItsDiagnosisFactsOnce_OnEveryChannel()
+    {
+        var alert = await ComposedAlertAsync();
+        var branding = EmailAlertService.Branding;
+
+        /* Email, both bodies. They are built by two different methods and a repair to one says nothing
+           about the other, so each is counted separately. */
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail(
+            alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue, 15, branding,
+            context: alert.Context, detailText: alert.DeliveredProse);
+        Assert.Equal(1, Occurrences(html, DatabaseMarker));
+        Assert.Equal(1, Occurrences(plain, DatabaseMarker));
+
+        var (htmlBefore, plainBefore) = EmailTemplateBuilder.BuildAlertEmail(
+            alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue, 15, branding,
+            context: alert.Context, detailText: alert.DetailText);
+        Assert.Equal(2, Occurrences(htmlBefore, DatabaseMarker));
+        Assert.Equal(2, Occurrences(plainBefore, DatabaseMarker));
+
+        /* Teams, Slack and the generic channel. PagerDuty takes the same resolved prose from the same
+           single resolution in the fan-out; its endpoint is the hardcoded Events v2 URL, and it is
+           covered at its builder in PagerDutyWebhookTests. */
+        var teams = WebhookAlertService.BuildTeamsPayload(
+            alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue, branding,
+            context: alert.Context, detailText: alert.DeliveredProse);
+        Assert.Equal(1, Occurrences(teams, DatabaseMarker));
+        Assert.Equal(2, Occurrences(WebhookAlertService.BuildTeamsPayload(
+            alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue, branding,
+            context: alert.Context, detailText: alert.DetailText), DatabaseMarker));
+
+        var slack = WebhookAlertService.BuildSlackPayload(
+            alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue, branding,
+            context: alert.Context, detailText: alert.DeliveredProse);
+        Assert.Equal(1, Occurrences(slack, DatabaseMarker));
+        Assert.Equal(2, Occurrences(WebhookAlertService.BuildSlackPayload(
+            alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue, branding,
+            context: alert.Context, detailText: alert.DetailText), DatabaseMarker));
+
+        var generic = WebhookAlertService.BuildGenericPayload(
+            alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue, branding,
+            context: alert.Context, detailText: alert.DeliveredProse);
+        Assert.Equal(1, Occurrences(generic, DatabaseMarker));
+        Assert.Equal(2, Occurrences(WebhookAlertService.BuildGenericPayload(
+            alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue, branding,
+            context: alert.Context, detailText: alert.DetailText), DatabaseMarker));
+    }
+
+    /// <summary>
+    /// The facts that are delivered are the STRUCTURED ones, not the prose. Stated separately from the
+    /// count above because "once" is satisfied by either survivor, and which one survives decides whether
+    /// the advice, the remediation T-SQL and the drill-down come with it.
+    /// </summary>
+    [Fact]
+    public async Task TheSurvivingRendering_IsTheStructuredContext_NotTheProse()
+    {
+        var alert = await ComposedAlertAsync();
+
+        var (_, plain) = EmailTemplateBuilder.BuildAlertEmail(
+            alert.MetricName, alert.ServerName, alert.CurrentValue, alert.ThresholdValue, 15,
+            EmailAlertService.Branding, context: alert.Context, detailText: alert.DeliveredProse);
+
+        /* The Diagnosis item's heading and its own field labels. */
+        Assert.Contains("Diagnosis", plain, StringComparison.Ordinal);
+        Assert.Contains("Notify threshold: 1.5", plain, StringComparison.Ordinal);
+
+        /* And not the prose's labels for the same values. */
+        Assert.DoesNotContain("Facts in chain", plain, StringComparison.Ordinal);
+        Assert.DoesNotContain("(notify threshold 1.5)", plain, StringComparison.Ordinal);
+
+        /* The context's other items are why it is the copy worth keeping. */
+        Assert.Contains("Investigation:", plain, StringComparison.Ordinal);
+    }
+
+    /* ─────────────── what the row keeps ─────────────── */
+
+    /// <summary>
+    /// The constraint the whole approach rests on: suppressing at delivery must not change what is
+    /// stored. Asserted on the record Lite's real <c>EmailAlertService</c> handed its history store,
+    /// against a frozen literal — the same text, byte for byte, that the pre-#3313 row held.
+    /// </summary>
+    [Fact]
+    public async Task ThePersistedDetailText_IsUnchanged_ByTheDeliverySuppression()
+    {
+        var alert = await ComposedAlertAsync();
+
+        /* The producer's own output, and the value carried on the record. */
+        Assert.Equal(PersistedDetailText, FindingMessageFormatter.DetailText(Finding(), NotifyThreshold));
+        Assert.Equal(PersistedDetailText, alert.DetailText);
+
+        /* And the value that reaches the store, through the real shell with the suppression active. */
+        var settings = new FixedThresholdSettings();
+        var store = new CapturingHistoryStore();
+        var email = new EmailAlertService(
+            settings, store,
+            new WebhookAlertService(settings, EmailAlertService.Branding, new AppLoggerAdapter<WebhookAlertService>()),
+            new AppLoggerAdapter<EmailAlertService>());
+
+        await email.SendFindingAlertAsync(alert);
+
+        var record = Assert.Single(store.Records);
+        Assert.Equal(PersistedDetailText, record.DetailText);
+        Assert.NotNull(record.ContextJson);
+    }
+
+    /* ─────────────── the other direction ─────────────── */
+
+    /// <summary>
+    /// A producer whose prose is NOT a restatement still has it delivered, and the suppression is read
+    /// off the producer's declaration rather than hardcoded per SKU.
+    ///
+    /// <para>Without this the fix is indistinguishable from reverting #3297 for the finding path: "never
+    /// deliver a finding's prose" passes every assertion above. The #2109 AG alerts are the standing
+    /// example of prose that carries a remedy no structured field does, which is the case
+    /// <c>AlertDetailText.ProseForDelivery</c> was deliberately built not to drop.</para>
+    /// </summary>
+    [Fact]
+    public void AProseThatIsNotARestatement_IsStillDelivered()
+    {
+        const string Remedy = "Fix the underlying cause, then resume it with ALTER DATABASE [Sales] SET HADR RESUME.";
+
+        var restating = new FindingAlert(
+            "Analysis: cpu_pressure [diag0000]", "TestServer", "CPU_SPIKE (92.5)", "1.5", "1",
+            new AlertContext(), 1.8, NotifyThreshold, Remedy, DeliverDetailText: false);
+        Assert.Null(restating.DeliveredProse);
+
+        var independent = restating with { DeliverDetailText = true };
+        Assert.Equal(Remedy, independent.DeliveredProse);
+
+        /* Both records carry the same DetailText: the declaration governs delivery only. */
+        Assert.Equal(Remedy, restating.DetailText);
+        Assert.Equal(Remedy, independent.DetailText);
+    }
+
+    /// <summary>
+    /// The same declaration, read through Lite's real send shell and measured on the bytes that left the
+    /// process. <c>EmailAlertService</c> constructs its own <c>EmailSendCore</c>, so there is no
+    /// interception point short of a channel: a loopback generic webhook is the cheapest one.
+    ///
+    /// <para>Both directions on one endpoint, because the pair is the claim — a shell that always
+    /// suppressed and a shell that never did would each satisfy half of it. Settings are a local fake
+    /// rather than the <c>App</c> statics <c>AppAlertSettings</c> reads: those are process-global and two
+    /// other test classes already write them, so a body count keyed on them would race.</para>
+    /// </summary>
+    [Fact]
+    public async Task LitesSendShell_DeliversTheProseOnlyWhenTheProducerSaysTo()
+    {
+        const string Prose = "Signal wait time has exceeded its ceiling. Check for a runaway parallel query.";
+
+        using var endpoint = new CapturingWebhookEndpoint();
+        var settings = new FixedThresholdSettings(genericWebhookUrl: endpoint.Url);
+        var store = new CapturingHistoryStore();
+        var email = new EmailAlertService(
+            settings, store,
+            new WebhookAlertService(settings, EmailAlertService.Branding, new AppLoggerAdapter<WebhookAlertService>()),
+            new AppLoggerAdapter<EmailAlertService>());
+
+        var delivered = new FindingAlert(
+            "Analysis: cpu_pressure [deliver0]", "TestServer", "CPU_SPIKE (92.5)", "1.5", "1",
+            new AlertContext(), 1.8, NotifyThreshold, Prose, DeliverDetailText: true);
+
+        await email.SendFindingAlertAsync(delivered);
+
+        var withProse = Assert.Single(endpoint.Bodies);
+        Assert.Contains("runaway parallel query", withProse, StringComparison.Ordinal);
+
+        /* The same alert, declared a restatement: nothing on the wire, everything on the row. */
+        await email.SendFindingAlertAsync(delivered with
+        {
+            MetricName = "Analysis: cpu_pressure [suppress]",
+            DeliverDetailText = false
+        });
+
+        Assert.Equal(2, endpoint.Bodies.Count);
+        Assert.DoesNotContain("runaway parallel query", endpoint.Bodies[1], StringComparison.Ordinal);
+        Assert.Equal(2, store.Records.Count);
+        Assert.All(store.Records, r => Assert.Equal(Prose, r.DetailText));
+    }
+
+    /* ─────────────── helpers ─────────────── */
+
+    private static int Occurrences(string haystack, string needle)
+    {
+        int count = 0, index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    private sealed class CapturingSender : IFindingAlertSender
+    {
+        public List<FindingAlert> Sent { get; } = new();
+
+        public Task<DateTime?> GetLastAlertTimeAsync(string serverId, string metricName) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task SendFindingAlertAsync(FindingAlert alert)
+        {
+            Sent.Add(alert);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CapturingHistoryStore : IAlertHistoryStore
+    {
+        public List<AlertHistoryRecord> Records { get; } = new();
+
+        public Task RecordAlertAsync(AlertHistoryRecord record)
+        {
+            Records.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastAlertTimeAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+    }
+
+    /// <summary>
+    /// Settings with a fixed analysis threshold and, optionally, one generic webhook pointed wherever the
+    /// caller says. Deliberately NOT <c>AppAlertSettings</c>: that reads process-global <c>App</c> statics.
+    /// </summary>
+    private sealed class FixedThresholdSettings : IAlertSettings
+    {
+        private readonly string _genericUrl;
+
+        public FixedThresholdSettings(string genericWebhookUrl = "") => _genericUrl = genericWebhookUrl;
+
+        public bool SmtpEnabled => false;
+        public string SmtpServer => "";
+        public int SmtpPort => 25;
+        public bool SmtpUseSsl => false;
+        public string SmtpUsername => "";
+        public string SmtpFromAddress => "";
+        public string SmtpRecipients => "";
+        public string? GetSmtpPassword() => null;
+        public int EmailCooldownMinutes => 15;
+
+        public bool TeamsWebhookEnabled => false;
+        public string TeamsWebhookUrl => "";
+        public string TeamsProxyAddress => "";
+
+        public bool SlackWebhookEnabled => false;
+        public string SlackWebhookUrl => "";
+        public string SlackProxyAddress => "";
+
+        public bool GenericWebhookEnabled => _genericUrl.Length > 0;
+        public string GenericWebhookUrl => _genericUrl;
+        public string GenericWebhookHeadersJson => "";
+        public string GenericWebhookBodyTemplate => "";
+        public string GenericWebhookProxyAddress => "";
+
+        public bool PagerDutyEnabled => false;
+        public string PagerDutyRoutingKey => "";
+        public bool PagerDutyUseEuRegion => false;
+        public string PagerDutyProxyAddress => "";
+
+        public double AnalysisNotifySeverity => NotifyThreshold;
+        public int AnalysisNotifyCooldownMinutes => 360;
+        public string TriageBaseUrl => "";
+    }
+
+    /// <summary>
+    /// A loopback endpoint that records the bodies posted to it. <c>TcpListener</c> rather than
+    /// <c>HttpListener</c> for the reason <c>Darling.Tests.AlertDeliveryChannelTests</c> gives: the latter
+    /// wants a URL ACL on Windows, and four lines of HTTP are cheaper than that dependency.
+    /// </summary>
+    private sealed class CapturingWebhookEndpoint : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly List<string> _bodies = new();
+        private readonly CancellationTokenSource _stop = new();
+        private readonly Task _accepting;
+
+        public CapturingWebhookEndpoint()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Url = $"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/hook";
+            _accepting = Task.Run(AcceptLoopAsync);
+        }
+
+        public string Url { get; }
+
+        /// <summary>
+        /// Safe to read without synchronization once the send has been awaited: each body is appended
+        /// before its response is written, and the sender awaits every response in turn.
+        /// </summary>
+        public IReadOnlyList<string> Bodies => _bodies;
+
+        private async Task AcceptLoopAsync()
+        {
+            try
+            {
+                while (!_stop.IsCancellationRequested)
+                {
+                    using var client = await _listener.AcceptTcpClientAsync(_stop.Token);
+                    using var stream = client.GetStream();
+                    _bodies.Add(await ReadRequestBodyAsync(stream));
+
+                    var response = Encoding.ASCII.GetBytes(
+                        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+                    await stream.WriteAsync(response, _stop.Token);
+                    await stream.FlushAsync(_stop.Token);
+                }
+            }
+            catch (OperationCanceledException) { /* Dispose */ }
+            catch (SocketException) { /* listener stopped */ }
+            catch (ObjectDisposedException) { /* listener stopped */ }
+        }
+
+        /// <summary>Reads headers to the blank line, then exactly Content-Length bytes of body.</summary>
+        private static async Task<string> ReadRequestBodyAsync(NetworkStream stream)
+        {
+            var buffer = new byte[16 * 1024];
+            var received = new List<byte>(capacity: 16 * 1024);
+            int headerEnd;
+
+            while ((headerEnd = IndexOfHeaderEnd(received)) < 0)
+            {
+                var read = await stream.ReadAsync(buffer);
+                if (read == 0)
+                {
+                    return Encoding.UTF8.GetString(received.ToArray());
+                }
+
+                received.AddRange(new ArraySegment<byte>(buffer, 0, read));
+            }
+
+            var headers = Encoding.ASCII.GetString(received.ToArray(), 0, headerEnd);
+            var contentLength = ParseContentLength(headers);
+            var bodyStart = headerEnd + 4;
+
+            while (received.Count - bodyStart < contentLength)
+            {
+                var read = await stream.ReadAsync(buffer);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                received.AddRange(new ArraySegment<byte>(buffer, 0, read));
+            }
+
+            var body = received.ToArray();
+            var available = Math.Min(contentLength, body.Length - bodyStart);
+            return Encoding.UTF8.GetString(body, bodyStart, Math.Max(0, available));
+        }
+
+        private static int IndexOfHeaderEnd(List<byte> bytes)
+        {
+            for (int i = 0; i + 3 < bytes.Count; i++)
+            {
+                if (bytes[i] == (byte)'\r' && bytes[i + 1] == (byte)'\n' &&
+                    bytes[i + 2] == (byte)'\r' && bytes[i + 3] == (byte)'\n')
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int ParseContentLength(string headers)
+        {
+            foreach (var line in headers.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase) &&
+                    int.TryParse(line.AsSpan("Content-Length:".Length).Trim(), out var length))
+                {
+                    return length;
+                }
+            }
+
+            return 0;
+        }
+
+        public void Dispose()
+        {
+            _stop.Cancel();
+            _listener.Stop();
+            try
+            {
+                _accepting.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (AggregateException) { /* the cancellation above */ }
+
+            _stop.Dispose();
+        }
+    }
+}

--- a/Lite/Services/EmailAlertService.cs
+++ b/Lite/Services/EmailAlertService.cs
@@ -48,6 +48,19 @@ public class EmailAlertService : IFindingAlertSender
     /// Attempts to send an alert (email + webhook via the shared core) and writes Lite's single
     /// combined <c>config_alert_log</c> row, regardless of email status. Never throws.
     /// </summary>
+    /// <param name="detailText">
+    /// The alert's prose. PERSISTED on the row either way; delivered to the channels only when
+    /// <paramref name="deliverProse"/>.
+    /// </param>
+    /// <param name="deliverProse">
+    /// Whether the channels render <paramref name="detailText"/>. True for every threshold and self
+    /// alert — that is the #3297 fix, and a self-alert's prose is the only thing it carries. The
+    /// analysis-finding path passes false: its prose restates the structured context the channels
+    /// already render (see <see cref="FindingAlert"/>).
+    /// <para>Defaults to TRUE so a caller that never considers it delivers the prose. The two failure
+    /// directions are not symmetric: delivering a redundant paragraph is visible and cosmetic, while
+    /// withholding one discards an operator's only copy of the remedy, which is the #3296 defect.</para>
+    /// </param>
     public async Task TrySendAlertEmailAsync(
         string metricName,
         string serverName,
@@ -58,13 +71,14 @@ public class EmailAlertService : IFindingAlertSender
         double? numericCurrentValue = null,
         double? numericThresholdValue = null,
         bool muted = false,
-        string? detailText = null)
+        string? detailText = null,
+        bool deliverProse = true)
     {
         try
         {
             var result = await _core.TrySendAsync(
                 metricName, serverName, currentValue, thresholdValue, serverId.ToString(), context, attemptChannels: !muted,
-                detailText: detailText);
+                detailText: deliverProse ? detailText : null);
 
             /* trayChannelPresent: true — LiteAlertDeliverer.DeliverAsync shows a styled balloon for every
                non-muted alert on the same call that reaches here, so a stored "tray" really does mean a
@@ -78,7 +92,9 @@ public class EmailAlertService : IFindingAlertSender
                carries both the display text and the optional numerics so no data is lost. The
                structured context is persisted as JSON alongside the flat detail_text so the
                in-app dialog can render the same advice / T-SQL / drill-down shape email and
-               webhooks show (and survive purge of the source findings). */
+               webhooks show (and survive purge of the source findings). detailText in full here
+               whatever the channels were handed — deliverProse governs delivery only, so the
+               column the Alerts tab, the MCP reader and the mute pre-fill read is unaffected. */
             string? contextJson = context is not null ? AlertContextSerializer.Serialize(context) : null;
             await _historyStore.RecordAlertAsync(new AlertHistoryRecord(
                 serverId.ToString(), serverName, metricName,
@@ -107,6 +123,8 @@ public class EmailAlertService : IFindingAlertSender
     /// Lite's cadence — one combined <c>config_alert_log</c> row written unconditionally by
     /// <see cref="TrySendAlertEmailAsync"/>, which already carries the muted/detailText/numeric
     /// params — so no separate fallback row is needed.
+    /// <para>The row persists <c>DetailText</c>; the channels render it only if the producer says
+    /// to. Darling's <c>DarlingFindingAlertSender</c> reads the same declaration.</para>
     /// </summary>
     public Task SendFindingAlertAsync(FindingAlert alert)
     {
@@ -121,6 +139,7 @@ public class EmailAlertService : IFindingAlertSender
             numericCurrentValue: alert.Severity,
             numericThresholdValue: alert.NotifyThreshold,
             muted: false,
-            detailText: alert.DetailText);
+            detailText: alert.DetailText,
+            deliverProse: alert.DeliverDetailText);
     }
 }

--- a/PerformanceMonitor.Notifications/AlertDetailText.cs
+++ b/PerformanceMonitor.Notifications/AlertDetailText.cs
@@ -74,18 +74,29 @@ public static class AlertDetailText
     /// The prose a channel should render, or null when there is none to add.
     /// <para>
     /// Every engine alert's detail text IS <see cref="Flatten"/> of its own context — <c>AlertEngine</c>
-    /// builds it that way at eleven fire sites — so rendering both would print the same content twice in
-    /// the alerts that already read correctly (blocking, deadlocks, long-running queries, low disk, jobs).
-    /// Suppressing on that equality keeps those deliveries byte-for-byte unchanged while the prose-only
-    /// alerts gain their detail. It is not the same as suppressing whenever a context is present: the
-    /// #2109 AG database alerts carry BOTH a structured context and independent prose naming the
-    /// <c>SET HADR RESUME</c> remedy, and that prose must still be delivered.
+    /// builds each <c>detailText</c> local that way, via <c>AlertContextBuilders.ContextToDetailText</c> —
+    /// so rendering both would print the same content twice in the alerts that already read correctly
+    /// (blocking, deadlocks, long-running queries, low disk, jobs). Suppressing on that equality keeps
+    /// those deliveries byte-for-byte unchanged while the prose-only alerts gain their detail. It is not
+    /// the same as suppressing whenever a context is present: the #2109 AG database alerts carry BOTH a
+    /// structured context and independent prose naming the <c>SET HADR RESUME</c> remedy, and that prose
+    /// must still be delivered.
     /// </para>
     /// <para>
     /// Compared against the shared <see cref="Flatten"/> rather than a local reimplementation, so the two
     /// texts are equal by construction. Should they ever disagree anyway, the alert is delivered twice —
     /// visible and harmless — rather than having its remedy dropped again, which is the failure this whole
     /// path exists to stop.
+    /// </para>
+    /// <para>
+    /// <b>Textual equality is not the only reason a prose is redundant, and this function only sees that
+    /// one.</b> A producer that formats the same facts as its own context under different labels defeats
+    /// the comparison while delivering pure duplication — <c>FindingMessageFormatter</c> does exactly
+    /// that, its <c>DetailText</c> and its <c>Diagnosis</c> item being two renderings of one set of
+    /// values. Widening the comparison to "every fact in the context appears somewhere in the prose"
+    /// would drop the #2109 remedy above, which is the one case this gate was built NOT to drop. So that
+    /// second kind of redundancy is declared by the producer instead, on
+    /// <c>FindingAlert.DeliverDetailText</c>, and resolved before a channel is reached.
     /// </para>
     /// </summary>
     public static string? ProseForDelivery(string? detailText, AlertContext? context)

--- a/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
+++ b/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
@@ -287,7 +287,18 @@ public sealed class AnalysisNotificationService
                     context,
                     lead.Severity,
                     threshold,
-                    FindingMessageFormatter.DetailText(lead, threshold)));
+                    FindingMessageFormatter.DetailText(lead, threshold),
+                    /* The prose is not delivered, and the row still persists it. DetailText and
+                       BuildContext's "Diagnosis" item are two renderings of the SAME values — story,
+                       severity, notify threshold, confidence, fact count, database, window — so a channel
+                       that renders the structured context and the prose prints every one of them twice.
+                       They differ in labels ("Facts in chain" vs "Facts", one combined severity line vs
+                       two fields) and in the window separator, so the textual equality in
+                       AlertDetailText.ProseForDelivery cannot see that they are the same facts; the
+                       producer has to say so. Delivery is the only half suppressed: DetailText remains
+                       config_alert_log.detail_text, which is the sole copy of these facts on the surfaces
+                       that render no structured context, and the input the mute pre-fill parses. */
+                    DeliverDetailText: false));
 
                 /* Always raise the tray balloon for a notify-worthy incident (user choice), the
                    same visible signal threshold alerts already pop — so a local-only user with no

--- a/PerformanceMonitor.Notifications/IFindingAlertSender.cs
+++ b/PerformanceMonitor.Notifications/IFindingAlertSender.cs
@@ -56,7 +56,7 @@ public interface IFindingAlertSender
 /// <c>AlertMuteContext.PopulateFromDetailText</c> for the mute pre-fill. <see cref="DeliveredProse"/> is
 /// what a delivery CHANNEL renders. Separating them is what lets a producer whose prose merely restates
 /// its own structured context stop delivering the same facts twice without changing a persisted column
-/// that five reading surfaces depend on.
+/// that every one of those surfaces depends on.
 /// </para>
 /// </summary>
 /// <param name="DeliverDetailText">

--- a/PerformanceMonitor.Notifications/IFindingAlertSender.cs
+++ b/PerformanceMonitor.Notifications/IFindingAlertSender.cs
@@ -49,7 +49,23 @@ public interface IFindingAlertSender
 /// A composed analysis-finding alert, ready to dispatch. Carries both the display strings
 /// and the numeric severity/threshold so each app's <see cref="IFindingAlertSender"/>
 /// implementation can persist its native row shape without loss.
+/// <para>
+/// <b>The prose has two destinations, and they are not the same value.</b> <c>DetailText</c> is what
+/// the alert-history row PERSISTS — <c>config_alert_log.detail_text</c>, read by the MCP alert reader,
+/// the triage endpoint, the Viewer's detail pane and the Dashboard's no-channel tray row, and PARSED by
+/// <c>AlertMuteContext.PopulateFromDetailText</c> for the mute pre-fill. <see cref="DeliveredProse"/> is
+/// what a delivery CHANNEL renders. Separating them is what lets a producer whose prose merely restates
+/// its own structured context stop delivering the same facts twice without changing a persisted column
+/// that five reading surfaces depend on.
+/// </para>
 /// </summary>
+/// <param name="DeliverDetailText">
+/// Whether a delivery channel renders <c>DetailText</c> as its own prose section. False when the prose
+/// restates <c>Context</c> under different labels: the channels all render the structured context, so
+/// both together print every fact twice. The PRODUCER answers this, because only the producer knows how
+/// it built the pair — <c>AlertDetailText.ProseForDelivery</c> compares the two texts and cannot see it
+/// when the labels and separators differ.
+/// </param>
 public sealed record FindingAlert(
     string MetricName,
     string ServerName,
@@ -59,4 +75,14 @@ public sealed record FindingAlert(
     AlertContext Context,
     double Severity,
     double NotifyThreshold,
-    string DetailText);
+    string DetailText,
+    bool DeliverDetailText)
+{
+    /// <summary>
+    /// The prose a delivery channel should render for this alert, or null when the structured
+    /// <c>Context</c> already carries every fact it states.
+    /// <para>Resolved once here rather than at each <see cref="IFindingAlertSender"/>, so both SKUs read
+    /// one answer instead of deriving it twice from the same flag.</para>
+    /// </summary>
+    public string? DeliveredProse => DeliverDetailText ? DetailText : null;
+}


### PR DESCRIPTION
Analysis-finding alerts render their Diagnosis facts twice on every channel. This is the open review thread on #3302 (`PerformanceMonitor.Notifications/AlertDetailText.cs`), settled.

## The regression

#3302 threaded each alert's prose `DetailText` through to all five delivery channels — the #3296 field defect was that it reached none. It gates delivery on `AlertDetailText.ProseForDelivery`, which suppresses the prose when it is textually equal to the flattening of the alert's own structured context.

`FindingMessageFormatter` is a third producer of `(Context, DetailText)` pairs and nothing in #3302 touched it. `BuildContext` puts story / severity / notify threshold / confidence / fact count / database / window into a `Diagnosis` item; `DetailText` formats the same values with different labels (`Facts in chain` vs `Facts`, one combined severity line vs two fields) and a different window separator. Different text, so the equality gate never fires, so both are delivered — on the largest alert category there is (CPU spikes, plan regressions, index and RCSI findings), on both SKUs, on email, Teams, Slack, PagerDuty and the generic webhook.

## What this does, and the seam it rests on

The prose is suppressed at **delivery**. The **persisted** value is untouched.

That distinction is the whole point. `FindingMessageFormatter.DetailText` is also `config_alert_log.detail_text` for every analysis row: the MCP alert reader, the triage endpoint, the Viewer's detail pane and the Dashboard's no-channel tray row all render it, and `AlertMuteContext.PopulateFromDetailText` *parses* it for the mute pre-fill. The alternative repair — make `DetailText` the flattening of its own context, as the thirteen `AlertEngine` fire sites do — would change that column for the largest alert category, gaining the `Diagnosis` heading, a separate `Notify threshold` field, the advice headline, the remediation-T-SQL item's heading and every drill-down item's fields.

**The seam exists, at two separate call sites in each sender**, and it is not a new one: `deprecated/Dashboard`'s `SendFindingAlertAsync` has always omitted the detail from its delivery call while passing it to its tray row. Lite and Darling each call `EmailSendCore.TrySendAsync(detailText:)` for delivery and `IAlertHistoryStore.RecordAlertAsync(... DetailText ...)` for the row.

`FindingAlert` now carries the producer's own declaration — `DeliverDetailText`, with `DeliveredProse` resolving it once so the two senders cannot disagree — and the senders route `DeliveredProse` to the channels and `DetailText` to the row. Keyed on producer rather than on text, which is what the equality gate cannot do here.

Not widened to "suppress when the context's facts all appear in the prose": that also drops the #2109 AG alerts' `SET HADR RESUME` remedy, the one case the gate was deliberately built not to drop.

Lite's shell shares one path with the engine, so it takes a `deliverProse` flag defaulting to **true**. The two failure directions are not symmetric — delivering a redundant paragraph is cosmetic, withholding one discards an operator's only copy of the remedy, which is #3296 — so a caller that never considers it delivers the prose.

Also in here: `AlertDetailText`'s doc said `AlertEngine` builds its detail text that way "at eleven fire sites". #3302 took that to thirteen. The numeral is gone rather than corrected — no test derives it, so it is a partial list with a number welded on.

## Verification

`Lite.Tests` and `Darling.Tests` are `net10.0-windows` and cannot run on macOS, so the ACTUAL committed test sources were compiled into two `net10.0` console harnesses over an xunit shim and RUN. `Lite/Services/EmailAlertService.cs` is compiled in as the real product source rather than shimmed — only its project is Windows-targeted — because it is the subject of two of the pins.

All three measured harness traps are controlled, not avoided. The shim's `--self-check` carries 6 controls that must pass (`Assert.Equal` on distinct-but-equal `List<T>`, arrays and nested collections; an `async Task` succeeding after two awaits; a two-case theory) and 5 that must fail, including a failure raised after an await and one thrown below the first await in a nested async call. All 6 green, all 5 red. `BaseOutputPath` sits inside the worktree so `DocCommentHygieneTests`' walk-up finds `PerformanceMonitor.sln`; all 77 of its cases ran and passed, which is how the new doc comments and crefs are checked.

| harness | result |
|---|---|
| `Lite.Tests` (8 real test files + the real `EmailAlertService.cs`) | 115 pass, 0 fail |
| `Darling.Tests` (`AlertDeliveryChannelTests`, `CustomAlertDisplayNameTests`, `DocCommentHygieneTests`, `CSharpSourceWalkerTests`) | 149 pass, 0 fail, 1 SKIP |

The SKIP is `TheViewerRow_RendersThroughTheSharedDescriber`, whose subject is the WPF `ViewerAlertRow`; it is reported SKIP rather than PASS because a shimmed subject would make the result the harness's. CI runs it for real.

### The pins

Both directions, or the fix is indistinguishable from reverting #3302 for this seam.

- **Facts once per channel** — driven through the real `AnalysisNotificationService`, not a hand-built `FindingAlert`: the declaration under test is the producer's. On the Darling side it is the whole path, `DarlingFindingAlertSender` through the send core, the fan-out and each payload builder, read off the bytes that left the process via the loopback TCP and SMTP sinks.
- **Occurrence counts, not absences.** Asserting only that the prose is gone would pass equally if the structured *context* had been dropped instead — the opposite defect and the more expensive one, since the context carries the advice, the remediation T-SQL and the drill-down that the prose does not. Each count is paired with the same builder fed `DetailText`, the argument #3302 shipped, which must come back with the facts twice.
- **A prose that is not a restatement is still delivered**, on both SKUs, measured on the wire.
- **`config_alert_log.detail_text` is unchanged** — a frozen list of lines on both SKUs, not a re-derivation of the code it pins. Darling.Tests cannot see `FindingMessageFormatter` at all (Notifications grants `InternalsVisibleTo` to Lite and Dashboard, not there), which makes that limitation useful.

### Mutations

Committed before every one; each applied, run, reverted, and the revert verified by blob hash against `HEAD` plus a whole-tree clean check. Every run goes through a driver that BUILDS first — a source-only restore leaves the previous mutation's DLL in `bin`, and the previous lane lost a round to reds that were its harness's stale state.

| # | mutation | result |
|---|---|---|
| 1 | the producer declares the prose independent (the shipped behaviour) | **RED** — 2 Lite + 2 Darling |
| 2 | `DeliveredProse` never suppresses | RED — 3 Lite + 3 Darling |
| 3 | `DeliveredProse` always suppresses | RED — the other-direction pin, both SKUs |
| 4 | Darling sender delivers `DetailText` instead of `DeliveredProse` | RED — 3 Darling, Lite green (separate seam) |
| 5 | **Darling sender PERSISTS the suppressed value** | **RED** — the constraint this approach rests on |
| 6 | Lite shell ignores `deliverProse` | RED — the Lite shell pin |
| 7 | **Lite shell PERSISTS the suppressed value** | **RED** — 2 Lite |
| 8 | Lite sender hardcodes `deliverProse: false` | RED |
| 9 | Lite sender hardcodes `deliverProse: true` | RED |
| 10 | **`BuildContext` drops the `Database` field** (the opposite defect) | **RED** — 1 Lite + 2 Darling; the counts are not satisfied by an absence |
| 11 | **`DetailText` becomes the flattening of its own context** (the declined approach) | **RED** — the persistence pin, both SKUs |
| 12 | `ProseForDelivery` always returns null | RED — 11 Lite + 3 Darling, including 9 of #3302's own pins and every control half |

Mutation 12 is what shows the control halves are load-bearing rather than decoration, and mutation 10 that the "once" claim discriminates which rendering survived. `TheSurvivingRendering_IsTheStructuredContext_NotTheProse` stays green under 12, correctly — that one is about which copy remains, not how many.

## Mechanics

Fresh worktree off `origin/dev`; `origin/dev` merged IN at `2a52dd5b` (no overlap with any file here), never rebased, never force-pushed. Solution builds with `-p:EnableWindowsTargeting=true`, 0 warnings. `global.json` untouched — 10.0.302 is installed and the pin edit is a stale ritual. `packages.lock.json` churn from the macOS restore reverted. Named paths only, never `git add -A`. No `CHANGELOG.md` edit.

One correction of my own, recorded because the artefact is durable: the branch was first pushed as `fix/3313-...`, a number I constructed as "next" rather than read. #3313 is an open issue about a webhook batch re-rendering already-delivered incidents. Branch renamed, the wrong remote ref deleted, and five code comments that referenced it rewritten to name #3302 instead. No issue is filed for this regression — it is carried here.

### CHANGELOG entry text (for the coordinator, not committed)

```
- Fixed analysis-finding alerts rendering their Diagnosis facts twice on every delivery channel. The
  finding's prose detail restates its own structured context under different labels, so the delivery
  gate's text comparison could not see the duplication. The prose is now suppressed at delivery for
  that producer; `config_alert_log.detail_text` is unchanged, so the MCP reader, the triage page, the
  Viewer's detail pane and the mute pre-fill all read what they always did.
```
