### PR TITLE
Cap enabled custom alert rules to bound sweep cost (#3285)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertRuleCapLiveTests.cs
+++ b/Darling/Darling.Tests/CustomAlertRuleCapLiveTests.cs
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NpgsqlTypes;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3285 (Round-2) gated live round-trips (DARLING_TEST_PG) for the enabled-rule count cap. The cap's
+/// count-then-write must be enforced against a REAL store (the count subquery, the advisory-locked transaction,
+/// and the enabled-vs-disabled bookkeeping cannot be exercised without Postgres): creates and enables are
+/// bounded at <see cref="CustomAlertRuleStore.EnabledRuleCap"/>, disabled creates are always allowed, and the
+/// evaluator's read is bounded one beyond the cap. The pure ceiling-trim logic is in
+/// <c>CustomAlertRuleCapTests</c>. All test rows are named with a per-run prefix and deleted in cleanup, so the
+/// shared store is left as it was found.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class CustomAlertRuleCapLiveTests
+{
+    private const int Cap = CustomAlertRuleStore.EnabledRuleCap;
+
+    private const string SampleDefinition =
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":0.25},\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1}}";
+
+    private static string RequireLivePostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string (owner/superuser) to run the custom-alert cap live tests.");
+        return connectionString!;
+    }
+
+    private static async Task<NpgsqlDataSource> MigrateAndOpenAsync(string connectionString, CancellationToken ct)
+    {
+        await using (var migrate = new NpgsqlConnection(connectionString))
+        {
+            await migrate.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(migrate, ct);
+        }
+
+        var dataSourceConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            SearchPath = "collect,config,public",
+        }.ConnectionString;
+
+        return NpgsqlDataSource.Create(dataSourceConnectionString);
+    }
+
+    private static async Task<int> CountEnabledAsync(NpgsqlDataSource dataSource, CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand("SELECT count(*) FROM custom_alert_rules WHERE enabled");
+        return Convert.ToInt32(await command.ExecuteScalarAsync(ct));
+    }
+
+    /// <summary>Bulk-inserts <paramref name="count"/> ENABLED test rules named <c>{prefix}1..N</c> in one
+    /// statement, DELIBERATELY bypassing the store's cap — this is setup that drives the store into the
+    /// near-/over-cap state the store itself would refuse to create.</summary>
+    private static async Task BulkInsertEnabledAsync(
+        NpgsqlDataSource dataSource, string prefix, int count, CancellationToken ct)
+    {
+        if (count <= 0)
+        {
+            return;
+        }
+
+        await using var command = dataSource.CreateCommand(@"
+INSERT INTO custom_alert_rules (name, definition, description, enabled, version, created_at, updated_at, updated_by)
+SELECT $1 || g::text, $2, NULL, true, 1, (now() AT TIME ZONE 'UTC'), (now() AT TIME ZONE 'UTC'), 'captest'
+FROM generate_series(1, $3) AS g");
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = prefix });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Jsonb, Value = SampleDefinition });
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = count });
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task DeleteByPrefixAsync(NpgsqlConnection cleanup, string prefix, CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand("DELETE FROM config.custom_alert_rules WHERE name LIKE $1", cleanup);
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = prefix + "%" });
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    [Fact]
+    public async Task EnabledCap_BoundsCreatesAndEnables()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = await MigrateAndOpenAsync(connectionString, ct);
+
+        var store = new CustomAlertRuleStore(dataSource);
+        var prefix = "carcap_" + Guid.NewGuid().ToString("N") + "_";
+        var bodySucceeded = false;
+        try
+        {
+            var current = await CountEnabledAsync(dataSource, ct);
+            // Need two free slots below the cap to show "up to the cap -> Ok" through the store first.
+            Assert.SkipWhen(current > Cap - 2,
+                $"Store already holds {current} enabled rules; need <= {Cap - 2} to exercise the cap boundary.");
+
+            // Fill to Cap-2 by direct insert, then re-count so a shift on the shared store skips rather than flakes.
+            await BulkInsertEnabledAsync(dataSource, prefix, Cap - 2 - current, ct);
+            var atFill = await CountEnabledAsync(dataSource, ct);
+            Assert.SkipWhen(atFill != Cap - 2, $"Enabled count drifted to {atFill} during setup; expected {Cap - 2}.");
+
+            // Up to the cap: two enabled creates THROUGH THE STORE succeed (reaching Cap-1, then exactly Cap).
+            var ok1 = Assert.IsType<CustomAlertRuleResult.Ok>(
+                await store.CreateAsync(prefix + "ok1", null, SampleDefinition, enabled: true, "test", ct));
+            Assert.True(ok1.Rule!.Enabled);
+            Assert.IsType<CustomAlertRuleResult.Ok>(
+                await store.CreateAsync(prefix + "ok2", null, SampleDefinition, enabled: true, "test", ct));
+            Assert.Equal(Cap, await CountEnabledAsync(dataSource, ct));
+
+            // At the cap: the next ENABLED create is refused, and nothing is inserted.
+            var capped = Assert.IsType<CustomAlertRuleResult.Invalid>(
+                await store.CreateAsync(prefix + "over", null, SampleDefinition, enabled: true, "test", ct));
+            Assert.Contains(Cap.ToString(), capped.Message, StringComparison.Ordinal);
+            Assert.Equal(Cap, await CountEnabledAsync(dataSource, ct));
+
+            // At the cap: a DISABLED create is still allowed (paused rules don't count against the cap).
+            var disabled = Assert.IsType<CustomAlertRuleResult.Ok>(
+                await store.CreateAsync(prefix + "disabled", null, SampleDefinition, enabled: false, "test", ct));
+            Assert.False(disabled.Rule!.Enabled);
+            Assert.Equal(Cap, await CountEnabledAsync(dataSource, ct));
+
+            // At the cap: ENABLING that disabled rule is refused too, or the create cap would be trivially
+            // bypassed by create-disabled-then-enable.
+            var enableCapped = Assert.IsType<CustomAlertRuleResult.Invalid>(
+                await store.UpdateAsync(disabled.Rule!.Id, disabled.Rule!.Name, null, SampleDefinition,
+                    enabled: true, disabled.Rule!.Version, "test", ct));
+            Assert.Contains(Cap.ToString(), enableCapped.Message, StringComparison.Ordinal);
+
+            // The refused enable was a true no-op: the rule is still disabled at its original version.
+            var reread = Assert.IsType<CustomAlertRuleResult.Ok>(await store.GetAsync(disabled.Rule!.Id, ct));
+            Assert.False(reread.Rule!.Enabled);
+            Assert.Equal(disabled.Rule!.Version, reread.Rule!.Version);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DeleteByPrefixAsync(cleanup, prefix, cleanupCt);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task EnabledLoad_IsBoundedByTheCeiling_WhenTableExceedsTheCap()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = await MigrateAndOpenAsync(connectionString, ct);
+
+        var store = new CustomAlertRuleStore(dataSource);
+        var prefix = "carceil_" + Guid.NewGuid().ToString("N") + "_";
+        var bodySucceeded = false;
+        try
+        {
+            var current = await CountEnabledAsync(dataSource, ct);
+            Assert.SkipWhen(current > Cap + 2,
+                $"Store already holds {current} enabled rules (> cap+2); cannot set up the ceiling test cleanly.");
+
+            // Push the table OVER the cap by direct insert (bypassing the store), so cap+2 enabled rows exist.
+            await BulkInsertEnabledAsync(dataSource, prefix, Cap + 2 - current, ct);
+
+            // The store's enabled read is bounded at cap+1 (the cap plus the one-beyond overflow sentinel), never
+            // the full over-cap set — so the evaluator can never load an unbounded number of enabled rules.
+            var loaded = await store.ListEnabledAsync(ct);
+            Assert.Equal(Cap + 1, loaded.Count);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DeleteByPrefixAsync(cleanup, prefix, cleanupCt);
+            });
+        }
+    }
+}

