### PR TITLE
Add the custom-alert web API mirroring /api/views (#3285)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertTemplatesTests.cs
+++ b/Darling/Darling.Tests/CustomAlertTemplatesTests.cs
@@ -81,7 +81,7 @@ public sealed class CustomAlertTemplatesTests
 
         Assert.Equal(CustomAlertTemplates.All.Count, templates.Count);
 
-        var toolKeys = templates.Select(t => (string?)((JsonObject)t!)["key"]).ToHashSet(StringComparer.Ordinal);
+        var toolKeys = templates.Select(t => (string)((JsonObject)t!)["key"]!).ToHashSet(StringComparer.Ordinal);
         Assert.Equal(CustomAlertTemplates.All.Select(t => t.Key).ToHashSet(StringComparer.Ordinal), toolKeys);
 
         foreach (var entry in templates)

--- a/Darling/Darling.Tests/DarlingWebEndpointsTests.cs
+++ b/Darling/Darling.Tests/DarlingWebEndpointsTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Nodes;
 using ModelContextProtocol.Server;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Service.Mcp;
@@ -179,4 +180,51 @@ public sealed class DarlingWebEndpointsTests
     [InlineData(-5, 1)]
     public void ClampRows_BoundsCallerSuppliedRowCounts(int requested, int expected) =>
         Assert.Equal(expected, DarlingWebEndpoints.ClampRows(requested));
+
+    /* ── custom-alert-rule wire-shape builders (#3285): the ONE shape shared by the /api/alerts responses AND
+       the MCP alert tools (get/create/update/list), so the two surfaces cannot drift. ── */
+
+    [Fact]
+    public void BuildFullRuleNode_CarriesEnabled_AndEmbedsTheDefinitionAsAnObject()
+    {
+        var created = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var updated = new DateTime(2026, 1, 2, 3, 5, 6, DateTimeKind.Utc);
+        var rule = new CustomAlertRule(
+            Id: 7, Name: "PG dead tuples", DefinitionJson: "{\"predicate\":{\"op\":\"gt\",\"warnThreshold\":1000}}",
+            Description: "desc", Enabled: false, Version: 3, CreatedAt: created, UpdatedAt: updated, UpdatedBy: "web");
+
+        var node = DarlingWebEndpoints.BuildFullRuleNode(rule);
+
+        foreach (var key in new[] { "id", "name", "description", "definition", "enabled", "version", "created_at", "updated_at", "updated_by" })
+        {
+            Assert.True(node.ContainsKey(key), "missing key: " + key);
+        }
+
+        Assert.Equal(7L, (long)node["id"]!);
+        Assert.Equal("PG dead tuples", (string)node["name"]!);
+        Assert.False((bool)node["enabled"]!);          // 'enabled' round-trips (the view shape carries no such field)
+        Assert.Equal(3, (int)node["version"]!);
+
+        // The definition is an embedded JSON object (NOT an escaped string), so a client reads its fields directly.
+        var definition = Assert.IsType<JsonObject>(node["definition"]);
+        Assert.Equal("gt", (string)definition["predicate"]!["op"]!);
+    }
+
+    [Fact]
+    public void BuildRuleSummariesNode_IsABareArray_WithEnabled_AndNoDefinitionBody()
+    {
+        var summaries = new List<CustomAlertRuleSummary>
+        {
+            new(Id: 11, Name: "blocking", Description: null, Enabled: true, Version: 2,
+                UpdatedAt: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), UpdatedBy: "mcp"),
+        };
+
+        var array = DarlingWebEndpoints.BuildRuleSummariesNode(summaries);
+
+        var only = Assert.IsType<JsonObject>(Assert.Single(array));
+        Assert.Equal(11L, (long)only["id"]!);
+        Assert.Equal("blocking", (string)only["name"]!);
+        Assert.True((bool)only["enabled"]!);
+        Assert.False(only.ContainsKey("definition"));  // the list projection never carries the definition body
+    }
 }

--- a/Darling/Darling.Tests/DarlingWebOidcTests.cs
+++ b/Darling/Darling.Tests/DarlingWebOidcTests.cs
@@ -510,6 +510,18 @@ public sealed class DarlingWebOidcTests
     [InlineData(false, "DELETE", "/api/views/3", false)]        // no delete
     [InlineData(false, "POST", "/api/anything/new", false)]     // a write endpoint added TOMORROW is born gated
     [InlineData(false, "PATCH", "/api/compose/run", false)]     // the compose exception is POST-only
