### PR TITLE
Stamp webhook payloads from an injected clock (#3355)

### DIFF
--- a/Darling/Darling.Tests/IncidentAttachmentDeliveryTests.cs
+++ b/Darling/Darling.Tests/IncidentAttachmentDeliveryTests.cs
@@ -8,7 +8,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using PerformanceMonitor.Alerting;
@@ -46,6 +48,20 @@ public sealed class IncidentAttachmentDeliveryTests
        heading or a fact label — so DoesNotContain cannot pass on a near-miss. */
     private const string StaleGraph = "<deadlock marker=\"GRAPH-FOR-ORDERS\"/>";
     private const string FreshGraph = "<deadlock marker=\"GRAPH-FOR-SHIPMENTS\"/>";
+
+    /// <summary>
+    /// The clock every delivery in this class renders its payload stamps from (#3355). A constant in the
+    /// past, distinctive enough that a stamp taken from the real clock instead is visibly not this one.
+    /// <para>Every payload the four non-email channels build embeds a stamp at SECOND precision. Left on
+    /// the wall clock, the two independently-built captures the byte-identity pin below compares carry two
+    /// separate reads of it, and a second boundary landing between them is a diff in the value under test —
+    /// which is exactly what cost an unrelated PR a red round. Fixing the clock makes the two arms render
+    /// the same stamp BY CONSTRUCTION rather than by winning a race.</para>
+    /// <para>It does not reach the cooldown, which runs on real elapsed time: a clock in the past would
+    /// otherwise place every seeded fingerprint outside its window and quietly defeat the suppression the
+    /// filtered-card tests are about.</para>
+    /// </summary>
+    private static readonly DateTime FixedUtc = new(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
 
     /// <summary>
     /// <b>The pin that matters.</b> An alert carrying two distinct fingerprints, in per-event mode, sends two
@@ -183,6 +199,11 @@ public sealed class IncidentAttachmentDeliveryTests
     /// listener; it takes the same context from the same call in the fan-out as the three checked here, and
     /// the property under test is "the attachment reaches no webhook builder", which is a property of what
     /// the fan-out HANDS them.</para>
+    /// <para>#3355: the payload stamp comes from <see cref="FixedUtc"/>, so both arms render the same
+    /// instant by construction and the comparison can stay byte-exact. On the wall clock the two arms are
+    /// two separate second-precision reads, and a boundary between them is a diff in the value under test —
+    /// which is a flake, not a finding. <see cref="TwoCapturesStraddlingASecondBoundary_PostIdenticalBytes"/>
+    /// is the pin that holds that.</para>
     /// </summary>
     [Fact]
     public async Task TheFourNonEmailChannels_PostIdenticalBytes_WithAndWithoutIncidentAttachments()
@@ -215,18 +236,109 @@ public sealed class IncidentAttachmentDeliveryTests
         Assert.All(withoutAttachments.Emails, e => Assert.DoesNotContain("GRAPH-FOR-", e, StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// #3355's own pin: the same two arms, with a rendered-second boundary of the REAL clock deliberately
+    /// placed between them. The bytes are unchanged, because the stamp comes from the injected clock and
+    /// the wall clock reaches the payload nowhere.
+    /// <para>This is the flake's mechanism made deterministic rather than waited for: the original failed
+    /// roughly once per few hundred runs, so a green run of the byte-identity pin above is not evidence it
+    /// is fixed. This one is red on every run against a build that reads the wall clock, and green on every
+    /// run against one that does not.</para>
+    /// <para>The wait is for a CONDITION, not a timeout: it exits on the first iteration that observes a
+    /// different rendered second, which is at most a second away and cannot be missed, because every
+    /// iteration re-reads the clock. A fixed deadline here would be the same defect class in a new place.
+    /// The stamp is read AFTER the first capture, so that capture's own read is at or before it and the
+    /// second capture's is provably in a later second.</para>
+    /// </summary>
+    [Fact]
+    public async Task TwoCapturesStraddlingASecondBoundary_PostIdenticalBytes()
+    {
+        var withAttachments = await CaptureAsync(TwoIncidents(alertLevelXml: null), perEvent: true);
+
+        var before = RenderedSecond(DateTime.UtcNow);
+        while (RenderedSecond(DateTime.UtcNow) == before)
+        {
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+
+        var withoutAttachments = await CaptureAsync(TwoIncidentsWithNoAttachments(), perEvent: true);
+
+        Assert.Equal(6, withAttachments.Webhooks.Count);
+        Assert.Equal(
+            withAttachments.Webhooks.OrderBy(b => b, StringComparer.Ordinal).ToList(),
+            withoutAttachments.Webhooks.OrderBy(b => b, StringComparer.Ordinal).ToList());
+    }
+
+    /// <summary>
+    /// The structural half, and the reason the two pins above cannot both be satisfied by luck: every
+    /// timestamp a non-email payload carries is a rendering of the INJECTED instant, and advancing that
+    /// instant by a second moves every one of them.
+    /// <para>The census arm is what catches a clock read the seam does not cover — it reads every
+    /// timestamp-shaped token in every body rather than the one field the flake happened to surface, so a
+    /// builder still reaching for the wall clock fails here whatever field it stamps. Teams and Slack each
+    /// render TWO (a UTC one and a local one), and the local one is allowed at its own date because a UTC
+    /// offset can carry it across midnight — both forms are derived from the constant, so this holds on a
+    /// UTC runner and on a machine that is not.</para>
+    /// <para>The advance arm is the control on the census. A seam that ignored its argument and read the
+    /// wall clock would render two captures moments apart nearly identically, and a census asserting only
+    /// an ABSENCE would be green on it. Requiring the stamps to MOVE when the injected clock moves is what
+    /// makes the absence mean something.</para>
+    /// </summary>
+    [Fact]
+    public async Task EveryNonEmailStamp_RendersTheInjectedClock_AndMovesWhenItDoes()
+    {
+        var atFixed = await CaptureAsync(TwoIncidents(alertLevelXml: null), perEvent: true);
+
+        var allowed = new[]
+        {
+            FixedUtc.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture),
+            FixedUtc.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+            FixedUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
+        };
+
+        Assert.All(atFixed.Webhooks, body =>
+        {
+            var stamps = Timestamps.Matches(body).Select(m => m.Value).ToList();
+
+            /* A body with no stamp at all would satisfy the loop below vacuously. */
+            Assert.NotEmpty(stamps);
+            Assert.All(stamps, stamp => Assert.Contains(stamp, allowed, StringComparer.Ordinal));
+        });
+
+        /* The control: move the clock, and every body moves with it. */
+        var aSecondLater = await CaptureAsync(
+            TwoIncidents(alertLevelXml: null), perEvent: true, utcNow: FixedUtc.AddSeconds(1));
+
+        Assert.Equal(atFixed.Webhooks.Count, aSecondLater.Webhooks.Count);
+        Assert.All(aSecondLater.Webhooks, body => Assert.All(
+            allowed, stamp => Assert.DoesNotContain(stamp, body, StringComparison.Ordinal)));
+    }
+
     /* ─────────────── helpers ─────────────── */
+
+    /// <summary>
+    /// Every timestamp shape the four non-email builders render: the generic channel's ISO-with-Z form and
+    /// the Teams/Slack fact form with a space. Matched rather than listed per field, so a stamp added to a
+    /// payload later is covered by the census without anyone remembering to extend it.
+    /// </summary>
+    private static readonly Regex Timestamps =
+        new(@"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}Z?", RegexOptions.Compiled);
+
+    private static string RenderedSecond(DateTime utc) =>
+        utc.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
 
     private sealed record Captured(IReadOnlyList<string> Webhooks, IReadOnlyList<string> Emails);
 
-    private static async Task<Captured> CaptureAsync(AlertContext context, bool perEvent = false)
+    private static async Task<Captured> CaptureAsync(
+        AlertContext context, bool perEvent = false, DateTime? utcNow = null)
     {
         using var endpoint = new CapturingWebhookEndpoint();
         using var smtp = new CapturingSmtpEndpoint();
 
         var deliverer = BuildDeliverer(
             endpoint, smtp, new SeedingHistoryStore(null, DateTime.UtcNow),
-            perEvent ? config => config.Alerts.DeliveryMode = AlertNotificationMode.PerEvent : null);
+            perEvent ? config => config.Alerts.DeliveryMode = AlertNotificationMode.PerEvent : null,
+            utcNow);
         await deliverer.DeliverAsync(Outcome(context), TestContext.Current.CancellationToken);
 
         return new Captured(endpoint.Bodies.ToList(), smtp.Messages.ToList());
@@ -272,11 +384,17 @@ public sealed class IncidentAttachmentDeliveryTests
         context, AlertContextBuilders.ContextToDetailText(context),
         NumericCurrentValue: 2, NumericThresholdValue: 1, Muted: false, Severity: null);
 
+    /// <param name="utcNow">
+    /// The instant the built payloads stamp themselves with, defaulting to <see cref="FixedUtc"/>. Passed
+    /// on every construction rather than only where a comparison needs it, so no test in this class
+    /// renders a wall-clock stamp at all.
+    /// </param>
     private static DarlingAlertDeliverer BuildDeliverer(
         CapturingWebhookEndpoint endpoint,
         CapturingSmtpEndpoint smtp,
         IAlertHistoryStore history,
-        Action<DarlingConfig>? configure = null)
+        Action<DarlingConfig>? configure = null,
+        DateTime? utcNow = null)
     {
         var config = new DarlingConfig();
         config.Webhooks.TeamsUrl = endpoint.Url;
@@ -290,8 +408,10 @@ public sealed class IncidentAttachmentDeliveryTests
         configure?.Invoke(config);
 
         var settings = new DarlingAlertSettings(config);
+        var stamp = utcNow ?? FixedUtc;
         var webhooks = new WebhookAlertService(
-            settings, DarlingAlertDeliverer.Branding, NullLogger<WebhookAlertService>.Instance, history);
+            settings, DarlingAlertDeliverer.Branding, NullLogger<WebhookAlertService>.Instance, history,
+            utcNow: () => stamp);
         return new DarlingAlertDeliverer(settings, history, webhooks, NullLogger.Instance);
     }
 

--- a/Lite.Tests/PagerDutyWebhookTests.cs
+++ b/Lite.Tests/PagerDutyWebhookTests.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Text.Json;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitorLite.Services;
@@ -280,6 +283,44 @@ public class PagerDutyWebhookTests
             .GetProperty("payload").GetProperty("custom_details");
 
         Assert.False(customDetails.TryGetProperty("Details", out _));
+    }
+
+    /* ---------------- #3355: the payload stamp's clock ---------------- */
+
+    /// <summary>
+    /// The stamp renders the injected instant, and moves when that instant moves.
+    /// <para>This channel needs its own pin because a delivery capture cannot reach it: PagerDuty's endpoint
+    /// is the hardcoded Events v2 URL, so a fan-out capture that redirects the other three channels to a
+    /// loopback leaves this one unconfigured and never observes its payload. A census over captured bodies
+    /// is green whether or not this builder is wired to the clock seam, which would leave its one call site
+    /// unheld.</para>
+    /// <para>Both arms carry weight. A builder that ignored its argument and read the wall clock renders
+    /// neither the fixed instant nor the advanced one, so asserting the stamp EQUALS the injected instant is
+    /// what catches an unwired seam; asserting it MOVES is what stops a hardcoded constant passing for one.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void BuildPagerDutyPayload_StampsTheInjectedClock_AndMovesWhenItDoes()
+    {
+        var fixedUtc = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var fixedStamp = fixedUtc.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+        var timestamps = new Regex(@"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}Z?");
+
+        var atFixed = WebhookAlertService.BuildPagerDutyPayload(
+            "High CPU", "SRV1", "95%", "90%", Branding, "rk", nowUtc: fixedUtc);
+
+        /* Every timestamp-shaped token rather than the one field it happens to stamp today, so a stamp added
+           to this payload later is covered without anyone remembering to extend this test. */
+        var stamps = timestamps.Matches(atFixed).Select(m => m.Value).ToList();
+
+        /* A payload carrying no stamp at all would satisfy the loop below vacuously. */
+        Assert.NotEmpty(stamps);
+        Assert.All(stamps, stamp => Assert.Equal(fixedStamp, stamp));
+
+        var aSecondLater = WebhookAlertService.BuildPagerDutyPayload(
+            "High CPU", "SRV1", "95%", "90%", Branding, "rk", nowUtc: fixedUtc.AddSeconds(1));
+
+        Assert.DoesNotContain(fixedStamp, aSecondLater, StringComparison.Ordinal);
     }
 
     /* ---------------- Fan-out (TrySendWebhookAlertsAsync) ---------------- */

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -75,6 +75,13 @@ public class WebhookAlertService
     private readonly AlertBranding _branding;
     private readonly ILogger<WebhookAlertService> _logger;
 