--- a/Darling/Darling.Tests/CustomAlertRuleCapTests.cs
+++ b/Darling/Darling.Tests/CustomAlertRuleCapTests.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Darling.Service;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pure pins for the enabled-rule count cap (#3285, Round-2): the cap constant sits in the sanctioned range,
+/// and the evaluator's hard ceiling (<see cref="CustomAlertEvaluator.ApplyEnabledCeiling"/>) trims an over-cap
+/// enabled set down to exactly the cap (deterministic id order) and WARNs, while leaving an at-or-under-cap set
+/// untouched and silent. The write-path cap's count/race behavior needs a real store, so it lives in the gated
+/// <c>CustomAlertRuleCapLiveTests</c>.
+/// </summary>
+public sealed class CustomAlertRuleCapTests
+{
+    private const int Cap = CustomAlertRuleStore.EnabledRuleCap;
+
+    private static CustomAlertRule EnabledRule(long id) => new(
+        id, "rule-" + id, "{}", Description: null, Enabled: true, Version: 1,
+        CreatedAt: DateTime.UtcNow, UpdatedAt: DateTime.UtcNow, UpdatedBy: "test");
+
+    private static IReadOnlyList<CustomAlertRule> EnabledRules(int count) =>
+        Enumerable.Range(1, count).Select(i => EnabledRule(i)).ToList();
+
+    [Fact]
+    public void EnabledRuleCap_IsInTheSanctionedRange()
+    {
+        // The plan requires "a concrete number"; the coordinator sanctioned 100-250 (100 is the plan's number).
+        Assert.InRange(CustomAlertRuleStore.EnabledRuleCap, 100, 250);
+    }
+
+    [Fact]
+    public void ApplyEnabledCeiling_ReturnsAllRows_WhenUnderTheCap()
+    {
+        var logger = new CapturingTestLogger();
+        var rows = EnabledRules(Cap - 1);
+
+        var result = CustomAlertEvaluator.ApplyEnabledCeiling(rows, logger);
+
+        Assert.Equal(Cap - 1, result.Count);
+        Assert.DoesNotContain("Warning", logger.Joined, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApplyEnabledCeiling_AtExactlyTheCap_IsNotTrimmedOrWarned()
+    {
+        var logger = new CapturingTestLogger();
+        var rows = EnabledRules(Cap);
+
+        var result = CustomAlertEvaluator.ApplyEnabledCeiling(rows, logger);
+
+        Assert.Equal(Cap, result.Count);
+        Assert.DoesNotContain("Warning", logger.Joined, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApplyEnabledCeiling_TrimsToTheCap_AndWarns_WhenMoreEnabledRowsExist()
+    {
+        var logger = new CapturingTestLogger();
+        var rows = EnabledRules(Cap + 5); // ids 1..Cap+5, already in the id order the store reads them in
+
+        var result = CustomAlertEvaluator.ApplyEnabledCeiling(rows, logger);
+
+        // Evaluates at most the cap, and deterministically the first Cap by id.
+        Assert.Equal(Cap, result.Count);
+        Assert.Equal(Enumerable.Range(1, Cap).Select(i => (long)i), result.Select(r => r.Id));
+
+        // The over-cap condition is surfaced (WARN), not silently swallowed.
+        Assert.Contains("Warning", logger.Joined, StringComparison.Ordinal);
+        Assert.Contains("ceiling", logger.Joined, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
@@ -524,7 +524,7 @@ public sealed class CustomAlertEvaluator
             return _cache;
         }
 
-        var rows = await _ruleStore.ListEnabledAsync(cancellationToken);
+        var rows = ApplyEnabledCeiling(await _ruleStore.ListEnabledAsync(cancellationToken), _logger);
         var (parsedPairs, broken) = ClassifyRules(rows);
 
         foreach (var b in broken)
@@ -551,6 +551,29 @@ public sealed class CustomAlertEvaluator
         _brokenRules = broken;
         _cacheRefreshedUtc = DateTime.UtcNow;
         return _cache;
+    }
+
+    /// <summary>
+    /// The evaluator's HARD ceiling on how many enabled rules a sweep will ever evaluate (#3285, Round-2). The
+    /// write path already caps enabled rules at <see cref="CustomAlertRuleStore.EnabledRuleCap"/>, so this is a
+    /// defense-in-depth backstop: even if the table somehow holds more enabled rows than the cap (a direct SQL
+    /// insert that bypassed the store, say), the sweep still evaluates at most the cap, in the deterministic
+    /// id order <see cref="CustomAlertRuleStore.ListEnabledSql"/> reads them in. When the ceiling is actually hit
+    /// it is logged (WARN) rather than silently trimmed, so an over-cap table is visible. The store reads one
+    /// beyond the cap, so a hit here means "at least cap+1 enabled rows exist". Pure over its inputs so the trim
+    /// is unit-testable without a store.
+    /// </summary>
+    internal static IReadOnlyList<CustomAlertRule> ApplyEnabledCeiling(IReadOnlyList<CustomAlertRule> enabledRows, ILogger? logger)
+    {
+        if (enabledRows.Count <= CustomAlertRuleStore.EnabledRuleCap)
+        {
+            return enabledRows;
+        }
+
+        logger?.LogWarning(
+            "Custom alert rule enabled-count ceiling hit: at least {Count} enabled rules exist but only the first {Cap} (by id) will be evaluated. The write-path cap should prevent this — a rule was likely inserted bypassing the store; disable the excess.",
+            enabledRows.Count, CustomAlertRuleStore.EnabledRuleCap);
+        return enabledRows.Take(CustomAlertRuleStore.EnabledRuleCap).ToList();
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleStore.cs
@@ -54,13 +54,17 @@ SELECT id, name, definition, description, enabled, version, created_at, updated_
 FROM custom_alert_rules
 WHERE id = $1";
 
-    /// <summary>Every ENABLED rule in full — the evaluator's per-sweep read (a handful of rows). Ordered by
-    /// id so evaluation order is stable across sweeps.</summary>
+    /// <summary>Every ENABLED rule in full — the evaluator's per-sweep read. Ordered by id so evaluation order
+    /// is stable across sweeps, and bounded by <c>LIMIT $1</c> (the evaluator's hard ceiling) so a table that
+    /// somehow holds more enabled rows than the cap can never make one sweep evaluate an unbounded set. $1 is
+    /// bound to <see cref="EnabledRuleCap"/> + 1 — one beyond the cap — so the caller can DETECT (and warn about)
+    /// an over-cap table while still reading a bounded number of rows.</summary>
     public const string ListEnabledSql = @"
 SELECT id, name, definition, description, enabled, version, created_at, updated_at, updated_by
 FROM custom_alert_rules
 WHERE enabled
-ORDER BY id";
+ORDER BY id
+LIMIT $1";
 
     /// <summary>Inserts a new rule at version 1. $1 name, $2 definition (jsonb), $3 description, $4 enabled, $5 updated_by.</summary>
     public const string InsertSql = @"
@@ -94,6 +98,73 @@ RETURNING id, name, definition, description, enabled, version, created_at, updat
     /// <summary>An abuse bound on the rule name (the column itself is unbounded text).</summary>
     public const int MaxNameLength = 200;
 
+    /// <summary>
+    /// The hard cap on ENABLED alert rules across the whole store (#3285, Round-2 "rule-count cap"). Only
+    /// ENABLED rules cost anything: each sweep, the evaluator runs one compose scalar query per (enabled rule,
+    /// in-scope server) pair — so the per-sweep store load scales as enabled_rules × in_scope_servers × the
+    /// sweep frequency, and nothing else bounds it. Disabled rules are never loaded or evaluated, so they are
+    /// deliberately NOT counted here (storing many paused rules is free). 100 sits far above any realistic
+    /// hand-authored rule set (operators run a handful to low dozens) while bounding the runaway/DoS worst case:
+    /// 100 enabled rules against a large fleet is already thousands of compose queries per sweep. Deliberately a
+    /// <c>const</c>, not a config knob (defaults over speculative config) — if a real deployment ever needs more,
+    /// that is a design change with a load conversation, not a setting to quietly raise.
+    /// </summary>
+    public const int EnabledRuleCap = 100;
+
+    /// <summary>The caller-facing refusal when a create would push the enabled count over <see cref="EnabledRuleCap"/>.</summary>
+    internal static readonly string EnabledCapCreateMessage =
+        $"Enabled custom alert rule limit ({EnabledRuleCap}) reached. Disable or delete an existing rule, or create this rule disabled.";
+
+    /// <summary>The caller-facing refusal when enabling an existing rule would push the enabled count over <see cref="EnabledRuleCap"/>.</summary>
+    internal static readonly string EnabledCapEnableMessage =
+        $"Enabled custom alert rule limit ({EnabledRuleCap}) reached. Disable or delete another rule before enabling this one.";
+
+    /// <summary>
+    /// A fixed advisory-lock key that serializes the enabled-rule cap's count-then-write critical section via
+    /// <c>pg_advisory_xact_lock</c>, so two concurrent enabled creates/enables cannot both read a stale
+    /// under-cap count and race past the ceiling (READ COMMITTED alone does not prevent that phantom — the count
+    /// subquery sees the same pre-insert total in both transactions). Distinct from
+    /// <c>PgMigrations.MigrationLockKey</c> (0x4441524C494E47 "DARLING") so the two never collide in Postgres's
+    /// single 64-bit advisory-lock key space.
+    /// </summary>
+    private const long EnabledCapAdvisoryLockKey = 0x4441524C_43415021; // "DARLCAP!"
+
+    /// <summary>Takes the transaction-scoped cap lock (released automatically on commit/rollback). $1 lock key.</summary>
+    private const string AcquireEnabledCapLockSql = "SELECT pg_advisory_xact_lock($1)";
+
+    /// <summary>Inserts a new ENABLED rule at version 1 ONLY while the enabled count is under the cap; returns
+    /// zero rows (nothing inserted) when the cap is already reached. $1 name, $2 definition (jsonb),
+    /// $3 description, $4 updated_by, $5 cap. Run inside the advisory-locked transaction so the count and the
+    /// insert are one atomic step.</summary>
+    public const string InsertEnabledIfUnderCapSql = @"
+INSERT INTO custom_alert_rules (name, definition, description, enabled, version, created_at, updated_at, updated_by)
+SELECT $1, $2, $3, true, 1, (now() AT TIME ZONE 'UTC'), (now() AT TIME ZONE 'UTC'), $4
+WHERE (SELECT count(*) FROM custom_alert_rules WHERE enabled) < $5
+RETURNING id, name, definition, description, enabled, version, created_at, updated_at, updated_by";
+
+    /// <summary>Enables (or re-saves an already-enabled) rule under optimistic concurrency, refusing a
+    /// disabled-&gt;enabled transition that would exceed the cap. $1 id, $2 name, $3 definition (jsonb),
+    /// $4 description, $5 updated_by, $6 expected_version, $7 cap. Zero rows means id gone OR stale version OR
+    /// (the row was disabled AND the cap is reached) — disambiguated by <see cref="EnabledStateProbeSql"/>. The
+    /// <c>enabled = true OR …</c> guard lets an already-enabled rule be re-saved without consuming a cap slot.
+    /// Run inside the advisory-locked transaction.</summary>
+    public const string UpdateEnableIfUnderCapSql = @"
+UPDATE custom_alert_rules
+SET name = $2,
+    definition = $3,
+    description = $4,
+    enabled = true,
+    version = version + 1,
+    updated_at = (now() AT TIME ZONE 'UTC'),
+    updated_by = $5
+WHERE id = $1 AND version = $6
+  AND (enabled = true OR (SELECT count(*) FROM custom_alert_rules WHERE enabled) < $7)
+RETURNING id, name, definition, description, enabled, version, created_at, updated_at, updated_by";
+
+    /// <summary>Disambiguates a 0-row enable: the current version and enabled state, or no row when the id is
+    /// gone. $1 id.</summary>
+    public const string EnabledStateProbeSql = "SELECT version, enabled FROM custom_alert_rules WHERE id = $1";
+
     /// <summary>Lists every rule as a lightweight summary (no <c>definition</c>), ordered by name.</summary>
     public async Task<IReadOnlyList<CustomAlertRuleSummary>> ListAsync(CancellationToken cancellationToken = default)
     {
@@ -122,6 +193,8 @@ RETURNING id, name, definition, description, enabled, version, created_at, updat
         var results = new List<CustomAlertRule>();
         await using var command = _dataSource.CreateCommand(ListEnabledSql);
         command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
+        // Read one beyond the cap: the evaluator's ceiling trims to the cap and warns if this extra row is present.
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = EnabledRuleCap + 1 });
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -149,7 +222,9 @@ RETURNING id, name, definition, description, enabled, version, created_at, updat
     /// <summary>
     /// Inserts a new rule. Returns <see cref="CustomAlertRuleResult.Ok"/> with the stored row (version 1),
     /// <see cref="CustomAlertRuleResult.Conflict"/> on a duplicate name (23505), or
-    /// <see cref="CustomAlertRuleResult.Invalid"/> on a failed argument guard. The caller is expected to have
+    /// <see cref="CustomAlertRuleResult.Invalid"/> on a failed argument guard OR when creating this rule ENABLED
+    /// would push the enabled count over <see cref="EnabledRuleCap"/>. A DISABLED create is always allowed (a
+    /// paused rule never evaluates, so it does not count against the cap). The caller is expected to have
     /// validated <paramref name="definitionJson"/>'s structure first.
     /// </summary>
     public async Task<CustomAlertRuleResult> CreateAsync(
@@ -162,12 +237,67 @@ RETURNING id, name, definition, description, enabled, version, created_at, updat
             return invalid;
         }
 
+        // A disabled rule never evaluates, so it does not count against the cap and takes the plain insert.
+        if (!enabled)
+        {
+            return await InsertDisabledAsync(name, description, definitionJson, updatedBy, cancellationToken);
+        }
+
+        // An ENABLED create must not push the enabled count over the cap. Serialize the count-then-insert with a
+        // transaction-scoped advisory lock so two concurrent enabled creates cannot both pass a stale under-cap
+        // count (the conditional insert alone, under READ COMMITTED, would let that phantom race through).
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+        await AcquireCapLockAsync(connection, transaction, cancellationToken);
+
+        await using var command = new NpgsqlCommand(InsertEnabledIfUnderCapSql, connection, transaction)
+        {
+            CommandTimeout = McpCommandDeadlines.ReadSeconds,
+        };
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = name });                                 // $1
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Jsonb, Value = definitionJson }); // $2
+        AddNullableText(command, description);                                                                      // $3
+        AddNullableText(command, updatedBy);                                                                        // $4
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = EnabledRuleCap });                          // $5
+
+        try
+        {
+            CustomAlertRule? row = null;
+            await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+            {
+                if (await reader.ReadAsync(cancellationToken))
+                {
+                    row = ReadFullRule(reader);
+                }
+            }
+
+            if (row is null)
+            {
+                // 0 rows: the cap guard failed (enabled count already at the cap). Nothing was inserted.
+                await transaction.RollbackAsync(cancellationToken);
+                return new CustomAlertRuleResult.Invalid(EnabledCapCreateMessage);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+            return new CustomAlertRuleResult.Ok(row);
+        }
+        catch (PostgresException ex) when (ex.SqlState == UniqueViolation)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return new CustomAlertRuleResult.Conflict($"An alert rule named '{name}' already exists.");
+        }
+    }
+
+    /// <summary>The plain insert for a DISABLED rule (no cap check needed). Shares the create result contract.</summary>
+    private async Task<CustomAlertRuleResult> InsertDisabledAsync(
+        string name, string? description, string definitionJson, string? updatedBy, CancellationToken cancellationToken)
+    {
         await using var command = _dataSource.CreateCommand(InsertSql);
         command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = name });                                 // $1
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Jsonb, Value = definitionJson }); // $2
         AddNullableText(command, description);                                                                      // $3