+    // The custom-alert-rule web API (#3285) shadows /api/views: reads open to any seat, writes born gated.
+    [InlineData(true, "POST", "/api/alerts", true)]             // edit seat: create
+    [InlineData(true, "PUT", "/api/alerts/3", true)]            // edit seat: update
+    [InlineData(true, "DELETE", "/api/alerts/3", true)]         // edit seat: delete
+    [InlineData(false, "GET", "/api/alerts", true)]             // viewer: list
+    [InlineData(false, "GET", "/api/alerts/3", true)]           // viewer: get one
+    [InlineData(false, "GET", "/api/alert-templates", true)]    // viewer: browse starter templates
+    [InlineData(false, "POST", "/api/alerts", false)]           // viewer: no create
+    [InlineData(false, "PUT", "/api/alerts/3", false)]          // no update
+    [InlineData(false, "DELETE", "/api/alerts/3", false)]       // no delete
+    [InlineData(false, "POST", "/api/alerts/validate", false)]  // validate is a POST, born gated (NOT compose/run-exempt)
+    [InlineData(false, "POST", "/api/alerts/test", false)]      // evaluate-now is a POST, born gated too
     public void IsRequestAllowed_Matrix(bool canEdit, string method, string path, bool expected)
         => Assert.Equal(expected, DarlingWebSeat.IsRequestAllowed(new DarlingWebSeat("who", canEdit), method, path));
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWebEndpoints.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWebEndpoints.cs
@@ -277,6 +277,7 @@ public static class DarlingWebEndpoints
         }
 
         MapCustomViews(app, postgres);
+        MapCustomAlerts(app, postgres);
 
         /* The per-alert triage page's assembly endpoint (#2710): everything it serves is already reachable
            through the /api/read mirror above — it adds assembly (alert match + anchored sections), not reach. */
@@ -470,6 +471,215 @@ public static class DarlingWebEndpoints
             return outcome.Payload is not null
                 ? JsonNodeResult(outcome.Payload)
                 : ErrorResult(outcome.Error!, outcome.IsServerError ? StatusCodes.Status500InternalServerError : StatusCodes.Status400BadRequest);