+    /* The clock every payload this service renders stamps itself from. Injectable because the stamp is
+       second-precision, and a caller comparing two independently-built payloads for byte-identity (#3330's
+       pin, via #3355) can only do so if both render the same instant by construction — on the wall clock,
+       a second boundary landing between the two builds is a diff in the value under test. A Func rather
+       than a settings member, matching DarlingSelfAlertEvaluator's clock seam. */
+    private readonly Func<DateTime> _utcNow;
+
     private int _consecutiveTeamsFailures;
     private string? _lastTeamsError;
     private int _consecutiveSlackFailures;
@@ -89,15 +96,23 @@ public class WebhookAlertService
     /// restart (#1145, mirroring the email seed #981). When null the cooldown is purely in-memory
     /// (the pre-#1145 behavior, seeding disabled) — the test call sites pass null.
     /// </param>
+    /// <param name="utcNow">
+    /// The clock the rendered payload stamps come from; defaults to <see cref="DateTime.UtcNow"/>. A fixed
+    /// clock makes two fan-outs render the same stamp by construction, which is what lets a caller compare
+    /// two independently-built payloads byte-for-byte (#3355). It does NOT feed the cooldown: whether an
+    /// incident is inside its window is a gating decision on real elapsed time, not a rendered value.
+    /// </param>
     public WebhookAlertService(
         IAlertSettings settings,
         AlertBranding branding,
         ILogger<WebhookAlertService> logger,
-        IAlertHistoryStore? historyStore = null)
+        IAlertHistoryStore? historyStore = null,
+        Func<DateTime>? utcNow = null)
     {
         _settings = settings;
         _branding = branding;
         _logger = logger;
+        _utcNow = utcNow ?? (() => DateTime.UtcNow);
         _cooldown = new IncidentCooldown(
             keyPrefix: "webhook:",
             // Null store -> null seed delegate -> no restart seeding (preserves the pre-#1145 in-memory path).
@@ -188,6 +203,14 @@ public class WebhookAlertService
             var renderContext = render.Context;
             var prose = render.Prose;
 
+            /* #3355: the firing's instant, read ONCE for the whole fan-out and threaded to every builder,
+               for the reason triageUrl below and the render above give — four channels describing the same
+               firing must not disagree about WHEN it fired, and a per-builder read makes that a race with
+               the second hand. It also feeds triageUrl, so the link's key and the cards' stamps name one
+               instant. Rendered stamps only: the cooldown decides on real elapsed time and reads its own
+               clock, because "is this fingerprint still inside its window" is not a display concern. */
+            var nowUtc = _utcNow();
+
             /* #2710: the triage-page link, computed ONCE for the whole fan-out so all four channels carry
                the SAME URL for the same firing. Keyed by (server, metric, now, dedup key) rather than an
                alert-history id, because the history row is written AFTER delivery — the page resolves the
@@ -196,17 +219,17 @@ public class WebhookAlertService
                channel's {{dedup_key}} token uses, so link, token, and PagerDuty all correlate — and it
                reads the RENDERED incidents, so the anchor names an incident the card actually shows. */
             var triageUrl = TriageLink.Build(
-                _settings.TriageBaseUrl, serverName, metricName, DateTime.UtcNow,
+                _settings.TriageBaseUrl, serverName, metricName, nowUtc,
                 DerivePagerDutyDedupKey(string.IsNullOrEmpty(serverId) ? serverName : serverId, metricName, renderContext));
 
             if (TeamsConfigured)
             {
-                sent |= await TrySendTeamsAlertAsync(metricName, serverName, currentValue, thresholdValue, renderContext, triageUrl, prose, displayName);
+                sent |= await TrySendTeamsAlertAsync(metricName, serverName, currentValue, thresholdValue, renderContext, triageUrl, prose, nowUtc, displayName);
             }
 
             if (SlackConfigured)
             {
-                sent |= await TrySendSlackAlertAsync(metricName, serverName, currentValue, thresholdValue, renderContext, triageUrl, prose, displayName);
+                sent |= await TrySendSlackAlertAsync(metricName, serverName, currentValue, thresholdValue, renderContext, triageUrl, prose, nowUtc, displayName);
             }
 
             if (GenericConfigured)
@@ -214,12 +237,12 @@ public class WebhookAlertService
                 /* Generic webhook: the payload's "metric" field is a machine key an automation correlates on,
                    so it stays the immutable metric name — the display name is a human-title concern only, and
                    this channel has no title. The prose detail DOES go, because it is alert content. */
-                sent |= await TrySendGenericAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, renderContext, triageUrl, prose);
+                sent |= await TrySendGenericAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, renderContext, triageUrl, prose, nowUtc);
             }
 
             if (PagerDutyConfigured)
             {
-                sent |= await TrySendPagerDutyAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, renderContext, triageUrl, prose, displayName);
+                sent |= await TrySendPagerDutyAlertAsync(metricName, serverName, currentValue, thresholdValue, serverId, renderContext, triageUrl, prose, nowUtc, displayName);
             }
 
             if (sent)
