### PR TITLE
Require a Collector Cost Regression to be worth reporting, not just real

### DIFF
--- a/Darling/Darling.Tests/CollectorCostRegressionMaterialityTests.cs
+++ b/Darling/Darling.Tests/CollectorCostRegressionMaterialityTests.cs
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service.Mcp;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3316 — a per-run cost regression must also be worth reporting.
+///
+/// <para><b>The defect this pins.</b> The predicate had two gates measuring different units: a floor on the
+/// average daily TOTAL (<c>baseline_ms &gt;= $2</c>) and a ratio on cost PER RUN. A total-cost floor is cleared
+/// by VOLUME, so it does not constrain the quantity the ratio tests — a collector averaging 3 ms per run clears
+/// a 1000 ms/day floor on run count alone and is then judged by a ratio on that 3 ms. The measured firing
+/// doubled 3.0 to 6.1 ms per run across 50 runs, which adds 0.16 s of collection time a day.</para>
+///
+/// <para><b>That firing was TRUTHFUL, which is why the fix is a materiality gate and not a precision one.</b>
+/// Both sides of the ratio are means over many runs, so integer-millisecond quantization averages down to
+/// hundredths of a millisecond and the doubling was real. The alert was correct and unactionable. So the third
+/// gate asks what the regression COSTS — the per-run rise times the volume it is paid on — which is
+/// unit-consistent with the ratio. A minimum per-run BASELINE would have been the wrong fix: it would exclude a
+/// 3 ms collector that runs 100,000 times a day, where the same doubling costs five minutes daily.</para>
+///
+/// <para><b>Why this has to be a live-Postgres test.</b> Same reason as
+/// <see cref="CollectorCostRegressionPerRunTests"/>: the gate is a line of
+/// <see cref="DarlingCollectorCostReader.RegressionSql"/>. A text assertion on the query would pass against any
+/// SQL containing the right words, and an in-memory test of the apply half only sees rows the SQL already chose
+/// to return. The property is asserted by planting rows and running the SHIPPED query against a real store.</para>
+///
+/// <para><b>The fixture is adversarial on purpose.</b> Both collectors have an IDENTICAL per-run baseline
+/// (100 ms), an IDENTICAL latest per-run cost (300 ms), the IDENTICAL 3x ratio, and a constant cadence — so
+/// #2846's per-run rule reports both, and both clear the daily-total floor. They differ in one thing only:
+/// volume, and therefore what the regression costs (4 s/day versus 40 s/day against a 5 s floor). Reverting the
+/// materiality predicate therefore fails on <c>volume_trivial</c> specifically, rather than on some incidental
+/// difference between the two.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class CollectorCostRegressionMaterialityTests
+{
+    private const string ServerName = "darling-costmateriality-3316-e2e";
+    private static readonly int ServerId = ServerIdHelper.GetDeterministicHashCode(ServerName);
+
+    /* 20 runs/day. A real 3x per-run rise that adds (300 - 100) * 20 = 4,000 ms/day. */
+    private const string VolumeTrivial = "volume_trivial_3316";
+
+    /* 200 runs/day. The SAME 3x per-run rise, adding (300 - 100) * 200 = 40,000 ms/day. */
+    private const string VolumeMaterial = "volume_material_3316";
+
+    /* The floor under test, between the two fixtures with 25% and 8x margin. Passed explicitly rather than
+       read from the evaluator's private constant: this pins the QUERY's property, which is what the SQL can
+       get wrong, and stays meaningful if the production value is retuned. */
+    private const long AddedMsFloor = 5_000;
+
+    /* Fixed dates, not offsets from now(): date_trunc('day') buckets the rows, so a test running near midnight
+       UTC could otherwise split a "day" across two buckets and stop being deterministic. */
+    private static readonly DateTime Day0 = new(2026, 6, 17, 12, 0, 0, DateTimeKind.Unspecified);
+
+    private static string? ConnectionString => Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+
+    [Fact]
+    public async Task MaterialityFloor_DropsATrivialRise_ButKeepsTheSameRiseAtVolume()
+    {
+        var cs = ConnectionString;
+        Assert.SkipWhen(string.IsNullOrEmpty(cs),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the cost-regression materiality test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new NpgsqlConnection(cs);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteRowsAsync(connection, ct);
+        await using var postgres = NpgsqlDataSource.Create(cs!);
+
+        var bodySucceeded = false;
+        try
+        {
+            await DarlingMcpTestData.RegisterServerAsync(connection, ServerId, ServerName, ct);
+
+            /* Four prior days at 100 ms/run for both. Daily totals are 2,000 and 20,000 ms, so BOTH clear the
+               1,000 ms/day eligibility floor and both reach the gate under test. */
+            for (var back = 4; back >= 1; back--)
+            {
+                await InsertCostAsync(connection, ct, Day0.AddDays(-back), VolumeTrivial, 20, 2_000);
+                await InsertCostAsync(connection, ct, Day0.AddDays(-back), VolumeMaterial, 200, 20_000);
+            }
+
+            /* Latest day: both rise to exactly 300 ms/run at unchanged cadence. Identical ratio, identical
+               per-run figures; only the volume the rise is paid on differs. */
+            await InsertCostAsync(connection, ct, Day0, VolumeTrivial, 20, 6_000);
+            await InsertCostAsync(connection, ct, Day0, VolumeMaterial, 200, 60_000);
+
+            var regressions = await DarlingCollectorCostReader.GetCostRegressionsAsync(
+                postgres, Day0.AddDays(-10), baselineFloorMs: 1_000, factor: 2.0,
+                addedMsFloor: AddedMsFloor, cancellationToken: ct);
+
+            var mine = regressions.Where(r => r.ServerId == ServerId).ToList();
+
+            /* The property: a truthful 3x that costs 4 s/day is not worth an alert. */
+            Assert.DoesNotContain(mine, r => r.CollectorName == VolumeTrivial);
+
+            /* ...and the SAME 3x at volume still is, so the fix cannot be "report nothing". */
+            var material = Assert.Single(mine, r => r.CollectorName == VolumeMaterial);
+
+            /* Both collectors' per-run figures are identical, which is what makes the exclusion above
+               attributable to volume and nothing else. */
+            Assert.Equal(300.0, material.LatestMsPerRun, 3);
+            Assert.Equal(100.0, material.BaselineMsPerRun, 3);
+            Assert.Equal(200, material.LatestRuns);
+
+            /* The derived cost the gate compares, and the figure the alert text now states. */
+            Assert.Equal(40_000.0, material.AddedMsPerDay, 3);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            /* RunAsync, not RunOwnedAsync: it opens the connection AND sets search_path to
+               "collect, config, public", which the unqualified `servers` delete below depends on. */
+            await LiveStoreCleanup.RunAsync(cs!, bodySucceeded, async (cleanup, cleanupCt) =>
+                await DeleteRowsAsync(cleanup, cleanupCt));
+        }
+    }
+
+    private static async Task InsertCostAsync(
+        NpgsqlConnection connection, CancellationToken ct, DateTime metricTime,
+        string collector, int runs, long totalSqlMs) =>
+        await DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO collect.collector_cost
+    (metric_time, server_id, database_name, collector_name, run_count, total_sql_ms, max_sql_ms, total_storage_ms, total_rows)
+VALUES ($1, $2, NULL, $3, $4, $5, $6, 0, 0);",
+            DarlingMcpTestData.Naive(metricTime), ServerId, collector, runs, totalSqlMs, totalSqlMs / runs);
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        using var cleanup = new NpgsqlCommand(
+            "DELETE FROM collect.collector_cost WHERE server_id = " + ServerId + "; " +
+            "DELETE FROM servers WHERE server_id = " + ServerId + ";", connection);
+        await cleanup.ExecuteNonQueryAsync(ct);
+    }
+}