+        });
+    }
+
+    /// <summary>
+    /// The custom-alert-rule web API (#3285, Component 7's backend) — the SAME surface the
+    /// <see cref="Mcp.DarlingMcpCustomAlertTools"/> MCP tools expose, mirrored onto HTTP so a web editor (its JS
+    /// deferred) can list / read / create / update / delete / validate / test the user-authored alert rules and
+    /// browse the starter templates. Deliberately a THIN wrapper, never a second implementation: persistence is
+    /// the same <see cref="CustomAlertRuleStore"/>, definition validation the same
+    /// <see cref="CustomAlertRuleDefinition.TryParse"/> authority, delete the same
+    /// <see cref="CustomAlertEvaluator.ResolveAndDeleteRuleAsync"/> (so an open incident is force-resolved before
+    /// the FK cascade drops its state, #3305), templates the same <see cref="CustomAlertTemplates"/>, and
+    /// evaluate-now the same <see cref="Mcp.DarlingMcpCustomAlertTools.TestCustomAlertRule"/> seam — so the web
+    /// and MCP surfaces cannot drift. The routes shadow <see cref="MapCustomViews"/> exactly: the reads are open
+    /// to any seat; the writes (POST/PUT/DELETE, plus the two evaluate POSTs) require <c>application/json</c> (the
+    /// CSRF gate) and are born gated by the host's method-based write gate
+    /// (<see cref="Hosting.DarlingWebSeat.IsRequestAllowed"/> refuses a read-only seat everything unsafe except
+    /// <c>POST /api/compose/run</c>), so a viewer seat gets a 403 on every one of them without this method
+    /// naming the gate. The store/evaluator run on the host's least-privilege VIEWER pool (the same
+    /// <paramref name="postgres"/> the reads and <c>/api/compose/run</c> use — never the owner pool).
+    /// </summary>
+    private static void MapCustomAlerts(WebApplication app, NpgsqlDataSource postgres)
+    {
+        var store = new CustomAlertRuleStore(postgres);
+
+        /* List — a bare array of summaries (no definition), carrying 'enabled'; [] when none. */
+        app.MapGet("/api/alerts", async (HttpContext context) =>
+        {
+            var rules = await store.ListAsync(context.RequestAborted);
+            return JsonNodeResult(BuildRuleSummariesNode(rules));
+        });
+
+        /* Get one — full, including the definition and 'enabled'; 404 when missing. */
+        app.MapGet("/api/alerts/{id:long}", async (HttpContext context, long id) =>
+        {
+            var result = await store.GetAsync(id, context.RequestAborted);
+            return result is CustomAlertRuleResult.Ok ok && ok.Rule is not null
+                ? JsonNodeResult(BuildFullRuleNode(ok.Rule))
+                : AlertNotFoundResult();
+        });
+
+        /* Create — 201 + Location; 400 on a bad body/definition, 409 on a duplicate name. The definition is
+           VALIDATED (CustomAlertRuleDefinition.TryParse — the SAME authority the evaluator applies on load)
+           BEFORE any store hit, so a stored rule always parses. application/json required (CSRF defense). */
+        app.MapPost("/api/alerts", async (HttpContext context) =>
+        {
+            if (!IsJsonContentType(context.Request.ContentType))
+            {
+                return UnsupportedMediaTypeResult();
+            }
+
+            var (request, bodyError) = await ParseAlertBodyAsync(context);
+            if (request is null)
+            {
+                return ErrorResult(bodyError!, StatusCodes.Status400BadRequest);
+            }
+
+            var (parsed, definitionError) = CustomAlertRuleDefinition.TryParse(request.DefinitionJson);
+            if (parsed is null || definitionError is not null)
+            {
+                return ErrorResult(definitionError ?? "definition is invalid.", StatusCodes.Status400BadRequest);
+            }
+
+            try
+            {
+                var result = await store.CreateAsync(
+                    request.Name, request.Description, request.DefinitionJson, request.Enabled,
+                    updatedBy: DarlingWebSeat.FromContext(context).EditorPrincipal, context.RequestAborted);
+                return result switch
+                {
+                    CustomAlertRuleResult.Ok ok => CreatedResult(context, $"/api/alerts/{ok.Rule!.Id}", BuildFullRuleNode(ok.Rule)),
+                    CustomAlertRuleResult.Conflict conflict => ErrorResult(conflict.Message, StatusCodes.Status409Conflict),
+                    CustomAlertRuleResult.Invalid invalid => ErrorResult(invalid.Message, StatusCodes.Status400BadRequest),
+                    _ => ErrorResult("Could not create the alert rule.", StatusCodes.Status500InternalServerError),
+                };
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                return ErrorResult($"Error saving alert rule: {ex.Message}", StatusCodes.Status500InternalServerError);
+            }
+        });
+
+        /* Update — 200 on success; 400 bad body/definition, 404 gone, 409 stale-version OR duplicate name. A
+           full replace (the client sends the whole rule it edited), exactly like PUT /api/views: 'version' is
+           required, and a mismatch is a 409, not a silent clobber. application/json required. */
+        app.MapPut("/api/alerts/{id:long}", async (HttpContext context, long id) =>
+        {
+            if (!IsJsonContentType(context.Request.ContentType))
+            {
+                return UnsupportedMediaTypeResult();
+            }
+
+            var (request, bodyError) = await ParseAlertBodyAsync(context);
+            if (request is null)
+            {
+                return ErrorResult(bodyError!, StatusCodes.Status400BadRequest);
+            }
+
+            if (request.Version is not { } expectedVersion)
+            {
+                return ErrorResult("'version' is required for an update (optimistic concurrency).", StatusCodes.Status400BadRequest);
+            }
+
+            var (parsed, definitionError) = CustomAlertRuleDefinition.TryParse(request.DefinitionJson);
+            if (parsed is null || definitionError is not null)
+            {
+                return ErrorResult(definitionError ?? "definition is invalid.", StatusCodes.Status400BadRequest);
+            }
+
+            try
+            {
+                var result = await store.UpdateAsync(
+                    id, request.Name, request.Description, request.DefinitionJson, request.Enabled, expectedVersion,
+                    updatedBy: DarlingWebSeat.FromContext(context).EditorPrincipal, context.RequestAborted);
+                return result switch
+                {
+                    CustomAlertRuleResult.Ok ok => JsonNodeResult(BuildFullRuleNode(ok.Rule!)),
+                    CustomAlertRuleResult.NotFound => AlertNotFoundResult(),
+                    CustomAlertRuleResult.Conflict conflict => ErrorResult(conflict.Message, StatusCodes.Status409Conflict),
+                    CustomAlertRuleResult.Invalid invalid => ErrorResult(invalid.Message, StatusCodes.Status400BadRequest),
+                    _ => ErrorResult("Could not update the alert rule.", StatusCodes.Status500InternalServerError),
+                };
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                return ErrorResult($"Error saving alert rule: {ex.Message}", StatusCodes.Status500InternalServerError);
+            }
+        });
+
+        /* Delete — 204 on success, 404 when missing. application/json required. Routes through
+           CustomAlertEvaluator.ResolveAndDeleteRuleAsync (NOT store.DeleteAsync): any OPEN incident is
+           force-resolved — a recovery row written to alert history — BEFORE the delete's FK cascade drops the
+           per-server state that says which (rule, server) pairs were firing (#3305), so nothing is left showing
+           as firing forever. The resolve is best-effort inside that method (its own failure isolation), so a
+           resolve blip never blocks the delete the operator asked for. Same call the MCP delete tool makes;
+           logger null here as there (the recovery row still writes; only the service-log line is skipped). */
+        app.MapDelete("/api/alerts/{id:long}", async (HttpContext context, long id) =>
+        {
+            if (!IsJsonContentType(context.Request.ContentType))
+            {
+                return UnsupportedMediaTypeResult();
+            }
+
+            try
+            {
+                var result = await CustomAlertEvaluator.ResolveAndDeleteRuleAsync(postgres, id, logger: null, context.RequestAborted);
+                return result is CustomAlertRuleResult.Ok ? Results.NoContent() : AlertNotFoundResult();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                return ErrorResult($"Error deleting alert rule: {ex.Message}", StatusCodes.Status500InternalServerError);
+            }
+        });
+
+        /* The starter templates (#3325): the SAME code-defined set the list_custom_alert_templates MCP tool
+           returns, byte-identical (wraps that tool), mapped through the shared ToHttpResult exactly as the
+           /api/read/* tool endpoints map their string results. Read-only, touches no store; open to any seat. */
+        app.MapGet("/api/alert-templates", async () =>
+            ToHttpResult(await Mcp.DarlingMcpCustomAlertTools.ListCustomAlertTemplates()));
+
+        /* Validate — dry-run a definition WITHOUT persisting; returns {valid, error}. The definition rides as an
+           embedded JSON object (same as create/update bodies), validated by the SAME
+           CustomAlertRuleDefinition.TryParse authority the MCP validate_custom_alert_rule tool uses, so the two
+           verdicts cannot diverge. A POST (application/json required); born gated like the mutations — an
+           evaluate/validate is an editor affordance, not a read the viewer seat is granted. */
+        app.MapPost("/api/alerts/validate", async (HttpContext context) =>
+        {
+            if (!IsJsonContentType(context.Request.ContentType))
+            {
+                return UnsupportedMediaTypeResult();
+            }
+
+            var (definitionJson, bodyError) = await ParseDefinitionBodyAsync(context);
+            if (definitionJson is null)
+            {
+                return ErrorResult(bodyError!, StatusCodes.Status400BadRequest);
+            }
+
+            var (parsed, validationError) = CustomAlertRuleDefinition.TryParse(definitionJson);
+            return JsonNodeResult(new JsonObject
+            {
+                ["valid"] = parsed is not null && validationError is null,
+                ["error"] = validationError,
+            });
+        });
+
+        /* Test (evaluate-now) — for a SAVED rule (rule_id) OR a supplied definition, read the metric's CURRENT
+           value on each in-scope server and report whether it WOULD breach right now, delivering/persisting
+           nothing. Wraps the MCP test_custom_alert_rule tool for zero divergence: that method resolves the
+           in-scope servers, runs the SHARED EvaluateScalarNowAsync per-server scalar seam, and applies
+           ClassifyTestValue — all on the pool it is handed, which here is the host's VIEWER pool (exactly as
+           /api/compose/run runs the composer — never the owner pool). rule_id XOR definition is enforced inside
+           the tool; its result is mapped through the shared ToHttpResult like every /api/read/* tool string — the
+           {status,...} envelope (invalid / not_found / no_in_scope_servers) passes through as 200, an unexpected
+           tool error becomes 500. A POST (application/json required); born gated like the mutations. */
+        app.MapPost("/api/alerts/test", async (HttpContext context) =>
+        {
+            if (!IsJsonContentType(context.Request.ContentType))
+            {
+                return UnsupportedMediaTypeResult();
+            }
+
+            var (ruleId, definitionJson, bodyError) = await ParseAlertTestBodyAsync(context);
+            if (bodyError is not null)
+            {
+                return ErrorResult(bodyError, StatusCodes.Status400BadRequest);
+            }
+
+            return ToHttpResult(await Mcp.DarlingMcpCustomAlertTools.TestCustomAlertRule(postgres, ruleId, definitionJson));
         });
     }
 