-        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = enabled });                                 // $4
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = false });                                  // $4 (disabled)
         AddNullableText(command, updatedBy);                                                                        // $5
 
         try
@@ -186,7 +316,10 @@ RETURNING id, name, definition, description, enabled, version, created_at, updat
     /// Updates a rule under optimistic concurrency. Returns <see cref="CustomAlertRuleResult.Ok"/> with the
     /// new row (version bumped) on success; <see cref="CustomAlertRuleResult.Conflict"/> on a stale
     /// <paramref name="expectedVersion"/> OR a duplicate name; <see cref="CustomAlertRuleResult.NotFound"/>
-    /// when the id no longer exists; <see cref="CustomAlertRuleResult.Invalid"/> on a failed argument guard.
+    /// when the id no longer exists; <see cref="CustomAlertRuleResult.Invalid"/> on a failed argument guard OR
+    /// when a disabled-&gt;enabled transition would push the enabled count over <see cref="EnabledRuleCap"/>
+    /// (else the create-time cap would be trivially bypassed by creating disabled then enabling). Disabling, or
+    /// re-saving an already-enabled rule, never increases the enabled count and so is never capped.
     /// </summary>
     public async Task<CustomAlertRuleResult> UpdateAsync(
         long id, string name, string? description, string definitionJson, bool enabled, int expectedVersion,
@@ -198,13 +331,71 @@ RETURNING id, name, definition, description, enabled, version, created_at, updat
             return invalid;
         }
 
