### PR TITLE
Resolve custom-alert incidents on delete via a SECURITY DEFINER function (#3334)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertResolveGrantLiveTests.cs
+++ b/Darling/Darling.Tests/CustomAlertResolveGrantLiveTests.cs
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using PerformanceMonitor.Alerting;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3334 gated live proof (DARLING_TEST_PG): the resolve-on-delete recovery row is written even when the delete
+/// runs on the LEAST-PRIVILEGE pool. This is what #3305's tests missed — they connected as the owner (which has
+/// INSERT on all of config), so the viewer/mcp grant gap on <c>config_alert_log</c> never surfaced. These tests
+/// connect as a DISPOSABLE low-privilege role (viewer/mcp-shaped: SELECT + a narrow custom_alert_rules write +
+/// EXECUTE on the SECURITY DEFINER function, and pointedly NO direct <c>config_alert_log</c> INSERT) and assert
+/// that both teardown paths — the caller-initiated delete AND the sweep reconcile — record the
+/// <c>&lt;name&gt; Resolved</c> row through the definer function. A direct-INSERT denial is asserted first, so a
+/// present row can only have come from the function, not an ambient grant.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class CustomAlertResolveGrantLiveTests
+{
+    private const string LowPrivRole = "sec_resolve_test";
+    private const string RolePassword = "ResolveGrantTestPw0123456789abcd"; // alnum, like the real generator
+
+    private const string SampleDefinition =
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":0.25},\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1}}";
+
+    private sealed class NoopDeliverer : IAlertDeliverer
+    {
+        public Task DeliverAsync(AlertOutcome outcome, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private static string RequireLivePostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string (owner/superuser, can CREATE ROLE) to run the resolve-grant live tests.");
+        return connectionString!;
+    }
+
+    private static async Task<NpgsqlDataSource> MigrateAndOpenAsync(string connectionString, CancellationToken ct)
+    {
+        await using (var migrate = new NpgsqlConnection(connectionString))
+        {
+            await migrate.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(migrate, ct);
+        }
+
+        var dataSourceConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            SearchPath = "collect,config,public",
+        }.ConnectionString;
+
+        return NpgsqlDataSource.Create(dataSourceConnectionString);
+    }
+
+    /// <summary>Creates the SECURITY DEFINER function (from the SHARED builder, so it is the real one) and a
+    /// disposable low-privilege role granted the viewer/mcp-shaped subset a rule-delete needs — SELECT, the
+    /// narrow custom_alert_rules write, and EXECUTE on the function — but NO direct config_alert_log INSERT.</summary>
+    private static async Task ProvisionFunctionAndLowPrivRoleAsync(NpgsqlDataSource owner, CancellationToken ct)
+    {
+        var ddl = DarlingManagedRoles.BuildCustomAlertResolveFunctionSql("config") + $@"
+DO $do$
+BEGIN
+   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{LowPrivRole}') THEN
+      CREATE ROLE {LowPrivRole} LOGIN NOSUPERUSER PASSWORD '{RolePassword}';
+   END IF;
+END $do$;
+GRANT USAGE ON SCHEMA collect, config TO {LowPrivRole};
+GRANT SELECT ON ALL TABLES IN SCHEMA collect TO {LowPrivRole};
+GRANT SELECT ON ALL TABLES IN SCHEMA config  TO {LowPrivRole};
+GRANT INSERT, UPDATE, DELETE ON config.custom_alert_rules TO {LowPrivRole};
+GRANT EXECUTE ON FUNCTION config.record_custom_alert_resolution(integer, text, text, text) TO {LowPrivRole};";
+        await using var command = owner.CreateCommand(ddl);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static NpgsqlDataSource OpenLowPriv(string connectionString) =>
+        NpgsqlDataSource.Create(new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            Username = LowPrivRole,
+            Password = RolePassword,
+            SearchPath = "collect,config,public",
+            Pooling = false,
+        }.ConnectionString);
+
+    private static CustomAlertRuleState Firing(int ruleVersion)
+    {
+        var evaluatedAt = new DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc);
+        return new CustomAlertRuleState(
+            new PersistenceState(ConsecutiveBreaches: 3, ConsecutiveClears: 0, Firing: true),
+            ruleVersion, "Critical", evaluatedAt, evaluatedAt.AddSeconds(60));
+    }
+
+    private static async Task<(int Count, bool AlertSent, string? NotificationType, bool Muted)> ReadResolveRowAsync(
+        NpgsqlDataSource dataSource, string metricName, int serverId, CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand(
+            "SELECT count(*), bool_or(alert_sent), min(notification_type), bool_or(muted) FROM config_alert_log WHERE metric_name = $1 AND server_id = $2");
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = metricName });
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        await reader.ReadAsync(ct);
+        var count = Convert.ToInt32(reader.GetValue(0));
+        return count == 0
+            ? (0, false, null, false)
+            : (count, reader.GetBoolean(1), reader.IsDBNull(2) ? null : reader.GetString(2), reader.GetBoolean(3));
+    }
+
+    [Fact]
+    public async Task Delete_AsLowPrivilegeRole_WritesResolveRow_ThroughTheDefinerFunction()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+        await using var owner = await MigrateAndOpenAsync(connectionString, ct);
+
+        var rules = new CustomAlertRuleStore(owner);
+        var state = new CustomAlertStateStore(owner);
+        var ruleName = "car_grant_del_" + Guid.NewGuid().ToString("N");
+        const int serverId = 991334;
+        var bodySucceeded = false;
+        try
+        {
+            await ProvisionFunctionAndLowPrivRoleAsync(owner, ct);
+
+            /* Set up an OPEN incident as the owner (seeding custom_alert_state needs owner — viewer/mcp cannot
+               write it, exactly as in production). */
+            var created = Assert.IsType<CustomAlertRuleResult.Ok>(
+                await rules.CreateAsync(ruleName, null, SampleDefinition, true, "test", ct));
+            var ruleId = created.Rule!.Id;
+            await state.SaveAsync(ruleId, serverId, Firing(created.Rule!.Version), ct);
+
+            await using var lowPriv = OpenLowPriv(connectionString);
+
+            /* The role genuinely CANNOT write config_alert_log directly — 42501 — so a resolve row appearing
+               after the delete can only have come through the SECURITY DEFINER function. */
+            await using (var directInsert = lowPriv.CreateCommand(
+                "INSERT INTO config_alert_log (alert_time, server_id, server_name, metric_name, current_value, threshold_value, alert_sent, notification_type, send_error, muted, detail_text, context_json) " +
+                "VALUES ((now() AT TIME ZONE 'UTC'), $1, 'x', 'direct-write-probe', 0, 0, false, 'none', NULL, false, NULL, NULL)"))
+            {
+                directInsert.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+                var denied = await Assert.ThrowsAsync<PostgresException>(async () => await directInsert.ExecuteNonQueryAsync(ct));
+                Assert.Equal("42501", denied.SqlState); // insufficient_privilege
+            }
+
+            /* The delete path, run entirely on the low-privilege pool (mirrors the deployed mcp delete tool and
+               the viewer web DELETE). Pre-fix, the resolve INSERT 42501'd, was swallowed, and the row was lost. */
+            Assert.IsType<CustomAlertRuleResult.Ok>(
+                await CustomAlertEvaluator.ResolveAndDeleteRuleAsync(lowPriv, ruleId, logger: null, ct));
+
+            /* The recovery row IS present now, and is a proper no-channel resolution (alert_sent false,
+               notification_type 'none', unmuted) — shape-identical to a normal resolve. */
+            var row = await ReadResolveRowAsync(owner, ruleName + " Resolved", serverId, ct);
+            Assert.Equal(1, row.Count);
+            Assert.False(row.AlertSent);
+            Assert.Equal("none", row.NotificationType);
+            Assert.False(row.Muted);
+
+            /* And the delete itself completed: rule gone, state cascaded away. */
+            Assert.IsType<CustomAlertRuleResult.NotFound>(await rules.GetAsync(ruleId, ct));
+            Assert.Empty(await state.ListForRuleAsync(ruleId, ct));
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await CleanupAsync(cleanup, ruleName, serverId, cleanupCt);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task ReconcileTeardown_WithLowPrivilegeHistoryPool_WritesResolveRow_ThroughTheDefinerFunction()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+        await using var owner = await MigrateAndOpenAsync(connectionString, ct);
+
+        var rules = new CustomAlertRuleStore(owner);
+        var state = new CustomAlertStateStore(owner);
+        var ruleName = "car_grant_rec_" + Guid.NewGuid().ToString("N");
+        const int serverId = 991335;
+        var bodySucceeded = false;
+        try
+        {
+            await ProvisionFunctionAndLowPrivRoleAsync(owner, ct);
+
+            var created = Assert.IsType<CustomAlertRuleResult.Ok>(
+                await rules.CreateAsync(ruleName, null, SampleDefinition, true, "test", ct));
+            var ruleId = created.Rule!.Id;
+            await state.SaveAsync(ruleId, serverId, Firing(created.Rule!.Version), ct);
+
+            /* Disable the rule so the reconcile sweep force-resolves its now-orphaned firing incident. */
+            var disabled = Assert.IsType<CustomAlertRuleResult.Ok>(
+                await rules.UpdateAsync(ruleId, ruleName, null, SampleDefinition, enabled: false, created.Rule!.Version, "test", ct));
+            Assert.False(disabled.Rule!.Enabled);
+
+            var monitored = new Dictionary<int, (string StorageName, string DisplayName)> { [serverId] = ("syn_storage", "SynServer") };
+
+            /* The evaluator's HISTORY writer is on the low-privilege pool — the seam under test — while its rule
+               and state stores stay on the owner pool (reconcile's state cleanup DELETEs custom_alert_state, an
+               owner-only write, exactly as in production). The teardown resolution must still land via the
+               definer function. */
+            await using var lowPriv = OpenLowPriv(connectionString);
+            var evaluator = new CustomAlertEvaluator(
+                rules, state, owner /* viewer: unused by reconcile */, new NoopDeliverer(),
+                isAlertMuted: null, new PgAlertHistoryStore(lowPriv), defaultIntervalSeconds: 60,
+                cacheTtl: TimeSpan.Zero, NullLogger.Instance);
+
+            await evaluator.ReconcileStateAsync(monitored, ct);
+
+            var row = await ReadResolveRowAsync(owner, ruleName + " Resolved", serverId, ct);
+            Assert.Equal(1, row.Count);
+            Assert.False(row.AlertSent);
+            Assert.Equal("none", row.NotificationType);
+
+            /* The incident was cleaned but the (disabled) rule row remains. */
+            Assert.Empty(await state.ListForRuleAsync(ruleId, ct));
+            Assert.IsType<CustomAlertRuleResult.Ok>(await rules.GetAsync(ruleId, ct));
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await CleanupAsync(cleanup, ruleName, serverId, cleanupCt);
+            });
+        }
+    }
+
+    private static async Task CleanupAsync(NpgsqlConnection cleanup, string ruleName, int serverId, CancellationToken ct)
+    {
+        using (var rule = new NpgsqlCommand("DELETE FROM config.custom_alert_rules WHERE name = $1", cleanup))
+        {
+            rule.Parameters.AddWithValue(ruleName);
+            await rule.ExecuteNonQueryAsync(ct);
+        }
+
+        using (var log = new NpgsqlCommand("DELETE FROM config.config_alert_log WHERE server_id = $1", cleanup))
+        {
+            log.Parameters.AddWithValue(serverId);
+            await log.ExecuteNonQueryAsync(ct);
+        }
+
+        /* DROP OWNED BY revokes the role's grants (incl. the function EXECUTE) so DROP ROLE has no dependents.
+           The function itself is owned by the store owner, not this role, so it is left in place (it is the real
+           provisioned object). DROP OWNED BY has no IF EXISTS, so tolerate 42704 when the role never existed. */
+        using (var dropOwned = new NpgsqlCommand($"DROP OWNED BY {LowPrivRole}", cleanup))
+        {
+            try
+            {
+                await dropOwned.ExecuteNonQueryAsync(ct);
+            }
+            catch (PostgresException ex) when (ex.SqlState == "42704")
+            {
+            }
+        }
+
+        using var dropRole = new NpgsqlCommand($"DROP ROLE IF EXISTS {LowPrivRole}", cleanup);
+        await dropRole.ExecuteNonQueryAsync(ct);
+    }
+}