@@ -1902,6 +2112,164 @@ public static class DarlingWebEndpoints
         return array;
     }
 
+    /* ── custom-alert-rule body parsing + response building (#3285) ── */
+
+    /// <summary>A parsed alert create/update body: name (required, trimmed), description (optional), the
+    /// definition as raw JSON text (re-serialized from the parsed node), <c>enabled</c> (defaults true when the
+    /// key is absent, matching create's default and a full-replace PUT), and version (present only on updates).
+    /// The definition's STRUCTURE is validated separately by <see cref="CustomAlertRuleDefinition.TryParse"/>.</summary>
+    private sealed record AlertWriteRequest(string Name, string? Description, string DefinitionJson, bool Enabled, int? Version);
+
+    /// <summary>Parses an alert create/update body into an <see cref="AlertWriteRequest"/>, or a caller-facing
+    /// error. Mirrors <see cref="ParseViewBodyAsync"/>, adding the <c>enabled</c> field alert rules carry.</summary>
+    private static async Task<(AlertWriteRequest? Request, string? Error)> ParseAlertBodyAsync(HttpContext context)
+    {
+        JsonNode? root;
+        try
+        {
+            root = await JsonNode.ParseAsync(context.Request.Body, cancellationToken: context.RequestAborted);
+        }
+        catch (JsonException)
+        {
+            return (null, "Request body is not valid JSON.");
+        }
+
+        if (root is not JsonObject obj)
+        {
+            return (null, "Request body must be a JSON object.");
+        }
+
+        var name = TryGetString(obj, "name");
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return (null, "'name' is required.");
+        }
+
+        var description = TryGetString(obj, "description");
+
+        var definitionNode = obj["definition"];
+        if (definitionNode is null)
+        {
+            return (null, "'definition' is required.");
+        }
+
+        var definitionJson = definitionNode.ToJsonString();
+
+        /* Absent 'enabled' defaults true: create's default, and a full-replace PUT of a rule that names no
+           enabled state is an enabled rule (the real full-document editor always sends the field). */
+        var enabled = true;
+        if (obj["enabled"] is JsonValue enabledValue && enabledValue.TryGetValue<bool>(out var e))
+        {
+            enabled = e;
+        }
+
+        int? version = null;
+        if (obj["version"] is JsonValue versionValue && versionValue.TryGetValue<int>(out var v))
+        {
+            version = v;
+        }
+
+        return (new AlertWriteRequest(name.Trim(), description, definitionJson, enabled, version), null);
+    }
+
+    /// <summary>Extracts just the embedded <c>definition</c> object from a body as raw JSON text — the
+    /// <c>POST /api/alerts/validate</c> shape — or a caller-facing error. The definition rides as a JSON object
+    /// (not an escaped string), the same way the create/update bodies carry it.</summary>
+    private static async Task<(string? DefinitionJson, string? Error)> ParseDefinitionBodyAsync(HttpContext context)
+    {
+        JsonNode? root;
+        try
+        {
+            root = await JsonNode.ParseAsync(context.Request.Body, cancellationToken: context.RequestAborted);
+        }
+        catch (JsonException)
+        {
+            return (null, "Request body is not valid JSON.");
+        }
+
+        if (root is not JsonObject obj)
+        {
+            return (null, "Request body must be a JSON object.");
+        }
+
+        var definitionNode = obj["definition"];
+        return definitionNode is null
+            ? (null, "'definition' is required.")
+            : (definitionNode.ToJsonString(), null);
+    }
+
+    /// <summary>Parses a <c>POST /api/alerts/test</c> body into <c>(rule_id, definition)</c> — both optional here
+    /// (the wrapped <see cref="Mcp.DarlingMcpCustomAlertTools.TestCustomAlertRule"/> enforces the rule_id XOR
+    /// definition rule and reports a violation in its envelope). Errors only on a body that is not a JSON object.
+    /// The definition rides as an embedded JSON object, re-serialized to the text the tool parses.</summary>
+    private static async Task<(long? RuleId, string? DefinitionJson, string? Error)> ParseAlertTestBodyAsync(HttpContext context)
+    {
+        JsonNode? root;
+        try
+        {
+            root = await JsonNode.ParseAsync(context.Request.Body, cancellationToken: context.RequestAborted);
+        }
+        catch (JsonException)
+        {
+            return (null, null, "Request body is not valid JSON.");
+        }
+
+        if (root is not JsonObject obj)
+        {
+            return (null, null, "Request body must be a JSON object.");
+        }
+
+        long? ruleId = null;
+        if (obj["rule_id"] is JsonValue ruleIdValue && ruleIdValue.TryGetValue<long>(out var r))
+        {
+            ruleId = r;
+        }
+
+        var definitionNode = obj["definition"];
+        var definitionJson = definitionNode?.ToJsonString();
+
+        return (ruleId, definitionJson, null);
+    }
+
+    /// <summary>The full single-rule wire shape — IDENTICAL to
+    /// <see cref="Mcp.DarlingMcpCustomAlertTools"/>'s (definition embedded as JSON, plus the <c>enabled</c>
+    /// column alert rules carry), so the web GET/POST/PUT and the MCP get/create/update return the same rule
+    /// shape.</summary>
+    internal static JsonObject BuildFullRuleNode(CustomAlertRule rule) => new()
+    {
+        ["id"] = rule.Id,
+        ["name"] = rule.Name,
+        ["description"] = rule.Description,
+        ["definition"] = JsonNode.Parse(rule.DefinitionJson),
+        ["enabled"] = rule.Enabled,
+        ["version"] = rule.Version,
+        ["created_at"] = rule.CreatedAt,
+        ["updated_at"] = rule.UpdatedAt,
+        ["updated_by"] = rule.UpdatedBy,
+    };
+
+    /// <summary>The bare-array list wire shape (no definition body), carrying <c>enabled</c> so the list can
+    /// badge a paused rule without fetching each full definition — mirrors the MCP list surface.</summary>
+    internal static JsonArray BuildRuleSummariesNode(IReadOnlyList<CustomAlertRuleSummary> rules)
+    {
+        var array = new JsonArray();
+        foreach (var rule in rules)
+        {
+            array.Add(new JsonObject
+            {
+                ["id"] = rule.Id,
+                ["name"] = rule.Name,
+                ["description"] = rule.Description,
+                ["enabled"] = rule.Enabled,
+                ["version"] = rule.Version,
+                ["updated_at"] = rule.UpdatedAt,
+                ["updated_by"] = rule.UpdatedBy,
+            });
+        }
+
+        return array;
+    }
+
     /* ── result helpers (JSON body written verbatim, bypassing any serializer naming policy) ── */
 
     private static IResult JsonNodeResult(JsonNode node, int statusCode = StatusCodes.Status200OK) =>