@@ -333,12 +356,13 @@ public class WebhookAlertService
         AlertContext? context,
         string? triageUrl,
         string? detailText,
+        DateTime nowUtc,
         string? displayName = null)
     {
         try
         {
             var payload = BuildTeamsPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl,
-                detailText: detailText, displayName: displayName);
+                detailText: detailText, displayName: displayName, nowUtc: nowUtc);
             var error = await PostWebhookAsync(_settings.TeamsWebhookUrl, payload, _settings.TeamsProxyAddress);
 
             if (error != null)
@@ -431,7 +455,8 @@ public class WebhookAlertService
         AlertContext? context = null,
         string? triageUrl = null,
         string? detailText = null,
-        string? displayName = null)
+        string? displayName = null,
+        DateTime? nowUtc = null)
     {
         var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
         var prose = AlertDetailText.ProseForDelivery(detailText, context);
@@ -439,8 +464,12 @@ public class WebhookAlertService
            name (the severity key), and a null/empty display name renders the metric name unchanged. */
         var titleName = string.IsNullOrEmpty(displayName) ? metricName : displayName;
         var themeColor = hexColor.TrimStart('#');
-        var utcNow = DateTime.UtcNow;
-        var localNow = DateTime.Now;
+        /* One instant, with the local rendering DERIVED from it rather than read separately: two reads can
+           land either side of a second, which would have the card's own "Time (UTC)" and "Time (Local)"
+           facts naming two different seconds of one alert. SpecifyKind because an injected clock may hand
+           back an Unspecified DateTime, which ToLocalTime would otherwise treat as already local. */
+        var utcNow = nowUtc ?? DateTime.UtcNow;
+        var localNow = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc).ToLocalTime();
 
         var facts = new List<object>();
 