--- a/Darling/Darling.Tests/CustomAlertTeardownLiveTests.cs
+++ b/Darling/Darling.Tests/CustomAlertTeardownLiveTests.cs
@@ -58,7 +58,19 @@ public sealed class CustomAlertTeardownLiveTests
             SearchPath = "collect,config,public",
         }.ConnectionString;
 
-        return NpgsqlDataSource.Create(dataSourceConnectionString);
+        var dataSource = NpgsqlDataSource.Create(dataSourceConnectionString);
+
+        // #3334: the teardown resolution row is now written through the SECURITY DEFINER
+        // config.record_custom_alert_resolution function -- a PROVISIONING artifact, not a migration. These
+        // tests migrate but do not run role provisioning, so create the function here (as the owner, mirroring
+        // production where provisioning runs after migration); otherwise ResolveAndDeleteRuleAsync's resolve
+        // write would no-op against a missing function and the recovery-row assertions would fail.
+        await using (var fn = dataSource.CreateCommand(DarlingManagedRoles.BuildCustomAlertResolveFunctionSql("config")))
+        {
+            await fn.ExecuteNonQueryAsync(ct);
+        }
+
+        return dataSource;
     }
 
     private static async Task<int> CountAlertLogAsync(NpgsqlDataSource dataSource, string metricName, int serverId, CancellationToken ct)