+        // Disabling, or staying disabled, can never increase the enabled count, so it takes the plain versioned
+        // update. Only a transition to enabled has to be checked against (and serialized around) the cap.
+        if (!enabled)
+        {
+            return await UpdateDisabledAsync(id, name, description, definitionJson, expectedVersion, updatedBy, cancellationToken);
+        }
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+        await AcquireCapLockAsync(connection, transaction, cancellationToken);
+
+        await using var command = new NpgsqlCommand(UpdateEnableIfUnderCapSql, connection, transaction)
+        {
+            CommandTimeout = McpCommandDeadlines.ReadSeconds,
+        };
+        command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = id });                                     // $1
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = name });                                 // $2
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Jsonb, Value = definitionJson }); // $3
+        AddNullableText(command, description);                                                                      // $4
+        AddNullableText(command, updatedBy);                                                                        // $5
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = expectedVersion });                         // $6
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = EnabledRuleCap });                          // $7
+
+        try
+        {
+            CustomAlertRule? row = null;
+            await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+            {
+                if (await reader.ReadAsync(cancellationToken))
+                {
+                    row = ReadFullRule(reader);
+                }
+            }
+
+            if (row is not null)
+            {
+                await transaction.CommitAsync(cancellationToken);
+                return new CustomAlertRuleResult.Ok(row);
+            }
+
+            // 0 rows: id gone, stale version, OR (the row was disabled AND the cap is reached). Probe under the
+            // same lock to tell the cap refusal apart from a NotFound / stale-version Conflict.
+            var classified = await ClassifyMissedEnableAsync(connection, transaction, id, expectedVersion, cancellationToken);
+            await transaction.RollbackAsync(cancellationToken);
+            return classified;
+        }
+        catch (PostgresException ex) when (ex.SqlState == UniqueViolation)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return new CustomAlertRuleResult.Conflict($"An alert rule named '{name}' already exists.");
+        }
+    }
+
+    /// <summary>The plain versioned update for a rule being set (or left) DISABLED (no cap check needed).</summary>
+    private async Task<CustomAlertRuleResult> UpdateDisabledAsync(
+        long id, string name, string? description, string definitionJson, int expectedVersion, string? updatedBy,
+        CancellationToken cancellationToken)
+    {
         await using var command = _dataSource.CreateCommand(UpdateSql);
         command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = id });                                     // $1
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = name });                                 // $2
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Jsonb, Value = definitionJson }); // $3
         AddNullableText(command, description);                                                                      // $4