@@ -1918,6 +2286,9 @@ public static class DarlingWebEndpoints
 
     private static IResult NotFoundResult() =>
         ErrorResult("View not found.", StatusCodes.Status404NotFound);
+
+    private static IResult AlertNotFoundResult() =>
+        ErrorResult("Alert rule not found.", StatusCodes.Status404NotFound);
 
     private static IResult UnsupportedMediaTypeResult() =>
         ErrorResult("Content-Type must be application/json.", StatusCodes.Status415UnsupportedMediaType);

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
@@ -38,12 +38,12 @@ namespace PerformanceMonitor.Darling.Service.Mcp;
 /// BEFORE persistence on create and on any update that carries a new definition, so a stored rule always
 /// parses.</para>
 ///
-/// <para><b>Evaluate-now is deliberately absent.</b> A faithful test-now would have to reproduce
-/// <see cref="CustomAlertEvaluator"/>'s per-server scalar run (its window, rollup routing, and scalar
-/// extraction) and then its predicate, which either couples this class to the evaluator or forks a divergent
-/// copy of it. Both are ruled out here; the clean home for an evaluate-now is a shared seam on the evaluator
-/// itself, tracked as a follow-up. To see a rule's current metric value in the meantime, run its
-/// <c>metric</c> panel through the custom-view <c>run_custom_view_panel</c> tool.</para>
+/// <para><b>Evaluate-now.</b> <see cref="TestCustomAlertRule"/> (#3299) reports a rule's CURRENT value on each
+/// in-scope server and whether it WOULD breach right now, delivering and persisting nothing. It does not fork
+/// the evaluator: it runs the SAME shared per-server scalar seam the sweep uses
+/// (<see cref="CustomAlertEvaluator.EvaluateScalarNowAsync"/> + <see cref="CustomAlertEvaluator.ClassifyTestValue"/>),
+/// so a test value can never diverge from what the running rule sees. What a one-shot cannot reproduce is the
+/// rule's hysteresis and per-server streak, so a breach here means "true this instant", not "has fired".</para>
 ///
 /// <para><b>Security.</b> These tools connect (like every MCP tool) as the least-privilege <c>mcp</c> role,
 /// which is granted INSERT/UPDATE/DELETE on ONLY <c>config.custom_alert_rules</c> (see