--- a/Darling/Darling.Tests/DarlingManagedRolesTests.cs
+++ b/Darling/Darling.Tests/DarlingManagedRolesTests.cs
@@ -387,4 +387,42 @@ public sealed class DarlingManagedRolesTests
         Assert.Contains($"PASSWORD '{viewer}'", sql, StringComparison.Ordinal);
         Assert.Contains($"PASSWORD '{mcp}'", sql, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void BuildProvisioningSql_CreatesResolveDefinerFunction_ScopedAndGrantedToViewerAndMcp()
+    {
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", "McpPassword03");
+
+        /* #3334: the SECURITY DEFINER resolve-on-delete write function, so viewer/mcp can record the recovery
+           row config_alert_log otherwise refuses them WITHOUT a blanket INSERT grant that would let them forge
+           history. Definer-safety is the whole point, so each safety property is pinned individually. */
+        Assert.Contains("CREATE OR REPLACE FUNCTION config.record_custom_alert_resolution(", sql, StringComparison.Ordinal);
+        Assert.Contains("SECURITY DEFINER", sql, StringComparison.Ordinal);
+
+        /* The pinned search_path (config first, then pg_catalog) is what makes injection impossible — no caller
+           path can redirect the unqualified config_alert_log or now(). */
+        Assert.Contains("SET search_path = config, pg_catalog", sql, StringComparison.Ordinal);
+
+        /* A fresh function is EXECUTE-able by PUBLIC by default, so the REVOKE is mandatory and must precede the
+           narrow grant; EXECUTE is the ONLY privilege the least-privilege roles get. */
+        Assert.Contains("REVOKE ALL ON FUNCTION config.record_custom_alert_resolution(integer, text, text, text) FROM PUBLIC;", sql, StringComparison.Ordinal);
+        Assert.Contains("GRANT EXECUTE ON FUNCTION config.record_custom_alert_resolution(integer, text, text, text) TO viewer, mcp;", sql, StringComparison.Ordinal);
+        var revokeAt = sql.IndexOf("REVOKE ALL ON FUNCTION config.record_custom_alert_resolution", StringComparison.Ordinal);
+        var grantAt = sql.IndexOf("GRANT EXECUTE ON FUNCTION config.record_custom_alert_resolution", StringComparison.Ordinal);
+        Assert.True(revokeAt >= 0 && grantAt > revokeAt, "the PUBLIC revoke must precede the EXECUTE grant.");
+
+        /* The body writes ONE config_alert_log row, shape-LOCKED to a no-channel resolution (alert_sent false,
+           notification_type 'none', zeroed values, unmuted) — so a grantee can page nothing and forge no fire. */
+        Assert.Contains("INSERT INTO config_alert_log", sql, StringComparison.Ordinal);
+        Assert.Contains("false, 'none', NULL, false,", sql, StringComparison.Ordinal);
+
+        /* NOT the rejected blanket grant: viewer/mcp never get a direct write on the history table. */
+        Assert.DoesNotContain("ON config.config_alert_log TO viewer", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("ON config.config_alert_log TO mcp", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("ON config_alert_log TO viewer", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("ON config_alert_log TO mcp", sql, StringComparison.Ordinal);
+
+        /* The shared builder emits the same CREATE + REVOKE the gated live proof test creates the function from. */
+        Assert.Contains(DarlingManagedRoles.BuildCustomAlertResolveFunctionSql("config"), sql, StringComparison.Ordinal);
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
@@ -496,11 +496,10 @@ public sealed class CustomAlertEvaluator
     /// Failure-isolated: an audit-row write must never break a delete or a sweep.
     /// </summary>
     public static async Task WriteTeardownResolutionAsync(
-        IAlertHistoryStore historyStore, ILogger? logger,
+        PgAlertHistoryStore historyStore, ILogger? logger,
         long ruleId, string ruleName, int serverId, string serverName, string reason)
     {
         var safeName = SanitizeDisplayText(ruleName, CustomAlertRuleStore.MaxNameLength);
-        var metricName = MetricNameFor(ruleId);
         var title = safeName + " Resolved";
         var message = string.Create(CultureInfo.InvariantCulture, $"{serverName}: {safeName} resolved because {reason}");
 
@@ -508,8 +507,12 @@ public sealed class CustomAlertEvaluator
 
         try
         {
-            await historyStore.RecordAlertAsync(DarlingSelfAlertEvaluator.BuildResolutionRecord(
-                new AlertResolution(serverId.ToString(CultureInfo.InvariantCulture), serverName, metricName, title, message)));
+            // #3334: route the recovery-row write through the SECURITY DEFINER config.record_custom_alert_resolution
+            // (owner-privileged, EXECUTE-granted to viewer/mcp) so it succeeds on the least-privilege delete pools
+            // (mcp delete tool / viewer web DELETE), which may not INSERT config_alert_log directly -- the gap that
+            // silently dropped this row (#3305). The written row is shape-identical to the BuildResolutionRecord
+            // resolve DeliverResolveAsync writes: title -> metric_name, message -> detail_text, no-channel/zeroed shape.
+            await historyStore.RecordCustomAlertResolutionAsync(serverId, serverName, title, message);
         }
         catch (Exception ex)
         {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedRoles.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedRoles.cs
@@ -750,8 +750,64 @@ GRANT UPDATE (email_cooldown_minutes) ON {config}.config_notification TO {mcp};
 --    which UPDATEs config_service.config_version AS mcp, and section 8 already granted mcp
 --    UPDATE (config_version, updated_at) ON config_service -- so no additional config_service grant is needed here.
 GRANT INSERT, UPDATE, DELETE ON {config}.config_monitored_servers TO {mcp};
+
+-- 10. Custom-alert resolve-on-delete privileged write (#3334). The recovery/resolution row a caller-initiated
+--     rule DELETE writes (CustomAlertEvaluator.WriteTeardownResolutionAsync) lands in config.config_alert_log,
+--     which ONLY admin/owner may INSERT (section 3's schema-wide grant). But that delete runs as the
+--     least-privilege caller -- mcp (the delete_custom_alert_rule tool) or viewer (DELETE /api/alerts) -- so a
+--     direct INSERT is permission-denied, the write is failure-isolated, and the resolution row #3305 intends
+--     was SILENTLY dropped, leaving a deleted firing rule showing ""open"" in history forever. Rather than a
+--     blanket INSERT grant on the history table to viewer/mcp (which would let those roles fabricate ARBITRARY
+--     history rows, including fake fires), a SECURITY DEFINER function confines the privileged write to EXACTLY
+--     a no-channel resolution row: every delivery-shape column is HARDCODED (alert_sent false, notification_type
+--     'none', current/threshold 0, muted false, no send_error/context) -- byte-identical to what
+--     BuildResolutionRecord + PgAlertHistoryStore.RecordAlertAsync write for a normal resolve -- so a caller can
+--     page nothing and fabricate no fire; only server_id/name and the already-sanitized title/detail vary.
+--     Definer-safe: owned by the store owner (the creating provisioning role, {owner}), an explicit pinned
+--     search_path so no injected path can redirect the unqualified config_alert_log or now(), and a fully
+--     parameterized INSERT with NO dynamic SQL. Created + REVOKEd-from-PUBLIC by the shared builder below;
+--     EXECUTE is the only privilege the least-privilege roles get, and admin/owner keep their direct INSERT and
+--     never call it. NOT a versioned migration: CREATE OR REPLACE is idempotent and owner-run every start and
+--     has no probeable schema footprint (the section-1c role-SET rationale), so a V-number would drag in the
+--     probe rung + ladder fixture + version-pin tests for no gain.
+{BuildCustomAlertResolveFunctionSql(config)}
+GRANT EXECUTE ON FUNCTION {config}.record_custom_alert_resolution(integer, text, text, text) TO {viewer}, {mcp};
 ";
     }
+
+    /// <summary>
+    /// The <c>SECURITY DEFINER</c> function (#3334) that lets the least-privilege viewer/mcp roles write the ONE
+    /// resolution row a caller-initiated custom-alert rule delete records in <c>config_alert_log</c> -- a table
+    /// they may not INSERT directly -- WITHOUT a blanket INSERT grant that would let them fabricate arbitrary
+    /// history. Returns the <c>CREATE OR REPLACE FUNCTION</c> plus the <c>REVOKE ALL ... FROM PUBLIC</c> (a
+    /// freshly created function is EXECUTE-able by PUBLIC by default, so revoking is mandatory); the caller adds
+    /// the narrow <c>GRANT EXECUTE</c>. Shared so the gated live proof test creates the IDENTICAL function rather
+    /// than a drifting hand-copy. Definer-safe by construction: owned by whoever runs it (the provisioning owner,
+    /// which holds the config_alert_log INSERT the body needs), an explicit <c>SET search_path = {config},
+    /// pg_catalog</c> so neither the unqualified table nor <c>now()</c> can be redirected by a caller's
+    /// search_path, and a fully parameterized INSERT that hardcodes the resolution shape (never a fire) with no
+    /// dynamic SQL. The 12-column list and its fixed values are kept identical to
+    /// <c>PgAlertHistoryStore.RecordAlertAsync</c>'s write for a <c>BuildResolutionRecord</c>.
+    /// </summary>
+    internal static string BuildCustomAlertResolveFunctionSql(string config) => $@"
+CREATE OR REPLACE FUNCTION {config}.record_custom_alert_resolution(
+   p_server_id integer,
+   p_server_name text,
+   p_metric_name text,
+   p_detail_text text)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = {config}, pg_catalog
+AS $fn$
+   INSERT INTO config_alert_log
+      (alert_time, server_id, server_name, metric_name, current_value, threshold_value,
+       alert_sent, notification_type, send_error, muted, detail_text, context_json)
+   VALUES
+      ((now() AT TIME ZONE 'UTC'), p_server_id, p_server_name, p_metric_name, 0, 0,
+       false, 'none', NULL, false, p_detail_text, NULL);
+$fn$;
+REVOKE ALL ON FUNCTION {config}.record_custom_alert_resolution(integer, text, text, text) FROM PUBLIC;";
 
     /// <summary>
     /// The generated passwords are alnum by construction; this fails closed if that ever changes,

--- a/Darling/PerformanceMonitor.Darling.Service/PgAlertHistoryStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/PgAlertHistoryStore.cs
@@ -99,6 +99,32 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)", connection) { Comma
         }
     }
 
+    /// <summary>
+    /// Writes ONE custom-alert teardown resolution row (#3334) through the <c>SECURITY DEFINER</c>
+    /// <c>config.record_custom_alert_resolution</c> function instead of a direct <c>INSERT INTO config_alert_log</c>.
+    /// A caller-initiated rule delete runs on the least-privilege viewer/mcp pool, which may not INSERT the
+    /// history table; the function (owned by the store owner, EXECUTE-granted to viewer/mcp) performs the
+    /// privileged write while confining it to exactly a no-channel resolution row -- the fixed delivery-shape
+    /// columns live in the function, so this passes only the four that vary. Shape-identical to what
+    /// <see cref="RecordAlertAsync"/> writes for a <see cref="Mcp.DarlingMcpCustomAlertTools"/>-adjacent
+    /// <c>BuildResolutionRecord</c>. NOT failure-isolated here: the sole caller
+    /// (<c>CustomAlertEvaluator.WriteTeardownResolutionAsync</c>) already wraps it best-effort, and swallowing
+    /// here would hide a missing grant/function behind a silent no-op -- exactly the class of bug #3334 is.
+    /// </summary>
+    public async Task RecordCustomAlertResolutionAsync(
+        int serverId, string serverName, string metricName, string detailText, System.Threading.CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _postgres.OpenConnectionAsync(cancellationToken);
+        using var command = new NpgsqlCommand(
+            "SELECT config.record_custom_alert_resolution($1, $2, $3, $4)", connection)
+            { CommandTimeout = DarlingAlertReadAdapter.AlertPassCommandTimeoutSeconds };
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = serverName });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = metricName });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = detailText });
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
     public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
         /* A successful email send is logged with notification_type 'email'/'email+webhook' and a
            null send_error — exactly when Lite stamps the email cooldown (#981). */