-        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = enabled });                                 // $5
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = false });                                  // $5 (disabled)
         AddNullableText(command, updatedBy);                                                                        // $6
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = expectedVersion });                         // $7
 
@@ -225,6 +416,60 @@ RETURNING id, name, definition, description, enabled, version, created_at, updat
 
         /* 0 rows updated: the id is gone (NotFound) or the version moved under us (stale Conflict). */
         return await ClassifyMissedUpdateAsync(id, cancellationToken);
+    }
+
+    /// <summary>Takes the transaction-scoped advisory lock that serializes the enabled-rule cap's
+    /// count-then-write critical section. Released automatically when the transaction commits or rolls back.</summary>
+    private static async Task AcquireCapLockAsync(
+        NpgsqlConnection connection, NpgsqlTransaction transaction, CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(AcquireEnabledCapLockSql, connection, transaction)
+        {
+            CommandTimeout = McpCommandDeadlines.ReadSeconds,
+        };
+        command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = EnabledCapAdvisoryLockKey });
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    /// <summary>Disambiguates a 0-row enable (see <see cref="UpdateEnableIfUnderCapSql"/>): NotFound when the id
+    /// is gone, Conflict on a stale version, else Invalid (the cap) — because a matching version on a row that
+    /// was NOT already enabled means the cap guard is the only clause that could have failed. Runs on the same
+    /// connection/transaction (still holding the cap lock) so it sees a consistent snapshot.</summary>
+    private static async Task<CustomAlertRuleResult> ClassifyMissedEnableAsync(
+        NpgsqlConnection connection, NpgsqlTransaction transaction, long id, int expectedVersion,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(EnabledStateProbeSql, connection, transaction)
+        {
+            CommandTimeout = McpCommandDeadlines.ReadSeconds,
+        };
+        command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = id });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return new CustomAlertRuleResult.NotFound();
+        }
+
+        var currentVersion = reader.GetInt32(0);
+        var currentEnabled = reader.GetBoolean(1);
+        if (currentVersion != expectedVersion)
+        {
+            return new CustomAlertRuleResult.Conflict(
+                $"This rule was changed by someone else (current version {currentVersion}). Reload it and re-apply your edit.");
+        }
+
+        // Version matched and the row was NOT already enabled, so the ONLY clause that could have blocked the
+        // guarded update is the cap: enabling this rule would exceed the limit.
+        if (!currentEnabled)
+        {
+            return new CustomAlertRuleResult.Invalid(EnabledCapEnableMessage);
+        }
+
+        // Version matched AND already enabled: the guard's `enabled = true` branch was satisfied, so the update
+        // should have fired. Reaching here means the row changed between the update and this probe — report a
+        // concurrency conflict rather than inventing a cap error.
+        return new CustomAlertRuleResult.Conflict(
+            $"This rule was changed by someone else (current version {currentVersion}). Reload it and re-apply your edit.");
     }
 
     /// <summary>Deletes a rule (its <c>custom_alert_state</c> rows cascade). Returns