@@ -590,12 +619,13 @@ public class WebhookAlertService
         AlertContext? context,
         string? triageUrl,
         string? detailText,
+        DateTime nowUtc,
         string? displayName = null)
     {
         try
         {
             var payload = BuildSlackPayload(metricName, serverName, currentValue, thresholdValue, _branding, context: context, triageUrl: triageUrl,
-                detailText: detailText, displayName: displayName);
+                detailText: detailText, displayName: displayName, nowUtc: nowUtc);
             var error = await PostWebhookAsync(_settings.SlackWebhookUrl, payload, _settings.SlackProxyAddress);
 
             if (error != null)
@@ -648,14 +678,16 @@ public class WebhookAlertService
         AlertContext? context = null,
         string? triageUrl = null,
         string? detailText = null,
-        string? displayName = null)
+        string? displayName = null,
+        DateTime? nowUtc = null)
     {
         var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
         var prose = AlertDetailText.ProseForDelivery(detailText, context);
         /* Human name in the header when present; ForMetric above keeps the immutable metric-name key. */
         var titleName = string.IsNullOrEmpty(displayName) ? metricName : displayName;
-        var utcNow = DateTime.UtcNow;
-        var localNow = DateTime.Now;
+        /* One instant, local derived from it — see the Teams builder's note. */
+        var utcNow = nowUtc ?? DateTime.UtcNow;
+        var localNow = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc).ToLocalTime();
 
         var title = isTest
             ? $"{emoji} TEST — {metricName}"