### PR DESCRIPTION
Part of #3285. Fixes #3334 (Fixes only auto-closes on dev->main, so close it manually on dev-merge).

The last correctness item before the client nightly: the resolve-on-delete grant gap flagged in #3305/#3333.

### The gap
`CustomAlertEvaluator.WriteTeardownResolutionAsync` writes the "&lt;name&gt; Resolved" recovery row to `config.config_alert_log`, but only admin/owner may INSERT there. On the two least-privilege delete paths -- the mcp `delete_custom_alert_rule` tool and the viewer `DELETE /api/alerts` -- the INSERT was permission-denied, failure-isolated (swallowed), and the row **silently dropped**, leaving a deleted firing rule showing "open" in history forever. #3305's tests missed it because they connect as the **owner**.

### Fix — a scoped SECURITY DEFINER function (Erik's greenlit approach, over a blanket INSERT grant)
`DarlingManagedRoles` provisioning gains, via a shared builder `BuildCustomAlertResolveFunctionSql`:

```sql
CREATE OR REPLACE FUNCTION config.record_custom_alert_resolution(
   p_server_id integer, p_server_name text, p_metric_name text, p_detail_text text)
RETURNS void
LANGUAGE sql
SECURITY DEFINER
SET search_path = config, pg_catalog
AS $fn$
   INSERT INTO config_alert_log
      (alert_time, server_id, server_name, metric_name, current_value, threshold_value,
       alert_sent, notification_type, send_error, muted, detail_text, context_json)
   VALUES
      ((now() AT TIME ZONE 'UTC'), p_server_id, p_server_name, p_metric_name, 0, 0,
       false, 'none', NULL, false, p_detail_text, NULL);
$fn$;
REVOKE ALL ON FUNCTION config.record_custom_alert_resolution(integer, text, text, text) FROM PUBLIC;
GRANT EXECUTE ON FUNCTION config.record_custom_alert_resolution(integer, text, text, text) TO viewer, mcp;
```

