### PR TITLE
Deliver custom-alert severity escalation on an open incident (#3341)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertSeverityEscalationLiveTests.cs
+++ b/Darling/Darling.Tests/CustomAlertSeverityEscalationLiveTests.cs
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using PerformanceMonitor.Alerting;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3341 gated live round-trip (DARLING_TEST_PG): the severity-escalation FIX through the real sweep + store.
+/// A two-tier rule fires at Warning, then the metric climbs into the Critical band while the incident stays
+/// open; the sweep must deliver a SECOND alert at Critical on the SAME incident (metric_name Custom:&lt;id&gt;)
+/// and persist FiredSeverity = Critical. This is the wiring the pure <c>CustomAlertSeverityEscalationTests</c>
+/// cannot prove: that the evaluator's <c>None</c> arm actually re-computes the band, delivers the change, and
+/// saves it. A Gauge metric (avg over the window) is used so ONE seeded row is a deterministic value, and the
+/// evaluator is built with a zero cadence so the second sweep is immediately due.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class CustomAlertSeverityEscalationLiveTests
+{
+    private sealed class CapturingDeliverer : IAlertDeliverer
+    {
+        public List<AlertOutcome> Delivered { get; } = new();
+
+        public Task DeliverAsync(AlertOutcome outcome, CancellationToken cancellationToken = default)
+        {
+            lock (Delivered)
+            {
+                Delivered.Add(outcome);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private static string RequireLivePostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string (owner/superuser) to run the severity-escalation live test.");
+        return connectionString!;
+    }
+
+    private static async Task<NpgsqlDataSource> MigrateAndOpenAsync(string connectionString, CancellationToken ct)
+    {
+        await using (var migrate = new NpgsqlConnection(connectionString))
+        {
+            await migrate.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(migrate, ct);
+        }
+
+        var dataSourceConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            SearchPath = "collect,config,public",
+        }.ConnectionString;
+
+        return NpgsqlDataSource.Create(dataSourceConnectionString);
+    }
+
+    private static async Task RegisterServerAsync(NpgsqlDataSource dataSource, int serverId, string storageName, CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand(
+            "INSERT INTO servers (server_id, server_name, display_name) VALUES ($1, $2, $3)");
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = storageName });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = storageName });
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>Seeds one raw cpu_utilization_stats row for the server with a CURRENT collection_time (server-side
+    /// <c>now() AT TIME ZONE 'UTC'</c>, avoiding the Kind=Utc-&gt;timestamptz zone-shift trap), so the gauge metric's
+    /// avg over the window is exactly <paramref name="cpuPercent"/>.</summary>
+    private static async Task SeedCpuAsync(NpgsqlDataSource dataSource, int serverId, string storageName, int cpuPercent, CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand(@"
+INSERT INTO cpu_utilization_stats
+    (collection_id, collection_time, server_id, server_name, sample_time, sqlserver_cpu_utilization, other_process_cpu_utilization)
+VALUES ($1, (now() AT TIME ZONE 'UTC'), $2, $3, (now() AT TIME ZONE 'UTC'), $4, 0)");
+        command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = DateTime.UtcNow.Ticks });
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = storageName });
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = cpuPercent });
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task DeleteCpuAsync(NpgsqlDataSource dataSource, int serverId, CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand("DELETE FROM cpu_utilization_stats WHERE server_id = $1");
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    [Fact]
+    public async Task OpenIncident_ClimbingPastCritical_DeliversCriticalOnTheSameIncident()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = await MigrateAndOpenAsync(connectionString, ct);
+
+        const int serverId = 991341;
+        var storage = "car_esc_srv_" + Guid.NewGuid().ToString("N");
+        var ruleName = "car_esc_" + Guid.NewGuid().ToString("N");
+        // Gauge metric (avg over 15m) so one seeded row = a deterministic value. warn >= 25, critical >= 40,
+        // fire on the first breach, scoped to exactly this server.
+        var definition =
+            "{\"metric\":{\"source\":\"cpu_utilization_stats\",\"measure\":\"sqlserver_cpu_utilization\",\"aggregate\":\"avg\",\"hours\":0.25}," +
+            "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":25,\"criticalThreshold\":40}," +
+            "\"hysteresis\":{\"breachSamples\":1,\"clearSamples\":1}," +
+            "\"scope\":{\"mode\":\"servers\",\"servers\":[\"" + storage + "\"]}}";
+
+        var deliverer = new CapturingDeliverer();
+        var rules = new CustomAlertRuleStore(dataSource);
+        var state = new CustomAlertStateStore(dataSource);
+        var bodySucceeded = false;
+        try
+        {
+            await RegisterServerAsync(dataSource, serverId, storage, ct);
+
+            var created = Assert.IsType<CustomAlertRuleResult.Ok>(
+                await rules.CreateAsync(ruleName, null, definition, true, "test", ct));
+            var ruleId = created.Rule!.Id;
+            var version = created.Rule!.Version;
+            var metricName = "Custom:" + ruleId;
+
+            // defaultIntervalSeconds 0 so the second sweep is immediately due (no 60s cadence wait); cacheTtl 0 so
+            // each sweep re-reads the rule.
+            var evaluator = new CustomAlertEvaluator(
+                rules, state, dataSource, deliverer, isAlertMuted: null,
+                new PgAlertHistoryStore(dataSource), defaultIntervalSeconds: 0,
+                cacheTtl: TimeSpan.Zero, NullLogger.Instance);
+
+            // Sweep 1: a Warning-band value (30) fires the incident at Warning.
+            await SeedCpuAsync(dataSource, serverId, storage, 30, ct);
+            await evaluator.EvaluateServerAsync(serverId, storage, storage, ct);
+
+            var warnDelivery = Assert.Single(deliverer.Delivered);
+            Assert.Equal(AlertSeverityLevel.Warning, warnDelivery.Severity);
+            Assert.Equal(metricName, warnDelivery.MetricName);
+            var warnState = await state.LoadAsync(ruleId, serverId, version, ct);
+            Assert.Equal("Warning", warnState.FiredSeverity);
+            Assert.True(warnState.Persistence.Firing);
+
+            // The evaluator clamps its per-rule cadence to a 30s minimum (too long to wait in a test), so clear
+            // the due-gate while KEEPING the open Firing state + delivered Warning band, making sweep 2 due now.
+            await state.SaveAsync(ruleId, serverId, warnState with { NextDueAt = null }, ct);
+
+            // Sweep 2: the value climbs into the Critical band (50) while the incident stays OPEN. Pre-fix this
+            // returned None with an empty break and never re-paged; now it must deliver a Critical escalation.
+            await DeleteCpuAsync(dataSource, serverId, ct);
+            await SeedCpuAsync(dataSource, serverId, storage, 50, ct);
+            await evaluator.EvaluateServerAsync(serverId, storage, storage, ct);
+
+            Assert.Equal(2, deliverer.Delivered.Count);
+            var escalation = deliverer.Delivered[1];
+            Assert.Equal(AlertSeverityLevel.Critical, escalation.Severity);
+            Assert.Equal(metricName, escalation.MetricName); // SAME incident (Custom:<id>), not a new one
+            var critState = await state.LoadAsync(ruleId, serverId, version, ct);
+            Assert.Equal("Critical", critState.FiredSeverity);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                using (var setPath = new NpgsqlCommand("SET search_path TO collect, config, public", cleanup))
+                {
+                    await setPath.ExecuteNonQueryAsync(cleanupCt);
+                }
+
+                using (var rule = new NpgsqlCommand("DELETE FROM custom_alert_rules WHERE name = $1", cleanup))
+                {
+                    rule.Parameters.AddWithValue(ruleName);
+                    await rule.ExecuteNonQueryAsync(cleanupCt);
+                }
+
+                using (var cpu = new NpgsqlCommand("DELETE FROM cpu_utilization_stats WHERE server_id = $1", cleanup))
+                {
+                    cpu.Parameters.AddWithValue(serverId);
+                    await cpu.ExecuteNonQueryAsync(cleanupCt);
+                }
+
+                using var server = new NpgsqlCommand("DELETE FROM servers WHERE server_id = $1", cleanup);
+                server.Parameters.AddWithValue(serverId);
+                await server.ExecuteNonQueryAsync(cleanupCt);
+            });
+        }
+    }
+}