@@ -790,7 +822,8 @@ public class WebhookAlertService
         string serverId,
         AlertContext? context,
         string? triageUrl,
-        string? detailText)
+        string? detailText,
+        DateTime nowUtc)
     {
         try
         {
@@ -806,7 +839,7 @@ public class WebhookAlertService
             var payload = BuildGenericPayload(
                 metricName, serverName, currentValue, thresholdValue, _branding,
                 context: context, bodyTemplate: _settings.GenericWebhookBodyTemplate, serverId: serverId,
-                triageUrl: triageUrl, detailText: detailText);
+                triageUrl: triageUrl, detailText: detailText, nowUtc: nowUtc);
 
             if (!IsWellFormedJson(payload, out var bodyError))
             {
@@ -907,7 +940,8 @@ public class WebhookAlertService
         string? bodyTemplate = null,
         string serverId = "",
         string? triageUrl = null,
-        string? detailText = null)
+        string? detailText = null,
+        DateTime? nowUtc = null)
     {
         var (_, badgeText, _) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
         var template = string.IsNullOrWhiteSpace(bodyTemplate) ? DefaultGenericBodyTemplate : bodyTemplate!;
@@ -934,7 +968,7 @@ public class WebhookAlertService
             ["threshold"] = EscapeForJson(thresholdValue),
             ["severity"] = EscapeForJson(isTest ? "TEST" : badgeText),
             ["context"] = EscapeForJson(contextText),
-            ["timestamp"] = EscapeForJson(DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture)),
+            ["timestamp"] = EscapeForJson((nowUtc ?? DateTime.UtcNow).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture)),
             /* Raw JSON values — never EscapeForJson (see the doc comment). "{}" / "[]" rather than empty
                so a template's `"context": {{context_json}}` stays well-formed on a context-less alert.
                Serialized from a REDACTED copy: the copy-paste remediation T-SQL never leaves the process
@@ -1286,6 +1320,7 @@ public class WebhookAlertService
         AlertContext? context,
         string? triageUrl,
         string? detailText,
+        DateTime nowUtc,
         string? displayName = null)
     {
         try
@@ -1298,7 +1333,7 @@ public class WebhookAlertService
             var payload = BuildPagerDutyPayload(
                 metricName, serverName, currentValue, thresholdValue, _branding,
                 _settings.PagerDutyRoutingKey, context: context, dedupKey: dedupKey, triageUrl: triageUrl,
-                detailText: detailText, displayName: displayName);
+                detailText: detailText, displayName: displayName, nowUtc: nowUtc);
 
             var endpoint = PagerDutyEndpoint(_settings.PagerDutyUseEuRegion);
             var error = await PostWebhookAsync(endpoint, payload, _settings.PagerDutyProxyAddress);
@@ -1359,14 +1394,15 @@ public class WebhookAlertService
         string? serverId = null,
         string? triageUrl = null,
         string? detailText = null,
-        string? displayName = null)
+        string? displayName = null,
+        DateTime? nowUtc = null)
     {
         var (_, badgeText, _) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
         var severity = MapToPagerDutySeverity(badgeText);
         /* The PD summary (the incident title) shows the human name when present; severity above and the
            dedup_key below stay on the immutable metric name so correlation/dedup are rename-safe. */
         var titleName = string.IsNullOrEmpty(displayName) ? metricName : displayName;