@@ -67,7 +67,7 @@ public sealed class DarlingMcpCustomAlertTools
         {
             var store = new CustomAlertRuleStore(postgres);
             var rules = await store.ListAsync();
-            return BuildSummariesNode(rules).ToJsonString(McpHelpers.JsonOptions);
+            return DarlingWebEndpoints.BuildRuleSummariesNode(rules).ToJsonString(McpHelpers.JsonOptions);
         }
         catch (Exception ex)
         {
@@ -89,7 +89,7 @@ public sealed class DarlingMcpCustomAlertTools
             var store = new CustomAlertRuleStore(postgres);
             var result = await store.GetAsync(rule_id);
             return result is CustomAlertRuleResult.Ok ok && ok.Rule is not null
-                ? BuildFullRuleNode(ok.Rule).ToJsonString(McpHelpers.JsonOptions)
+                ? DarlingWebEndpoints.BuildFullRuleNode(ok.Rule).ToJsonString(McpHelpers.JsonOptions)
                 : Outcome("not_found", $"No custom alert rule with id {rule_id}.");
         }
         catch (Exception ex)
@@ -152,7 +152,7 @@ public sealed class DarlingMcpCustomAlertTools
             var result = await store.CreateAsync(name, description, definition, enabled, DarlingWebEndpoints.McpEditorPrincipal);
             return result switch
             {
-                CustomAlertRuleResult.Ok ok => BuildFullRuleNode(ok.Rule!).ToJsonString(McpHelpers.JsonOptions),
+                CustomAlertRuleResult.Ok ok => DarlingWebEndpoints.BuildFullRuleNode(ok.Rule!).ToJsonString(McpHelpers.JsonOptions),
                 CustomAlertRuleResult.Conflict conflict => Outcome("conflict", conflict.Message),
                 CustomAlertRuleResult.Invalid invalid => Outcome("invalid", invalid.Message),
                 _ => Outcome("error", "Could not create the rule."),
@@ -220,7 +220,7 @@ public sealed class DarlingMcpCustomAlertTools
                 DarlingWebEndpoints.McpEditorPrincipal);
             return result switch
             {
-                CustomAlertRuleResult.Ok ok => BuildFullRuleNode(ok.Rule!).ToJsonString(McpHelpers.JsonOptions),
+                CustomAlertRuleResult.Ok ok => DarlingWebEndpoints.BuildFullRuleNode(ok.Rule!).ToJsonString(McpHelpers.JsonOptions),
                 CustomAlertRuleResult.NotFound => Outcome("not_found", $"No custom alert rule with id {rule_id}."),
                 CustomAlertRuleResult.Conflict conflict => Outcome("conflict", conflict.Message),
                 CustomAlertRuleResult.Invalid invalid => Outcome("invalid", invalid.Message),
@@ -404,45 +404,6 @@ public sealed class DarlingMcpCustomAlertTools
         }
 
         return Task.FromResult(new JsonObject { ["templates"] = templates }.ToJsonString(McpHelpers.JsonOptions));