--- a/Darling/Darling.Tests/CustomAlertSeverityEscalationTests.cs
+++ b/Darling/Darling.Tests/CustomAlertSeverityEscalationTests.cs
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pure pins for the severity-escalation decision (#3341): while an incident stays OPEN, a still-breaching value
+/// that crosses into a different band than the one delivered is a severity change (in EITHER direction, per the
+/// plan's Decision 3), and nothing else is. The store wiring — that the evaluator's <c>None</c> arm actually
+/// delivers the change on the same incident and persists the new band — is proved by the gated
+/// <c>CustomAlertSeverityEscalationLiveTests</c>.
+/// </summary>
+public sealed class CustomAlertSeverityEscalationTests
+{
+    [Fact]
+    public void WarningToCritical_Escalates()
+    {
+        // Open incident delivered at Warning, value has climbed into the Critical band: page Critical.
+        Assert.Equal(
+            AlertSeverityLevel.Critical,
+            CustomAlertEvaluator.ClassifySeverityChange(firing: true, breaching: true, AlertSeverityLevel.Critical, "Warning"));
+    }
+
+    [Fact]
+    public void CriticalToWarning_IsASeverityChange_NotAResolve()
+    {
+        // Decision 3: a drop back to Warning on an open incident is delivered as a severity change, not a resolve.
+        Assert.Equal(
+            AlertSeverityLevel.Warning,
+            CustomAlertEvaluator.ClassifySeverityChange(firing: true, breaching: true, AlertSeverityLevel.Warning, "Critical"));
+    }
+
+    [Fact]
+    public void SameBand_IsNoChange()
+    {
+        Assert.Null(CustomAlertEvaluator.ClassifySeverityChange(firing: true, breaching: true, AlertSeverityLevel.Warning, "Warning"));
+        Assert.Null(CustomAlertEvaluator.ClassifySeverityChange(firing: true, breaching: true, AlertSeverityLevel.Critical, "Critical"));
+    }
+
+    [Fact]
+    public void NotFiring_IsNoChange()
+    {
+        // A subject not yet firing has no delivered band to change (the Fire edge sets the initial severity).
+        Assert.Null(CustomAlertEvaluator.ClassifySeverityChange(firing: false, breaching: true, AlertSeverityLevel.Critical, "Warning"));
+    }
+
+    [Fact]
+    public void FiringButNotBreaching_HoldsSeverityUntilResolve()
+    {
+        // A clearing value keeps its delivered severity until the resolve edge — no severity change here.
+        Assert.Null(CustomAlertEvaluator.ClassifySeverityChange(firing: true, breaching: false, AlertSeverityLevel.Critical, "Warning"));
+    }
+
+    [Fact]
+    public void NeverDelivered_IsNoChange()
+    {
+        // firedSeverity null = the incident was never delivered (e.g. loaded firing but undelivered), so there is
+        // no prior band to escalate from.
+        Assert.Null(CustomAlertEvaluator.ClassifySeverityChange(firing: true, breaching: true, AlertSeverityLevel.Critical, firedSeverity: null));
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
@@ -235,6 +235,26 @@ public sealed class CustomAlertEvaluator
         }
     }
 
+    /// <summary>
+    /// Decides whether an ALREADY-OPEN incident's severity band changed on this observation (#3341), returning
+    /// the new severity to deliver or <c>null</c> for no change. Pure so the escalate/de-escalate decision is
+    /// unit-testable without a store. Only an open incident (<paramref name="firing"/>) that is STILL breaching
+    /// (<paramref name="breaching"/>) and was already delivered (<paramref name="firedSeverity"/> non-null) can
+    /// change band: a clearing value holds its severity until the resolve edge, and a subject not yet firing has
+    /// no delivered band to change. Per the plan's Decision 3 a change in EITHER direction is delivered — a climb
+    /// to Critical pages Critical, and a drop back to Warning is a severity change, not a resolve.
+    /// </summary>
+    internal static AlertSeverityLevel? ClassifySeverityChange(
+        bool firing, bool breaching, AlertSeverityLevel currentSeverity, string? firedSeverity)
+    {
+        if (!firing || !breaching || firedSeverity is null)
+        {
+            return null;
+        }
+
+        return currentSeverity.ToString() != firedSeverity ? currentSeverity : null;
+    }
+
     private async Task EvaluateRuleForServerAsync(
         CustomAlertRule row, CustomAlertRuleDefinition def, int serverId, string storageName, string displayName,
         DateTime now, RollupAvailability rollups, RollupCoverage coverage, int composedSeconds, CancellationToken cancellationToken)
@@ -290,6 +310,21 @@ public sealed class CustomAlertEvaluator
 
             case PersistenceOutcome.None:
             default:
+                // #3341: severity is re-evaluated while an incident stays OPEN, not only on the rising Fire edge.
+                // If the still-breaching value has crossed into a different band than the one delivered, deliver
+                // the change on the SAME incident (Custom:<id>) and record the new band. Decision 3: a higher band
+                // wins (Warning -> Critical pages Critical), and a drop back to Warning is a severity change, not a
+                // resolve, so BOTH directions are delivered. No tier-change debounce yet: a value oscillating right
+                // at a band boundary could re-deliver — low in practice (windowed aggregate, 60s cadence, tier
+                // gap), tracked as a possible follow-up.
+                if (ClassifySeverityChange(
+                        newState.Persistence.Firing, breaching, def.SeverityFor(value.Value), state.FiredSeverity)
+                    is { } changedSeverity)
+                {
+                    await DeliverFireAsync(row, def, serverId, displayName, value.Value, changedSeverity, cancellationToken);
+                    newState = newState with { FiredSeverity = changedSeverity.ToString() };
+                }
+
                 break;
         }
 