### PR DESCRIPTION
Part of #3285.

Closes the plan's Round-2 **rule-count cap**, which never shipped: nothing bounded the evaluator's per-sweep cost. Each enabled rule runs one compose scalar query per in-scope server every sweep, so the store load scales as `enabled_rules × in_scope_servers × sweep_frequency` — an unbounded runaway/DoS surface. This adds the concrete ceiling, enforced **at the write path AND as a hard ceiling in the evaluator** (the plan is explicit it must be both, "not just asserted").

### The cap
`CustomAlertRuleStore.EnabledRuleCap = 100` — a `const`, not a config knob (defaults over speculative config). Only **enabled** rules cost anything, so only they are counted; disabled rules are unbounded (a paused rule is never loaded or evaluated). 100 sits far above any realistic hand-authored set (operators run a handful to low dozens) while bounding the worst case — 100 enabled rules against a large fleet is already thousands of compose queries per sweep.

### Write-path enforcement (covers `POST /api/alerts` and the MCP create tool for free — both route through the store)
- **`CreateAsync`**: an ENABLED create that would exceed the cap returns `Invalid` ("Enabled custom alert rule limit (100) reached. Disable or delete an existing rule, or create this rule disabled."); a DISABLED create is always allowed.
- **`UpdateAsync`**: a disabled→enabled transition that would exceed the cap is refused (else the create cap is trivially bypassed by create-disabled-then-enable); disabling or re-saving an already-enabled rule is never capped.