**Definer-safety** (first SECURITY DEFINER function in the codebase, so each property is deliberate):
- **owner**: created by the provisioning connection (the store owner), which holds the `config_alert_log` INSERT the body runs with; `CREATE OR REPLACE` by the owner keeps ownership.
- **pinned search_path** `config, pg_catalog`: no caller search_path can redirect the unqualified `config_alert_log` or `now()`.
- **parameters only, no dynamic SQL**: a static, fully-parameterized INSERT.
- **thin + shape-locked**: writes ONE row and HARDCODES the no-channel resolution shape (`alert_sent` false, `notification_type` 'none', current/threshold 0, unmuted, no send_error/context) -- byte-identical to what `RecordAlertAsync` writes for a `BuildResolutionRecord`. A grantee can page nothing and **forge no fire**; only server_id/name and the already-sanitized title/detail vary.
- **REVOKE ALL FROM PUBLIC** before the narrow `GRANT EXECUTE TO viewer, mcp` (a fresh function is PUBLIC-executable by default).
- **provisioning, not a migration**: `CREATE OR REPLACE` is idempotent + owner-run every start with no probeable schema footprint, so no `SchemaVersion` bump (which would drag in the probe rung + ladder fixture + version pins).

**Routing**: `WriteTeardownResolutionAsync` (the delete AND sweep-reconcile teardown writer) now calls `PgAlertHistoryStore.RecordCustomAlertResolutionAsync` → `SELECT config.record_custom_alert_resolution(...)` on the caller's pool (runs as owner via the definer). Normal fire/resolve history writes (the owner service path, `DeliverFireAsync`/`DeliverResolveAsync`) stay on `RecordAlertAsync`, unchanged.