### PR DESCRIPTION
Part of #3285. Fixes #3341 (Fixes only auto-closes on dev->main, so close it manually on dev-merge).

The last correctness item from the final audit: **severity escalation on an already-open custom-alert incident was never delivered.**

### The bug
`CustomAlertEvaluator.EvaluateRuleForServerAsync` computed and delivered severity **only on the rising `Fire` edge**. While an incident stayed open the persistence gate returned `PersistenceOutcome.None`, whose switch arm was an empty `break` — severity was never re-evaluated. `FiredSeverity` was persisted on fire but only null-checked to gate the resolve, never compared. So a two-tier rule (warn 25 / critical 40) that fired at **Warning** and then climbed past 40 **kept Warning and never paged Critical**, violating the plan's Decision 3 ("higher band wins; crossing down to Warning is a severity change, not a resolve").

### The fix
1. A pure static helper — the exact logic:
   ```
   AlertSeverityLevel? ClassifySeverityChange(bool firing, bool breaching, AlertSeverityLevel currentSeverity, string? firedSeverity)
       if (!firing || !breaching || firedSeverity is null) return null;
       return currentSeverity.ToString() != firedSeverity ? currentSeverity : null;
   ```
   Only an open incident (`firing`) that is **still breaching** and was already delivered (`firedSeverity` non-null) can change band; a clearing value holds its severity until the resolve edge, and a not-yet-firing subject has no delivered band to change.