-        var utcNow = DateTime.UtcNow;
+        var utcNow = nowUtc ?? DateTime.UtcNow;
 
         /* PD-CEF caps summary at 1024 chars — no truncation needed given the source strings, but document
            the constraint matching this codebase's habit of documenting limits even when unreachable. */


### PR DESCRIPTION
Closes #3355.

`IncidentAttachmentDeliveryTests.TheFourNonEmailChannels_PostIdenticalBytes_WithAndWithoutIncidentAttachments` asserts byte-identity between two independently-built webhook payload sets, and those payloads embed a wall-clock stamp at second precision. Two separate reads, so a second boundary landing between the two captures is a diff in the value under test — a red round on whatever PR it lands under, with nothing in the diff to point at.

## The fix takes the clock out of the comparison, not out of the payload

`WebhookAlertService` gains a `Func<DateTime>` clock seam (`_utcNow`), the shape `DarlingSelfAlertEvaluator` already uses, defaulting to `DateTime.UtcNow`. The fan-out reads it ONCE per firing and threads that instant to all four channel builders, which take it as an optional `nowUtc` parameter and fall back to `DateTime.UtcNow` when unsupplied — so the ~100 existing builder call sites are untouched.

Reading once per fan-out rather than once per builder is the same reasoning `triageUrl` and #3313's render already carry: four channels describing one firing must not disagree about when it fired. It also fixes two real inconsistencies in the shipped payloads, both narrow:

