### PR TITLE
Add the custom-alert web authoring editor (#3285, Component 7)

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/css/editor.css
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/css/editor.css
@@ -586,3 +586,44 @@ button.template-item:focus-visible { outline: 2px solid var(--muted); outline-of
 .views-hero .hero-chip.clickable:hover { color: var(--fg); border-color: var(--accent); }
 .views-hero .hero-chip.clickable:focus-visible { outline: 2px solid var(--muted); outline-offset: 1px; }
 .views-hero .starter-server { justify-content: center; padding: 0; }
+
+/* ─────────────────────────── custom alert rules (#3285) ─────────────────────────── */
+
+/* The "Paused" badge on a disabled rule's list card — the muted twin of the notebook badge. */
+.paused-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  background: var(--lighter);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+.view-card .vc-name .paused-badge { flex: 0 0 auto; }
+
+/* The alert editor's card sections (Condition / Hysteresis / Scope) — the same inset the panel editor uses. */
+.alert-section { padding: 0.9rem 1rem; }
+
+/* The Enabled checkbox field sits left-aligned under its label rather than stretching. */
+.editor-field.field-enabled { align-items: flex-start; }
+.editor-field.field-enabled .editor-check { margin-top: 0.2rem; }
+
+/* The "Create alert from this metric" action row inside a composed panel editor — set off from the config above. */
+.composed-panel-actions { margin-top: 0.85rem; border-top: 1px solid var(--border); padding-top: 0.7rem; }
+
+/* The alert editor's advanced (cadence) disclosure — the twin of the composer's Advanced. */
+.alert-advanced { margin: 0.85rem 0 1.25rem; }
+.alert-advanced > summary { cursor: pointer; font-size: 0.8rem; font-weight: 600; color: var(--muted); }
+.alert-advanced > summary:hover { color: var(--fg); }
+.alert-advanced > summary::-webkit-details-marker { display: none; }
+.alert-advanced > summary::before { content: "▸ "; color: var(--muted); }
+.alert-advanced[open] > summary::before { content: "▾ "; }
+.alert-advanced > .cfg { margin-top: 0.6rem; }
+
+/* The would-fire preview area. */
+.alert-preview { margin-bottom: 1rem; }

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/index.html
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/index.html
@@ -26,6 +26,7 @@
                regardless, so a deep link is never broken by the entry being hidden. -->
           <a data-route="ag" href="#/ag" hidden>Availability Groups</a>
           <a data-route="alerts" href="#/alerts">Alert History</a>
+          <a data-route="alert-rules" href="#/alert-rules">Alert Rules</a>
           <a data-route="views" href="#/views">Custom Views</a>
         </nav>
         <div class="server-list-header">Servers</div>

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
@@ -1,0 +1,740 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+/*
+ * The #3285 custom-alert-rule EDITOR (Component 7) — the twin of editor.js's view composer, for a rule instead of
+ * a dashboard. A rule is name + description + enabled + a definition { metric, predicate, hysteresis, scope,
+ * evaluationIntervalSeconds? }, saved through the /api/alerts CRUD (alerts-api.js) that mirrors the /api/views CRUD
+ * (version optimistic concurrency, 409 on a stale version or duplicate name). The metric picker is the SHARED
+ * composer body (buildComposedPanelBody in metricOnly mode), restricted to a Scalar metric — no chart, group-by, or
+ * shape, because an alert evaluates the metric to ONE value. The predicate/hysteresis/scope are alert-specific
+ * controls here.
+ *
+ * The backend is the authority on the whole definition: POST /api/alerts/validate gives the inline verdict and
+ * POST /api/alerts/test the live "current value / would-fire per server" preview, both debounced. The client also
+ * mirrors the cheap structural rules (window ceiling, warn/critical ordering, the count-with-'<' trap) as an
+ * immediate save-blocker so the operator gets a reason without a round-trip — exactly as the composer's saveBlocker
+ * does, with the server re-validating on every write.
+ *
+ * All user text reaches the DOM via util.el()/textContent (R4 — never innerHTML). The 60s poll in app.js SKIPS
+ * this route (the editor-route poll guard), so an in-progress edit is never clobbered by a background refresh.
+ */
+
+import { el, mount, loadingStrip, errorStrip, emptyStrip, noticeStrip } from "./util.js";
+import {
+  buildComposedPanelBody,
+  loadFleetOptions,
+  newComposedPanel,
+  descToComposedPanel,
+  composedPanelToDesc,
+  field,
+  labeledBlock,
+} from "./editor.js";
+import { formatComposedValue } from "./compose.js";
+import { takePendingAlertSeed, metricSpecFromDesc } from "./alert-seed.js";
+import * as api from "./alerts-api.js";
+
+/* Debounce for the validate + test round-trips, matching the composer's preview debounce. */
+const CHECK_DEBOUNCE_MS = 350;
+
+/* Alert-window bounds mirrored from CustomAlertRuleDefinition (MaxWindowHours / MinWindowHours / the cadence floor)
+   so the editor reports them inline rather than only as a 400. An alert window is RECENT — never the 90-day compose
+   chart ceiling. */
+const MAX_WINDOW_HOURS = 24;
+const MIN_WINDOW_HOURS = 1 / 60;
+const MIN_INTERVAL_SECONDS = 30;
+const DEFAULT_WINDOW_HOURS = 1;
+
+/* The evaluation-window choices (all within [MinWindowHours, MaxWindowHours]); a loaded rule's own window is added
+   if it is not one of these, so the select always shows exactly what is applied. */
+const WINDOW_OPTIONS = [
+  { hours: 5 / 60, label: "Last 5 minutes" },
+  { hours: 15 / 60, label: "Last 15 minutes" },
+  { hours: 30 / 60, label: "Last 30 minutes" },
+  { hours: 1, label: "Last hour" },
+  { hours: 2, label: "Last 2 hours" },
+  { hours: 3, label: "Last 3 hours" },
+  { hours: 6, label: "Last 6 hours" },
+  { hours: 12, label: "Last 12 hours" },
+  { hours: 24, label: "Last 24 hours" },
+];
+
+/* The comparison operators an alert predicate offers. Between / outside are deferred (#3351), so only the four
+   scalar comparisons appear — matching the CustomAlertOp enum the backend parses. */
+const OP_OPTIONS = [
+  { value: "gt", label: "is greater than (>)" },
+  { value: "ge", label: "is greater than or equal to (≥)" },
+  { value: "lt", label: "is less than (<)" },
+  { value: "le", label: "is less than or equal to (≤)" },
+];
+
+/* ─────────────────────────── entry ─────────────────────────── */
+
+export async function renderAlertEditor(main, id, templateKey) {
+  mount(main, loadingStrip("Loading alert-rule editor…"));
+
+  const session = await api.getSession();
+  if (!session.can_edit) {
+    mount(main, [
+      alertBackHead(),
+      emptyStrip(
+        session.probe_failed
+          ? "Couldn't confirm your session, so the editor is read-only for now. Reload the page to author a rule."
+          : "Your account has read-only access, so the alert-rule editor is read-only."
+      ),
+    ]);
+    return;
+  }
+
+  /* The metric picker needs the compose catalog; the scope picker needs the fleet server names. */
+  const [catalog, fleet] = await Promise.all([api.getCatalog(), loadFleetOptions()]);
+
+  let model;
+  let editingId = null;
+  let loadedVersion = null;
+
+  if (id != null && id !== "new") {
+    const res = await api.getAlertRule(id);
+    if (res.kind !== "data" || !res.data) {
+      mount(main, [alertBackHead(), errorStrip(res.message || "Could not load this alert rule.")]);
+      return;
+    }
+    editingId = res.data.id;
+    loadedVersion = res.data.version;
+    model = ruleToModel(res.data);
+  } else if (templateKey) {
+    /* Start from a starter template (its definition pre-fills the form; the operator tunes the thresholds/scope
+       before saving — the starters are deliberately conservative, not tuned). */
+    const tplRes = await api.listAlertTemplates();
+    const template =
+      tplRes.kind === "data" && tplRes.data && Array.isArray(tplRes.data.templates)
+        ? tplRes.data.templates.find((t) => t.key === templateKey)
+        : null;
+    model = template
+      ? definitionToModel(template.definition, template.name, template.description, true)
+      : blankModel();
+  } else {
+    /* A pending "Create alert from this metric" seed (from a composer panel), consumed once, else a blank rule. */
+    const seed = takePendingAlertSeed();
+    model = seed ? seededModel(seed) : blankModel();
+  }
+
+  buildAlertEditor(main, { model, editingId, loadedVersion, catalog, fleet });
+}
+
+/* ─────────────────────────── model <-> definition ─────────────────────────── */
+
+/** A fresh Scalar metric picker model (the composer's model, locked to a single value). */
+function scalarMetricModel() {
+  return { ...newComposedPanel(), shape: "scalar", groupBy: [], hours: null };
+}
+
+/** A brand-new blank rule model. */
+function blankModel() {
+  return {
+    name: "",
+    description: "",
+    enabled: true,
+    metric: scalarMetricModel(),
+    windowHours: DEFAULT_WINDOW_HOURS,
+    op: "gt",
+    warn: "",
+    critical: "",
+    breachSamples: 1,
+    clearSamples: 1,
+    scopeMode: "all",
+    scopeServers: [],
+    intervalSeconds: "",
+  };
+}
+
+/** A blank rule pre-filled from a "Create alert from this metric" seed ({metric, name}). */
+function seededModel(seed) {
+  const model = blankModel();
+  if (seed.metric) {
+    model.metric = { ...descToComposedPanel(seed.metric), shape: "scalar", groupBy: [], hours: null };
+  }
+  if (seed.name) model.name = seed.name;
+  return model;
+}
+
+/** A stored rule ({name, description, enabled, definition}) -> the editor model. */
+function ruleToModel(rule) {
+  return definitionToModel(rule.definition || {}, rule.name, rule.description, rule.enabled !== false);
+}
+
+/** A rule DEFINITION (+ name/description/enabled) -> the editor model. Shared by the load path and the template
+ *  path. The metric is parsed by the SAME descToComposedPanel the composer uses (it reads only the composed keys),
+ *  then locked to Scalar; predicate/hysteresis/scope map to their controls. */
+function definitionToModel(def, name, description, enabled) {
+  const metricJson = def && def.metric ? def.metric : {};
+  const pred = def && def.predicate ? def.predicate : {};
+  const hyst = def && def.hysteresis ? def.hysteresis : {};
+  const scope = def && def.scope ? def.scope : {};
+  return {
+    name: name || "",
+    description: description || "",
+    enabled: enabled !== false,
+    metric: { ...descToComposedPanel(metricJson), shape: "scalar", groupBy: [], hours: null },
+    windowHours: typeof metricJson.hours === "number" ? metricJson.hours : DEFAULT_WINDOW_HOURS,
+    op: normalizeOp(pred.op),
+    warn: pred.warnThreshold != null ? String(pred.warnThreshold) : "",
+    critical: pred.criticalThreshold != null ? String(pred.criticalThreshold) : "",
+    breachSamples: intOr(hyst.breachSamples, 1),
+    clearSamples: intOr(hyst.clearSamples, 1),
+    scopeMode: scope.mode === "servers" ? "servers" : "all",
+    scopeServers: Array.isArray(scope.servers) ? scope.servers.map(String) : [],
+    intervalSeconds: typeof def.evaluationIntervalSeconds === "number" ? String(def.evaluationIntervalSeconds) : "",
+  };
+}
+
+/** The editor model -> the stored rule definition. The metric carries ONLY the compose-authority keys (via
+ *  metricSpecFromDesc) plus the alert window; predicate/hysteresis/scope/cadence map back to the definition shape
+ *  the backend's CustomAlertRuleDefinition.TryParse validates. Blank optional fields are omitted. */
+function modelToDefinition(model) {
+  const metric = metricSpecFromDesc(composedPanelToDesc(model.metric));
+  metric.hours = model.windowHours;
+
+  const predicate = { op: model.op, warnThreshold: parseNumOrNull(model.warn) };
+  if (model.critical.trim() !== "") predicate.criticalThreshold = parseNumOrNull(model.critical);
+
+  const def = {
+    metric,
+    predicate,
+    hysteresis: { breachSamples: model.breachSamples, clearSamples: model.clearSamples },
+    scope: model.scopeMode === "servers" ? { mode: "servers", servers: [...model.scopeServers] } : { mode: "all" },
+  };
+
+  const interval = model.intervalSeconds.trim();
+  if (interval !== "") def.evaluationIntervalSeconds = parseInt(interval, 10);
+  return def;
+}
+
+/* ─────────────────────────── save blocker (mirrors the server's cheap rules) ─────────────────────────── */
+
+/** The reason SAVE is blocked, or null when savable. The subtle cross-checks stay the server's job (POST
+ *  /api/alerts/validate), but the immediate structural rules — name, a chosen metric, a numeric warning threshold,
+ *  the window ceiling, warn/critical ordering, and the count-with-'<' trap — are mirrored here so the operator gets
+ *  a reason inline, exactly as the composer's saveBlocker does. */
+function alertSaveBlocker(model) {
+  if (!model.name || !model.name.trim()) return "Enter a rule name.";
+
+  const metric = model.metric;
+  if (!metric.measure && !metric.ratio) return "Choose a metric.";
+  if (metric.measure && !metric.aggregate) return "Choose an aggregate for the metric.";
+
+  if (!(model.windowHours >= MIN_WINDOW_HOURS)) return "Choose an evaluation window.";
+  if (model.windowHours > MAX_WINDOW_HOURS) return "The evaluation window can be at most 24 hours (an alert window is recent).";
+
+  const warn = parseNumOrNull(model.warn);
+  if (warn == null) return "Enter a warning threshold (a number).";
+
+  /* A '<'/'<=' alert on a COUNT can't tell zero matching events from a stalled collector reading zero rows, so it
+     would false-fire exactly when the true signal is "no data" — the same rule the backend enforces. */
+  if (metric.aggregate === "count" && (model.op === "lt" || model.op === "le")) {
+    return "A '<' or '≤' alert on a count can't tell zero events from a stalled collector — use '≥' instead.";
+  }
+
+  if (model.critical.trim() !== "") {
+    const critical = parseNumOrNull(model.critical);
+    if (critical == null) return "The critical threshold must be a number (or leave it blank).";
+    const ordered = model.op === "gt" || model.op === "ge" ? critical >= warn : critical <= warn;
+    if (!ordered) return "The critical threshold must be more extreme than the warning threshold, in the operator's direction.";
+  }
+
+  if (!(model.breachSamples >= 1)) return "Breach samples must be at least 1.";
+  if (!(model.clearSamples >= 1)) return "Clear samples must be at least 1.";
+
+  if (model.scopeMode === "servers" && !model.scopeServers.length) {
+    return "Pick at least one server, or scope the rule to all servers.";
+  }
+
+  const interval = model.intervalSeconds.trim();
+  if (interval !== "") {
+    const n = parseInt(interval, 10);
+    if (!(n >= MIN_INTERVAL_SECONDS)) return "The evaluation interval must be at least " + MIN_INTERVAL_SECONDS + " seconds.";
+  }
+
+  return null;
+}
+
+/** Whether the definition is complete enough to send to /api/alerts/validate + /test (a chosen metric + a numeric
+ *  warning threshold). Below this the preview area shows a neutral hint rather than a stream of "required" errors. */
+function readyToCheck(model) {
+  const metric = model.metric;
+  if (!metric.measure && !metric.ratio) return false;
+  if (metric.measure && !metric.aggregate) return false;
+  return parseNumOrNull(model.warn) != null;
+}
+
+/* ─────────────────────────── the editor shell ─────────────────────────── */
+
+function buildAlertEditor(main, ctx) {
+  const { model } = ctx;
+
+  const nameInput = el("input", { class: "editor-input", type: "text", placeholder: "Rule name (required)", "aria-label": "Rule name" });
+  nameInput.value = model.name;
+  nameInput.addEventListener("input", () => {
+    model.name = nameInput.value;
+    refreshSaveState();
+  });
+
+  const descInput = el("input", { class: "editor-input", type: "text", placeholder: "Description (optional)", "aria-label": "Rule description" });
+  descInput.value = model.description;
+  descInput.addEventListener("input", () => {
+    model.description = descInput.value;
+  });
+
+  const enabledBox = el("input", { type: "checkbox", class: "editor-check", "aria-label": "Rule enabled" });
+  enabledBox.checked = model.enabled;
+  enabledBox.addEventListener("change", () => {
+    model.enabled = enabledBox.checked;
+  });
+
+  const saveStatus = el("div", { class: "save-status" });
+  const previewBox = el("div", { class: "alert-preview" });
+  const saveBtn = el("button", { class: "btn primary", type: "button", text: ctx.editingId != null ? "Save changes" : "Create rule" });
+  const cancelBtn = el("button", { class: "btn", type: "button", text: "Cancel" });
+
+  cancelBtn.addEventListener("click", () => {
+    location.hash = "#/alert-rules";
+  });
+  saveBtn.addEventListener("click", onSave);
+
+  /* The metric picker: the SHARED composer body, locked to a Scalar metric. onChange re-checks save state and
+     re-runs the debounced validate + test; the body owns its own config rebuild. No group/chart/shape controls,
+     and no live compose preview (this editor renders its own would-fire preview below). */
+  const metricBody = buildComposedPanelBody(model.metric, {
+    catalog: ctx.catalog,
+    getVariables: () => [],
+    getScopeServer: () => null,
+    onChange: onFieldChange,
+    metricOnly: true,
+  });
+
+  let checkTimer = null;
+  function scheduleCheck() {
+    clearTimeout(checkTimer);
+    checkTimer = setTimeout(runCheck, CHECK_DEBOUNCE_MS);
+  }
+
+  /* Every field change refreshes the (synchronous) save gate and reschedules the (async) authority preview. */
+  function onFieldChange() {
+    refreshSaveState();
+    scheduleCheck();
+  }
+
+  function refreshSaveState() {
+    const problem = alertSaveBlocker(model);
+    saveBtn.disabled = problem != null;
+    mount(saveStatus, problem ? el("span", { class: "muted", text: problem }) : null);
+  }
+
+  /* The authority preview: POST /api/alerts/validate for the inline verdict, then — only when valid — POST
+     /api/alerts/test for the per-server current-value / would-fire table. Guarded by readyToCheck so an
+     incomplete draft shows a neutral hint, not a stream of "required" errors. */
+  async function runCheck() {
+    if (!readyToCheck(model)) {
+      mount(previewBox, emptyStrip("Choose a metric and a warning threshold to preview what this rule would do."));
+      return;
+    }
+    const def = modelToDefinition(model);
+    mount(previewBox, loadingStrip("Checking…"));
+
+    const vres = await api.validateAlertRule(def);
+    if (vres.kind === "error") {
+      mount(previewBox, errorStrip(vres.message || "Could not validate this rule."));
+      return;
+    }
+    if (vres.kind === "data" && vres.data && vres.data.valid === false) {
+      mount(previewBox, errorStrip(vres.data.error || "This rule definition is not valid."));
+      return;
+    }
+
+    const tres = await api.testAlertRule({ definition: def });
+    mount(previewBox, renderTestResult(tres, model.metric.unit));
+  }
+
+  const deleteBtn = ctx.editingId != null ? buildDeleteButton(ctx.editingId, saveStatus) : null;
+
+  async function onSave() {
+    saveBtn.disabled = true;
+    const problem = alertSaveBlocker(model);
+    if (problem) {
+      saveBtn.disabled = false;
+      mount(saveStatus, el("span", { class: "strip error", text: problem }));
+      return;
+    }
+
+    mount(saveStatus, el("span", { class: "muted", text: "Saving…" }));
+    const body = {
+      name: model.name.trim(),
+      description: model.description ? model.description : null,
+      enabled: model.enabled,
+      definition: modelToDefinition(model),
+    };
+
+    let res;
+    if (ctx.editingId != null) {
+      body.version = ctx.loadedVersion;
+      res = await api.updateAlertRule(ctx.editingId, body);
+    } else {
+      res = await api.createAlertRule(body);
+    }
+
+    if (res.kind === "data" && res.data) {
+      location.hash = "#/alert-rules";
+      return;
+    }
+
+    saveBtn.disabled = false;
+    handleSaveError(res, saveStatus, ctx, main);
+  }
+
+  const footer = [saveBtn, cancelBtn];
+  if (deleteBtn) footer.push(deleteBtn);
+  footer.push(saveStatus);
+
+  mount(main, [
+    el("div", { class: "page-head" }, [
+      el("a", { href: "#/alert-rules", text: "← Alert Rules" }),
+      el("h2", { text: ctx.editingId != null ? "Edit alert rule" : "New alert rule" }),
+    ]),
+    el("div", { class: "editor-meta" }, [
+      field("Name", nameInput),
+      field("Description", descInput),
+      field("Enabled", enabledBox, "field-enabled"),
+    ]),
+    el("h3", { class: "section-title", text: "Metric" }),
+    el("div", { class: "panel-editor card" }, [metricBody]),
+    el("h3", { class: "section-title", text: "Condition" }),
+    el("div", { class: "alert-section card" }, [conditionSection(model, onFieldChange)]),
+    el("h3", { class: "section-title", text: "Hysteresis" }),
+    el("div", { class: "alert-section card" }, [hysteresisSection(model, onFieldChange)]),
+    el("h3", { class: "section-title", text: "Scope" }),
+    el("div", { class: "alert-section card" }, [scopeSection(model, ctx.fleet, onFieldChange)]),
+    advancedSection(model, onFieldChange),
+    el("h3", { class: "section-title", text: "Preview" }),
+    previewBox,
+    el("div", { class: "editor-footer" }, footer),
+  ]);
+
+  refreshSaveState();
+  runCheck();
+}
+
+/* ─────────────────────────── condition (window + predicate) ─────────────────────────── */
+
+/* When the metric fires: the evaluation window, the comparison operator, and the warning / critical thresholds.
+   Warn = the Warning tier; adding a (more-extreme) critical threshold arms the Critical tier — the severity is the
+   two thresholds, not a separate control (CustomAlertRuleDefinition.SeverityFor). */
+function conditionSection(model, onChange) {
+  const windowSel = buildWindowSelect(model, onChange);
+
+  const opSel = el("select", { class: "editor-select", "aria-label": "Comparison" });
+  for (const o of OP_OPTIONS) opSel.appendChild(el("option", { value: o.value, text: o.label }));
+  opSel.value = model.op;
+  opSel.addEventListener("change", () => {
+    model.op = opSel.value;
+    onChange();
+  });
+
+  const warnInput = el("input", { class: "editor-input", type: "number", step: "any", placeholder: "warning value", "aria-label": "Warning threshold" });
+  warnInput.value = model.warn;
+  warnInput.addEventListener("input", () => {
+    model.warn = warnInput.value;
+    onChange();
+  });
+
+  const critInput = el("input", { class: "editor-input", type: "number", step: "any", placeholder: "critical value (optional)", "aria-label": "Critical threshold" });
+  critInput.value = model.critical;
+  critInput.addEventListener("input", () => {
+    model.critical = critInput.value;
+    onChange();
+  });
+
+  return el("div", {}, [
+    el("div", { class: "composed-fields" }, [
+      field("Evaluate over", windowSel),
+      field("When the value", opSel),
+      field("Warning threshold", warnInput),
+      field("Critical threshold", critInput),
+    ]),
+    el("div", {
+      class: "block-help",
+      text: "The metric is aggregated to one value over the window, then compared. Crossing the warning threshold fires a Warning; crossing the (more-extreme) critical threshold fires a Critical. Leave critical blank for a single Warning tier.",
+    }),
+  ]);
+}
+
+/* The evaluation-window select (bound to model.windowHours): the presets, plus a loaded rule's own window when it is
+   not a preset (kept selectable so it shows exactly what is applied). Capped at MaxWindowHours — an alert window is
+   recent, never the 90-day compose chart span. */
+function buildWindowSelect(model, onChange) {
+  const sel = el("select", { class: "editor-select", "aria-label": "Evaluation window" });
+  const added = new Set();
+  for (const o of WINDOW_OPTIONS) {
+    sel.appendChild(el("option", { value: String(o.hours), text: o.label }));
+    added.add(String(o.hours));
+  }
+  const cur = String(model.windowHours);
+  if (model.windowHours > 0 && !added.has(cur)) {
+    sel.appendChild(el("option", { value: cur, text: windowLabel(model.windowHours) }));
+  }
+  sel.value = cur;
+  sel.addEventListener("change", () => {
+    model.windowHours = Number(sel.value) || DEFAULT_WINDOW_HOURS;
+    onChange();
+  });
+  return sel;
+}
+
+/** A human label for an arbitrary window (hours), matching the preset style — sub-hour windows render as minutes. */
+function windowLabel(hours) {
+  if (hours < 1) {
+    const mins = Math.round(hours * 60);
+    return "Last " + mins + (mins === 1 ? " minute" : " minutes");
+  }
+  return "Last " + hours + (hours === 1 ? " hour" : " hours");
+}
+
+/* ─────────────────────────── hysteresis ─────────────────────────── */
+
+/* How many consecutive evaluations gate a fire and a clear — so a single spike does not page and a single dip does
+   not resolve prematurely. Both are integers >= 1 (the backend's floor). */
+function hysteresisSection(model, onChange) {
+  const breach = el("input", { class: "editor-input", type: "number", step: "1", min: "1", "aria-label": "Breach samples" });
+  breach.value = String(model.breachSamples);
+  breach.addEventListener("input", () => {
+    model.breachSamples = clampIntAtLeast(breach.value, 1);
+    onChange();
+  });
+
+  const clear = el("input", { class: "editor-input", type: "number", step: "1", min: "1", "aria-label": "Clear samples" });
+  clear.value = String(model.clearSamples);
+  clear.addEventListener("input", () => {
+    model.clearSamples = clampIntAtLeast(clear.value, 1);
+    onChange();
+  });
+
+  return el("div", {}, [
+    el("div", { class: "composed-fields" }, [
+      field("Breach samples (to fire)", breach),
+      field("Clear samples (to resolve)", clear),
+    ]),
+    el("div", {
+      class: "block-help",
+      text: "The condition must hold for this many consecutive evaluations before the rule fires, and clear for this many before it resolves. 1 fires on the first breaching sample.",
+    }),
+  ]);
+}
+
+/* ─────────────────────────── scope ─────────────────────────── */
+
+/* Which servers the rule evaluates against: all servers (the fleet), or a chosen set. Tag scope is deferred
+   (#3350), so only All / Specific servers are offered. */
+function scopeSection(model, fleet, onChange) {
+  const list = el("div", { class: "scope-list" });
+  const box = el("div", {});
+
+  const modeSel = el("select", { class: "editor-select", "aria-label": "Scope" }, [
+    el("option", { value: "all", text: "All servers (fleet)" }),
+    el("option", { value: "servers", text: "Specific servers" }),
+  ]);
+  modeSel.value = model.scopeMode;
+  modeSel.addEventListener("change", () => {
+    model.scopeMode = modeSel.value === "servers" ? "servers" : "all";
+    redraw();
+    onChange();
+  });
+
+  function redraw() {
+    if (model.scopeMode !== "servers") {
+      mount(box, el("div", { class: "block-help", text: "This rule evaluates against every monitored server." }));
+      return;
+    }
+    if (!fleet.length) {
+      mount(box, noticeStrip("No servers are in the fleet yet, so a specific-server scope has nothing to pick."));
+      return;
+    }
+    const rows = fleet.map((s) => {
+      const on = model.scopeServers.includes(s.value);
+      return checkRow(s.label, on, (checked) => {
+        if (checked) {
+          if (!model.scopeServers.includes(s.value)) model.scopeServers.push(s.value);
+        } else {
+          model.scopeServers = model.scopeServers.filter((x) => x !== s.value);
+        }
+        onChange();
+      });
+    });
+    mount(list, rows);
+    mount(box, [list, el("div", { class: "block-help", text: "The rule fires per server; pick the servers it applies to." })]);
+  }
+
+  redraw();
+  return el("div", {}, [field("Servers", modeSel), box]);
+}
+
+function checkRow(label, checked, onToggle) {
+  const cbox = el("input", { type: "checkbox", class: "editor-check" });
+  cbox.checked = checked;
+  cbox.addEventListener("change", () => onToggle(cbox.checked));
+  return el("label", { class: "scope-item" }, [cbox, el("span", { text: label })]);
+}
+
+/* ─────────────────────────── advanced (cadence) ─────────────────────────── */
+
+/* The optional per-rule evaluation cadence — how often the sweep evaluates this rule. Folded away because the
+   default (the sweep's own interval) is right for almost every rule; a floor of MinEvaluationIntervalSeconds keeps
+   a rule from asking to run faster than the collectors move. */
+function advancedSection(model, onChange) {
+  const input = el("input", { class: "editor-input", type: "number", step: "1", min: String(MIN_INTERVAL_SECONDS), placeholder: "default", "aria-label": "Evaluation interval (seconds)" });
+  input.value = model.intervalSeconds;
+  input.addEventListener("input", () => {
+    model.intervalSeconds = input.value;
+    onChange();
+  });
+  return el("details", { class: "alert-advanced" }, [
+    el("summary", { text: "Advanced" }),
+    el("div", { class: "cfg" }, [
+      field("Evaluation interval (seconds)", input),
+      el("div", { class: "block-help", text: "How often to evaluate this rule. Leave blank for the default cadence; at least " + MIN_INTERVAL_SECONDS + " seconds." }),
+    ]),
+  ]);
+}
+
+/* ─────────────────────────── test result (current value / would-fire) ─────────────────────────── */
+
+/* The POST /api/alerts/test result: per-server CURRENT value + whether it would breach right now, in a table, with
+   the hysteresis caveat above it. This is the instantaneous predicate only — the running evaluator also gates on
+   hysteresis + per-server streak, which the note spells out. Every value reaches the DOM as text (R4). */
+function renderTestResult(res, unit) {
+  if (res.kind === "empty") {
+    /* An invalid/not-found draft comes back as {status, message}; surface the message (validate already ran, so
+       this is the belt-and-suspenders path). */
+    return errorStrip(res.message || "This rule definition is not valid.");
+  }
+  if (res.kind === "error") {
+    return errorStrip(res.message || "Could not evaluate this rule.");
+  }
+
+  const data = res.data || {};
+  const results = Array.isArray(data.results) ? data.results : [];
+  const nodes = [];
+  if (typeof data.note === "string" && data.note) nodes.push(noticeStrip(data.note));
+
+  if (data.status === "no_in_scope_servers" || !results.length) {
+    nodes.push(emptyStrip("No monitored servers match this scope right now."));
+    return el("div", {}, nodes);
+  }
+
+  const head = el("tr", {}, [
+    el("th", { text: "Server" }),
+    el("th", { class: "num", text: "Current value" }),
+    el("th", { text: "Would fire now" }),
+  ]);
+  const rows = results.map((r) => {
+    let verdict;
+    if (r.no_data) verdict = el("span", { class: "muted", text: "no data" });
+    else if (r.breaching) {
+      const sev = r.severity || "Warning";
+      verdict = el("span", { class: "status-cell sev-" + sev }, [el("span", { class: "glyph", text: "●" }), el("span", { text: "Yes — " + sev })]);
+    } else {
+      verdict = el("span", { class: "status-cell sev-Healthy" }, [el("span", { class: "glyph", text: "○" }), el("span", { text: "No" })]);
+    }
+    return el("tr", {}, [
+      el("td", { text: r.server }),
+      el("td", { class: "num", text: r.no_data ? "—" : formatComposedValue(r.current_value, unit || "") }),
+      el("td", {}, [verdict]),
+    ]);
+  });
+  nodes.push(el("div", { class: "table-wrap" }, [el("table", { class: "data" }, [el("thead", {}, [head]), el("tbody", {}, rows)])]));
+  return el("div", {}, nodes);
+}
+
+/* ─────────────────────────── delete + errors ─────────────────────────── */
+
+function buildDeleteButton(id, saveStatus) {
+  const btn = el("button", { class: "btn small danger", type: "button", text: "Delete" });
+  btn.addEventListener("click", async () => {
+    if (!window.confirm("Delete this alert rule? Any open incident for it is resolved first. This cannot be undone.")) {
+      return;
+    }
+    btn.disabled = true;
+    mount(saveStatus, el("span", { class: "muted", text: "Deleting…" }));
+    const res = await api.deleteAlertRule(id);
+    if (res.kind === "data") {
+      location.hash = "#/alert-rules";
+      return;
+    }
+    btn.disabled = false;
+    mount(saveStatus, errorStrip(res.message || "Could not delete this rule."));
+  });
+  return btn;
+}
+
+/* On a 409 while EDITING, the row changed under us (stale version) or the name now collides — offer to reload the
+   latest (discarding local edits), mirroring the view/notebook composers. */
+function handleSaveError(res, saveStatus, ctx, main) {
+  const parts = [el("span", { text: res.message || "Could not save the alert rule." })];
+  if (res.status === 409 && ctx.editingId != null) {
+    const reload = el("button", { class: "btn small", type: "button", text: "Reload latest" });
+    reload.addEventListener("click", () => renderAlertEditor(main, ctx.editingId));
+    parts.push(reload);
+  }
+  mount(saveStatus, el("div", { class: "strip error" }, parts));
+}
+
+/* ─────────────────────────── small helpers ─────────────────────────── */
+
+function alertBackHead() {
+  return el("div", { class: "page-head" }, [
+    el("a", { href: "#/alert-rules", text: "← Alert Rules" }),
+    el("h2", { text: "Alert-rule editor" }),
+  ]);
+}
+
+/** Map a stored/loose op to one of the four select values; defaults to "gt". */
+function normalizeOp(raw) {
+  switch (String(raw == null ? "" : raw).trim().toLowerCase()) {
+    case "gt":
+    case ">":
+      return "gt";
+    case "ge":
+    case ">=":
+      return "ge";
+    case "lt":
+    case "<":
+      return "lt";
+    case "le":
+    case "<=":
+      return "le";
+    default:
+      return "gt";
+  }
+}
+
+/** A finite number from a text input, or null (blank or non-numeric). */
+function parseNumOrNull(raw) {
+  if (raw == null || String(raw).trim() === "") return null;
+  const n = Number(raw);
+  return isFinite(n) ? n : null;
+}
+
+/** An integer >= min from a loose value, falling back to min. */
+function clampIntAtLeast(raw, min) {
+  const n = parseInt(raw, 10);
+  return isFinite(n) && n >= min ? n : min;
+}
+
+/** An integer from a value, or a fallback. */
+function intOr(v, dflt) {
+  const n = parseInt(v, 10);
+  return isFinite(n) ? n : dflt;
+}

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-seed.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-seed.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+/*
+ * The "Create alert from this panel" handoff (#3285, Component 7) — a LEAF module so BOTH the dashboard composer
+ * (editor.js) and the notebook composer (notebook.js) can offer the action, and the alert editor (alert-editor.js)
+ * can pick it up, WITHOUT an import cycle. This module imports only util.js: editor.js and notebook.js import the
+ * action builder here (they pass their own composedPanelToDesc in, so this module never imports editor.js), and
+ * alert-editor.js imports the pending-seed getter here — a clean DAG, no editor.js <-> alert-editor.js cycle.
+ *
+ * The seed is a COPY, never a live binding (the plan's requirement): the button snapshots the panel's metric spec
+ * into module state and navigates to #/alert-rule/new, where the editor consumes it once and clears it. Editing
+ * the source panel afterwards does not touch the drafted rule, and editing the rule does not touch the panel.
+ */
+
+import { el } from "./util.js";
+
+/* The one-shot handoff slot: a panel's metric spec waiting for the next #/alert-rule/new render to consume. */
+let _pendingSeed = null;
+
+/** Stash a metric seed ({metric, name}) for the next new-alert-rule editor to pre-fill from. */
+export function setPendingAlertSeed(seed) {
+  _pendingSeed = seed;
+}
+
+/** Take (and clear) the pending metric seed, or null when none is waiting. Consumed once by the editor. */
+export function takePendingAlertSeed() {
+  const seed = _pendingSeed;
+  _pendingSeed = null;
+  return seed;
+}
+
+/**
+ * Extract the alert-metric keys from a stored composed-panel descriptor — ONLY the keys the compose authority
+ * (ComposeSpec.TryParsePanel) reads, so nothing frontend-only (title / span / viz) rides along into a rule
+ * definition (the backend rejects unknown keys, and supplies its own scalar viz). Deliberately omits the window:
+ * a dashboard panel's chart window is not an alert window, so the target editor supplies `hours` itself. Shared
+ * by the create-from-panel handoff and the alert editor's own serialize.
+ */
+export function metricSpecFromDesc(desc) {
+  const d = desc || {};
+  const metric = { source: d.source };
+  if (d.ratio) metric.ratio = d.ratio;
+  else if (d.measure) metric.measure = d.measure;
+  if (d.aggregate) metric.aggregate = d.aggregate;
+  if (d.unit) metric.unit = d.unit;
+  if (Array.isArray(d.filters) && d.filters.length) metric.filters = d.filters;
+  return metric;
+}
+
+/**
+ * Whether a composed-panel model is a legal alert metric source: a SCALAR panel (no timeBucket/topN) that names a
+ * measure or ratio. An alert metric is a single value, so only a scalar panel can seed one — a timeseries/ranked
+ * panel would carry a shape the alert editor can't use. Mirrors the CustomAlertRuleDefinition Scalar rule.
+ */
+function isScalarMetricPanel(p) {
+  return !!p && p.shape === "scalar" && !!(p.measure || p.ratio);
+}
+
+/**
+ * The "Create alert from this panel" action row for a composed-panel editor — a button that copies THIS panel's
+ * metric into a new alert-rule draft and opens the editor. Returns null unless the panel is a scalar metric (so a
+ * timeseries/ranked panel shows nothing), which is why it is rebuilt through buildComposedPanelBody's panelExtraAction
+ * hook: flipping the panel to/from "Single value" reveals/hides it live. `toDesc` is the caller's composedPanelToDesc
+ * (passed in to keep this module cycle-free). The copy is a snapshot — a later edit to the panel never touches the draft.
+ */
+export function buildCreateAlertAction(p, toDesc) {
+  if (!isScalarMetricPanel(p)) {
+    return null;
+  }
+  const btn = el("button", {
+    class: "btn small",
+    type: "button",
+    text: "Create alert from this metric",
+    title: "Copy this metric into a new alert rule (a copy — later edits here don't change the rule)",
+  });
+  btn.addEventListener("click", () => {
+    const metric = metricSpecFromDesc(toDesc(p));
+    setPendingAlertSeed({ metric, name: (p.title || "").trim() });
+    location.hash = "#/alert-rule/new";
+  });
+  return el("div", { class: "composed-panel-actions" }, [btn]);
+}

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alerts-api.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alerts-api.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+/*
+ * The #3285 custom-alert-rule API client (Component 7) — the twin of views-api.js, thin wrappers over util.js's
+ * apiGet/apiSend for the seven /api/alerts endpoints. The rule CRUD mirrors the view CRUD EXACTLY: a bare-array
+ * list of summaries, a full single rule with its embedded definition, create (POST -> 201/400/409), a full-replace
+ * update (PUT with `version` for optimistic concurrency -> 200/400/404/409), and delete (204/404). Two alert-only
+ * POSTs sit beside them: /validate dry-runs a definition ({valid,error}) and /test evaluates it now (per-server
+ * current value + would-fire). The backend re-validates every write and the /validate + /test verdicts as the
+ * authority — this client only shapes the requests and forwards the classified response.
+ *
+ * The session ({can_edit}) and read catalog are the SAME per-page-load resources the composer uses, so they are
+ * re-exported from views-api.js rather than re-fetched: one cached promise backs the views composer, the notebook
+ * composer, and this editor alike (see the "maximize shared base code" rule). can_edit is the server's answer for
+ * this seat; the UI hides every edit affordance when it is false, and the server's method-based write gate refuses
+ * a viewer-seat mutation regardless (this is the affordance layer, never the enforcement).
+ */
+
+import { apiGet, apiSend } from "./util.js";
+
+/* Shared session + catalog — one cache for every composer surface (re-exported, not re-implemented). */
+export { getSession, getCatalog } from "./views-api.js";
+
+/** GET the bare-array list of rule summaries (no definition), each carrying `enabled`. */
+export function listAlertRules() {
+  return apiGet("/api/alerts");
+}
+
+/** GET one rule in full (with its embedded definition and `enabled`). */
+export function getAlertRule(id) {
+  return apiGet("/api/alerts/" + encodeURIComponent(id));
+}
+
+/** POST a new rule {name, description?, definition, enabled?} — 201 + the full rule, or 400/409(dup)/403. */
+export function createAlertRule(body) {
+  return apiSend("POST", "/api/alerts", body);
+}
+
+/** PUT an existing rule {name, description?, definition, enabled?, version} — 200 + the full rule, or 400/404/409/403. */
+export function updateAlertRule(id, body) {
+  return apiSend("PUT", "/api/alerts/" + encodeURIComponent(id), body);
+}
+
+/** DELETE a rule — 204, or 404/403. (An open incident is force-resolved server-side before the delete, #3305.) */
+export function deleteAlertRule(id) {
+  return apiSend("DELETE", "/api/alerts/" + encodeURIComponent(id));
+}
+
+/** GET the built-in starter templates — {templates:[{key,name,description,definition}]}; server-authored (#3325). */
+export function listAlertTemplates() {
+  return apiGet("/api/alert-templates");
+}
+
+/** POST a dry-run validation of a definition — {valid, error}; the SAME authority the write path applies. */
+export function validateAlertRule(definition) {
+  return apiSend("POST", "/api/alerts/validate", { definition });
+}
+
+/**
+ * POST an evaluate-now test — read the metric's CURRENT value on each in-scope server and report whether it WOULD
+ * breach right now (delivering/persisting nothing). Pass exactly one of {rule_id} (a saved rule) or {definition}
+ * (an unsaved draft). Returns {rule_id,name,note,results:[{server,current_value,breaching,severity,no_data}]} as
+ * data; an invalid/not-found draft comes back as the {status,message} envelope (classified "empty"); a valid draft
+ * with no matching servers as data carrying status "no_in_scope_servers".
+ */
+export function testAlertRule(body) {
+  return apiSend("POST", "/api/alerts/test", body);
+}

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/app.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/app.js
@@ -14,6 +14,9 @@
  *   #/server/{name}     — one server's detail (Overview)
  *   #/server/{name}/{tab} — one server's detail, opened on a named sub-tab (pages/server-tabs.js)
  *   #/alerts            — fleet-wide Alert History
+ *   #/alert-rules       — Custom Alert Rules list (#3285)
+ *   #/alert-rule/new    — the alert-rule editor creating a new rule (optionally /new/{template})
+ *   #/alert-rule/{id}   — the alert-rule editor editing a saved rule (#3285)
  *   #/views             — Custom Views list (#1563)
  *   #/view/{id}         — a saved custom view, rendered (#1563)
  *   #/view/{id}/edit    — the composer editing a saved view (#1563)
@@ -33,10 +36,12 @@ import { renderFleet } from "./pages/fleet.js";
 import { renderAg } from "./pages/ag.js";
 import { renderServer } from "./pages/server.js";
 import { renderAlerts } from "./pages/alerts.js";
+import { renderAlertRuleList } from "./pages/alert-rules.js";
 import { renderViewList, renderView } from "./pages/views.js";
 import { renderTriage } from "./pages/triage.js";
 import { renderEditor } from "./editor.js";
 import { renderNotebookEditor } from "./notebook.js";
+import { renderAlertEditor } from "./alert-editor.js";
 import { getSession, listViews } from "./views-api.js";
 
 const POLL_MS = 60000;
@@ -60,6 +65,14 @@ function currentRoute() {
     return { name: "triage", query: q >= 0 ? h.slice(q + 1) : "" };
   }
   if (h.startsWith("#/alerts")) return { name: "alerts" };
+  /* Alert-rule routes (#3285): the list, the new form (optionally /new/{template}), then the bare /{id} edit form,
+     tested most-specific first. Distinct from #/alerts above (which cannot collide: #/alert- never starts #/alerts). */
+  if (h === "#/alert-rules" || h === "#/alert-rules/") return { name: "alertRules" };
+  if (h === "#/alert-rule/new") return { name: "alertEditor", id: "new" };
+  if (h.startsWith("#/alert-rule/new/")) {
+    return { name: "alertEditor", id: "new", template: decodeURIComponent(h.slice("#/alert-rule/new/".length)) };
+  }
+  if (h.startsWith("#/alert-rule/")) return { name: "alertEditor", id: decodeURIComponent(h.slice("#/alert-rule/".length)) };
   /* #/views (list) is checked before the #/view/ forms; and the /edit form is tested before the bare /view/. */
   if (h === "#/views" || h === "#/views/") return { name: "views" };
   if (h === "#/view/new") return { name: "editor", id: "new" };
@@ -100,6 +113,8 @@ function route() {
   if (r.name === "server") renderServer(main, r.param, r.tab);
   else if (r.name === "ag") renderAg(main);
   else if (r.name === "alerts") renderAlerts(main);
+  else if (r.name === "alertRules") renderAlertRuleList(main);
+  else if (r.name === "alertEditor") renderAlertEditor(main, r.id, r.template);
   else if (r.name === "triage") renderTriage(main, r.query);
   else if (r.name === "views") renderViewList(main);
   else if (r.name === "view") renderView(main, r.id);
@@ -115,9 +130,12 @@ function isViewItemRoute(name) {
   return name === "view" || name === "editor" || name === "notebook" || name === "notebookEditor";
 }
 
-/* The sidebar's "Custom Views" nav stays lit across the list, both renderers, and both composers. */
+/* The sidebar's "Custom Views" nav stays lit across the list, both renderers, and both composers; the "Alert Rules"
+   nav stays lit across its list + editor. */
 function navKeyFor(r) {
-  return r.name === "views" || isViewItemRoute(r.name) ? "views" : r.name;
+  if (r.name === "views" || isViewItemRoute(r.name)) return "views";
+  if (r.name === "alertRules" || r.name === "alertEditor") return "alert-rules";
+  return r.name;
 }
 
 function setActiveNav(r) {
@@ -267,11 +285,11 @@ function refresh() {
   refreshSidebar();
   refreshViewList();
   refreshAgNav();
-  /* Poll-clobber guard (#1563): never re-render a composer (dashboard OR notebook, #1563 D7) from the background
-     poll — a rebuild would discard an in-progress edit. hashchange still routes to it normally; only this periodic
-     refresh skips it. */
+  /* Poll-clobber guard (#1563, extended #3285): never re-render an editor (dashboard/notebook composer OR the
+     alert-rule editor) from the background poll — a rebuild would discard an in-progress edit. hashchange still
+     routes to it normally; only this periodic refresh skips it. */
   const routeName = currentRoute().name;
-  if (routeName === "editor" || routeName === "notebookEditor") return;
+  if (routeName === "editor" || routeName === "notebookEditor" || routeName === "alertEditor") return;
   route();
 }
 

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/editor.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/editor.js
@@ -31,6 +31,7 @@ import { el, mount, apiGet, readTool } from "./util.js";
 import { renderPanel, VIZ } from "./panels.js";
 import { SERIES_COLORS, normalizeColor } from "./charts.js";
 import { renderComposedPanelCard } from "./compose.js";
+import { buildCreateAlertAction } from "./alert-seed.js";
 import * as api from "./views-api.js";
 import * as derive from "./derive.js";
 
@@ -945,6 +946,8 @@ function buildComposedPanelEditor(p, index, ctx, kindToggle) {
       ctx.refreshSaveState();
     },
     showWidth: true,
+    /* #3285: a scalar panel can seed a new alert rule from its metric (a copy, not a live binding). */
+    panelExtraAction: (pm) => buildCreateAlertAction(pm, composedPanelToDesc),
   });
 
   refreshHead();
@@ -978,6 +981,13 @@ function buildComposedPanelEditor(p, index, ctx, kindToggle) {
  *   onChange      — () => notify the wrapper a field changed (refresh its head echo + save state); the body owns
  *                   its own config rebuild + debounced preview, so onChange never rebuilds anything itself.
  *   showWidth     — show the Width (span 1|2) control; false for a notebook cell (single-column document flow).
+ *   metricOnly    — (#3285) lock the body to a SCALAR metric picker (Metric + Aggregate + Unit + Filters) for the
+ *                   alert editor: no shape / group / chart / identity controls, and no live compose preview (the
+ *                   alert editor renders its own would-fire preview from /api/alerts/test). The window is an alert
+ *                   concern with its own ceiling, so it lives in the alert editor, not here.
+ *   panelExtraAction — (p) => a node rendered at the foot of the config on each rebuild (or null to render nothing);
+ *                   a GENERIC hook with no alert knowledge — the composers pass the "Create alert from this metric"
+ *                   action, which returns null off a scalar panel, so it reveals/hides live as the shape flips.
  */
 export function buildComposedPanelBody(p, opts) {
   const catalog = opts.catalog;
@@ -987,6 +997,8 @@ export function buildComposedPanelBody(p, opts) {
   const previewScope = opts.previewScope || (() => ({}));
   const onChange = opts.onChange || (() => {});
   const showWidth = opts.showWidth !== false;
+  const metricOnly = opts.metricOnly === true;
+  const panelExtraAction = typeof opts.panelExtraAction === "function" ? opts.panelExtraAction : null;
   let previewTimer = null;
 
   const bodyBox = el("div", { class: "panel-editor-body" });
@@ -995,6 +1007,7 @@ export function buildComposedPanelBody(p, opts) {
   previewSection.classList.add("panel-preview-col");
 
   function schedulePreview() {
+    if (metricOnly) return; // the alert metric picker has no compose preview (its editor owns the would-fire preview)
     clearTimeout(previewTimer);
     previewTimer = setTimeout(renderComposedPreview, PREVIEW_DEBOUNCE_MS);
   }
@@ -1036,6 +1049,20 @@ export function buildComposedPanelBody(p, opts) {
       m ? el("div", { class: "measure-caption", text: measureCaption(m, compose) }) : null,
       m ? measureAvailabilityNote(m, scopeServer) : null,
     ]);
+  }
+
+  /* #3285: the alert metric picker's fields — Aggregate (a ratio has none) + Unit, and no shape/group/chart. The
+     evaluation window is deliberately absent: it is an alert concern with its own ceiling, so the alert editor owns
+     it. Reuses the SAME aggregate + unit controls the full composer builds, so the two can't drift. */
+  function metricScalarBlock(m) {
+    const kids = [];
+    if (m.kind === "ratio") {
+      kids.push(field("Aggregation", el("div", { class: "static-field muted", text: "Ratio (numerator ÷ denominator)" })));
+    } else {
+      kids.push(field("Aggregate", aggregateSelect(m)));
+    }
+    kids.push(field("Unit / magnitude", unitControl(m)));
+    return el("div", { class: "composed-fields" }, kids);
   }
 
   function shapeAndAggBlock(m) {
@@ -1152,6 +1179,10 @@ export function buildComposedPanelBody(p, opts) {
 
   function filtersBlock(m) {
     const editor = buildComposedFiltersEditor(p, m, compose, onLive);
+    /* An alert metric has no view template variables, so its filter help is just the literal-value rule (no $name). */
+    if (metricOnly) {
+      return el("div", {}, [editor, el("div", { class: "block-help", text: "Values are literals (comma-separated for is/is-not)." })]);
+    }
     const declared = (getVariables() || []).filter((v) => v.name).map((v) => "$" + v.name);
     const help = declared.length
       ? el("div", { class: "block-help", text: "Values are literals (comma-separated for is/is-not); reference a view variable as " + declared.join(", ") + "." })
@@ -1350,6 +1381,10 @@ export function buildComposedPanelBody(p, opts) {
     const config = [labeledBlock("Metric", measureBlock(m))];
     if (!m) {
       config.push(el("div", { class: "panel-hint", text: "Choose a metric to begin." }));
+    } else if (metricOnly) {
+      /* Alert metric (#3285): a scalar value only — measure + aggregate + unit + filters, nothing that shapes a chart. */
+      config.push(metricScalarBlock(m));
+      config.push(labeledBlock("Filters", filtersBlock(m)));
     } else {
       config.push(shapeAndAggBlock(m));
       config.push(labeledBlock("Group by", groupByBlock(m)));
@@ -1357,8 +1392,14 @@ export function buildComposedPanelBody(p, opts) {
       config.push(labeledBlock("Chart", chartBlock(m)));
       config.push(advancedBlock(m));
       config.push(identityBlock());
+      /* A caller-supplied per-panel action (#3285 "Create alert from this metric"), rebuilt here so it reveals/hides
+         live as the shape flips; returns null (nothing rendered) off a non-scalar panel. */
+      if (panelExtraAction) {
+        const extra = panelExtraAction(p);
+        if (extra) config.push(extra);
+      }
     }
-    const hasPreview = !!(m && p.viz);
+    const hasPreview = !metricOnly && !!(m && p.viz);
     const kids = [el("div", { class: "panel-config" }, config)];
     if (hasPreview) kids.push(previewSection);
     bodyBox.className = "panel-editor-body" + (hasPreview ? " has-preview" : "");

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/notebook.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/notebook.js
@@ -34,6 +34,7 @@ import {
   composedBlocker,
   field,
 } from "./editor.js";
+import { buildCreateAlertAction } from "./alert-seed.js";
 import * as api from "./views-api.js";
 
 /** The definition discriminator: a notebook definition carries kind:"notebook"; a dashboard omits it. */
@@ -415,6 +416,8 @@ function buildPanelCellEditor(cell, index, ctx) {
     previewScope: ctx.previewScope,
     onChange: () => ctx.refreshSaveState(),
     showWidth: false,
+    /* #3285: a scalar panel cell can seed a new alert rule from its metric (a copy, not a live binding). */
+    panelExtraAction: (pm) => buildCreateAlertAction(pm, composedPanelToDesc),
   });
   return el("div", { class: "notebook-cell panel-cell card" }, [cellHead(index, ctx, "Panel"), pinnedWindowStrip(cell, ctx), body]);
 }

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/alert-rules.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/alert-rules.js
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+/*
+ * Custom Alert Rules (#3285, Component 7): the list page — the twin of pages/views.js's renderViewList, for
+ * user-authored alert rules instead of custom views. A rule is stored JSON { metric, predicate, hysteresis, scope }
+ * behind the /api/alerts CRUD; this page lists the summaries as cards (name, enabled/paused, and — enriched per
+ * card from the rule's definition — its metric, condition, and scope), and offers New rule + a "start from a
+ * template" menu of the server-authored starter templates.
+ *
+ * Unlike a custom view, an alert rule has no read-only "rendered" surface — the card links straight to the editor
+ * (alert-editor.js). Edit affordances (New / New from template) show only when the session reports can_edit (the
+ * server is the authority for every write); the list itself is open to every seat. All user text (names,
+ * descriptions, server names) reaches the DOM through el()/textContent (R4 — never innerHTML).
+ */
+
+import { el, mount, loadingStrip, errorStrip, emptyStrip, relTime } from "../util.js";
+import * as api from "../alerts-api.js";
+
+/** The operator's human symbol for a condition chip (mirrors CustomAlertRuleDefinition.OpSymbol). */
+const OP_SYMBOLS = { gt: ">", ge: "≥", lt: "<", le: "≤" };
+
+/* ─────────────────────────── list page ─────────────────────────── */
+
+export async function renderAlertRuleList(main) {
+  mount(main, [listHead(false, []), loadingStrip("Loading alert rules…")]);
+
+  /* The templates read rides along with the session + list; a failed templates read is not fatal (the New-from-
+     template menu just says it is unavailable — every other affordance still works). */
+  const [session, res, templates] = await Promise.all([api.getSession(), api.listAlertRules(), loadTemplates()]);
+  const canEdit = !!session.can_edit;
+
+  if (res.kind === "error") {
+    mount(main, [listHead(canEdit, templates), errorStrip(res.message)]);
+    return;
+  }
+
+  const rules = Array.isArray(res.data) ? res.data : [];
+  const nodes = [listHead(canEdit, templates)];
+
+  /* Empty list -> a real first-run hero that sells the feature, not a bare strip. */
+  if (!rules.length) {
+    nodes.push(firstRunHero(canEdit, templates));
+    mount(main, nodes);
+    return;
+  }
+
+  nodes.push(el("div", { class: "view-cards" }, rules.map((r) => ruleCard(r))));
+  mount(main, nodes);
+}
+
+/** The starter templates for the "New from template" menu, or [] on any failure (every caller handles empty). */
+async function loadTemplates() {
+  const res = await api.listAlertTemplates();
+  if (res.kind !== "data" || !res.data || !Array.isArray(res.data.templates)) return [];
+  return res.data.templates;
+}
+
+function listHead(canEdit, templates) {
+  return el("div", { class: "page-head" }, [
+    el("h2", { text: "Alert Rules" }),
+    el("div", { class: "spacer" }),
+    canEdit ? templateMenu(templates) : null,
+    canEdit ? el("a", { class: "btn primary", href: "#/alert-rule/new", text: "New rule" }) : null,
+  ]);
+}
+
+/* First-run hero: a centered pitch + a prominent New rule + the template menu. A read-only seat can't author, so
+   it gets an explanatory variant (no New rule / templates). */
+function firstRunHero(canEdit, templates) {
+  if (!canEdit) {
+    return el("div", { class: "views-hero" }, [
+      el("div", { class: "hero-title", text: "No alert rules yet" }),
+      el("div", {
+        class: "hero-pitch",
+        text:
+          "Your session couldn't be confirmed, so authoring is read-only right now — reload the page to create a " +
+          "rule. Once created, alert rules evaluate on every collection and deliver to your configured channels.",
+      }),
+    ]);
+  }
+  return el("div", { class: "views-hero" }, [
+    el("div", { class: "hero-title", text: "Alert on any metric you can chart" }),
+    el("div", {
+      class: "hero-pitch",
+      text:
+        "Pick a metric, aggregate it over a recent window, and fire a Warning or Critical when it crosses a " +
+        "threshold you set — with hysteresis so a single spike doesn't page, and a scope of all servers or a chosen " +
+        "few. Start from a conservative template and tune it, or build one from scratch. No SQL to write.",
+    }),
+    el("div", { class: "hero-ctas" }, [
+      el("a", { class: "btn primary hero-cta", href: "#/alert-rule/new", text: "New rule" }),
+      templateMenu(templates),
+    ]),
+  ]);
+}
+
+/* The "New from template" menu: a <details> dropdown of the server-authored starter templates (#3325). Each links
+   to the editor pre-filled from that template's definition, because the starters are deliberately conservative and
+   want tuning before they are saved (unlike a dashboard template, which is created as-is). Built with
+   el()/textContent like everything else. */
+function templateMenu(templates) {
+  if (!templates.length) {
+    return el("details", { class: "template-menu" }, [
+      el("summary", { class: "btn template-summary", text: "New from template ▾" }),
+      el("div", { class: "template-list" }, [el("div", { class: "template-note", text: "Starter templates are unavailable right now." })]),
+    ]);
+  }
+  const items = templates.map((t) =>
+    el("a", { class: "template-item", href: "#/alert-rule/new/" + encodeURIComponent(t.key), title: t.description }, [
+      el("span", { class: "template-label", text: t.name }),
+      el("span", { class: "template-desc", text: t.description }),
+    ])
+  );
+  return el("details", { class: "template-menu" }, [
+    el("summary", { class: "btn template-summary", text: "New from template ▾" }),
+    el("div", { class: "template-list" }, items),
+  ]);
+}
+
+/* One rule -> a card linking to its editor. The summary carries name + enabled synchronously; the metric /
+   condition / scope chips are filled in progressively from the rule's own definition (enrichCard), so the card
+   renders immediately and never blocks on that fetch. */
+function ruleCard(r) {
+  const meta = "v" + r.version + " · updated " + relTime(r.updated_at) + (r.updated_by ? " by " + r.updated_by : "");
+  const chips = el("div", { class: "vc-chips" });
+  const card = el("a", { class: "view-card card", href: "#/alert-rule/" + encodeURIComponent(r.id) }, [
+    el("div", { class: "vc-name" }, [
+      el("span", { class: "vc-name-text", text: r.name }),
+      r.enabled === false ? el("span", { class: "paused-badge", text: "Paused" }) : null,
+    ]),
+    r.description ? el("div", { class: "vc-desc", text: r.description }) : null,
+    chips,
+    el("div", { class: "vc-meta", text: meta }),
+  ]);
+  enrichCard(r.id, chips);
+  return card;
+}
+
+/* Fill a card's chips from the rule's full definition (metric / condition / scope) — fetched per card and filled in
+   progressively; a failed/empty fetch just leaves the (display:none-when-empty) chip row absent. */
+async function enrichCard(id, chips) {
+  const res = await api.getAlertRule(id);
+  if (res.kind !== "data" || !res.data) return;
+  const def = res.data.definition || {};
+  const nodes = [];
+
+  const metricChip = describeMetric(def.metric);
+  if (metricChip) nodes.push(el("span", { class: "vc-chip", text: metricChip }));
+
+  const condChip = describeCondition(def.predicate);
+  if (condChip) nodes.push(el("span", { class: "vc-chip count", text: condChip }));
+
+  nodes.push(el("span", { class: "vc-chip", text: describeScope(def.scope) }));
+
+  mount(chips, nodes);
+}
+
+/** A compact metric label from a definition's metric ("max cpu_utilization" / a ratio's key), or null. */
+function describeMetric(metric) {
+  if (!metric || typeof metric !== "object") return null;
+  const name = metric.ratio || metric.measure;
+  if (!name) return null;
+  const agg = metric.ratio ? "" : metric.aggregate ? metric.aggregate + " " : "";
+  return agg + name;
+}
+
+/** A compact condition label ("> 25" or "≥ 30000 / crit 120000"), or null. */
+function describeCondition(pred) {
+  if (!pred || typeof pred !== "object" || pred.warnThreshold == null) return null;
+  const sym = OP_SYMBOLS[pred.op] || pred.op || "?";
+  let text = sym + " " + pred.warnThreshold;
+  if (pred.criticalThreshold != null) text += " / crit " + pred.criticalThreshold;
+  return text;
+}
+
+/** A compact scope label ("All servers" / "3 servers"). */
+function describeScope(scope) {
+  if (scope && scope.mode === "servers" && Array.isArray(scope.servers)) {
+    const n = scope.servers.length;
+    return n === 1 ? "1 server" : n + " servers";
+  }
+  return "All servers";
+}


### PR DESCRIPTION
## Custom-alert web authoring editor (#3285, Component 7)

The one remaining unbuilt piece of custom alerting — the web **rule authoring editor**. The backend, MCP tools, templates, and the `/api/alerts` endpoints all already shipped; this is a faithful front-end port of the custom-views editor onto that surface.

### What's here
- **`wwwroot/js/alerts-api.js`** — the `/api/alerts` client, the twin of `views-api.js`: list / get / create / update / delete with the same `version` optimistic-concurrency + response classification, plus the alert-only `validate` and `test` POSTs. Re-exports the shared `getSession` / `getCatalog` so one cache backs every composer surface.
- **`wwwroot/js/pages/alert-rules.js`** — the rule list, the twin of `renderViewList`: cards (name, enabled/paused, and per-card metric / condition / scope chips enriched from the definition), a first-run hero, and a "New from template" menu.
- **`wwwroot/js/alert-editor.js`** — the rule editor. Reuses the shared composer body for the metric (a Scalar metric), plus predicate (`gt`/`ge`/`lt`/`le` + warn/critical thresholds), hysteresis (breach/clear samples), scope (all / specific servers), and an optional evaluation cadence (Advanced). Inline validation via `POST /api/alerts/validate`, and a live **"current value / would-fire per server"** preview via `POST /api/alerts/test`, both debounced. Mirrors the composer's save-blocker for the cheap structural rules — window ceiling (24h), warn/critical ordering, and the count-with-`<` trap — so the operator gets a reason without a round-trip, with the server re-validating on every write.
- **`wwwroot/js/editor.js`** — `buildComposedPanelBody` gains a `metricOnly` mode (a Scalar metric picker: metric + aggregate + unit + filters; no shape/group/chart/identity or preview) and a generic `panelExtraAction` hook. **No alert knowledge added to the shared composer.**
- **`wwwroot/js/alert-seed.js`** — a leaf module for the **"Create alert from this metric"** handoff (a copy, not a live binding), offered on a Scalar panel in **both** the dashboard and notebook composers via the `panelExtraAction` hook. A leaf so there's no `editor.js` ↔ `alert-editor.js` import cycle (callers pass their own `composedPanelToDesc`).
- **`app.js` / `index.html` / `editor.css`** — the `#/alert-rules` + `#/alert-rule/new[/{template}]` + `#/alert-rule/{id}` routes, the "Alert Rules" nav entry, the poll-clobber guard (`alertEditor` never re-rendered mid-edit), and the styles.

### Template-serving approach (the decision you asked me to make + note)
Templates are read from the **existing `GET /api/alert-templates`** (which wraps the `list_custom_alert_templates` MCP tool), not hardcoded in JS. Rationale: unlike custom-views' templates — which are client-side JS constants (`view-templates.js`) — the alert starter set is **server-authored C# (`CustomAlertTemplates.All`), drift-guarded against the live catalog on every build**. Re-hardcoding it in JS would duplicate that set and let it drift. A dedicated fetch endpoint already ships and is the exact analog of how the views template picker gets its ready-made set, so mirroring "how views serves templates" here means consuming the server's set. Clicking a template opens the editor **pre-filled** (not an immediate save), because the starters are deliberately conservative and want tuning — mirroring the notebook-template flow.

### For a reviewer to eyeball
- **`metricOnly` on the shared composer body** — the load-bearing reuse. It hides shape/group/chart/identity and the compose preview, forces the Scalar metric, and reuses the same measure/aggregate/unit/filter controls. Worth confirming it reads as a restriction of the existing picker, not a fork.
- **`panelExtraAction` hook + `alert-seed.js`** — the cycle-free way both composers offer "Create alert from this metric". It's rebuilt on each structural change, so the action reveals/hides live as the panel's shape flips to/from Single value.
- **Severity is the two thresholds** — there's no separate severity control because the definition has none: warn = Warning tier, warn+critical = Critical tier (`CustomAlertRuleDefinition.SeverityFor`). Labels + help text carry that.
- **validate + test split** — `validate` gives the inline verdict (cheap, no DB); `test` runs only when valid, for the per-server preview. Mirrors the composer's saveBlocker-then-preview shape.

### Verification
- `dotnet build …Darling.Service.csproj -c Debug` → **0 Warning(s) / 0 Error(s)**.
- All new/modified JS pass `node --check` as ES modules; every cross-module import resolves to a real export.
- The two source-scan pins my files touch verified **green**: `DarlingWebSelfContainmentTests` (air-gap) and `DarlingWebEditorAttributionTests` (incl. the composer probe-failed pin, which now discovers `alert-editor.js` as a third composer and requires it to distinguish a read-only seat from a failed probe — it does).
- CRLF preserved (`* text=auto eol=crlf`); no mixed-ending files.
- Did **not** run any live/integration tests.

### Deferrals / gaps
- **"Last-fired" on the list cards** is not shown — it isn't available from the rule endpoints (the summary carries no fired-at, and correlating `config_alert_log` to a rule would need a backend change outside this front-end lane, plus a design decision on the correlation/endpoint shape). The spec said "last-fired *if available*"; flagging rather than filing an issue unilaterally — say the word if you want a tracked backend enhancement.
- **Between/outside operators (#3351)** and **tag scope (#3350)** are intentionally omitted (only `gt`/`ge`/`lt`/`le` and all/specific-servers), per the plan; both already have issues.
- **No CHANGELOG entry** — the task scoped me to the front-end and several sibling lanes are editing CHANGELOG concurrently (line-ending conflict risk); happy to add one if you'd like it in this PR.
- **No sidebar rule list** (unlike the Views sidebar list) — deliberately mirrors Alert History (nav-only), keeping the refresh loop untouched. Easy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