2. Wired into the `None` arm: when the helper returns a band, `DeliverFireAsync` at that severity and update `FiredSeverity`. **Both directions are delivered** per Decision 3 — a climb to Critical pages Critical, and a drop back to Warning is a severity change, not a resolve.
3. The re-delivery goes through the same `DeliverFireAsync` → `BuildFireOutcome`, which keys on `metric_name = Custom:<id>`, so it **updates the SAME incident**, not a new one (verified in the live test).

No tier-change debounce yet — a value oscillating right at a band boundary could re-deliver; low in practice (windowed aggregate, 60s cadence, tier gap), left as a possible follow-up per the issue, with a one-line comment at the site.

### Tests
- **Pure** (`CustomAlertSeverityEscalationTests`): Warning→Critical escalates; Critical→Warning changes; same-band, not-firing, firing-but-not-breaching, and null-`firedSeverity` all no-change.
- **Gated live** (`CustomAlertSeverityEscalationLiveTests`, `DARLING_TEST_PG`): a two-tier gauge rule fires at Warning (seeded CPU 30), then a Critical-crossing value (50) on the next sweep delivers a **second alert at Critical on the same incident** (`Custom:<id>`) with `FiredSeverity` persisted as Critical. **Run green against a local PostgreSQL 18.4 + TimescaleDB rig** (skips when the env var is unset); the other custom-alert live tests were re-run green against the same rig to confirm no regression from the `None`-arm change.

No MCP tool added, so the tool-inventory pins do not apply.

### Build & full-suite results (post-rebase onto current dev)
- Build **0 warnings / 0 errors**.
- **Darling.Tests**: 8723 total, 0 errors, 3 failed, 348 skipped (live-gated). The 3 failures are the known worktree/platform baseline (`FleetIdentifierScrubTests` ×2 "scanned 0 files", `NpgsqlRootCertificateValidationTests` ×1 TLS), unrelated to this change.
- **Lite.Tests**: 3706 total, 0 errors, 4 failed — all the known `AuroraOnlySqlIsGatedTests` worktree source-scan baseline; no Lite files were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
