### PR TITLE
Keep the mute rules in force when a reload cannot read the store (#3354)

### DIFF
--- a/Darling/Darling.Tests/AlertReadFailureSurfaceTests.cs
+++ b/Darling/Darling.Tests/AlertReadFailureSurfaceTests.cs
@@ -389,9 +389,15 @@ public sealed class AlertReadFailureSurfaceTests
         "SweepStoreSelfMetricsAsync",
         "NotifyPgResolutionAsync",
         "FetchFailedJobsAsync",
+        /* #3354: the mute-rule reload. Not an alert pass — a control-plane read — but its swallowed
+           failure decides what the engine suppresses on every following sweep, so it belongs to this
+           population. It is also the member whose scope this list was designed to admit: an alerting read
+           arriving in a new member of this file cannot inherit clean status, because the totals stop
+           matching the moment its catch block is neither counted nor exempt. */
+        "LoadMuteRulesAsync",
     };
 
-    private const int WorkerCountedSites = 9;
+    private const int WorkerCountedSites = 10;
     private const int WorkerExemptSites = 7;
 
     /// <summary>
@@ -403,9 +409,10 @@ public sealed class AlertReadFailureSurfaceTests
     /// <para>Cross-checked against the compiler rather than counted by eye: making the counter's elapsed
     /// parameter required errored at exactly 13 sites in <c>AlertEngine.cs</c>, 5 in
     /// <c>DarlingSelfAlertEvaluator.cs</c>, 9 in <c>DarlingWorker.cs</c> and 0 in Lite, which is a census
-    /// that cannot miss a site or invent one.</para>
+    /// that cannot miss a site or invent one. <c>DarlingWorker.cs</c> carries a tenth since #3354's
+    /// mute-rule reload.</para>
     /// </summary>
-    private const int CountedSites = 27;
+    private const int CountedSites = 28;
 
     /// <summary>
     /// Log-message fragments that identify a catch block DELIBERATELY not counted, each paired with the

--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -1499,6 +1499,57 @@ public sealed class DarlingSelfAlertTests
         Assert.Equal(DarlingSelfAlertEvaluator.StaleMuteResolvedMetric, resolution.MetricName);
     }
 