--- a/Darling/Darling.Tests/CollectorCostRegressionPerRunTests.cs
+++ b/Darling/Darling.Tests/CollectorCostRegressionPerRunTests.cs
@@ -90,7 +90,11 @@ public sealed class CollectorCostRegressionPerRunTests
             await InsertCostAsync(connection, ct, Day0, PerRunSlower,     1000, 300_000);  /* 300 ms/run: 3x   */
 
             var regressions = await DarlingCollectorCostReader.GetCostRegressionsAsync(
-                postgres, Day0.AddDays(-10), baselineFloorMs: 1000, factor: 2.0, ct);
+                /* addedMsFloor 0: this fixture pins the #2846 per-run property in isolation. The #3316
+                   materiality floor has its own adversarial fixture and would otherwise be a second
+                   reason this test could fail. */
+                postgres, Day0.AddDays(-10), baselineFloorMs: 1000, factor: 2.0, addedMsFloor: 0,
+                cancellationToken: ct);
 
             var mine = regressions.Where(r => r.ServerId == ServerId).ToList();
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -174,8 +174,15 @@ internal sealed class DarlingSelfAlertEvaluator
        CostRegressionFactor, before it alerts — so a cheap collector, or a new one, cannot trip it.
        #2846: the comparison is per RUN, not per day. Daily totals are runs x cost-per-run, so a cadence
        recovery — more of the same work, each unit cheaper — used to read as a regression. It fired 3,259 times