-    }
-
-    /// <summary>The full single-rule wire shape (definition embedded as JSON, NOT an escaped string) - mirrors
-    /// <see cref="DarlingWebEndpoints.BuildFullViewNode"/>, adding the <c>enabled</c> column that alert rules
-    /// carry and views do not. Returned by get / create / update.</summary>
-    private static JsonObject BuildFullRuleNode(CustomAlertRule rule) => new()
-    {
-        ["id"] = rule.Id,
-        ["name"] = rule.Name,
-        ["description"] = rule.Description,
-        ["definition"] = JsonNode.Parse(rule.DefinitionJson),
-        ["enabled"] = rule.Enabled,
-        ["version"] = rule.Version,
-        ["created_at"] = rule.CreatedAt,
-        ["updated_at"] = rule.UpdatedAt,
-        ["updated_by"] = rule.UpdatedBy,
-    };
-
-    /// <summary>The bare-array list wire shape (no definition body) - mirrors
-    /// <see cref="DarlingWebEndpoints.BuildSummariesNode"/>, carrying <c>enabled</c> so the list can show a
-    /// paused rule without fetching each full definition.</summary>
-    private static JsonArray BuildSummariesNode(IReadOnlyList<CustomAlertRuleSummary> rules)
-    {
-        var array = new JsonArray();
-        foreach (var rule in rules)
-        {
-            array.Add(new JsonObject
-            {
-                ["id"] = rule.Id,
-                ["name"] = rule.Name,
-                ["description"] = rule.Description,
-                ["enabled"] = rule.Enabled,
-                ["version"] = rule.Version,
-                ["updated_at"] = rule.UpdatedAt,
-                ["updated_by"] = rule.UpdatedBy,
-            });
-        }
-
-        return array;
     }
 
     /// <summary>A small <c>{status, message}</c> envelope for a non-data write outcome (conflict / invalid /


### PR DESCRIPTION
Part of #3285.