+    /// <summary>
+    /// #3354, the second-order half. This condition reads the LIVE <c>MuteRuleService</c> cache, which is
+    /// exactly why it is the surface a wrongly-emptied cache damages most: with the cache empty it finds
+    /// nothing stale, clears the edge and writes a RESOLUTION — the surface built to make an invisible mute
+    /// visible asserting that nothing is being suppressed, at the moment everything has been un-suppressed.
+    ///
+    /// <para>So the fixture is a real service over a scripted store rather than a hand-built rule list: the
+    /// claim is about what this condition sees AFTER a failed reload, and a list handed in directly cannot
+    /// express a failed reload at all.</para>
+    ///
+    /// <para>Three steps, because the middle one alone would be satisfied by a condition that never
+    /// resolves anything. A failed read must not clear it; a SUCCESSFUL empty read — the operator deleting
+    /// the rule, which is the whole point of the resolution — still must.</para>
+    /// </summary>
+    [Fact]
+    public async Task StaleMute_AFailedMuteReload_CannotReportAllClear_ButAnEmptyOneStillDoes()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        var store = new ScriptedMuteRuleStore()
+            .Returning(Mute(StaleDays + 1))
+            .Failing()
+            .Returning();
+        var service = new MuteRuleService(
+            store, Microsoft.Extensions.Logging.Abstractions.NullLogger<MuteRuleService>.Instance);
+
+        await service.LoadAsync();
+        await e.ApplyStaleMuteRulesAsync(service.GetRules(), Ct);
+
+        var fired = Assert.Single(h.Deliverer.Outcomes);
+        Assert.Equal(DarlingSelfAlertEvaluator.StaleMuteMetric, fired.MetricName);
+        Assert.Empty(h.History.Records);
+
+        /* The reload faults. The rules stay in force inside the service, so this condition still sees the
+           rule it reported — and writes nothing, because the standing condition has not changed. */
+        await Assert.ThrowsAsync<InvalidOperationException>(service.LoadAsync);
+        await e.ApplyStaleMuteRulesAsync(service.GetRules(), Ct);
+
+        Assert.Single(h.Deliverer.Outcomes);
+        Assert.Empty(h.History.Records);
+
+        /* The operator deletes it for real. Same evaluator, same edge, and the only thing that differs is
+           the store's answer — so the resolution this condition exists to write still gets written. */
+        await service.LoadAsync();
+        await e.ApplyStaleMuteRulesAsync(service.GetRules(), Ct);
+
+        var resolution = Assert.Single(h.History.Records);
+        Assert.Equal(DarlingSelfAlertEvaluator.StaleMuteResolvedMetric, resolution.MetricName);
+    }
+
     [Fact]
     public async Task StaleMute_QuietStore_WritesNothingAtAll()
     {

--- a/Darling/Darling.Tests/MuteRuleReloadRetentionTests.cs
+++ b/Darling/Darling.Tests/MuteRuleReloadRetentionTests.cs
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// An <see cref="IMuteRuleStore"/> whose READ is scripted per call, so a reload can be made to fail the way
+/// a store blip makes it fail — and only the read. The mutating members record what the service asked of
+/// them, because "does a failed reload also write to the store it could not read" is a question about this
+/// seam rather than about the cache.
+///
+/// <para>Shared with <c>DarlingSelfAlertTests</c>, whose stale-mute fixtures feed a real
+/// <see cref="MuteRuleService"/> cache into the condition: that condition's input IS this cache, so its
+/// fixture has to be able to produce a cache whose last load failed.</para>
+/// </summary>
+internal sealed class ScriptedMuteRuleStore : IMuteRuleStore
+{
+    private readonly Queue<Func<IReadOnlyList<MuteRule>>> _reads = new();
+
+    /// <summary>Ids handed to <see cref="DeleteExpiredAsync"/>, in call order.</summary>
+    public List<string> PurgedIds { get; } = new();
+
+    /// <summary>How many times the service asked this store for the rules.</summary>
+    public int Loads { get; private set; }
+
+    /// <summary>Queues a successful read returning exactly these rules.</summary>
+    public ScriptedMuteRuleStore Returning(params MuteRule[] rules)
+    {
+        var snapshot = rules.ToList();
+        _reads.Enqueue(() => snapshot);
+        return this;
+    }
+
+    /// <summary>Queues a read that faults the way an unreachable or locked store faults.</summary>
+    public ScriptedMuteRuleStore Failing(string message = "store read boom")
+    {
+        _reads.Enqueue(() => throw new InvalidOperationException(message));
+        return this;
+    }
+
+    public Task<IReadOnlyList<MuteRule>> LoadAllAsync()
+    {
+        Loads++;
+
+        Assert.True(_reads.Count > 0, $"read #{Loads} was not scripted by this fixture");
+
+        /* Invoked OUTSIDE the returned task on purpose: both real stores fault while opening a connection
+           or executing, so the exception leaves LoadAllAsync rather than arriving on an awaited task. */
+        return Task.FromResult(_reads.Dequeue()());
+    }
+
+    public Task InsertAsync(MuteRule rule) => Task.CompletedTask;
+
+    public Task UpdateAsync(MuteRule rule) => Task.CompletedTask;
+
+    public Task SetEnabledAsync(string ruleId, bool enabled) => Task.CompletedTask;
+
+    public Task DeleteAsync(string ruleId) => Task.CompletedTask;
+
+    public Task DeleteExpiredAsync(IReadOnlyList<string> expiredIds)
+    {
+        PurgedIds.AddRange(expiredIds);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// #3354: <b>a failed reload must not reduce the set of rules in force.</b>
+///
+/// <para>The defect was three links, each of which read correctly on its own. Both stores swallowed a
+/// failed <c>LoadAllAsync</c> and returned an empty list; <c>MuteRuleService.LoadAsync</c> replaced its
+/// cache with whatever came back, with nothing distinguishing "this store has no rules" from "I could not
+/// read them"; and <c>LoadAsync</c> is reached on every control-plane reload, not only at startup. So one
+/// failed read dropped every mute an operator had in force, the alert engine delivered the flood those
+/// rules existed to stop, and the change was invisible — the rule list and the stale-mute condition read
+/// the same wrongly-empty cache.</para>
+///
+/// <para><b>Why the original rationale was right where it was written.</b> At first load an empty set is a
+/// real answer: a fresh or unmigrated store has no rules, and refusing to start over that would be worse.
+/// That case still works and needs no special case — the cache is empty at first load, so retaining it IS
+/// starting clean. One rule covers startup and reload, which is why the fix is a deletion.</para>
+///
+/// <para>The pins below come in PAIRS wherever they can. A retention arm alone is satisfied by a cache that
+/// never updates at all, so each one has an arm beside it proving a legitimately-empty read still empties
+/// the cache.</para>
+/// </summary>
+public sealed class MuteRuleReloadRetentionTests
+{
+    private static MuteRule Rule(string id, string? metric = "High CPU") => new()
+    {
+        Id = id,
+        Enabled = true,
+        CreatedAtUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        MetricName = metric,
+    };
+
+    private static MuteRuleService Service(IMuteRuleStore store) =>
+        new(store, NullLogger<MuteRuleService>.Instance);
+
+    private static AlertMuteContext Cpu =>
+        new() { ServerName = "srv-1", MetricName = "High CPU" };
+
+    [Fact]
+    public async Task AFailedReload_LeavesThePreviouslyLoadedRulesInForce()
+    {
+        var store = new ScriptedMuteRuleStore().Returning(Rule("a"), Rule("b")).Failing();
+        var service = Service(store);
+
+        await service.LoadAsync();
+        Assert.Equal(2, service.GetRules().Count);
+        Assert.True(service.IsAlertMuted(Cpu));
+
+        /* The reload the control plane fires on any config write. The read faults — which is not evidence
+           that the operator deleted the rules they put in force a minute ago. */
+        await Assert.ThrowsAsync<InvalidOperationException>(service.LoadAsync);
+
+        Assert.Equal(new[] { "a", "b" }, service.GetRules().Select(r => r.Id).OrderBy(id => id, StringComparer.Ordinal));
+        Assert.True(service.IsAlertMuted(Cpu));
+        Assert.Equal(2, store.Loads);
+    }
+
+    [Fact]
+    public async Task ALegitimatelyEmptyReload_StillEmptiesTheCache()
+    {
+        /* The arm that makes the one above mean something. An operator deleting their last rule is the case
+           a "never shrink the cache" fix would break, and it is indistinguishable from a failed read unless
+           the store answers the two differently — which is the whole change. */
+        var store = new ScriptedMuteRuleStore().Returning(Rule("a"), Rule("b")).Returning();
+        var service = Service(store);
+
+        await service.LoadAsync();
+        Assert.True(service.IsAlertMuted(Cpu));
+
+        await service.LoadAsync();
+
+        Assert.Empty(service.GetRules());
+        Assert.False(service.IsAlertMuted(Cpu));
+    }
+
+    [Fact]
+    public async Task TheFirstLoadOnAnUnreadableStore_StartsCleanRatherThanInventingRules()
+    {
+        /* The sound half of the original rationale, kept. A headless service against a store that is not
+           migrated yet mutes nothing, and the retention rule delivers that for free because there is
+           nothing to retain. */
+        var store = new ScriptedMuteRuleStore().Failing("relation config_mute_rules does not exist");
+        var service = Service(store);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(service.LoadAsync);
+
+        Assert.Empty(service.GetRules());
+        Assert.False(service.IsAlertMuted(Cpu));
+    }
+
+    [Fact]
+    public async Task AFailedReload_WritesNothingToTheStoreItCouldNotRead()
+    {
+        /* The expiry purge runs after the cache assignment, so a failed read skips it — right for two
+           reasons. It is a DELETE against a store that just failed a SELECT, and it is the one path that
+           could legitimately shrink the retained set: a rule that expired during the outage must not be
+           dropped from the cache on the strength of a read that never happened. */
+        var expired = Rule("gone");
+        expired.ExpiresAtUtc = new DateTime(2026, 9, 2, 0, 0, 0, DateTimeKind.Utc);
+
+        var store = new ScriptedMuteRuleStore().Returning(Rule("a")).Failing();
+        var service = Service(store);
+
+        await service.LoadAsync();
+        await Assert.ThrowsAsync<InvalidOperationException>(service.LoadAsync);
+
+        Assert.Empty(store.PurgedIds);
+
+        /* The control: a SUCCESSFUL load carrying an expired rule does purge, so the emptiness above is the
+           failure path and not a purge that never fires for anyone. */
+        var live = new ScriptedMuteRuleStore().Returning(Rule("a"), expired);
+        await Service(live).LoadAsync();
+        Assert.Equal(new[] { "gone" }, live.PurgedIds);
+    }
+
+    /* ---------------- the mechanism, pinned from source ---------------- */
+
+    /// <summary>
+    /// The retention is an ORDERING, not a branch: the read is awaited before the cache assignment, and
+    /// nothing in between catches. Pinned from source because the behavioural arms above survive neither
+    /// edit that would put the defect back — a <c>catch</c> around the read that carried on, or the
+    /// assignment hoisted above the await — until somebody makes one, and both read perfectly fine.
+    /// </summary>
+    [Fact]
+    public void TheServiceReadsTheStoreBeforeItTouchesTheCache_AndCatchesNothingInBetween()
+    {
+        var body = Member(
+            RepoFile.ReadRepoFile("PerformanceMonitor.Notifications", "MuteRuleService.cs"),
+            "LoadAsync").Stripped;
+
+        var read = body.IndexOf("await _store.LoadAllAsync()", StringComparison.Ordinal);
+        var assign = body.IndexOf("_rules = rules.ToList()", StringComparison.Ordinal);
+
+        Assert.True(read >= 0, "LoadAsync no longer reads the store through LoadAllAsync");
+        Assert.True(assign >= 0, "LoadAsync no longer replaces the cache — this pin is reading the wrong member");
+        Assert.True(read < assign, "the cache is replaced before the read completes, so a failed read empties it");
+
+        Assert.DoesNotContain("catch", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Neither store renders a failed read as an empty rule set. This is the pin that would have caught the
+    /// defect: both swallows were deliberate, documented, and correct for the case they were written for,
+    /// so neither looked wrong in isolation — and the caller they shared made them wrong together.
+    /// </summary>
+    [Theory]
+    [InlineData("Darling/PerformanceMonitor.Darling.Service/PgMuteRuleStore.cs")]
+    [InlineData("Lite/Services/DuckDbMuteRuleStore.cs")]
+    public void NeitherStore_TurnsAFailedReadIntoAnEmptyRuleSet(string relative)
+    {
+        var body = Member(RepoFile.ReadRepoFile(relative), "LoadAllAsync");
+
+        /* Read over STRIPPED source, so the paragraph in each store's remarks explaining why it no longer
+           swallows cannot itself trip a scan for the keyword it names. */
+        Assert.DoesNotContain("catch", body.Stripped, StringComparison.Ordinal);
+
+        /* The control for that silence: the scan is reading a real body that really does read the table, so
+           finding no catch is an absence rather than an empty span. The table name lives in a verbatim
+           string literal, hence the RAW body — which is also why the assertion above cannot use it. */
+        Assert.Contains("FROM config_mute_rules", body.Raw, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Darling reaches <c>LoadAsync</c> from exactly one place, and that place swallows and reports.
+    ///
+    /// <para>Two call sites are what made this a standing defect rather than a startup one, and two call
+    /// sites are also how a fix gets applied to one of them. One helper means the guard cannot be
+    /// half-installed, and the counts are what say so.</para>
+    ///
+    /// <para>The swallow is asserted because an unhandled throw at either site would take down a service
+    /// whose collection is healthy. The count is asserted because a cache that is correct and STALE is
+    /// indistinguishable from one that is correct and current without an artefact of the failure.</para>
+    /// </summary>
+    [Fact]
+    public void DarlingReachesTheReloadOnlyThroughOneGuardedHelper()
+    {
+        var raw = RepoFile.ReadRepoFile(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs");
+        var stripped = CSharpSourceWalker.StripCommentsAndStrings(raw);
+
+        Assert.Equal(1, Occurrences(stripped, "muteRuleService.LoadAsync("));
+        Assert.Equal(2, Occurrences(stripped, "await LoadMuteRulesAsync(muteRuleService);"));
+
+        var body = Member(raw, "LoadMuteRulesAsync");
+
+        Assert.Contains("await muteRuleService.LoadAsync();", body.Stripped, StringComparison.Ordinal);
+        Assert.Contains("catch (Exception ex)", body.Stripped, StringComparison.Ordinal);
+        Assert.Contains("RecordReadFailure(null, \"mute-rule reload\"", body.Raw, StringComparison.Ordinal);
+
+        /* It must SWALLOW. A catch that logged and rethrew satisfies every Contains above and still kills
+           the service on the startup path. */
+        Assert.DoesNotContain("throw", body.Stripped, StringComparison.Ordinal);
+
+        /* And the retained count has to reach the log line: that number is what says the mute set is stale
+           rather than gone, and it is the only place the distinction is written down. */
+        Assert.Contains("muteRuleService.GetRules().Count", body.Stripped, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Lite's arm was the worse of the two — a bare <c>catch</c> with no logging, so the event left no
+    /// artefact at all on that SKU. Its call site now swallows the throw the store propagates and says so.
+    /// </summary>
+    [Fact]
+    public void LitesCallSite_SwallowsTheThrowAndLeavesAnArtefact()
+    {
+        var raw = RepoFile.ReadRepoFile("Lite", "MainWindow.xaml.cs");
+        var stripped = CSharpSourceWalker.StripCommentsAndStrings(raw);
+
+        const string call = "await _muteRuleService.LoadAsync();";
+        var at = stripped.IndexOf(call, StringComparison.Ordinal);
+
+        Assert.True(at > 0, "Lite no longer loads its mute rules here — this pin is reading the wrong file");
+        Assert.Equal(at, stripped.LastIndexOf(call, StringComparison.Ordinal));
+
+        var guard = EnclosingTryBlock(stripped, at);
+        Assert.True(
+            guard.HasValue,
+            "Lite's mute-rule load is not inside a try, so a store fault aborts the rest of its startup");
+
+        /* The handler, read from the raw source at the same offsets — StripCommentsAndStrings preserves
+           length, so they line up — because the artefact this asserts is a log MESSAGE. */
+        var handler = raw[guard!.Value.End..];
+        var strippedHandler = stripped[guard.Value.End..];
+
+        Assert.StartsWith("catch (Exception", strippedHandler.TrimStart(), StringComparison.Ordinal);
+
+        var end = strippedHandler.IndexOf('}');
+        Assert.True(end > 0, "Lite's mute-rule catch block never closes");
+        Assert.Contains("AppLogger.Warn(", handler[..end], StringComparison.Ordinal);
+        Assert.Contains("stay in force", handler[..end], StringComparison.Ordinal);
+    }
+
+    /* ---------------- helpers ---------------- */
+
+    private static int Occurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var at = haystack.IndexOf(needle, StringComparison.Ordinal);
+             at >= 0;
+             at = haystack.IndexOf(needle, at + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// One named member's body, in both spellings at the same offsets.
+    ///
+    /// <para>Both are needed and for opposite reasons. A keyword scan has to read STRIPPED source or the
+    /// paragraph explaining why a <c>catch</c> is gone satisfies a scan for one — every member this file
+    /// reads now carries such a paragraph. A scan for a read name or a table name has to read RAW source,
+    /// because those live in string literals and stripping blanks them. Returning one value carrying both
+    /// keeps a call site from reaching for whichever it happens to have.</para>
+    /// </summary>
+    private static (string Raw, string Stripped) Member(string source, string member)
+    {
+        var stripped = CSharpSourceWalker.StripCommentsAndStrings(source);
+
+        var decl = Regex.Match(
+            stripped,
+            @"^[ \t]*(?:private|internal|public|protected)[^\r\n=]*?\b" + Regex.Escape(member) + @"\s*\(",
+            RegexOptions.Multiline);
+
+        Assert.True(decl.Success, $"{member} has no declaration — a rename has moved it out from under this pin");
+
+        var open = stripped.IndexOf('{', decl.Index);
+        Assert.True(open > 0, $"{member} has no block body");
+
+        var body = CSharpSourceWalker.BraceBalanced(stripped, open);
+        return (source[open..(open + body.Length)], body);
+    }
+
+    /// <summary>
+    /// The innermost <c>try { … }</c> block containing <paramref name="offset"/>, or null when the offset
+    /// sits in no try at all. Every try in the file is brace-balanced and the TIGHTEST enclosing one wins,
+    /// rather than trusting the nearest preceding <c>try</c> token — a call in a sibling block after an
+    /// unrelated try would otherwise read as guarded.
+    /// </summary>
+    private static (int Start, int End)? EnclosingTryBlock(string stripped, int offset)
+    {
+        (int Start, int End)? tightest = null;
+
+        foreach (Match m in Regex.Matches(stripped, @"\btry\s*\{"))
+        {
+            var open = stripped.IndexOf('{', m.Index);
+            var block = CSharpSourceWalker.BraceBalanced(stripped, open);
+            var end = open + block.Length;
+
+            if (offset <= open || offset >= end)
+            {
+                continue;
+            }
+
+            if (tightest is null || open > tightest.Value.Start)
+            {
+                tightest = (open, end);
+            }
+        }
+
+        return tightest;
+    }
+}

--- a/Darling/Darling.Tests/MuteRuleReloadRetentionTests.cs
+++ b/Darling/Darling.Tests/MuteRuleReloadRetentionTests.cs
@@ -284,8 +284,16 @@ public sealed class MuteRuleReloadRetentionTests
     }
 
     /// <summary>
-    /// Lite's arm was the worse of the two — a bare <c>catch</c> with no logging, so the event left no
-    /// artefact at all on that SKU. Its call site now swallows the throw the store propagates and says so.
+    /// Lite's call site swallows the throw the store propagates and leaves BOTH artefacts Darling's does —
+    /// the log line and the #3013 count.
+    ///
+    /// <para>Both, not just the log, and asserted rather than assumed for a reason that is specific to this
+    /// read. <c>AlertReadFailureCounter.FleetScopedReads</c> is concatenated into both SKUs'
+    /// <c>get_collection_health</c> description byte-for-byte, and this is the only member of that set a
+    /// Lite process can produce — the other two are Darling store self-alerts. So a Lite arm that logged
+    /// and did not count would leave that description promising a reading Lite cannot produce, which is a
+    /// confident zero on the surface built to end confident zeroes. The first draft of this pin asserted
+    /// only the log line, so the asymmetry was PINNED rather than caught.</para>
     /// </summary>
     [Fact]
     public void LitesCallSite_SwallowsTheThrowAndLeavesAnArtefact()
@@ -315,6 +323,27 @@ public sealed class MuteRuleReloadRetentionTests
         Assert.True(end > 0, "Lite's mute-rule catch block never closes");
         Assert.Contains("AppLogger.Warn(", handler[..end], StringComparison.Ordinal);
         Assert.Contains("stay in force", handler[..end], StringComparison.Ordinal);
+
+        /* The count, on the same surface and under the same read name Darling uses — with the null key and
+           a measured elapsed, in ONE expression so a site cannot satisfy the name while dropping either.
+           Same name as Darling's on purpose: it is the same read, the counters are per-process, and a
+           second spelling would split one read across two labels on a surface whose whole job is naming
+           which read went blind. Matched with a pattern rather than a literal because the call wraps. */
+        Assert.True(
+            Regex.IsMatch(
+                handler[..end],
+                @"RecordReadFailure\(\s*null,\s*""mute-rule reload"",\s*muteReadClock\.ElapsedMilliseconds\s*\)"),
+            "Lite's mute-rule catch does not record the failure on #3013's surface with a null key and a "
+            + "measured elapsed, so the read this SKU's get_collection_health description names cannot "
+            + "reach its own instance total");
+
+        /* And the clock is started BEFORE the try, not inside the handler — a clock started in the catch
+           compiles, reads correctly, and can only ever measure zero. The Darling census closes that route
+           on its own sites; this file is the only guard over Lite's. */
+        Assert.Contains(
+            "var muteReadClock = System.Diagnostics.Stopwatch.StartNew();",
+            raw[..guard.Value.Start],
+            StringComparison.Ordinal);
     }
 
     /* ---------------- helpers ---------------- */

--- a/Darling/Darling.Tests/MuteRuleReloadRetentionTests.cs
+++ b/Darling/Darling.Tests/MuteRuleReloadRetentionTests.cs
@@ -207,12 +207,21 @@ public sealed class MuteRuleReloadRetentionTests
             "LoadAsync").Stripped;
 
         var read = body.IndexOf("await _store.LoadAllAsync()", StringComparison.Ordinal);
-        var assign = body.IndexOf("_rules = rules.ToList()", StringComparison.Ordinal);
+
+        /* The FIRST write to the cache, whatever it assigns — not the assignment of the loaded rules.
+           Anchoring on "_rules = rules.ToList()" reads the same on a body that CLEARS the cache first and
+           then assigns, which is the defect exactly: the clear lands, the read throws, and the assignment
+           the pin was watching never runs. Mutating this file proved it — the narrower form stayed green
+           while all three behavioural arms went red, which is the shape of a pin that cannot fail. */
+        var write = body.IndexOf("_rules =", StringComparison.Ordinal);
 
         Assert.True(read >= 0, "LoadAsync no longer reads the store through LoadAllAsync");
-        Assert.True(assign >= 0, "LoadAsync no longer replaces the cache — this pin is reading the wrong member");
-        Assert.True(read < assign, "the cache is replaced before the read completes, so a failed read empties it");
+        Assert.True(write >= 0, "LoadAsync no longer writes the cache — this pin is reading the wrong member");
+        Assert.True(
+            read < write,
+            "the cache is written before the store read completes, so a failed read reduces it");
 
+        Assert.Contains("_rules = rules.ToList()", body, StringComparison.Ordinal);
         Assert.DoesNotContain("catch", body, StringComparison.Ordinal);
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1479,8 +1479,8 @@ public sealed class DarlingWorker : BackgroundService
             alertSettings, DarlingAlertDeliverer.Branding,
             _loggerFactory.CreateLogger<WebhookAlertService>(), historyStore);
         var muteRuleService = new MuteRuleService(
-            new PgMuteRuleStore(postgres, _logger), _loggerFactory.CreateLogger<MuteRuleService>());
-        await muteRuleService.LoadAsync();
+            new PgMuteRuleStore(postgres), _loggerFactory.CreateLogger<MuteRuleService>());
+        await LoadMuteRulesAsync(muteRuleService);
 
         /* The shared record-and-send deliverer — hoisted so BOTH the shared alert engine and the Stage 4
            service self-alerts (DarlingSelfAlertEvaluator) fire through the SAME instance: identical
@@ -2912,7 +2912,7 @@ public sealed class DarlingWorker : BackgroundService
            upserting), and an enable_server flips it back. */
         await DarlingObservability.SyncServerEnabledStatesAsync(_postgres!, _logger, cancellationToken);
 
-        await muteRuleService.LoadAsync();
+        await LoadMuteRulesAsync(muteRuleService);
 
         /* view.ConfigVersion rather than _lastConfigVersion: the caller has not advanced the watermark yet
            (it advances from this method's RETURN value), so the field still holds the PREVIOUS version
@@ -2923,6 +2923,45 @@ public sealed class DarlingWorker : BackgroundService
             view.ConfigVersion, servers.Count, _paused);
 
         return view.ConfigVersion;
+    }
+
+    /// <summary>
+    /// The ONLY route from this service to <see cref="MuteRuleService.LoadAsync"/> — startup and every
+    /// control-plane reload both come through here, so neither path can be guarded while the other is not.
+    ///
+    /// <para>The service keeps the rules it already read when the store read throws, so the operator's
+    /// suppression survives a store blip: that guarantee lives in <c>LoadAsync</c> and holds whatever this
+    /// method does. What this method owns is the reporting. A failed reload leaves a cache that is CORRECT
+    /// and STALE, and the only way to tell that apart from a cache that is correct and current is an
+    /// artefact of the failure — so the event is logged with the number of rules left standing, and counted
+    /// on #3013's swallowed-alerting-read surface with a null server key, because
+    /// <c>config_mute_rules</c> belongs to the store rather than to any monitored server.</para>
+    ///
+    /// <para>Counted rather than exempt: this is a store read, on the alert pass's own command deadline,
+    /// whose failure changes what the alert engine does on its next sweep. That is the population #3013
+    /// measures, and it is the one member of it whose failure makes the fleet report MORE health rather
+    /// than less.</para>
+    ///
+    /// <para>Swallowed here, and it has to be: an unhandled throw at either site takes down a service whose
+    /// collection is otherwise healthy, and losing the fleet's monitoring is a larger error than running on
+    /// a stale mute set. The elapsed is the store read's alone — <c>LoadAsync</c>'s expiry purge runs only
+    /// after a read that succeeded, and swallows its own write failures.</para>
+    /// </summary>
+    private async Task LoadMuteRulesAsync(MuteRuleService muteRuleService)
+    {
+        var readClock = Stopwatch.StartNew();
+        try
+        {
+            await muteRuleService.LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                "Could not reload mute rules after {ElapsedMs} ms — the {Rules} rule(s) already in force "
+                + "stay in force until a read succeeds: {Message}",
+                readClock.ElapsedMilliseconds, muteRuleService.GetRules().Count, ex.Message);
+            _readFailures.RecordReadFailure(null, "mute-rule reload", readClock.ElapsedMilliseconds);
+        }
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/PgMuteRuleStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/PgMuteRuleStore.cs
@@ -9,7 +9,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Npgsql;
 using NpgsqlTypes;
 using PerformanceMonitor.Notifications;
@@ -19,60 +18,56 @@ namespace PerformanceMonitor.Darling.Service;
 /// <summary>
 /// Postgres-backed <see cref="IMuteRuleStore"/> over the V3 <c>config_mute_rules</c> table —
 /// Lite's <c>DuckDbMuteRuleStore</c> ported statement-for-statement. The shared
-/// <see cref="MuteRuleService"/> keeps the in-memory cache + matching; per its contract the
-/// mutating methods here THROW on failure (the service catches, logs, and skips the cache
-/// mutation — persist-then-cache ordering) while <see cref="LoadAllAsync"/> swallows errors and
-/// returns an empty set (a headless service with no rules configured — or a store not yet
-/// migrated — simply mutes nothing). Timestamps are stored naive-UTC and tagged UTC on read.
+/// <see cref="MuteRuleService"/> keeps the in-memory cache + matching; per its contract EVERY method
+/// here throws on failure — the mutating ones because the service catches, logs and skips the cache
+/// mutation (persist-then-cache ordering), and <see cref="LoadAllAsync"/> because an empty list is the
+/// answer "this store holds no rules" and must not also be the answer "I could not read them".
+/// Timestamps are stored naive-UTC and tagged UTC on read.
 /// </summary>
 public sealed class PgMuteRuleStore : IMuteRuleStore
 {
     private readonly NpgsqlDataSource _postgres;
-    private readonly ILogger? _logger;
 
-    public PgMuteRuleStore(NpgsqlDataSource postgres, ILogger? logger = null)
+    public PgMuteRuleStore(NpgsqlDataSource postgres)
     {
         _postgres = postgres ?? throw new ArgumentNullException(nameof(postgres));
-        _logger = logger;
     }
 
+    /// <summary>
+    /// Every persisted rule, newest first. A store fault propagates: the one caller that caches these rows
+    /// leaves its cache alone when this throws, and the MCP reads report the fault rather than answering
+    /// "no mute rules are configured for this store". This store carries no logger of its own for the same
+    /// reason Lite's does not — the caller that swallows the fault is the one that knows what it cost.
+    /// </summary>
     public async Task<IReadOnlyList<MuteRule>> LoadAllAsync()
     {
         var rules = new List<MuteRule>();
-        try
-        {
-            await using var connection = await _postgres.OpenConnectionAsync();
-            using var command = new NpgsqlCommand(@"
+
+        await using var connection = await _postgres.OpenConnectionAsync();
+        using var command = new NpgsqlCommand(@"
 SELECT id, enabled, created_at_utc, expires_at_utc, reason,
        server_name, metric_name, database_pattern,
        query_text_pattern, wait_type_pattern, job_name_pattern
 FROM config_mute_rules
 ORDER BY created_at_utc DESC", connection) { CommandTimeout = DarlingAlertReadAdapter.AlertPassCommandTimeoutSeconds };
 
-            using var reader = await command.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-            {
-                rules.Add(new MuteRule
-                {
-                    Id = reader.GetString(0),
-                    Enabled = reader.GetBoolean(1),
-                    CreatedAtUtc = DateTime.SpecifyKind(reader.GetDateTime(2), DateTimeKind.Utc),
-                    ExpiresAtUtc = reader.IsDBNull(3) ? null : DateTime.SpecifyKind(reader.GetDateTime(3), DateTimeKind.Utc),
-                    Reason = reader.IsDBNull(4) ? null : reader.GetString(4),
-                    ServerName = reader.IsDBNull(5) ? null : reader.GetString(5),
-                    MetricName = reader.IsDBNull(6) ? null : reader.GetString(6),
-                    DatabasePattern = reader.IsDBNull(7) ? null : reader.GetString(7),
-                    QueryTextPattern = reader.IsDBNull(8) ? null : reader.GetString(8),
-                    WaitTypePattern = reader.IsDBNull(9) ? null : reader.GetString(9),
-                    JobNamePattern = reader.IsDBNull(10) ? null : reader.GetString(10)
-                });
-            }
-        }
-        catch (Exception ex)
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
         {
-            /* Non-fatal — start with empty rules if the store is not ready (Lite's behavior). */
-            _logger?.LogWarning("Could not load mute rules — starting with none: {Message}", ex.Message);
-            rules.Clear();
+            rules.Add(new MuteRule
+            {
+                Id = reader.GetString(0),
+                Enabled = reader.GetBoolean(1),
+                CreatedAtUtc = DateTime.SpecifyKind(reader.GetDateTime(2), DateTimeKind.Utc),
+                ExpiresAtUtc = reader.IsDBNull(3) ? null : DateTime.SpecifyKind(reader.GetDateTime(3), DateTimeKind.Utc),
+                Reason = reader.IsDBNull(4) ? null : reader.GetString(4),
+                ServerName = reader.IsDBNull(5) ? null : reader.GetString(5),
+                MetricName = reader.IsDBNull(6) ? null : reader.GetString(6),
+                DatabasePattern = reader.IsDBNull(7) ? null : reader.GetString(7),
+                QueryTextPattern = reader.IsDBNull(8) ? null : reader.GetString(8),
+                WaitTypePattern = reader.IsDBNull(9) ? null : reader.GetString(9),
+                JobNamePattern = reader.IsDBNull(10) ? null : reader.GetString(10)
+            });
         }
 
         return rules;

--- a/Lite.Tests/AlertReadFailureSurfaceTests.cs
+++ b/Lite.Tests/AlertReadFailureSurfaceTests.cs
@@ -202,8 +202,12 @@ public sealed class AlertReadFailureSurfaceTests
     ///
     /// <para>So the set is derived from SOURCE (every <c>RecordReadFailure(null, ...)</c> call, matched
     /// across line breaks because those calls are wrapped) and each one must be represented in the single
-    /// constant every surface now concatenates. A sixth fleet-scoped site fails here until the constant
+    /// constant every surface now concatenates. A fourth fleet-scoped site fails here until the constant
     /// names it.</para>
+    ///
+    /// <para>Derived from the LITERAL, which is why the call sites spell the read name inline rather than
+    /// through a constant: a named constant at the site would leave this regex finding nothing there, and
+    /// the pin would report the set complete while an un-inventoried fleet-scoped read shipped.</para>
     /// </summary>
     [Fact]
     public void TheFleetScopedInventory_MatchesWhatTheCounterActuallyRecords()
@@ -228,7 +232,7 @@ public sealed class AlertReadFailureSurfaceTests
             }
         }
 
-        Assert.Equal(2, nullKeyReads.Count);
+        Assert.Equal(3, nullKeyReads.Count);
 
         var inventory = AlertReadFailureCounter.FleetScopedReads;
 
@@ -236,8 +240,13 @@ public sealed class AlertReadFailureSurfaceTests
            name, because the constant is prose for an operator and the read name is a label for a log. */
         Assert.Contains(nullKeyReads, r => r.Contains("collector-cost", StringComparison.Ordinal));
         Assert.Contains(nullKeyReads, r => r.Contains("background-job health", StringComparison.Ordinal));
+        /* #3354: config_mute_rules belongs to the store, not to any monitored server, so its failed read
+           lands in the instance total and in no server's count — exactly the case a per-server-only
+           surface would have given no home. */
+        Assert.Contains(nullKeyReads, r => r.Contains("mute-rule reload", StringComparison.Ordinal));
         Assert.Contains("collector-cost regression", inventory, StringComparison.Ordinal);
         Assert.Contains("background-job health", inventory, StringComparison.Ordinal);
+        Assert.Contains("mute-rule reload", inventory, StringComparison.Ordinal);
 
         /* And the phantom stays gone. Disk pressure's feed reads are exempt — a local filesystem read and a
            recorded-store-size lookup that is context for the alert text — so naming it here would send an

--- a/Lite.Tests/AlertReadFailureSurfaceTests.cs
+++ b/Lite.Tests/AlertReadFailureSurfaceTests.cs
@@ -222,6 +222,11 @@ public sealed class AlertReadFailureSurfaceTests
             Path.Combine("PerformanceMonitor.Alerting", "AlertEngine.cs"),
             Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "DarlingSelfAlertEvaluator.cs"),
             Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs"),
+            /* Lite's own recording site. The constant is concatenated into BOTH SKUs' descriptions, so a
+               derivation that read only Darling's files could not see a Lite fleet-scoped read at all — and
+               the reverse gap is the one that bites: a read named here that the reading SKU cannot
+               increment is this counter's own defect, a confident zero, written into its documentation. */
+            Path.Combine("Lite", "MainWindow.xaml.cs"),
         })
         {
             var src = File.ReadAllText(Path.Combine(root, relative));
@@ -234,7 +239,7 @@ public sealed class AlertReadFailureSurfaceTests
             }
         }
 