- a fan-out straddling a boundary posted the Teams and Slack cards a second apart
- the Teams and Slack cards each read `DateTime.UtcNow` and `DateTime.Now` separately, so one card's own "Time (UTC)" and "Time (Local)" facts could name two different seconds. The local render is now derived from the same instant.

The seam feeds RENDERED stamps only. `IncidentCooldown` keeps its own clock: whether a fingerprint is still inside its window is a gating decision on real elapsed time, not a display value, and putting a test's fixed clock in front of it would have quietly defeated the suppression the filtered-card tests are about.

## Proving it, since a green run is not evidence

The flake fires roughly once per few hundred runs, so the byte-identity pin passing proves nothing. Two things establish the property directly, and both are red against a build that reads the wall clock:

- `TwoCapturesStraddlingASecondBoundary_PostIdenticalBytes` — the flake made deterministic. It places a real rendered-second boundary between the two captures and asserts the bytes are unchanged. The wait is for a CONDITION (the rendered second changing), not a fixed deadline: a hard timeout here would be the same defect class in a new place.
- `EveryNonEmailStamp_RendersTheInjectedClock_AndMovesWhenItDoes` — a census over every timestamp-shaped token in every captured body, asserting each is a rendering of the injected instant, plus the control that advancing the injected clock by a second moves all of them. The census catches an unwired clock read whatever field it stamps; the advance arm is what stops the census being green on a seam that ignores its argument.
- `PagerDutyWebhookTests.BuildPagerDutyPayload_StampsTheInjectedClock_AndMovesWhenItDoes` — the same two arms for the one channel a capture cannot observe. PagerDuty's endpoint is the hardcoded Events v2 URL, so the fan-out capture leaves it unconfigured and never sees its payload; that is why the byte-identity assertions count six bodies rather than eight. Without this the census is green whether or not the PagerDuty builder reads the seam, leaving its single call site unheld. It lives in `Lite.Tests` because `BuildPagerDutyPayload` is `internal` and `PerformanceMonitor.Notifications` grants `InternalsVisibleTo` to `Lite.Tests` and `Dashboard.Tests` but not to `Darling.Tests`.