### Provisioning-pin test updates
Added `BuildProvisioningSql_CreatesResolveDefinerFunction_ScopedAndGrantedToViewerAndMcp` to `DarlingManagedRolesTests`: pins the CREATE, `SECURITY DEFINER`, the pinned `search_path`, the PUBLIC-revoke-before-EXECUTE-grant order, the locked resolution shape, and the ABSENCE of any blanket `config_alert_log` grant. The existing pins are unaffected (all substring `Assert.Contains`/`DoesNotContain`; the new section is additive).

### The proof test #3305 lacked (gated live, run green on a local PG 18.4 + TimescaleDB rig)
`CustomAlertResolveGrantLiveTests` connects as a **disposable low-privilege role** (viewer/mcp-shaped: SELECT + narrow `custom_alert_rules` write + EXECUTE on the function, and **no** direct `config_alert_log` INSERT):
- **delete path**: a direct `config_alert_log` INSERT by the role is asserted **denied (42501)**; then `ResolveAndDeleteRuleAsync` on the low-priv pool writes the `&lt;name&gt; Resolved` row (asserted present + a proper no-channel resolution shape) and deletes the rule. A present row can only have come through the definer function.
- **sweep-reconcile path**: the reconcile teardown with a low-priv history pool writes the resolution row the same way.