-        Assert.Equal(3, nullKeyReads.Count);
+        Assert.Equal(4, nullKeyReads.Count);
 
         var inventory = AlertReadFailureCounter.FleetScopedReads;
 
@@ -244,8 +249,13 @@ public sealed class AlertReadFailureSurfaceTests
         Assert.Contains(nullKeyReads, r => r.Contains("background-job health", StringComparison.Ordinal));
         /* #3354: config_mute_rules belongs to the store, not to any monitored server, so its failed read
            lands in the instance total and in no server's count — exactly the case a per-server-only
-           surface would have given no home. */
-        Assert.Contains(nullKeyReads, r => r.Contains("mute-rule reload", StringComparison.Ordinal));
+           surface would have given no home. Recorded TWICE across the tree, once per SKU, and that is the
+           point rather than a duplicate: both SKUs perform this read, the counters are per-process, and a
+           SKU that named it without recording it would promise a reading it cannot produce. The other two
+           entries are Darling store self-alerts with no Lite equivalent. */
+        Assert.Equal(
+            2,
+            nullKeyReads.Count(r => r.Contains("mute-rule reload", StringComparison.Ordinal)));
         Assert.Contains("collector-cost regression", inventory, StringComparison.Ordinal);
         Assert.Contains("background-job health", inventory, StringComparison.Ordinal);
         Assert.Contains("mute-rule reload", inventory, StringComparison.Ordinal);