-       over 612 pairs in one day, 53% of them on collectors whose per-run cost had FALLEN. The floor stays on
-       the daily TOTAL so a cheap-but-frequent collector still cannot trip on a per-run doubling. */
+       over 612 pairs in one day, 53% of them on collectors whose per-run cost had FALLEN.
+       #3316: the two gates measure DIFFERENT UNITS, so the daily-total floor does not constrain the per-run
+       ratio — a total-cost floor is cleared by VOLUME, so a collector averaging 3 ms per run clears
+       CostRegressionBaselineFloorMs on run count alone and is then judged by a ratio on that 3 ms. Such a
+       firing is TRUTHFUL (both sides are means over many runs, so this is not rounding) and useless: the
+       measured case doubled 3.0 -> 6.1 ms per run over 50 runs, which costs 0.16 s a day. So a third gate
+       asks what the regression COSTS — the per-run rise times the volume it is paid on — and requires
+       CostRegressionAddedMsFloor of it. That is unit-consistent with the ratio, and unlike a minimum
+       per-run baseline it still reports a 3 ms collector that runs often enough for the rise to matter. */
     private readonly ConcurrentDictionary<string, string> _activeCostRegression = new();
     private readonly ConcurrentDictionary<string, DateTime> _lastCostRegressionAlert = new();
 
@@ -204,6 +211,14 @@ internal sealed class DarlingSelfAlertEvaluator
 
     private const double CostRegressionFactor = 2.0;
     private const long CostRegressionBaselineFloorMs = 1000;
+
+    /// <summary>#3316: the minimum ADDED cost per day, in ms, before a per-run regression is worth an
+    /// alert and its paired resolution. Derived from a measured 41-hour fleet sample rather than chosen:
+    /// the firings that identified a real regression added 21.8-22.6 s/day, while the ones that were
+    /// truthful and unactionable added 0.16-3.6 s/day. 5 s sits in the empty band between them with more
+    /// than 4x headroom on both sides. It is also 5x <see cref="CostRegressionBaselineFloorMs"/>, which
+    /// is the eligibility floor for the collector rather than for the regression.</summary>
+    private const long CostRegressionAddedMsFloor = 5000;
     private static readonly TimeSpan CostRegressionBaselineWindow = TimeSpan.FromDays(14);
 
     /// <summary>The fixed key for the fleet-level Store Disk Pressure edge (not a real server).</summary>
@@ -758,7 +773,8 @@ internal sealed class DarlingSelfAlertEvaluator
         {
             regressions = await Mcp.DarlingCollectorCostReader.GetCostRegressionsAsync(
                 postgres, _utcNow() - CostRegressionBaselineWindow,
-                CostRegressionBaselineFloorMs, CostRegressionFactor, cancellationToken);
+                CostRegressionBaselineFloorMs, CostRegressionFactor, CostRegressionAddedMsFloor,
+                cancellationToken);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -807,7 +823,8 @@ internal sealed class DarlingSelfAlertEvaluator
                     detail: $"The '{regression.CollectorName}' collector's OWN query time on {regression.ServerName} rose to " +
                         $"{regression.LatestMsPerRun:N1} ms per run, {ratio:N1}x its {CostRegressionBaselineWindow.TotalDays:N0}-day " +
                         $"baseline of {regression.BaselineMsPerRun:N1} ms per run ({regression.LatestRuns:N0} runs totalling " +