`CustomAlertTeardownLiveTests` now provisions the function in its fixture (the teardown path depends on this provisioning artifact; those tests migrate but do not provision). All 9 custom-alert live tests pass on a fresh DB.

### Out of scope (flagged, not changed)
The BYO `Darling/tools/provision-roles.sql` (bring-your-own-Postgres, viewer-only, no mcp) is a separate hand-maintained surface with its own drift guard. A BYO viewer's `DELETE /api/alerts` would still hit the gap. It was not in the stated scope (which named `DarlingManagedRoles`), and adding a SECURITY DEFINER function to the shipped BYO script is a security-surface decision for the operator -- worth a follow-up decision.

### Build & full-suite results (post-rebase onto current dev)
- Build **0 warnings / 0 errors**.
- **Darling.Tests**: 8750 total, 0 errors, **4 failed**, 350 skipped (live-gated). Three are the known worktree/platform baseline (`FleetIdentifierScrubTests` x2 "scanned 0 files", `NpgsqlRootCertificateValidationTests` x1 TLS). The fourth, `IncidentAttachmentDeliveryTests.TheFourNonEmailChannels_PostIdenticalBytes_WithAndWithoutIncidentAttachments`, is a test-ISOLATION issue in dev's newly-merged #3330 class: it **passes in isolation** and fails only in the full parallel run, and has no code path to this change (it exercises delivery-channel bytes; this touches config_alert_log resolution provisioning). It affects any branch off current dev -- flagging for a dev-side look, not caused here.
- **Lite.Tests**: 3713 total, 0 errors, 4 failed -- all the known `AuroraOnlySqlIsGatedTests` worktree source-scan baseline; no Lite files touched.

No MCP tool added, so the tool-inventory pins do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