### How the count + write is non-racy
The enabled paths run inside a transaction that first takes a **transaction-scoped advisory lock** (`pg_advisory_xact_lock`, a fixed key distinct from `PgMigrations`), so two concurrent enabled creates/enables cannot both read a stale under-cap count and slip past — READ COMMITTED alone does not prevent that phantom (the count subquery sees the same pre-insert total in both transactions). Under the lock:
- create is a single conditional `INSERT … SELECT … WHERE (SELECT count(*) … WHERE enabled) < cap` (0 rows ⇒ cap hit);
- enable is a single guarded `UPDATE … WHERE id=$ AND version=$ AND (enabled = true OR (count) < cap)`, whose 0-row result is disambiguated (NotFound / stale-version Conflict / cap Invalid) by a probe **on the same connection under the same lock**.

The lock releases automatically on commit/rollback. Disabled creates/updates keep the existing plain single-statement path (no lock, no cap).

### Evaluator hard ceiling (defense in depth)
`ListEnabledSql` now reads `ORDER BY id LIMIT cap+1`, and `CustomAlertEvaluator.ApplyEnabledCeiling` trims the load to the cap and logs a **WARN** when more enabled rows exist — so even a table that somehow holds more enabled rows than the cap (a direct insert bypassing the store) never makes one sweep evaluate an unbounded set, and the anomaly is visible rather than silent. The `+1` read is the overflow sentinel.