The existing byte-identity pin keeps its byte-exactness. Nothing was widened.

## Verification

`Darling.Tests` cannot run on macOS, so the actual test `.cs` was compiled into a `net10.0` console harness with an xunit shim, alongside the repo-wide source-scanning guards: `DocCommentHygieneTests`, `CommentFilterAdoptionTests`, `CSharpSourceWalkerTests`, `AlertReadFailureSurfaceTests`, `TsqlConventionGuardTests`, `SerialLoopStoreSizeSourceTests`, `StartupCommandTimeoutTests`, `CommandPlaneCommandTimeoutTests`. 106 tests, all green — the one apparent failure was `TheDerivedProjectListCoversEveryProjectInTheTree` counting the harness's own throwaway `.csproj`, confirmed by re-running the built binary with that file renamed.

Five mutations, each restored and verified by content:

| mutation | result |
|---|---|
| test stops injecting the clock | both new pins RED — and the byte-identity pin PASSED, which is the point |
| all four builder seams ignore `nowUtc` | both new pins RED |
| the Slack builder alone loses the seam | both new pins RED |
| the fan-out ignores `_utcNow` | both new pins RED |
| the census regex cannot match | census RED via its own emptiness guard |
| the PagerDuty builder alone ignores `nowUtc` | PagerDuty pin RED on its equality arm — and its advance arm still PASSED, because two wall-clock reads do differ, which is why both arms are carried |
| the PagerDuty builder returns a hardcoded constant equal to the fixture's instant | PagerDuty pin RED on its advance arm — the converse case, and the reason the equality arm alone would not be enough |

Before the fix, a deterministic reproduction driving the shipped test helpers across a second boundary was red 5 runs out of 5, failing exactly as reported — `Collections differ at index 0`, on the `"timestamp"` field.

## Siblings

Swept the three test projects for other equality assertions over a clock-rendered value built from two separate reads. Nothing else in this file, and nothing else that compares payload bytes — the other double-build sites (`AlertIncidentRenderTests`, `AnalysisProseDeliveryTests`) compare marker COUNTS and are clock-insensitive.

Ten assertions in two files are the same defect class at DAY precision rather than second, so they fail only across UTC midnight: `Lite.Tests/DailySummaryRangeToolTests.cs` and `Darling/Darling.Tests/DarlingDailySummaryRangeTests.cs` render their own `DateTime.UtcNow.Date` and compare it against a `from_date`/`to_date`/`summary_date` that `McpHelpers.ResolveAsOf` derived from a separate read. Fixing those needs a clock seam in a different subsystem and is reported rather than folded in here.

`EmailTemplateBuilder` has no clock seam and renders six stamps. Nothing asserts equality over an email body today, so it is latent rather than broken.

## No migration rung

Test-plus-seam only. `StorageVersion.SchemaVersion` is unchanged at 119.