The **custom-alert web API** — the backend half of Component 7's web editor. Erik reviews on mobile (no visual pass), so the API ships now and the JS editor UI stays deferred. `MapCustomAlerts` mirrors `MapCustomViews` route-for-route, reusing the **same** store / evaluator / templates the MCP tools use ("no new logic, just a web wrapper"):

| Method | Route | Backed by |
| --- | --- | --- |
| GET | `/api/alerts` | `CustomAlertRuleStore.ListAsync` (summaries, no definition) |
| GET | `/api/alerts/{id:long}` | `CustomAlertRuleStore.GetAsync` (full, 404 when missing) |
| POST | `/api/alerts` | create — `CustomAlertRuleDefinition.TryParse` **before** persist; 201 / 400 / 409 |
| PUT | `/api/alerts/{id:long}` | update — same optimistic-concurrency/`version` handling as `/api/views`; 200 / 400 / 404 / 409 |
| DELETE | `/api/alerts/{id:long}` | **`CustomAlertEvaluator.ResolveAndDeleteRuleAsync`** (not raw `DeleteAsync`) so an open incident force-resolves before the FK cascade (#3305); 204 / 404 |
| GET | `/api/alert-templates` | `CustomAlertTemplates.All` |
| POST | `/api/alerts/validate` | dry-run `TryParse` → `{valid, error}` |
| POST | `/api/alerts/test` | evaluate-now — wraps `test_custom_alert_rule` |

`CustomAlertRuleResult` maps onto the same HTTP codes `/api/views` maps `CustomViewResult` to.

### How the writes are gated
The three mutations **and** the two evaluate POSTs (`/validate`, `/test`) require `application/json` (the CSRF gate) and are **born gated** by the host's method-based write gate: `DarlingWebSeat.IsRequestAllowed` refuses a read-only seat everything unsafe except `POST /api/compose/run`, so a viewer seat gets a 403 on every one of them without this layer naming the gate. `/test` runs the shared per-server scalar seam (`EvaluateScalarNowAsync` + `ClassifyTestValue`) on the host's **viewer** pool, exactly as `/api/compose/run` runs the composer — never the owner pool.

### Shared, drift-free wire shape
The full-rule and summary builders now live once in `DarlingWebEndpoints` (`BuildFullRuleNode` / `BuildRuleSummariesNode`) and are called by the MCP alert tools, removing the private duplicates those tools carried — the same way `/api/views` shares its builders. Also corrects a stale `DarlingMcpCustomAlertTools` class-doc paragraph that still claimed evaluate-now was "deliberately absent" after #3299 shipped it.

### Flag: pre-existing #3305 grant gap (NOT changed here)
`ResolveAndDeleteRuleAsync` writes the force-resolve recovery row via `INSERT INTO config_alert_log`, but **neither the `viewer` nor the `mcp` role has INSERT on `config_alert_log`** (only `admin` does). So on both the web (viewer-pool) DELETE **and** the already-shipped MCP (mcp-pool) delete, that INSERT fails permission-denied. It is failure-isolated (`WriteTeardownResolutionAsync` swallows and logs), so the delete still succeeds (204) and the rule stops firing — but the "Resolved" history row #3305 intends is silently skipped on both least-privilege paths. It is masked in #3305's live tests because they connect as **owner**. This is a security-surface decision (may the least-privilege roles write alert history?), so I did not change the grant here; it wants its own issue.

### Tests
- Extended `DarlingWebOidcTests.IsRequestAllowed_Matrix` with `/api/alerts` rows: CRUD writes + `/validate` + `/test` all born gated for a viewer; reads (list/get/templates) open; edit seat allowed.
- Pinned the shared rule wire shape in `DarlingWebEndpointsTests` (`enabled` present; definition embedded as a JSON object, not an escaped string).
- Fixed a pre-existing CS8620 nullability warning in `CustomAlertTemplatesTests`.
- No MCP tool added, so the tool-inventory pins are unchanged.

### Build & full-suite results
- Service + tests build **0 warnings / 0 errors**.
- **Darling.Tests**: 8680 total, 0 errors, 3 failed, 345 skipped (live-gated). The 3 failures are the known worktree/platform baseline (`FleetIdentifierScrubTests` × 2 "scanned 0 files — the sweep lost the tree", `NpgsqlRootCertificateValidationTests` × 1 TLS), unrelated to this change.
- **Lite.Tests**: 3703 total, 0 errors, 4 failed. All 4 are the known `AuroraOnlySqlIsGatedTests` worktree source-scan baseline; no Lite files were touched, and the cross-app MCP inventory pin passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