-                        $"{regression.LatestMs:N0} ms so far today). This is the MONITORING TOOL's own cost, not the " +
+                        $"{regression.LatestMs:N0} ms so far today, adding {regression.AddedMsPerDay / 1000.0:N1} s of collection " +
+                        $"time a day at that volume). This is the MONITORING TOOL's own cost, not the " +
                         $"server's workload - each individual run is costing more than it used to. Measured PER RUN (#2846) so " +
                         $"a cadence change cannot read as a cost change. get_collector_cost with " +
                         $"collector_name={regression.CollectorName} shows the trend. {CostIsNotAllTargetSide}",

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingCollectorCostReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingCollectorCostReader.cs
@@ -208,6 +208,7 @@ AND   sc.baseline_ms >= $2
 AND   sc.latest_ms_per_run IS NOT NULL
 AND   sc.baseline_ms_per_run IS NOT NULL
 AND   sc.latest_ms_per_run > sc.baseline_ms_per_run * $3
+AND   (sc.latest_ms_per_run - sc.baseline_ms_per_run) * sc.latest_runs >= $4
 ORDER BY (sc.latest_ms_per_run - sc.baseline_ms_per_run) DESC";
 
     /// <summary>#2846: <see cref="LatestMsPerRun"/> and <see cref="BaselineMsPerRun"/> are what the
@@ -224,11 +225,19 @@ ORDER BY (sc.latest_ms_per_run - sc.baseline_ms_per_run) DESC";
         DateTime LatestMetricTime,
         long LatestRuns,
         double LatestMsPerRun,
-        double BaselineMsPerRun);
+        double BaselineMsPerRun)
+    {
+        /// <summary>#3316: the per-run rise multiplied by the volume it is paid on, in ms per day -
+        /// what this regression actually COSTS. Derived from the members rather than carried, so it
+        /// cannot disagree with the parts that explain it, and the query gates on the same
+        /// expression. A truthful per-run doubling on a collector costing 3 ms per run and 305 ms
+        /// per day is 0.16 s here, which is why the ratio alone is not a reason to alert.</summary>
+        public double AddedMsPerDay => (LatestMsPerRun - BaselineMsPerRun) * LatestRuns;
+    }
 
     public static async Task<List<CostRegression>> GetCostRegressionsAsync(
         NpgsqlDataSource postgres, DateTime baselineSinceUtc, long baselineFloorMs, double factor,
-        CancellationToken cancellationToken = default)
+        long addedMsFloor, CancellationToken cancellationToken = default)
     {
         var rows = new List<CostRegression>();
         await using var command = postgres.CreateCommand(RegressionSql);
@@ -236,6 +245,7 @@ ORDER BY (sc.latest_ms_per_run - sc.baseline_ms_per_run) DESC";
         command.Parameters.AddWithValue(baselineSinceUtc);
         command.Parameters.AddWithValue(baselineFloorMs);
         command.Parameters.AddWithValue(factor);
+        command.Parameters.AddWithValue(addedMsFloor);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))


### PR DESCRIPTION
Closes #3316 (closing keywords no-op on `dev`, so this will be closed explicitly).

The predicate had two gates measuring **different units**: a floor on the average daily TOTAL (`baseline_ms >= $2`, 1000 ms) and a ratio on cost PER RUN. A total-cost floor is cleared by **volume**, so it never constrained the quantity the ratio tests — a collector averaging 3 ms per run clears 1000 ms/day on run count alone and is then judged by a 2.0x ratio on that 3 ms. The comment at `DarlingSelfAlertEvaluator.cs:172-178` asserted the opposite ("the floor stays on the daily TOTAL so a cheap-but-frequent collector still cannot trip on a per-run doubling"); the alert firing at all proved the floor was satisfied. That comment is corrected here.