### Tests
- **Pure** (`CustomAlertRuleCapTests`): the cap is in the sanctioned range; `ApplyEnabledCeiling` returns an at/under-cap set untouched and silent, and trims an over-cap set to exactly the cap (first N by id) with a WARN.
- **Gated live** (`CustomAlertRuleCapLiveTests`, `DARLING_TEST_PG`): create up to the cap → Ok, the next enabled create → Invalid, a disabled create past the cap → Ok, enabling at the cap → Invalid (a verified no-op — rule stays disabled at its version), and the enabled read is bounded at cap+1 when the table exceeds the cap. **These were run green against a local PostgreSQL 18.4 + TimescaleDB rig** (they skip when the env var is unset). Existing custom-alert live tests were re-run green against the same rig to confirm the `CreateAsync`/`UpdateAsync` refactor introduced no regression.

No MCP tool added, so the tool-inventory pins do not apply.

### Build & full-suite results (post-rebase onto current dev)
- Build **0 warnings / 0 errors**.
- **Darling.Tests**: 8707 total, 0 errors, 3 failed, 347 skipped (live-gated). The 3 failures are the known worktree/platform baseline (`FleetIdentifierScrubTests` ×2 "scanned 0 files — the sweep lost the tree", `NpgsqlRootCertificateValidationTests` ×1 TLS), unrelated to this change.
- **Lite.Tests**: 3706 total, 0 errors, 4 failed — all the known `AuroraOnlySqlIsGatedTests` worktree source-scan baseline; no Lite files were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