--- a/Lite.Tests/AlertReadFailureSurfaceTests.cs
+++ b/Lite.Tests/AlertReadFailureSurfaceTests.cs
@@ -202,8 +202,10 @@ public sealed class AlertReadFailureSurfaceTests
     ///
     /// <para>So the set is derived from SOURCE (every <c>RecordReadFailure(null, ...)</c> call, matched
     /// across line breaks because those calls are wrapped) and each one must be represented in the single
-    /// constant every surface now concatenates. A fourth fleet-scoped site fails here until the constant
-    /// names it.</para>
+    /// constant every surface now concatenates. A site beyond the count asserted below fails here until
+    /// the constant names it — stated that way rather than as its own numeral, because the numeral here
+    /// was wrong from the day it was written (it said "a sixth" beside an asserted count of two) and a
+    /// second copy of a pinned number has nothing keeping it honest.</para>
     ///
     /// <para>Derived from the LITERAL, which is why the call sites spell the read name inline rather than
     /// through a constant: a named constant at the site would leave this regex finding nothing there, and

--- a/Lite.Tests/MuteRuleServiceTests.cs
+++ b/Lite.Tests/MuteRuleServiceTests.cs
@@ -17,16 +17,24 @@ namespace PerformanceMonitorLite.Tests;
 /// </summary>
 public class MuteRuleServiceTests
 {
-    /// <summary>In-memory fake; InsertAsync optionally throws to exercise the error path.</summary>
+    /// <summary>In-memory fake; the persist and the READ each optionally throw to exercise the two error
+    /// paths, which are opposite by design — a failed persist must not enter the cache, and a failed read
+    /// must not empty it.</summary>
     private sealed class FakeMuteRuleStore : IMuteRuleStore
     {
         private readonly bool _throwOnInsert;
         public List<MuteRule> Persisted { get; } = new();
 
+        /// <summary>#3354: when set, the READ faults the way a store blip makes it fault.</summary>
+        public bool ThrowOnLoad { get; set; }
+
         public FakeMuteRuleStore(bool throwOnInsert = false) => _throwOnInsert = throwOnInsert;
 
         public Task<IReadOnlyList<MuteRule>> LoadAllAsync()
-            => Task.FromResult<IReadOnlyList<MuteRule>>(Persisted.ToList());
+        {
+            if (ThrowOnLoad) throw new InvalidOperationException("store read boom");
+            return Task.FromResult<IReadOnlyList<MuteRule>>(Persisted.ToList());
+        }
 
         public Task InsertAsync(MuteRule rule)
         {
@@ -74,6 +82,49 @@ public class MuteRuleServiceTests
         /* Persist-then-cache: nothing persisted, and the cache must be empty too
            (the deliberate Dashboard behaviour change in §4.2). */
         Assert.Empty(store.Persisted);
+        Assert.Empty(service.GetRules());
+    }
+
+    /// <summary>
+    /// #3354, asserted on THIS SKU as well: a failed reload must not reduce the set of rules in force.
+    /// Lite's store used to swallow the read fault and return an empty list with no log line at all, so
+    /// Lite lost every mute on a DuckDB blip and left no artefact of having done so. The invariant lives in
+    /// the shared service — the read is awaited before the cache assignment and nothing catches — and this
+    /// is the arm that says Lite's compilation of it behaves the same way Darling's does.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_ReadFails_TheRulesAlreadyInForceStayInForce()
+    {
+        var store = new FakeMuteRuleStore();
+        var service = new MuteRuleService(store, new AppLoggerAdapter<MuteRuleService>());
+
+        await service.AddRuleAsync(NewRule("rule-1"));
+        await service.LoadAsync();
+        Assert.Single(service.GetRules());
+
+        store.ThrowOnLoad = true;
+        await Assert.ThrowsAsync<InvalidOperationException>(service.LoadAsync);
+
+        Assert.Single(service.GetRules());
+        Assert.Contains(service.GetRules(), r => r.Id == "rule-1");
+    }
+
+    /// <summary>
+    /// The arm that keeps the one above from being satisfied by a cache that never updates: a SUCCESSFUL
+    /// empty read is an operator deleting their last rule, and it still empties the cache.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_ReadSucceedsAndIsEmpty_TheCacheIsEmptied()
+    {
+        var store = new FakeMuteRuleStore();
+        var service = new MuteRuleService(store, new AppLoggerAdapter<MuteRuleService>());
+
+        await service.AddRuleAsync(NewRule("rule-1"));
+        Assert.Single(service.GetRules());
+
+        store.Persisted.Clear();
+        await service.LoadAsync();
+
         Assert.Empty(service.GetRules());
     }
 }

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -276,9 +276,20 @@ public partial class MainWindow : Window
                fault rather than as an empty rule set — and it is swallowed here for the reason Darling
                swallows it: the rules already in force stay in force inside MuteRuleService whatever
                happens out here, and an unhandled throw would abandon the rest of this startup sequence
-               over a transient DuckDB read. Logged, because a cache that is correct and STALE is
-               indistinguishable from one that is correct and current without an artefact of the
-               failure. */
+               over a transient DuckDB read.
+
+               Logged AND counted on #3013's surface, the same two artefacts Darling's
+               LoadMuteRulesAsync leaves, because a cache that is correct and STALE is indistinguishable
+               from one that is correct and current without them. This is the ONE member of
+               AlertReadFailureCounter.FleetScopedReads that both SKUs can actually record — the other
+               two are Darling store self-alerts — and that constant is concatenated into both SKUs'
+               get_collection_health description, so a Lite process that named this read and could never
+               increment it would describe a failure mode it cannot surface.
+
+               The elapsed is a plain duration here rather than a deadline comparison: DuckDbMuteRuleStore
+               sets no CommandTimeout, which is the gap the counter's own remarks already state for every
+               Lite alerting read. */
+            var muteReadClock = System.Diagnostics.Stopwatch.StartNew();
             try
             {
                 await _muteRuleService.LoadAsync();
@@ -287,8 +298,11 @@ public partial class MainWindow : Window
             {
                 AppLogger.Warn(
                     "MuteRules",
-                    $"Could not load mute rules — the {_muteRuleService.GetRules().Count} rule(s) already "
-                    + $"in force stay in force until a read succeeds: {muteEx.Message}");
+                    $"Could not load mute rules after {muteReadClock.ElapsedMilliseconds} ms — the "
+                    + $"{_muteRuleService.GetRules().Count} rule(s) already in force stay in force until a "
+                    + $"read succeeds: {muteEx.Message}");
+                AlertReadFailureCounter.Shared.RecordReadFailure(
+                    null, "mute-rule reload", muteReadClock.ElapsedMilliseconds);
             }
 
             // Initialize alerts history tab

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -272,8 +272,23 @@ public partial class MainWindow : Window
                    constructs its own and cannot pollute this one. */
                 readFailures: AlertReadFailureCounter.Shared);
 