**The firing was truthful, so this is a materiality gate and not a precision one.** My original issue text argued the 2.0x test was comparing integer-millisecond quantization noise. That was wrong and is retracted on the issue: both sides of the ratio are means over many runs (`latest_ms / latest_runs` and `baseline_total_ms / baseline_total_runs`), so rounding averages down to hundredths of a millisecond. The measured collector genuinely did double, 3.0 to 6.1 ms per run over 50 runs — and adding 0.16 s of collection time a day, it is correct and unactionable.

So a third gate asks what the regression **costs**: the per-run rise times the volume it is paid on, which is unit-consistent with the ratio it accompanies.

```sql
AND   (sc.latest_ms_per_run - sc.baseline_ms_per_run) * sc.latest_runs >= $4
```

**A minimum per-run baseline would have been the wrong fix**, and was my first suggestion. It excludes a 3 ms collector that runs 100,000 times a day, where the same doubling costs five minutes daily and is a real incident. Mutation 2 below exists specifically to keep that wrong fix from passing.

## The floor is derived from measurement, not chosen

A 41-hour fleet sample, computed from the delivered alert text. The firings that identified a real regression added 21.8–22.6 s/day; the ones that were truthful and unactionable added 0.16–3.6 s/day. 5 s sits between them and is 5x the existing eligibility floor.

**Correcting my own claim, twenty minutes after opening this PR:** I wrote that 5 s sat "in the empty band between them with better than 4x headroom on both sides." That band was empty only in that 9-point sample. Two firings arrived immediately afterwards, on one server in one sweep with an identical run count, and both land inside it:

| collector | baseline → latest | runs | added/day | under this gate |
|---|---|---|---|---|
| `session_stats` | 8.70 → 18.98 ms | 236 | **2.4 s** | suppressed |
| `session_summary_stats` | 25.62 → 52.95 ms | 236 | **6.5 s** | still fires |

So the floor is doing fine-grained discrimination near its own boundary rather than sitting in a void, and any threshold does — but "4x headroom" overstated the confidence and was a numeral welded onto a small sample. The *placement* still looks right on this pair: a 10 ms rise costing 2.4 s/day is not worth waking anyone, and a 27 ms rise costing 6.5 s/day on the same collector family plausibly is. Whoever retunes it should expect near-boundary cases as normal rather than as evidence the gate is wrong.

`CostRegression.AddedMsPerDay` is a **derived** property rather than a carried column, so it cannot disagree with the parts that explain it and the query gates on the same expression. The alert text now states it, since it is the quantity that justified the alert.

## Verification

The gate is a line of SQL, so — following `CollectorCostRegressionPerRunTests`' own stated rationale — a text assertion on the query would pass against any SQL containing the right words, and an in-memory test only sees rows the SQL already chose to return. The property is asserted by planting rows and running the **shipped** query against a real PostgreSQL 17 + TimescaleDB 2.30 store.

`CollectorCostRegressionMaterialityTests` is adversarial on one axis only: both collectors have an identical per-run baseline (100 ms), identical latest per-run cost (300 ms), the identical 3x ratio and constant cadence, and both clear the daily-total floor. They differ **only** in volume, so 4 s/day versus 40 s/day against a 5 s floor.

Run locally against a throwaway TimescaleDB via a harness driving the real `DarlingCollectorCostReader` and real `PgMigrations`:

| | result |
|---|---|
| floor 5000 | only the material collector reported; all 6 assertions pass |
| **control**, floor 0 | **both** reported — proves the fixture trips the per-run rule at all, so the exclusion above is attributable to this gate and nothing incidental |
| mutation 1: predicate deleted | **red on "trivial is NOT reported"** only — the property under test, control unaffected |
| mutation 2: volume term dropped (the wrong fix) | **red on 5 checks** — the trivial case still passes while the material one is now wrongly excluded |

Mutation 2 is the one that matters: it discriminates the correct fix from the plausible wrong one.

`CollectorCostRegressionPerRunTests` passes `addedMsFloor: 0` so it keeps pinning the #2846 per-run property in isolation rather than gaining a second reason to fail.

