### PR TITLE
Skip mute-from-history pre-fill parsing for custom alerts (#3309)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertDisplayNameTests.cs
+++ b/Darling/Darling.Tests/CustomAlertDisplayNameTests.cs
@@ -169,4 +169,46 @@ public class CustomAlertDisplayNameTests
 
         Assert.Equal("CPU pressure", outcome.DetailText);
     }
+
+    // ─────────────────── #3309: the single-line-label residual, closed at the mute pre-fill ───────────────────
+
+    /// <summary>
+    /// #3309: a rule literally NAMED with a leading mute-label ("Database: master") produces a ONE-line
+    /// detail_text that does lead with "Database: " — the residual the slice-1 sanitizer (which only defeats
+    /// MULTI-line injection) cannot close on its own. A custom alert has no database dimension, so the
+    /// mute-from-history pre-fill now skips parsing entirely when the metric is "Custom:&lt;id&gt;", closing it.
+    /// </summary>
+    [Fact]
+    public void PopulateFromDetailText_CustomMetric_SkipsParsing_SoASingleLineLabelNameCannotForgeAField()
+    {
+        var outcome = CustomAlertEvaluator.BuildFireOutcome(
+            Rule(42, "Database: master"), Definition(),
+            serverKey: "7", serverDisplayName: "PROD01",
+            value: 1500, severity: AlertSeverityLevel.Warning, muted: false);
+
+        var ctx = new AlertMuteContext();
+        ctx.PopulateFromDetailText(outcome.DetailText, outcome.MetricName); // metric is "Custom:42"
+
+        Assert.Null(ctx.DatabaseName); // skipped: a custom alert has no database dimension to pre-fill
+        Assert.Null(ctx.WaitType);
+        Assert.Null(ctx.JobName);
+        Assert.Null(ctx.QueryText);
+    }
+
+    /// <summary>
+    /// The guard is METRIC-GATED, not blanket: a built-in alert (any non-"Custom:" metric, or none supplied)
+    /// still pre-fills from its structured detail_text exactly as before, so #3309 never regresses built-in muting.
+    /// </summary>
+    [Fact]
+    public void PopulateFromDetailText_BuiltInMetric_StillParses()
+    {
+        var ctx = new AlertMuteContext();
+        ctx.PopulateFromDetailText("Database: master", "High CPU");
+        Assert.Equal("master", ctx.DatabaseName);
+
+        // The legacy single-argument call (no metric) is unchanged.
+        var legacy = new AlertMuteContext();
+        legacy.PopulateFromDetailText("Database: master");
+        Assert.Equal("master", legacy.DatabaseName);
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/AlertsHistoryTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AlertsHistoryTab.xaml.cs
@@ -460,7 +460,10 @@ public partial class AlertsHistoryTab : UserControl
             ServerName = item.ServerName,
             MetricName = item.MetricName
         };
-        context.PopulateFromDetailText(item.DetailText);
+        /* #3309: pass the metric name so a custom alert ("Custom:<id>") skips detail_text pre-fill parsing -
+           a custom rule has no Database/Wait Type/Job/Query dimension to pre-fill, and its user-authored name
+           must not be able to forge a mute-context label line. */
+        context.PopulateFromDetailText(item.DetailText, item.MetricName);
 
         await CreateMuteRuleAsync(context);
     }

--- a/PerformanceMonitor.Notifications/MuteRule.cs
+++ b/PerformanceMonitor.Notifications/MuteRule.cs
@@ -113,9 +113,18 @@ public class AlertMuteContext
     /// Query values may span multiple lines and use variant labels
     /// (Blocked Query, Blocking Query, Victim SQL).
     /// </summary>
-    public void PopulateFromDetailText(string? detailText)
+    /// <param name="metricName">The alert's metric name, when known. A custom alert rule
+    /// (<c>"Custom:&lt;id&gt;"</c>) has no Database/Wait Type/Job/Query dimension, so its detail_text is
+    /// NOT parsed for a mute-context pre-fill (#3309); omit or pass null for built-in alerts to parse as before.</param>
+    public void PopulateFromDetailText(string? detailText, string? metricName = null)
     {
         if (string.IsNullOrEmpty(detailText)) return;
+
+        /* #3309: a custom alert rule ("Custom:<id>") carries NO Database/Wait Type/Job/Query dimension. Its
+           detail_text is the user-authored rule name/description, so DMV-label parsing it for a mute-context
+           pre-fill is meaningless AND is the vector by which a crafted single-line name (e.g. "Database: master")
+           could forge a label line. Skip it for custom alerts; their mute context is ServerName + MetricName. */
+        if (metricName is not null && metricName.StartsWith("Custom:", StringComparison.Ordinal)) return;
 
         System.Text.StringBuilder? queryBuilder = null;
         var lines = detailText.Split('\n');


### PR DESCRIPTION
Closes the low-severity residual from #3303 (tracked as #3309): the slice-1 sanitizer defeats MULTI-line mute-pre-fill injection, but a rule literally NAMED with a leading label (e.g. `Database: master`) still produces a one-line `detail_text` that leads with `Database: `, forging one field into the viewer's mute-from-history pre-fill.

Fix is viewer-side and semantic, not a band-aid: a custom alert (`Custom:<id>`) has no Database/Wait Type/Job/Query dimension, so `PopulateFromDetailText` now takes the metric name and skips DMV-label parsing for `Custom:` metrics entirely (its mute context is ServerName + MetricName). Built-in alerts are untouched (metric-gated; the legacy single-arg call is unchanged).

Tests: `PopulateFromDetailText_CustomMetric_SkipsParsing_...` (a `Database: master`-named rule's detail_text forges nothing) and `PopulateFromDetailText_BuiltInMetric_StillParses` (metric-gated, no built-in regression). Full Darling.Tests (only the pre-existing #2117 TLS failure) and full Lite.Tests (0 failures) green locally.

Part of #3285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