-            // Load mute rules from database
-            await _muteRuleService.LoadAsync();
+            /* Load mute rules from the local store. A failed read THROWS (the store no longer renders one
+               as an empty rule set), and it is swallowed here for the reason Darling swallows it: the rules
+               already in force stay in force inside MuteRuleService whatever happens out here, and an
+               unhandled throw would abandon the rest of this startup sequence over a transient DuckDB
+               read. Logged so the event leaves an artefact on this SKU too — it used to leave none at
+               all. */
+            try
+            {
+                await _muteRuleService.LoadAsync();
+            }
+            catch (Exception muteEx)
+            {
+                AppLogger.Warn(
+                    "MuteRules",
+                    $"Could not load mute rules — the {_muteRuleService.GetRules().Count} rule(s) already "
+                    + $"in force stay in force until a read succeeds: {muteEx.Message}");
+            }
 
             // Initialize alerts history tab
             AlertsHistoryContent.Initialize(_dataService);

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -272,12 +272,13 @@ public partial class MainWindow : Window
                    constructs its own and cannot pollute this one. */
                 readFailures: AlertReadFailureCounter.Shared);
 
-            /* Load mute rules from the local store. A failed read THROWS (the store no longer renders one
-               as an empty rule set), and it is swallowed here for the reason Darling swallows it: the rules
-               already in force stay in force inside MuteRuleService whatever happens out here, and an
-               unhandled throw would abandon the rest of this startup sequence over a transient DuckDB
-               read. Logged so the event leaves an artefact on this SKU too — it used to leave none at
-               all. */
+            /* Load mute rules from the local store. A failed read THROWS — the store reports a fault as a
+               fault rather than as an empty rule set — and it is swallowed here for the reason Darling
+               swallows it: the rules already in force stay in force inside MuteRuleService whatever
+               happens out here, and an unhandled throw would abandon the rest of this startup sequence
+               over a transient DuckDB read. Logged, because a cache that is correct and STALE is
+               indistinguishable from one that is correct and current without an artefact of the
+               failure. */
             try
             {
                 await _muteRuleService.LoadAsync();

--- a/Lite/Services/DuckDbMuteRuleStore.cs
+++ b/Lite/Services/DuckDbMuteRuleStore.cs
@@ -22,9 +22,9 @@ namespace PerformanceMonitorLite.Services;
 /// EVERY method throws on failure; <see cref="MuteRuleService"/> keeps the
 /// try/catch + logging + in-memory cache (persist-then-cache ordering preserved).
 /// <see cref="LoadAllAsync"/> throws too, so an empty list is the answer "this store holds no rules" and
-/// never also the answer "I could not read them" — the swallow it used to carry returned whatever rows had
-/// already been read when the fault hit, so a mid-read failure silently narrowed the set in force rather
-/// than merely emptying it.
+/// never also the answer "I could not read them". A swallow here would be worse than an empty answer:
+/// the rows read before the fault are already in the list, so it would report a silently NARROWED set in
+/// force rather than an absent one, and the caller cannot tell a short list from a short table.
 ///
 /// <para><b>Four of the five write-lock sites are earned; <see cref="InsertAsync"/> is not (#2463).</b>
 /// Worth saying because <c>FindingStore.MuteStoryAsync</c> writes a mute row under the READ lock, and the

--- a/Lite/Services/DuckDbMuteRuleStore.cs
+++ b/Lite/Services/DuckDbMuteRuleStore.cs
@@ -19,10 +19,12 @@ namespace PerformanceMonitorLite.Services;
 /// Wraps the persistence that previously lived directly inside
 /// <see cref="MuteRuleService"/> (LoadAsync / PersistRuleAsync / RemoveRuleAsync /
 /// UpdateRuleAsync / SetRuleEnabledAsync / PurgeExpiredRulesAsync) — verbatim SQL.
-/// The mutating methods throw on failure; <see cref="MuteRuleService"/> keeps the
+/// EVERY method throws on failure; <see cref="MuteRuleService"/> keeps the
 /// try/catch + logging + in-memory cache (persist-then-cache ordering preserved).
-/// <see cref="LoadAllAsync"/> swallows errors and returns an empty set, matching
-/// the old LoadAsync ("start with empty rules if DB not ready").
+/// <see cref="LoadAllAsync"/> throws too, so an empty list is the answer "this store holds no rules" and
+/// never also the answer "I could not read them" — the swallow it used to carry returned whatever rows had
+/// already been read when the fault hit, so a mid-read failure silently narrowed the set in force rather
+/// than merely emptying it.
 ///
 /// <para><b>Four of the five write-lock sites are earned; <see cref="InsertAsync"/> is not (#2463).</b>
 /// Worth saying because <c>FindingStore.MuteStoryAsync</c> writes a mute row under the READ lock, and the
@@ -48,41 +50,35 @@ public sealed class DuckDbMuteRuleStore : IMuteRuleStore
     public async Task<IReadOnlyList<MuteRule>> LoadAllAsync()
     {
         var rules = new List<MuteRule>();
-        try
-        {
-            using var readLock = _dbInitializer.AcquireReadLock();
-            using var connection = _dbInitializer.CreateConnection();
-            await connection.OpenAsync();
-            using var cmd = connection.CreateCommand();
-            cmd.CommandText = @"
+
+        using var readLock = _dbInitializer.AcquireReadLock();
+        using var connection = _dbInitializer.CreateConnection();
+        await connection.OpenAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
                     SELECT id, enabled, created_at_utc, expires_at_utc, reason,
                            server_name, metric_name, database_pattern,
                            query_text_pattern, wait_type_pattern, job_name_pattern
                     FROM config_mute_rules
                     ORDER BY created_at_utc DESC";
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-            {
-                rules.Add(new MuteRule
-                {
-                    Id = reader.GetString(0),
-                    Enabled = reader.GetBoolean(1),
-                    CreatedAtUtc = reader.GetDateTime(2),
-                    ExpiresAtUtc = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
-                    Reason = reader.IsDBNull(4) ? null : reader.GetString(4),
-                    ServerName = reader.IsDBNull(5) ? null : reader.GetString(5),
-                    MetricName = reader.IsDBNull(6) ? null : reader.GetString(6),
-                    DatabasePattern = reader.IsDBNull(7) ? null : reader.GetString(7),
-                    QueryTextPattern = reader.IsDBNull(8) ? null : reader.GetString(8),
-                    WaitTypePattern = reader.IsDBNull(9) ? null : reader.GetString(9),
-                    JobNamePattern = reader.IsDBNull(10) ? null : reader.GetString(10)
-                });
-            }
-        }
-        catch
+        using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
         {
-            /* Non-fatal — start with empty rules if DB not ready */
+            rules.Add(new MuteRule
+            {
+                Id = reader.GetString(0),
+                Enabled = reader.GetBoolean(1),
+                CreatedAtUtc = reader.GetDateTime(2),
+                ExpiresAtUtc = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+                Reason = reader.IsDBNull(4) ? null : reader.GetString(4),
+                ServerName = reader.IsDBNull(5) ? null : reader.GetString(5),
+                MetricName = reader.IsDBNull(6) ? null : reader.GetString(6),
+                DatabasePattern = reader.IsDBNull(7) ? null : reader.GetString(7),
+                QueryTextPattern = reader.IsDBNull(8) ? null : reader.GetString(8),
+                WaitTypePattern = reader.IsDBNull(9) ? null : reader.GetString(9),
+                JobNamePattern = reader.IsDBNull(10) ? null : reader.GetString(10)
+            });
         }
 
         return rules;

--- a/PerformanceMonitor.Alerting/AlertReadFailureCounter.cs
+++ b/PerformanceMonitor.Alerting/AlertReadFailureCounter.cs
@@ -460,6 +460,13 @@ public sealed class AlertReadFailureCounter
     /// from a cache that is correct and current: the rule list, every mute surface and the stale-mute
     /// condition all read what the last successful load put there. A nonzero instance total naming this
     /// read is the artefact, which is why it is counted rather than exempt.</para>
+    ///
+    /// <para>It is also the only member of this set that BOTH SKUs can produce, and that is load-bearing
+    /// for a constant both descriptions concatenate. The other two are Darling store self-alerts that have
+    /// no Lite equivalent at all, so naming them there describes a shared inventory rather than promising a
+    /// Lite reading. The mute-rule reload is different: Lite performs that read, Lite swallows its failure,
+    /// and Lite's call site therefore records it here too. A read this constant names on a SKU that cannot
+    /// increment it would be this class's own defect — a confident zero — reproduced in its documentation.</para>
     /// </summary>
     public const string FleetScopedReads =
         "the collector-cost regression self-alert, the mute-rule reload, and the store background-job "

--- a/PerformanceMonitor.Alerting/AlertReadFailureCounter.cs
+++ b/PerformanceMonitor.Alerting/AlertReadFailureCounter.cs
@@ -453,10 +453,17 @@ public sealed class AlertReadFailureCounter
     /// collector-cost regression self-alert, which does. An operator reading the phantom list would
     /// have hunted a disk-pressure read that cannot fail into this number, and would not have thought
     /// to check the one that can.</para>
+    ///
+    /// <para>The mute-rule reload is the member of this set whose failure leaves a cache that is correct
+    /// and STALE rather than absent — the rules already in force stay in force, so nothing is un-muted, but
+    /// a rule written or deleted during the outage is not honoured yet. Nothing else can tell that apart
+    /// from a cache that is correct and current: the rule list, every mute surface and the stale-mute
+    /// condition all read what the last successful load put there. A nonzero instance total naming this
+    /// read is the artefact, which is why it is counted rather than exempt.</para>
     /// </summary>
     public const string FleetScopedReads =
-        "the collector-cost regression self-alert, and the store background-job health reads behind "
-        + "compression-job health, store-job cadence and retention holds";
+        "the collector-cost regression self-alert, the mute-rule reload, and the store background-job "
+        + "health reads behind compression-job health, store-job cadence and retention holds";
 
     /// <summary>
     /// The window these figures cover, and the window they do NOT.

--- a/PerformanceMonitor.Notifications/IMuteRuleStore.cs
+++ b/PerformanceMonitor.Notifications/IMuteRuleStore.cs
@@ -20,10 +20,19 @@ namespace PerformanceMonitor.Notifications;
 ///               wrapped in completed tasks).
 /// Insert/Update are kept SEPARATE (not a single Upsert) to preserve Lite's
 /// exact SQL — INSERT throws on a duplicate id, UPDATE is a narrow update.
+///
+/// <para><b>Every member THROWS on a store failure, reads included.</b> An empty result from
+/// <see cref="LoadAllAsync"/> means the store holds no rules, and nothing else. A store that swallowed a
+/// failed read and returned empty made those two answers one value, and
+/// <see cref="MuteRuleService.LoadAsync"/> then replaced a live cache with it — so a store blip un-muted
+/// every rule an operator had in force, which is the outcome a permanent rule is chosen to avoid. The
+/// service's reload skips its cache assignment when the read throws, so the previously-loaded set stays
+/// in force; each caller decides how loudly to report the event.</para>
 /// </summary>
 public interface IMuteRuleStore
 {
-    /// <summary>Loads every persisted rule. Lite: SELECT … ORDER BY created_at_utc DESC. Dash: the already-loaded set.</summary>
+    /// <summary>Loads every persisted rule. Lite: SELECT … ORDER BY created_at_utc DESC. Dash: the already-loaded set.
+    /// An empty list means the store holds no rules; a failed read throws rather than rendering as one.</summary>
     Task<IReadOnlyList<MuteRule>> LoadAllAsync();
 
     /// <summary>Persists a new rule. Lite: INSERT one row. Dash: add + rewrite file.</summary>

--- a/PerformanceMonitor.Notifications/IMuteRuleStore.cs
+++ b/PerformanceMonitor.Notifications/IMuteRuleStore.cs
@@ -22,12 +22,12 @@ namespace PerformanceMonitor.Notifications;
 /// exact SQL — INSERT throws on a duplicate id, UPDATE is a narrow update.
 ///
 /// <para><b>Every member THROWS on a store failure, reads included.</b> An empty result from
-/// <see cref="LoadAllAsync"/> means the store holds no rules, and nothing else. A store that swallowed a
-/// failed read and returned empty made those two answers one value, and
-/// <see cref="MuteRuleService.LoadAsync"/> then replaced a live cache with it — so a store blip un-muted
-/// every rule an operator had in force, which is the outcome a permanent rule is chosen to avoid. The
-/// service's reload skips its cache assignment when the read throws, so the previously-loaded set stays
-/// in force; each caller decides how loudly to report the event.</para>
+/// <see cref="LoadAllAsync"/> means the store holds no rules, and nothing else. An implementation that
+/// swallowed a failed read and returned empty would make those two answers one value, and
+/// <see cref="MuteRuleService.LoadAsync"/> replaces its live cache with whatever it is handed — so the
+/// swallow would un-mute every rule an operator has in force on a store blip, which is the outcome a
+/// permanent rule is chosen to avoid. Throwing instead makes the reload skip its cache assignment, so the
+/// set already loaded stays in force; each caller decides how loudly to report the event.</para>
 /// </summary>
 public interface IMuteRuleStore
 {

--- a/PerformanceMonitor.Notifications/MuteRuleService.cs
+++ b/PerformanceMonitor.Notifications/MuteRuleService.cs
@@ -69,8 +69,8 @@ public class MuteRuleService
     /// BEFORE the cache assignment and this method catches nothing, so a read that throws leaves the
     /// previously-loaded rules exactly where they were: the service keeps suppressing what the operator
     /// asked it to suppress until a read succeeds. That ordering is the whole mechanism — a catch here, or
-    /// hoisting the assignment above the await, would put back the defect where a store blip un-muted every
-    /// rule at once and the only surfaces that would have shown it read the same empty cache.</para>
+    /// a cache write hoisted above the await, would let a store blip un-mute every rule at once, and every
+    /// surface that could report it reads this same cache.</para>
     ///
     /// <para>The first load needs no special case and deliberately has none. A fresh or unmigrated store
     /// genuinely has no rules and must not stop the service from starting — and at that point the cache is
@@ -81,8 +81,8 @@ public class MuteRuleService
     /// the store's job, and <see cref="IMuteRuleStore"/> requires it.</para>
     ///
     /// <para>Callers must handle the throw — not to preserve the cache, which is guaranteed here whatever
-    /// they do, but because an unhandled one would take down the host that was collecting. Each does, and
-    /// reports it on the surfaces its own SKU has.</para>
+    /// they do, but because an unhandled one takes down a host whose collection is otherwise healthy. Each
+    /// does, and reports it on the surfaces its own SKU has.</para>
     /// </summary>
     public async Task LoadAsync()
     {

--- a/PerformanceMonitor.Notifications/MuteRuleService.cs
+++ b/PerformanceMonitor.Notifications/MuteRuleService.cs
@@ -61,6 +61,29 @@ public class MuteRuleService
         }
     }
 
+    /// <summary>
+    /// Replaces the cache with the store's rules and purges any that have expired. Reached at service start
+    /// AND on every control-plane reload, so it is a RELOAD as often as it is a startup path.
+    ///
+    /// <para><b>A failed load must not reduce the set of rules in force.</b> The store read is awaited
+    /// BEFORE the cache assignment and this method catches nothing, so a read that throws leaves the
+    /// previously-loaded rules exactly where they were: the service keeps suppressing what the operator
+    /// asked it to suppress until a read succeeds. That ordering is the whole mechanism — a catch here, or
+    /// hoisting the assignment above the await, would put back the defect where a store blip un-muted every
+    /// rule at once and the only surfaces that would have shown it read the same empty cache.</para>
+    ///
+    /// <para>The first load needs no special case and deliberately has none. A fresh or unmigrated store
+    /// genuinely has no rules and must not stop the service from starting — and at that point the cache is
+    /// already empty, so retaining it IS starting clean. One rule covers both.</para>
+    ///
+    /// <para>An empty list from a SUCCESSFUL read still empties the cache: that is an operator deleting
+    /// their last rule, and refusing to honour it would be the opposite error. Distinguishing the two is
+    /// the store's job, and <see cref="IMuteRuleStore"/> requires it.</para>
+    ///
+    /// <para>Callers must handle the throw — not to preserve the cache, which is guaranteed here whatever
+    /// they do, but because an unhandled one would take down the host that was collecting. Each does, and
+    /// reports it on the surfaces its own SKU has.</para>
+    /// </summary>
     public async Task LoadAsync()
     {
         var rules = await _store.LoadAllAsync();


### PR DESCRIPTION
Closes #3354.

## The defect

`MuteRuleService.LoadAsync` read the store and then replaced its cache with whatever came back. Both `IMuteRuleStore` implementations swallowed a failed `LoadAllAsync` and returned an empty list, so "this store holds no rules" and "I could not read them" arrived at that assignment as the same value. `LoadAsync` runs at service start **and** inside the `config_version`-gated control-plane reload, so it runs whenever any config changes — and one failed read dropped every mute in force, delivered the flood those rules existed to stop, and left the service behaving exactly as though the operator had deleted them.

The original rationale is sound where it was written: at first load an empty set is a real answer, because a fresh or unmigrated store genuinely has no rules and refusing to start over that would be worse. At reload the two answers are not interchangeable.

## The change

Both stores propagate the fault, so every `IMuteRuleStore` member now throws on failure rather than one of them rendering a failure as data. `LoadAsync` awaits the read **before** it writes the cache and catches nothing, so a throwing read leaves the previously-loaded rules exactly where they were. The invariant is an ordering, not a branch — the fix is a deletion.

The first load needs no special case and has none: the cache is already empty at that point, so retaining it *is* starting clean. One rule covers startup and reload.

`DuckDbMuteRuleStore`'s swallow was worse than empty in a second way — it returned whatever rows had already been read when the fault hit, so a mid-read failure silently narrowed the set in force.

## Reporting

Darling reaches `LoadAsync` through one guarded helper, so the guard cannot be half-installed across the two call sites. It logs the number of rules left standing and records the failure on #3013's swallowed-alerting-read surface with a null server key, because `config_mute_rules` belongs to the store and not to any monitored server. That read is **counted rather than exempt**: it is a store read, on the alert pass's own command deadline, whose failure changes what the alert engine suppresses on the next sweep. `AlertReadFailureCounter.FleetScopedReads` names it, which both SKUs' `get_collection_health` descriptions concatenate.

Lite's arm was a bare `catch` with no logging, so the event left no artefact on that SKU at all. Its call site now swallows the propagated throw and leaves both artefacts Darling's does — the log line and the count. Both call sites swallow deliberately: the cache is protected inside the service whatever the caller does, and an unhandled throw would take down a host whose collection is otherwise healthy — a larger error than running on a stale mute set.

**Lite records it too, and that is load-bearing rather than tidiness.** `FleetScopedReads` is concatenated into both SKUs' description byte-for-byte, and the mute-rule reload is the only member of that set a Lite process can produce — the other two are Darling store self-alerts with no Lite equivalent. A Lite arm that logged and did not count would leave Lite's own description naming a read that could never reach its instance total: a confident zero, on the surface built to end confident zeroes.

That gap was invisible to the pin that should have caught it. `TheFleetScopedInventory_MatchesWhatTheCounterActuallyRecords` derived the recorded set from the three Darling-side files only, so a Lite recording site was outside what it could see **in either direction** — it could neither find one nor notice one missing. It now reads Lite's call site as well, and dropping that file back out reds it.

`get_mute_rules` and `delete_mute_rule` already wrap their reads, so they now report the fault instead of answering "no mute rules are configured for this store, so no alert is being suppressed anywhere" — the same lie one level up.

## The second-order effect

`Stale Mute Rules` (#3306) reads the live `MuteRuleService` cache. With the cache wrongly empty it found nothing stale, cleared its edge and wrote a **resolution** row: the surface built to make an invisible mute visible asserting that nothing was suppressed, at the moment everything had been un-suppressed. It is pinned in `DarlingSelfAlertTests` against a real service over a scripted store — a rule list handed in directly cannot express a failed reload.

## Pins

Every behavioural pin comes as a pair, because a retention arm alone is satisfied by a cache that never updates:

- a failed reload leaves the previously-loaded rules in force / a legitimately-empty read still empties the cache
- the first load on an unreadable store starts clean rather than inventing rules
- a failed reload writes nothing to the store it could not read / a successful load carrying an expired rule does purge
- `Stale Mute Rules` cannot write a resolution off a failed read / still writes one when the rule is really gone
- the ordering, pinned from source: the read precedes the first cache write and nothing between them catches
- neither store turns a failed read into an empty rule set — the pin that would have caught this
- Darling reaches the reload through one helper that swallows, logs the retained count and records the failure
- Lite's call site is inside a try whose handler leaves an artefact
- the same invariant asserted in `Lite.Tests`, so both SKUs' compilations of the shared service are covered

No migration rung: this is in-process logic, and `StorageVersion.SchemaVersion` is untouched at 119.

## Verification

The Windows-only suites cannot run on macOS, so the actual committed test sources were compiled into two `net10.0` console harnesses with an xunit shim and run — one for `Darling.Tests` (580 passed, 0 failed, 7 skipped for live-Postgres or DPAPI), one for the `Lite.Tests` files this touches (10 passed). Both harnesses build inside the worktree so the whole-tree guards that walk up from the test binary find `PerformanceMonitor.sln`, and the runner's own must-fail fixtures were confirmed red before either pass was trusted.

Sixteen mutations, each verified to have landed by content and each restored by content:

| mutation | reds |
|---|---|
| cache cleared before the read (the defect, throw intact) | the ordering pin, both retention arms, the stale-mute pin |
| `LoadAsync` swallows the fault and carries on empty | six pins across both harnesses |
| a reload never shrinks the cache (the over-correction) | both empty-read arms, the stale-mute pin |
| a genuine swallow back in `PgMuteRuleStore` | the Pg store pin only |
| a genuine swallow back in `DuckDbMuteRuleStore` | the Lite store pin only |
| the helper rethrows | the helper pin |
| the reload path bypasses the helper | the helper pin |
| the count dropped from the helper | all five census pins plus the helper pin |
| the inventory constant stops naming the read | the fleet-scoped inventory |
| the read name behind a constant instead of a literal | three census pins — a constant does not pass silently |
| Lite's guard removed | Lite's call-site pin |
| Lite logs the failure but does not count it | Lite's call-site pin and the fleet-scoped inventory |
| Lite's clock started inside the catch (can only measure zero) | Lite's call-site pin |
| Lite records the same read under a second name | Lite's call-site pin |
| **the instrument** — `Member()` returns an empty span; `EnclosingTryBlock()` never finds a try; the inventory scan drops Lite's file | the pins each one feeds, so their controls are real |

One finding came out of that: the ordering pin's first form anchored on `_rules = rules.ToList()`, which stayed green under the clear-then-read mutation while all three behavioural arms went red — the clear lands, the read throws, and the assignment it was watching never runs. It now anchors on the first write to the cache whatever it assigns.


## Review round

`claude[bot]` found the Lite counting gap described above — accurately, and at the right place. Its first pass raised one further nit, that `Lite.Tests/AlertReadFailureSurfaceTests.cs` said "a fourth fleet-scoped site" beside an asserted count of three. That reading was wrong (the sentence is about the NEXT site, so with three the fourth is correct), but checking it turned up something real: the numeral had been wrong since #3040 introduced "a sixth" alongside an asserted count of **two**, and it survived a whole issue cycle. The sentence now points at the assertion instead of carrying its own numeral.
