### PR TITLE
Add tag scope to custom alert rules (#3350)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertRuleDefinitionTests.cs
+++ b/Darling/Darling.Tests/CustomAlertRuleDefinitionTests.cs
@@ -140,11 +140,48 @@ public class CustomAlertRuleDefinitionTests
     }
 
     [Fact]
-    public void TagScope_IsRejectedForNow()
+    public void TagScope_Parses_WithStableTagId()
+    {
+        // #3350: a tag-scoped rule stores the tag's STABLE integer id (scope.tagId), so a rename never
+        // re-scopes it; the evaluator resolves the id -> the tag's server set at sweep time.
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1}," +
+            "\"scope\":{\"mode\":\"tag\",\"tagId\":7}}");
+
+        Assert.Null(error);
+        Assert.NotNull(def);
+        Assert.Equal(CustomAlertScopeMode.Tag, def!.ScopeMode);
+        Assert.Equal(7, def.ScopeTagId);
+        // A tag rule cannot be decided from a storage name alone — AppliesTo (All/Servers only) returns false.
+        Assert.False(def.AppliesTo("anything"));
+    }
+
+    [Fact]
+    public void TagScope_MissingTagId_IsError()
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1},\"scope\":{\"mode\":\"tag\"}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TagScope_NonIntegerTagId_IsError()
+    {
+        // A tag is stored by its stable integer id, never its name — a string tagId is rejected.
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1}," +
+            "\"scope\":{\"mode\":\"tag\",\"tagId\":\"prod\"}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TagScope_NonPositiveTagId_IsError()
     {
         var (def, error) = CustomAlertRuleDefinition.TryParse(
             "{" + Metric + ",\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1}," +
-            "\"scope\":{\"mode\":\"tag\",\"tag\":\"prod\"}}");
+            "\"scope\":{\"mode\":\"tag\",\"tagId\":0}}");
         Assert.Null(def);
         Assert.NotNull(error);
     }

--- a/Darling/Darling.Tests/CustomAlertRuleHealthTests.cs
+++ b/Darling/Darling.Tests/CustomAlertRuleHealthTests.cs
@@ -117,7 +117,7 @@ public class CustomAlertRuleHealthTests
         var def = Parse(row.DefinitionJson);
 
         var issue = CustomAlertEvaluator.ClassifyNeverFiring(
-            row, def, "pg cpu", new[] { "PROD01", "PROD02" }, noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
+            row, def, null, "pg cpu", new[] { (1, "PROD01"), (2, "PROD02") }, noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
 
         Assert.NotNull(issue);
         Assert.Equal(3, issue!.RuleId);
@@ -131,7 +131,7 @@ public class CustomAlertRuleHealthTests
         var def = Parse(row.DefinitionJson);
 
         var issue = CustomAlertEvaluator.ClassifyNeverFiring(
-            row, def, "pg cpu", new[] { "PROD01", "PROD02" }, noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
+            row, def, null, "pg cpu", new[] { (1, "PROD01"), (2, "PROD02") }, noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
 
         Assert.Null(issue);
     }
@@ -144,7 +144,7 @@ public class CustomAlertRuleHealthTests
         var def = Parse(row.DefinitionJson);
 
         var issue = CustomAlertEvaluator.ClassifyNeverFiring(
-            row, def, "everywhere", Array.Empty<string>(), noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
+            row, def, null, "everywhere", Array.Empty<(int, string)>(), noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
 
         Assert.Null(issue);
     }
@@ -157,7 +157,7 @@ public class CustomAlertRuleHealthTests
         var now = new DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc);
 
         var issue = CustomAlertEvaluator.ClassifyNeverFiring(
-            row, def, "always null", new[] { "PROD01" },
+            row, def, null, "always null", new[] { (1, "PROD01") },
             noDataSinceUtc: now - CustomAlertEvaluator.NoDataFlagWindow - TimeSpan.FromMinutes(1),
             nowUtc: now);
 
@@ -173,7 +173,7 @@ public class CustomAlertRuleHealthTests
         var now = new DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc);
 
         var issue = CustomAlertEvaluator.ClassifyNeverFiring(
-            row, def, "recent gap", new[] { "PROD01" },
+            row, def, null, "recent gap", new[] { (1, "PROD01") },
             noDataSinceUtc: now - TimeSpan.FromMinutes(2), // well within the window
             nowUtc: now);
 
@@ -187,7 +187,55 @@ public class CustomAlertRuleHealthTests
         var def = Parse(row.DefinitionJson);
 
         var issue = CustomAlertEvaluator.ClassifyNeverFiring(
-            row, def, "healthy", new[] { "PROD01" }, noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
+            row, def, null, "healthy", new[] { (1, "PROD01") }, noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
+
+        Assert.Null(issue);
+    }
+
+    // ─────────────────────────── ClassifyNeverFiring (tag scope, #3350) ───────────────────────────
+
+    [Fact]
+    public void ClassifyNeverFiring_TagScope_NoMonitoredMember_IsFlagged()
+    {
+        var row = Rule(6, "tagged", ValidJson("\"scope\":{\"mode\":\"tag\",\"tagId\":5}"));
+        var def = Parse(row.DefinitionJson);
+
+        // The tag resolves to server 999, which is not among the monitored servers -> the rule never evaluates.
+        var issue = CustomAlertEvaluator.ClassifyNeverFiring(
+            row, def, new HashSet<int> { 999 }, "tagged",
+            new[] { (1, "PROD01"), (2, "PROD02") }, noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
+
+        Assert.NotNull(issue);
+        Assert.Equal(6, issue!.RuleId);
+        Assert.Contains("tag", issue.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ClassifyNeverFiring_TagScope_EmptyTag_IsFlagged()
+    {
+        // A tag that resolves to no members (empty / deleted / renamed away) matches no server, so a rule scoped
+        // to it can never fire — the #3350 integrity requirement, surfaced through the SAME #3304 self-health.
+        var row = Rule(6, "empty tag", ValidJson("\"scope\":{\"mode\":\"tag\",\"tagId\":5}"));
+        var def = Parse(row.DefinitionJson);
+
+        var issue = CustomAlertEvaluator.ClassifyNeverFiring(
+            row, def, new HashSet<int>(), "empty tag",
+            new[] { (1, "PROD01") }, noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
+
+        Assert.NotNull(issue);
+        Assert.Contains("tag", issue!.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ClassifyNeverFiring_TagScope_WithMonitoredMember_IsNotFlagged()
+    {
+        var row = Rule(6, "tagged", ValidJson("\"scope\":{\"mode\":\"tag\",\"tagId\":5}"));
+        var def = Parse(row.DefinitionJson);
+
+        // The tag resolves to server 1, which IS monitored -> firing-eligible, not flagged.
+        var issue = CustomAlertEvaluator.ClassifyNeverFiring(
+            row, def, new HashSet<int> { 1 }, "tagged",
+            new[] { (1, "PROD01"), (2, "PROD02") }, noDataSinceUtc: null, nowUtc: DateTime.UtcNow);
 
         Assert.Null(issue);
     }

--- a/Darling/Darling.Tests/CustomAlertTagScopeTests.cs
+++ b/Darling/Darling.Tests/CustomAlertTagScopeTests.cs
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+using PerformanceMonitor.Darling.Service;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3350: the tag-aware scope gate <see cref="CustomAlertEvaluator.RuleAppliesToServer"/> — the single "does this
+/// rule evaluate this server" decision the sweep, the reconcile teardown, and the never-firing check all route
+/// through. All/Servers is the pure name-based <see cref="CustomAlertRuleDefinition.AppliesTo"/>; Tag is
+/// membership of the server-id set the evaluator resolves from <c>config.server_tag_map</c>. A tag that resolves
+/// to no members (a null or empty set) matches no server, so the rule never fires. The live tag-membership READ
+/// is exercised through the evaluate-now / evaluator live tests; this pins the pure gate.
+/// </summary>
+public class CustomAlertTagScopeTests
+{
+    private const string Metric = "\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}";
+
+    private static CustomAlertRuleDefinition Parse(string? scope)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1}" + (scope is null ? "" : "," + scope) + "}");
+        Assert.Null(error);
+        Assert.NotNull(def);
+        return def!;
+    }
+
+    private static CustomAlertRuleDefinition AllScope() => Parse(null);
+
+    private static CustomAlertRuleDefinition ServersScope(string server) =>
+        Parse("\"scope\":{\"mode\":\"servers\",\"servers\":[\"" + server + "\"]}");
+
+    private static CustomAlertRuleDefinition TagScope(int tagId) =>
+        Parse("\"scope\":{\"mode\":\"tag\",\"tagId\":" + tagId + "}");
+
+    [Fact]
+    public void AllScope_AppliesToAnyServer_IgnoringTheTagSet()
+    {
+        Assert.True(CustomAlertEvaluator.RuleAppliesToServer(
+            AllScope(), tagServerIds: null, serverId: 42, storageName: "PROD01"));
+    }
+
+    [Fact]
+    public void ServersScope_MatchesOnStorageName_CaseInsensitive_IgnoringServerId()
+    {
+        var def = ServersScope("PROD01");
+        Assert.True(CustomAlertEvaluator.RuleAppliesToServer(def, tagServerIds: null, serverId: 999, storageName: "prod01"));
+        Assert.False(CustomAlertEvaluator.RuleAppliesToServer(def, tagServerIds: null, serverId: 999, storageName: "PROD02"));
+    }
+
+    [Fact]
+    public void TagScope_ServerInTheResolvedSet_Applies()
+    {
+        var members = new HashSet<int> { 101, 202 };
+        Assert.True(CustomAlertEvaluator.RuleAppliesToServer(TagScope(5), members, serverId: 101, storageName: "PROD01"));
+    }
+
+    [Fact]
+    public void TagScope_ServerNotInTheResolvedSet_DoesNotApply()
+    {
+        // The storage name would satisfy a 'servers' scope, but tag scope is decided by server-id membership only.
+        var members = new HashSet<int> { 202 };
+        Assert.False(CustomAlertEvaluator.RuleAppliesToServer(TagScope(5), members, serverId: 101, storageName: "PROD01"));
+    }
+
+    [Fact]
+    public void TagScope_NullResolvedSet_NeverApplies()
+    {
+        // A tag not resolved this pass matches no server -> the rule never fires (no accidental fleet-wide fire).
+        Assert.False(CustomAlertEvaluator.RuleAppliesToServer(TagScope(5), tagServerIds: null, serverId: 101, storageName: "PROD01"));
+    }
+
+    [Fact]
+    public void TagScope_EmptyResolvedSet_NeverApplies()
+    {
+        // An empty / deleted / renamed-away tag resolves to no members -> matches nothing.
+        Assert.False(CustomAlertEvaluator.RuleAppliesToServer(TagScope(5), new HashSet<int>(), serverId: 101, storageName: "PROD01"));
+    }
+}

--- a/Darling/Darling.Tests/CustomAlertTeardownTests.cs
+++ b/Darling/Darling.Tests/CustomAlertTeardownTests.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System.Collections.Generic;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
 
@@ -27,6 +28,10 @@ public class CustomAlertTeardownTests
         "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
         "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1000},\"scope\":{\"mode\":\"servers\",\"servers\":[\"" + server + "\"]}}");
 
+    private static CustomAlertRuleDefinition TagScope() => Parse(
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
+        "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1000},\"scope\":{\"mode\":\"tag\",\"tagId\":5}}");
+
     private static CustomAlertRuleDefinition Parse(string json)
     {
         var (def, error) = CustomAlertRuleDefinition.TryParse(json);
@@ -41,26 +46,26 @@ public class CustomAlertTeardownTests
         // A disabled rule is not in the enabled cache, so the reconcile passes a null definition; disabled wins.
         Assert.Equal(
             CustomAlertEvaluator.TeardownReasonDisabled,
-            CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: false, definition: null, serverStorageName: "PROD01"));
+            CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: false, definition: null, tagServerIds: null, serverId: 1, serverStorageName: "PROD01"));
     }
 
     [Fact]
     public void EnabledRule_WithNoCachedDefinition_IsLeftAlone()
     {
         // Just-enabled or a stale cache: don't tear down on uncertainty.
-        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, definition: null, serverStorageName: "PROD01"));
+        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, definition: null, tagServerIds: null, serverId: 1, serverStorageName: "PROD01"));
     }
 
     [Fact]
     public void EnabledAllScopeRule_WithAMonitoredServer_IsKept()
     {
-        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, AllScope(), serverStorageName: "PROD01"));
+        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, AllScope(), tagServerIds: null, serverId: 1, serverStorageName: "PROD01"));
     }
 
     [Fact]
     public void EnabledServersScopeRule_ServerInScope_IsKept()
     {
-        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, ServersScope("PROD01"), serverStorageName: "PROD01"));
+        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, ServersScope("PROD01"), tagServerIds: null, serverId: 1, serverStorageName: "PROD01"));
     }
 
     [Fact]
@@ -68,7 +73,7 @@ public class CustomAlertTeardownTests
     {
         Assert.Equal(
             CustomAlertEvaluator.TeardownReasonOutOfScope,
-            CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, ServersScope("PROD01"), serverStorageName: "PROD02"));
+            CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, ServersScope("PROD01"), tagServerIds: null, serverId: 1, serverStorageName: "PROD02"));
     }
 
     [Fact]
@@ -79,6 +84,37 @@ public class CustomAlertTeardownTests
         // even though an "all"-scoped rule would otherwise apply to it.
         Assert.Equal(
             CustomAlertEvaluator.TeardownReasonOutOfScope,
-            CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, AllScope(), serverStorageName: null));
+            CustomAlertEvaluator.ClassifyStateTeardown(ruleEnabled: true, AllScope(), tagServerIds: null, serverId: 1, serverStorageName: null));
+    }
+
+    [Fact]
+    public void EnabledTagScopeRule_ServerInTag_IsKept()
+    {
+        // The server's id is in the tag's resolved member set -> in scope, keep the row.
+        var members = new HashSet<int> { 101 };
+        Assert.Null(CustomAlertEvaluator.ClassifyStateTeardown(
+            ruleEnabled: true, TagScope(), members, serverId: 101, serverStorageName: "PROD01"));
+    }
+
+    [Fact]
+    public void EnabledTagScopeRule_ServerLeftTag_IsTornDown()
+    {
+        // The server is still monitored, but its id is no longer in the tag's resolved set (it left the tag) —
+        // out of scope, so its open incident is force-resolved (#3350), the same idiom as leaving a 'servers' scope.
+        var members = new HashSet<int> { 202 };
+        Assert.Equal(
+            CustomAlertEvaluator.TeardownReasonOutOfScope,
+            CustomAlertEvaluator.ClassifyStateTeardown(
+                ruleEnabled: true, TagScope(), members, serverId: 101, serverStorageName: "PROD01"));
+    }
+
+    [Fact]
+    public void EnabledTagScopeRule_EmptyTag_IsTornDown()
+    {
+        // A tag that resolves to no members (empty / deleted) matches no server, so any lingering state is stale.
+        Assert.Equal(
+            CustomAlertEvaluator.TeardownReasonOutOfScope,
+            CustomAlertEvaluator.ClassifyStateTeardown(
+                ruleEnabled: true, TagScope(), new HashSet<int>(), serverId: 101, serverStorageName: "PROD01"));
     }
 }

--- a/Darling/Darling.Tests/DarlingMcpCustomAlertToolsTests.cs
+++ b/Darling/Darling.Tests/DarlingMcpCustomAlertToolsTests.cs
@@ -146,6 +146,31 @@ public sealed class DarlingMcpCustomAlertToolsSurfaceTests
     }
 
     [Fact]
+    public async Task ValidateCustomAlertRule_TagScope_ReturnsValidTrue()
+    {
+        // #3350: a tag-scoped rule stores the tag's stable integer id; the validator accepts it (the evaluator
+        // resolves the id -> the tag's server set at sweep time — no store hit in the validator).
+        var rule =
+            "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
+            "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1000},\"scope\":{\"mode\":\"tag\",\"tagId\":7}}";
+        var result = await DarlingMcpCustomAlertTools.ValidateCustomAlertRule(rule);
+        using var doc = JsonDocument.Parse(result);
+        Assert.True(doc.RootElement.GetProperty("valid").GetBoolean(), result);
+    }
+
+    [Fact]
+    public async Task ValidateCustomAlertRule_TagScopeMissingTagId_ReturnsValidFalse()
+    {
+        var rule =
+            "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
+            "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1000},\"scope\":{\"mode\":\"tag\"}}";
+        var result = await DarlingMcpCustomAlertTools.ValidateCustomAlertRule(rule);
+        using var doc = JsonDocument.Parse(result);
+        Assert.False(doc.RootElement.GetProperty("valid").GetBoolean(), result);
+        Assert.Contains("tagId", doc.RootElement.GetProperty("error").GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task CreateCustomAlertRule_InvalidDefinition_ReturnsInvalid_WithoutTouchingTheStore()
     {
         /* Validation runs BEFORE persistence, so a bad definition returns 'invalid' without ever opening a
@@ -196,6 +221,12 @@ public sealed class DarlingMcpCustomAlertToolsLivePostgresTests
     private const string BadMeasureRule =
         "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"nope\",\"aggregate\":\"sum\",\"hours\":1}," +
         "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1}}";
+
+    /* #3350: a tag-scoped rule. The tag id rides as opaque scope JSON — the rule stores/returns it verbatim, so
+       the round-trip does not require the tag itself to exist (membership is resolved only at evaluation time). */
+    private const string TagScopedRule =
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
+        "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1000},\"scope\":{\"mode\":\"tag\",\"tagId\":123456}}";
 
     private static string? ConnectionString => Environment.GetEnvironmentVariable("DARLING_TEST_PG");
 
@@ -317,6 +348,63 @@ public sealed class DarlingMcpCustomAlertToolsLivePostgresTests
             {
                 await DarlingMcpTestData.ExecAsync(cleanup, cleanupCt,
                     "DELETE FROM config.custom_alert_rules WHERE name = $1 OR name = $2", name, name + "_invalid");
+            });
+        }
+    }
+
+    [Fact]
+    public async Task CustomAlertRule_TagScope_RoundTripsThroughCreateAndGet_AgainstDevPostgres()
+    {
+        // #3350: a tag-scoped rule survives create -> get with its scope intact (mode "tag" + the stable tagId).
+        // The definition is stored as jsonb and returned verbatim, so tag scope rides through the CRUD the same
+        // way All/Servers do — no tag row needs to exist for the round-trip (resolution happens at sweep time).
+        var cs = ConnectionString;
+        Assert.SkipWhen(string.IsNullOrEmpty(cs),
+            "Set DARLING_TEST_PG to a Postgres connection string (owner/superuser) to run the tag-scope round-trip live test.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await using (var migrate = new NpgsqlConnection(cs))
+        {
+            await migrate.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(migrate, ct);
+        }
+
+        var dataSourceConnectionString = new NpgsqlConnectionStringBuilder(cs)
+        {
+            SearchPath = "collect,config,public",
+        }.ConnectionString;
+
+        await using var postgres = NpgsqlDataSource.Create(dataSourceConnectionString);
+
+        var name = "car_tag_live_" + Guid.NewGuid().ToString("N");
+        var bodySucceeded = false;
+        try
+        {
+            long id;
+            using (var created = JsonDocument.Parse(
+                await DarlingMcpCustomAlertTools.CreateCustomAlertRule(postgres, name, TagScopedRule)))
+            {
+                id = created.RootElement.GetProperty("id").GetInt64();
+            }
+
+            using (var fetched = JsonDocument.Parse(await DarlingMcpCustomAlertTools.GetCustomAlertRule(postgres, id)))
+            {
+                // definition is embedded as a JSON object (BuildFullRuleNode parses the stored jsonb).
+                var scope = fetched.RootElement.GetProperty("definition").GetProperty("scope");
+                Assert.Equal("tag", scope.GetProperty("mode").GetString());
+                Assert.Equal(123456, scope.GetProperty("tagId").GetInt32());
+            }
+
+            Assert.Equal("deleted", DarlingMcpTestData.StatusOf(await DarlingMcpCustomAlertTools.DeleteCustomAlertRule(postgres, id)));
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(cs!, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DarlingMcpTestData.ExecAsync(cleanup, cleanupCt,
+                    "DELETE FROM config.custom_alert_rules WHERE name = $1", name);
             });
         }
     }

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
@@ -70,7 +70,49 @@ public sealed class CustomAlertEvaluator
 
     private DateTime _cacheRefreshedUtc = DateTime.MinValue;
 
-    private sealed record ParsedRule(CustomAlertRule Row, CustomAlertRuleDefinition Definition);
+    /// <summary>A parsed, enabled rule plus — for a tag-scoped rule (#3350) — the server-id set its tag currently
+    /// resolves to (from <c>config.server_tag_map</c>, refreshed alongside the rule cache). <c>null</c> for an
+    /// All/Servers rule (those are decided purely from the storage name); an EMPTY set for a tag that currently
+    /// has no members, so the rule matches no server and never fires.</summary>
+    private sealed record ParsedRule(
+        CustomAlertRule Row, CustomAlertRuleDefinition Definition, IReadOnlySet<int>? TagServerIds)
+    {
+        /// <summary>Whether this rule evaluates the given monitored server, honoring tag scope.</summary>
+        public bool AppliesToServer(int serverId, string storageName) =>
+            RuleAppliesToServer(Definition, TagServerIds, serverId, storageName);
+    }
+
+    /// <summary>An empty tag→members map (an empty rule set, or when no rule is tag-scoped this pass).</summary>
+    private static readonly IReadOnlyDictionary<int, IReadOnlySet<int>> EmptyTagMembers =
+        new Dictionary<int, IReadOnlySet<int>>();
+
+    /// <summary>The shared "matches no server" set for a tag that currently resolves to no member — read-only,
+    /// so one shared instance is safe.</summary>
+    private static readonly IReadOnlySet<int> EmptyServerIds = new HashSet<int>();
+
+    /// <summary>
+    /// Whether a rule applies to one monitored server, across ALL scope modes (#3350) — the single tag-aware
+    /// gate the sweep, the reconcile teardown, and the never-firing check all route through. All/Servers is the
+    /// pure <see cref="CustomAlertRuleDefinition.AppliesTo"/> over the storage name; <see cref="CustomAlertScopeMode.Tag"/>
+    /// is membership of the resolved server-id set (<paramref name="tagServerIds"/>, resolved once per cache
+    /// refresh from <c>config.server_tag_map</c>). A tag that resolves to no servers — empty, deleted, or
+    /// renamed away — is a null/empty set, so the rule matches no server and never fires; that 0-server case is
+    /// surfaced by the #3304 never-firing self-health check. Pure so it is unit-testable without a store.
+    /// </summary>
+    internal static bool RuleAppliesToServer(
+        CustomAlertRuleDefinition definition, IReadOnlySet<int>? tagServerIds, int serverId, string storageName) =>
+        definition.ScopeMode == CustomAlertScopeMode.Tag
+            ? tagServerIds is not null && tagServerIds.Contains(serverId)
+            : definition.AppliesTo(storageName);
+
+    /// <summary>The resolved server-id set to attach to a parsed rule: for a tag-scoped rule, its tag's current
+    /// members from <paramref name="tagMembers"/> (an EMPTY set when the tag has no members / is gone, so the
+    /// rule matches nothing); <c>null</c> for an All/Servers rule (those are decided from the storage name).</summary>
+    private static IReadOnlySet<int>? ResolveTagServers(
+        CustomAlertRuleDefinition definition, IReadOnlyDictionary<int, IReadOnlySet<int>> tagMembers) =>
+        definition.ScopeMode != CustomAlertScopeMode.Tag || definition.ScopeTagId is not int tagId
+            ? null
+            : tagMembers.TryGetValue(tagId, out var ids) ? ids : EmptyServerIds;
 
     public CustomAlertEvaluator(
         CustomAlertRuleStore ruleStore,
@@ -192,7 +234,7 @@ public sealed class CustomAlertEvaluator
             return;
         }
 
-        var applicable = rules.Where(r => r.Definition.AppliesTo(storageName)).ToList();
+        var applicable = rules.Where(r => r.AppliesToServer(serverId, storageName)).ToList();
         if (applicable.Count == 0)
         {
             return;
@@ -217,7 +259,7 @@ public sealed class CustomAlertEvaluator
         }
 
         var now = DateTime.UtcNow;
-        foreach (var (row, def) in applicable)
+        foreach (var (row, def, _) in applicable)
         {
             try
             {
@@ -575,7 +617,22 @@ public sealed class CustomAlertEvaluator
             _logger.LogWarning("Custom alert rule {Id} '{Name}' will NOT fire: {Reason}", b.RuleId, b.RuleName, b.Reason);
         }
 
-        var parsed = parsedPairs.Select(p => new ParsedRule(p.Row, p.Definition)).ToList();
+        // #3350: resolve every tag-scoped rule's CURRENT server membership once per cache refresh (one round-trip
+        // for all tags), so the per-server gate + the reconcile teardown honor the live tag assignment without a
+        // per-server query. A store failure here propagates like a rule-load failure — the caller skips this tick
+        // and the cache is not advanced, so the next tick retries; the previous good cache is not returned stale.
+        var tagIds = parsedPairs
+            .Where(p => p.Definition.ScopeMode == CustomAlertScopeMode.Tag && p.Definition.ScopeTagId is not null)
+            .Select(p => p.Definition.ScopeTagId!.Value)
+            .Distinct()
+            .ToList();
+        var tagMembers = tagIds.Count > 0
+            ? await _ruleStore.ListTagMembersAsync(tagIds, cancellationToken)
+            : EmptyTagMembers;
+
+        var parsed = parsedPairs
+            .Select(p => new ParsedRule(p.Row, p.Definition, ResolveTagServers(p.Definition, tagMembers)))
+            .ToList();
 
         // Drop no-data bookkeeping for rules that are gone (disabled/deleted) or now broken, so the in-memory
         // map tracks only the currently-parsed, evaluable set and cannot grow without bound.
@@ -650,24 +707,30 @@ public sealed class CustomAlertEvaluator
     }
 
     /// <summary>
-    /// Classifies whether a rule that DOES compile is nonetheless "armed but never fires" (#3304) — the two
-    /// cases that pass the compile-check yet can never deliver: a rule scoped to specific servers that are not
-    /// currently monitored (so it never evaluates), and a rule that has produced no data for longer than
-    /// <see cref="NoDataFlagWindow"/> (an always-NULL measure, or a dead collector). Returns the issue, or null
-    /// when the rule is firing-eligible. Pure so both cases are unit-testable with controlled inputs.
+    /// Classifies whether a rule that DOES compile is nonetheless "armed but never fires" (#3304) — the cases
+    /// that pass the compile-check yet can never deliver: a rule whose scope matches no currently-monitored
+    /// server (a 'servers' scope naming only unmonitored servers, or a #3350 tag scope whose tag is empty /
+    /// deleted / holds only unmonitored servers — <paramref name="tagServerIds"/> is that tag's resolved set),
+    /// and a rule that has produced no data for longer than <see cref="NoDataFlagWindow"/> (an always-NULL
+    /// measure, or a dead collector). Returns the issue, or null when the rule is firing-eligible. Pure so every
+    /// case is unit-testable with controlled inputs.
     /// </summary>
     internal static CustomAlertRuleHealthIssue? ClassifyNeverFiring(
-        CustomAlertRule row, CustomAlertRuleDefinition definition, string sanitizedName,
-        IReadOnlyCollection<string> monitoredStorageNames, DateTime? noDataSinceUtc, DateTime nowUtc)
+        CustomAlertRule row, CustomAlertRuleDefinition definition, IReadOnlySet<int>? tagServerIds,
+        string sanitizedName, IReadOnlyCollection<(int ServerId, string StorageName)> monitoredServers,
+        DateTime? noDataSinceUtc, DateTime nowUtc)
     {
-        // A server-scoped rule whose named servers are not currently monitored never enters any server's
-        // applicable set, so it is evaluated zero times, so it can never fire. (An "all"-scoped rule always
-        // applies to whatever fleet exists, so an empty fleet is not a per-rule defect and is not flagged.)
-        if (definition.ScopeMode == CustomAlertScopeMode.Servers && !monitoredStorageNames.Any(definition.AppliesTo))
+        // A server- or tag-scoped rule that matches no CURRENTLY-monitored server never enters any server's
+        // applicable set, so it is evaluated zero times and can never fire. (An "all"-scoped rule always applies
+        // to whatever fleet exists, so an empty fleet is not a per-rule defect and is not flagged.) Both the
+        // 'servers'-scope case and the #3350 tag-scope 0-server case flow through the SAME tag-aware gate.
+        if (definition.ScopeMode != CustomAlertScopeMode.All
+            && !monitoredServers.Any(s => RuleAppliesToServer(definition, tagServerIds, s.ServerId, s.StorageName)))
         {
-            return new CustomAlertRuleHealthIssue(
-                row.Id, sanitizedName,
-                "armed but scoped only to servers that are not currently monitored, so it never evaluates");
+            var reason = definition.ScopeMode == CustomAlertScopeMode.Tag
+                ? "armed but its tag currently matches no monitored server (the tag is empty, was deleted, or none of its servers are monitored), so it never evaluates"
+                : "armed but scoped only to servers that are not currently monitored, so it never evaluates";
+            return new CustomAlertRuleHealthIssue(row.Id, sanitizedName, reason);
         }
 
         // Produced no data continuously for longer than the window: an always-NULL measure for every in-scope
@@ -692,7 +755,7 @@ public sealed class CustomAlertEvaluator
     /// empty report would read as "all healthy" and clear a real broken-rule alert.
     /// </summary>
     public async Task<CustomAlertHealthReport?> BuildHealthReportAsync(
-        IReadOnlyCollection<string> monitoredStorageNames, CancellationToken cancellationToken)
+        IReadOnlyCollection<(int ServerId, string StorageName)> monitoredServers, CancellationToken cancellationToken)
     {
         IReadOnlyList<ParsedRule> parsed;
         try
@@ -714,12 +777,12 @@ public sealed class CustomAlertEvaluator
 
         var now = DateTime.UtcNow;
         var neverFiring = new List<CustomAlertRuleHealthIssue>();
-        foreach (var (row, def) in parsed)
+        foreach (var p in parsed)
         {
-            var since = _noDataSinceUtc.TryGetValue(row.Id, out var s) ? s : (DateTime?)null;
+            var since = _noDataSinceUtc.TryGetValue(p.Row.Id, out var s) ? s : (DateTime?)null;
             var issue = ClassifyNeverFiring(
-                row, def, SanitizeDisplayText(row.Name, CustomAlertRuleStore.MaxNameLength),
-                monitoredStorageNames, since, now);
+                p.Row, p.Definition, p.TagServerIds, SanitizeDisplayText(p.Row.Name, CustomAlertRuleStore.MaxNameLength),
+                monitoredServers, since, now);
             if (issue is not null)
             {
                 neverFiring.Add(issue);
@@ -733,13 +796,16 @@ public sealed class CustomAlertEvaluator
     /// Decides whether one persisted (rule, server) state row should be TORN DOWN (#3305): a disabled rule's
     /// state is orphaned (the evaluator's <c>ListEnabledAsync</c> skips it, so its incident never resolves on its
     /// own), and an enabled rule's state for a server that has left its scope — or left monitoring entirely
-    /// (<paramref name="serverStorageName"/> null) — is stale. Returns the teardown reason, or null to KEEP the
-    /// row. Conservative on uncertainty: an enabled rule whose definition is not currently in the cache
-    /// (<paramref name="definition"/> null — just enabled, or a stale cache) is left alone rather than torn down.
-    /// Pure so both teardown cases are unit-testable without a store.
+    /// (<paramref name="serverStorageName"/> null) — is stale. Scope is the tag-aware
+    /// <see cref="RuleAppliesToServer"/>, so a server that has LEFT a tag-scoped rule's tag (#3350) — its id no
+    /// longer in <paramref name="tagServerIds"/> — is torn down exactly like one that left a 'servers' scope.
+    /// Returns the teardown reason, or null to KEEP the row. Conservative on uncertainty: an enabled rule whose
+    /// definition is not currently in the cache (<paramref name="definition"/> null — just enabled, or a stale
+    /// cache) is left alone rather than torn down. Pure so every teardown case is unit-testable without a store.
     /// </summary>
     internal static string? ClassifyStateTeardown(
-        bool ruleEnabled, CustomAlertRuleDefinition? definition, string? serverStorageName)
+        bool ruleEnabled, CustomAlertRuleDefinition? definition, IReadOnlySet<int>? tagServerIds,
+        int serverId, string? serverStorageName)
     {
         if (!ruleEnabled)
         {
@@ -752,7 +818,8 @@ public sealed class CustomAlertEvaluator
             return null;
         }
 
-        if (serverStorageName is null || !definition.AppliesTo(serverStorageName))
+        if (serverStorageName is null
+            || !RuleAppliesToServer(definition, tagServerIds, serverId, serverStorageName))
         {
             return TeardownReasonOutOfScope;
         }
@@ -789,7 +856,7 @@ public sealed class CustomAlertEvaluator
             return;
         }
 
-        var definitionsById = parsed.ToDictionary(p => p.Row.Id, p => p.Definition);
+        var parsedById = parsed.ToDictionary(p => p.Row.Id, p => p);
 
         IReadOnlyList<CustomAlertStateRow> rows;
         try
@@ -811,8 +878,9 @@ public sealed class CustomAlertEvaluator
             cancellationToken.ThrowIfCancellationRequested();
 
             var storageName = monitoredServers.TryGetValue(row.ServerId, out var server) ? server.StorageName : null;
-            var definition = definitionsById.TryGetValue(row.RuleId, out var def) ? def : null;
-            var reason = ClassifyStateTeardown(row.RuleEnabled, definition, storageName);
+            var parsedRule = parsedById.TryGetValue(row.RuleId, out var pr) ? pr : null;
+            var reason = ClassifyStateTeardown(
+                row.RuleEnabled, parsedRule?.Definition, parsedRule?.TagServerIds, row.ServerId, storageName);
             if (reason is null)
             {
                 continue;

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleDefinition.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleDefinition.cs
@@ -24,11 +24,15 @@ public enum CustomAlertOp
     LessOrEqual,
 }
 
-/// <summary>Which servers a rule evaluates against. Tag scope is deferred to a later slice.</summary>
+/// <summary>Which servers a rule evaluates against: every monitored server (<see cref="All"/>), an explicit
+/// set of storage names (<see cref="Servers"/>), or the members of a fleet tag (<see cref="Tag"/>, #3350).
+/// Tag membership is store state that changes independently of the rule, so a tag-scoped rule stores only the
+/// tag's stable id and the evaluator resolves it to a server-id set each sweep.</summary>
 public enum CustomAlertScopeMode
 {
     All,
     Servers,
+    Tag,
 }
 
 /// <summary>
@@ -54,6 +58,7 @@ public sealed record CustomAlertRuleDefinition(
     int ClearSamples,
     CustomAlertScopeMode ScopeMode,
     IReadOnlyList<string> ScopeServers,
+    int? ScopeTagId,
     int? EvaluationIntervalSeconds)
 {
     /// <summary>Alert windows are recent (hours), never the 90-day compose chart ceiling — R2 hardening.</summary>
@@ -65,7 +70,14 @@ public sealed record CustomAlertRuleDefinition(
     /// <summary>Cadence floor so a rule cannot ask to be evaluated faster than the collectors move.</summary>
     public const int MinEvaluationIntervalSeconds = 30;
 
-    /// <summary>Whether this rule evaluates against the given storage server name.</summary>
+    /// <summary>
+    /// Whether this rule evaluates against the given storage server name — the PURE All/Servers decision
+    /// (no store). <see cref="CustomAlertScopeMode.Tag"/> cannot be decided from a name alone (its membership
+    /// is the <c>config.server_tag_map</c> set the evaluator resolves at sweep time), so this returns
+    /// <c>false</c> for a tag-scoped rule; the tag-aware gate is
+    /// <see cref="CustomAlertEvaluator.RuleAppliesToServer"/>, which delegates the non-tag modes back to this
+    /// one authority so All/Servers is resolved in exactly one place.
+    /// </summary>
     public bool AppliesTo(string storageName) =>
         ScopeMode == CustomAlertScopeMode.All
         || ScopeServers.Any(s => string.Equals(s, storageName, StringComparison.OrdinalIgnoreCase));
@@ -225,6 +237,7 @@ public sealed record CustomAlertRuleDefinition(
         // ---- scope ----
         var scopeMode = CustomAlertScopeMode.All;
         IReadOnlyList<string> scopeServers = Array.Empty<string>();
+        int? scopeTagId = null;
         if (root["scope"] is JsonObject scope)
         {
             var mode = (scope["mode"] as JsonValue)?.ToString() ?? "all";
@@ -252,9 +265,27 @@ public sealed record CustomAlertRuleDefinition(
 
                     break;
                 case "tag":
-                    return (null, "tag scope is not yet supported; use scope.mode 'all' or 'servers'.");
+                    // Tag scope (#3350): the rule evaluates the DIRECTLY-assigned members of one fleet tag,
+                    // stored by the tag's STABLE id (not its name — a rename must not silently re-scope the rule),
+                    // the same immutable-id discipline the metric key uses. The id -> current server-id set is
+                    // resolved by the evaluator from config.server_tag_map each sweep; a tag that resolves to no
+                    // servers (empty, deleted, or renamed away) matches nothing, so the rule never fires — and
+                    // that 0-server case is surfaced by the #3304 never-firing self-health check.
+                    scopeMode = CustomAlertScopeMode.Tag;
+                    if (scope["tagId"] is not JsonNode tagIdNode || !TryInt(tagIdNode, out var tagId))
+                    {
+                        return (null, "'scope.tagId' (an integer fleet-tag id) is required when scope.mode is 'tag'.");
+                    }
+
+                    if (tagId <= 0)
+                    {
+                        return (null, "'scope.tagId' must be a positive integer fleet-tag id.");
+                    }
+
+                    scopeTagId = tagId;
+                    break;
                 default:
-                    return (null, $"'scope.mode' must be 'all' or 'servers' (got '{mode}').");
+                    return (null, $"'scope.mode' must be 'all', 'servers', or 'tag' (got '{mode}').");
             }
         }
 
@@ -272,7 +303,7 @@ public sealed record CustomAlertRuleDefinition(
 
         var definition = new CustomAlertRuleDefinition(
             plan, plan.Measure.DisplayName, windowHours, op, warn, critical,
-            breachSamples, clearSamples, scopeMode, scopeServers, intervalSeconds);
+            breachSamples, clearSamples, scopeMode, scopeServers, scopeTagId, intervalSeconds);
         return (definition, null);
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleStore.cs
@@ -66,6 +66,20 @@ WHERE enabled
 ORDER BY id
 LIMIT $1";
 
+    /// <summary>Resolves each given fleet-tag id to the set of server ids DIRECTLY assigned to it (#3350 tag
+    /// scope) — one round-trip for every tag via <c>= ANY($1)</c>. Reads <c>config.server_tag_map</c> (bare
+    /// name; the pool's search_path resolves it, the same as <c>custom_alert_rules</c> above). $1 the tag ids.
+    ///
+    /// <para>A tag with no rows — never assigned, or deleted so the map rows cascaded away — is simply absent
+    /// from the result, which the caller treats as "resolves to no server", so a tag-scoped rule on it never
+    /// fires (the #3350 integrity requirement; the 0-server case then flows to the #3304 never-firing surface).
+    /// Membership is DIRECT only: descendant tags' servers are NOT pulled in (a v1 decision — the tree is not
+    /// traversed here; that is a possible later slice).</para></summary>
+    public const string ListTagMembersSql = @"
+SELECT tag_id, server_id
+FROM server_tag_map
+WHERE tag_id = ANY($1)";
+
     /// <summary>Inserts a new rule at version 1. $1 name, $2 definition (jsonb), $3 description, $4 enabled, $5 updated_by.</summary>
     public const string InsertSql = @"
 INSERT INTO custom_alert_rules (name, definition, description, enabled, version, created_at, updated_at, updated_by)
@@ -202,6 +216,49 @@ RETURNING id, name, definition, description, enabled, version, created_at, updat
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Resolves each fleet-tag id to the set of server ids directly assigned to it (#3350 tag scope), in ONE
+    /// round-trip. The single shared tag-membership read: the evaluator calls it on the owner pool each cache
+    /// refresh, and the evaluate-now test tool calls it on the least-privilege mcp/viewer pool — both of which
+    /// carry <c>SELECT</c> on <c>config.server_tag_map</c> (it holds no secret column). A tag with no assigned
+    /// servers is absent from the returned map (the caller reads that as an empty set → the rule matches no
+    /// server). Returns an empty map for an empty input without touching the store.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<int, IReadOnlySet<int>>> ListTagMembersAsync(
+        IReadOnlyCollection<int> tagIds, CancellationToken cancellationToken = default)
+    {
+        if (tagIds.Count == 0)
+        {
+            return new Dictionary<int, IReadOnlySet<int>>();
+        }
+
+        var byTag = new Dictionary<int, HashSet<int>>();
+        await using var command = _dataSource.CreateCommand(ListTagMembersSql);
+        command.CommandTimeout = McpCommandDeadlines.ReadSeconds;
+        command.Parameters.Add(new NpgsqlParameter<int[]> { TypedValue = System.Linq.Enumerable.ToArray(tagIds) });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var tagId = reader.GetInt32(0);
+            var serverId = reader.GetInt32(1);
+            if (!byTag.TryGetValue(tagId, out var set))
+            {
+                set = new HashSet<int>();
+                byTag[tagId] = set;
+            }
+
+            set.Add(serverId);
+        }
+
+        var result = new Dictionary<int, IReadOnlySet<int>>(byTag.Count);
+        foreach (var pair in byTag)
+        {
+            result[pair.Key] = pair.Value;
+        }
+
+        return result;
     }
 
     /// <summary>Reads one rule in full (with <c>definition</c>), or <see cref="CustomAlertRuleResult.NotFound"/>.</summary>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -4726,7 +4726,7 @@ LIMIT 1";
     /// <summary>
     /// #3304: the fleet-level custom-alert-rule integrity check. Asks the <see cref="CustomAlertEvaluator"/> to
     /// re-parse the enabled rules against the live catalog and flag broken / never-firing ones (the current
-    /// monitored-storage-name set feeds the 0-server-scope case), then hands the report to
+    /// monitored (server_id, storage name) set feeds the 0-server-scope case, including #3350 tag scope), then hands the report to
     /// <see cref="DarlingSelfAlertEvaluator.EvaluateCustomRuleHealthAsync"/>, which raises ONE aggregated
     /// self-health alert. Both halves are failure-isolated internally (BuildHealthReportAsync returns null on a
     /// load error and this method then HOLDS the standing alert rather than resolving it; the Evaluate* wrapper
@@ -4735,12 +4735,14 @@ LIMIT 1";
     /// </summary>
     private async Task EvaluateCustomAlertRuleHealthAsync(List<ServerLoopState> servers, CancellationToken cancellationToken)
     {
-        var storageNames = servers
+        // #3350: (server_id, storage name) pairs so the tag-scope 0-server case can be resolved by id (the tag
+        // membership is keyed on server_id) while the 'servers' scope still matches on the storage name.
+        var monitoredServers = servers
             .Where(s => !s.Retired)
-            .Select(s => s.Config.StorageName)
+            .Select(s => (s.Config.ServerId, s.Config.StorageName))
             .ToList();
 
-        var report = await _customAlertEvaluator!.BuildHealthReportAsync(storageNames, cancellationToken);
+        var report = await _customAlertEvaluator!.BuildHealthReportAsync(monitoredServers, cancellationToken);
 
         // Null = the rule load failed this tick; HOLD the standing alert (never resolve on uncertainty).
         if (report is not null)

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
@@ -108,7 +108,8 @@ public sealed class DarlingMcpCustomAlertTools
         "must reduce to a single value), a 'predicate' ('op' one of gt/ge/lt/le, a numeric 'warnThreshold', and " +
         "an optional 'criticalThreshold' that must be more extreme than warn in the operator's direction), an " +
         "optional 'hysteresis' ('breachSamples'/'clearSamples', each an integer >= 1), an optional 'scope' " +
-        "('mode' 'all' or 'servers' with a non-empty 'servers' list; tag scope is not yet supported), and an " +
+        "('mode' 'all', or 'servers' with a non-empty 'servers' list, or 'tag' with an integer 'tagId' fleet-tag " +
+        "id whose directly-assigned servers the rule then evaluates), and an " +
         "optional 'evaluationIntervalSeconds' (>= 30). Build the metric panel from the compose catalog exposed " +
         "by describe_custom_view_catalog. A '<'/'<=' predicate on a count aggregate is rejected because it " +
         "cannot tell zero events from a stalled collector; use '>=' instead.")]
@@ -326,9 +327,21 @@ public sealed class DarlingMcpCustomAlertTools
                 def = parsed;
             }
 
-            // In-scope = the enabled monitored servers the rule applies to (the same AppliesTo the sweep uses).
+            // In-scope = the enabled monitored servers the rule applies to, via the SAME tag-aware gate the sweep
+            // uses (#3350). A tag-scoped rule resolves its tag's current members from config.server_tag_map on
+            // this same least-privilege mcp/viewer pool (which carries SELECT on the config tag tables); an
+            // All/Servers rule is decided purely from the storage name and never hits the tag tables.
             var servers = await DarlingServerResolver.LoadEnabledAsync(postgres);
-            var inScope = servers.Where(s => def.AppliesTo(s.ServerName)).ToList();
+            IReadOnlySet<int>? tagServerIds = null;
+            if (def.ScopeMode == CustomAlertScopeMode.Tag && def.ScopeTagId is int tagId)
+            {
+                var members = await new CustomAlertRuleStore(postgres).ListTagMembersAsync(new[] { tagId });
+                tagServerIds = members.TryGetValue(tagId, out var ids) ? ids : null;
+            }
+
+            var inScope = servers
+                .Where(s => CustomAlertEvaluator.RuleAppliesToServer(def, tagServerIds, s.ServerId, s.ServerName))
+                .ToList();
             if (inScope.Count == 0)
             {
                 return JsonSerializer.Serialize(new

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
@@ -29,6 +29,7 @@ import { el, mount, loadingStrip, errorStrip, emptyStrip, noticeStrip } from "./
 import {
   buildComposedPanelBody,
   loadFleetOptions,
+  loadFleetTagOptions,
   newComposedPanel,
   descToComposedPanel,
   composedPanelToDesc,
@@ -91,8 +92,9 @@ export async function renderAlertEditor(main, id, templateKey) {
     return;
   }
 
-  /* The metric picker needs the compose catalog; the scope picker needs the fleet server names. */
-  const [catalog, fleet] = await Promise.all([api.getCatalog(), loadFleetOptions()]);
+  /* The metric picker needs the compose catalog; the scope picker needs the fleet server names AND the fleet tag
+     forest (#3350 tag scope). */
+  const [catalog, fleet, tags] = await Promise.all([api.getCatalog(), loadFleetOptions(), loadFleetTagOptions()]);
 
   let model;
   let editingId = null;
@@ -124,7 +126,7 @@ export async function renderAlertEditor(main, id, templateKey) {
     model = seed ? seededModel(seed) : blankModel();
   }
 
-  buildAlertEditor(main, { model, editingId, loadedVersion, catalog, fleet });
+  buildAlertEditor(main, { model, editingId, loadedVersion, catalog, fleet, tags });
 }
 
 /* ─────────────────────────── model <-> definition ─────────────────────────── */
@@ -149,6 +151,7 @@ function blankModel() {
     clearSamples: 1,
     scopeMode: "all",
     scopeServers: [],
+    scopeTagId: null,
     intervalSeconds: "",
   };
 }
@@ -187,8 +190,9 @@ function definitionToModel(def, name, description, enabled) {
     critical: pred.criticalThreshold != null ? String(pred.criticalThreshold) : "",
     breachSamples: intOr(hyst.breachSamples, 1),
     clearSamples: intOr(hyst.clearSamples, 1),
-    scopeMode: scope.mode === "servers" ? "servers" : "all",
+    scopeMode: scope.mode === "servers" ? "servers" : scope.mode === "tag" ? "tag" : "all",
     scopeServers: Array.isArray(scope.servers) ? scope.servers.map(String) : [],
+    scopeTagId: typeof scope.tagId === "number" ? scope.tagId : null,
     intervalSeconds: typeof def.evaluationIntervalSeconds === "number" ? String(def.evaluationIntervalSeconds) : "",
   };
 }
@@ -207,12 +211,22 @@ function modelToDefinition(model) {
     metric,
     predicate,
     hysteresis: { breachSamples: model.breachSamples, clearSamples: model.clearSamples },
-    scope: model.scopeMode === "servers" ? { mode: "servers", servers: [...model.scopeServers] } : { mode: "all" },
+    scope: scopeToDefinition(model),
   };
 
   const interval = model.intervalSeconds.trim();
   if (interval !== "") def.evaluationIntervalSeconds = parseInt(interval, 10);
   return def;
+}
+
+/** The model's scope -> the definition's scope object: all servers, a specific-server list, or a fleet tag by
+ *  its STABLE id (#3350). A "tag" mode with no chosen id still emits { mode:"tag", tagId:null } so the backend
+ *  returns its own "scope.tagId required" verdict — the same way an empty "servers" list is left for the backend
+ *  to reject; the save-blocker already blocks the save in both cases. */
+function scopeToDefinition(model) {
+  if (model.scopeMode === "servers") return { mode: "servers", servers: [...model.scopeServers] };
+  if (model.scopeMode === "tag") return { mode: "tag", tagId: model.scopeTagId };
+  return { mode: "all" };
 }
 
 /* ─────────────────────────── save blocker (mirrors the server's cheap rules) ─────────────────────────── */
@@ -252,6 +266,10 @@ function alertSaveBlocker(model) {
 
   if (model.scopeMode === "servers" && !model.scopeServers.length) {
     return "Pick at least one server, or scope the rule to all servers.";
+  }
+
+  if (model.scopeMode === "tag" && !(model.scopeTagId > 0)) {
+    return "Pick a tag, or scope the rule to all servers.";
   }
 
   const interval = model.intervalSeconds.trim();
@@ -417,7 +435,7 @@ function buildAlertEditor(main, ctx) {
     el("h3", { class: "section-title", text: "Hysteresis" }),
     el("div", { class: "alert-section card" }, [hysteresisSection(model, onFieldChange)]),
     el("h3", { class: "section-title", text: "Scope" }),
-    el("div", { class: "alert-section card" }, [scopeSection(model, ctx.fleet, onFieldChange)]),
+    el("div", { class: "alert-section card" }, [scopeSection(model, ctx.fleet, ctx.tags, onFieldChange)]),
     advancedSection(model, onFieldChange),
     el("h3", { class: "section-title", text: "Preview" }),
     previewBox,
@@ -536,24 +554,30 @@ function hysteresisSection(model, onChange) {
 
 /* ─────────────────────────── scope ─────────────────────────── */
 
-/* Which servers the rule evaluates against: all servers (the fleet), or a chosen set. Tag scope is deferred
-   (#3350), so only All / Specific servers are offered. */
-function scopeSection(model, fleet, onChange) {
+/* Which servers the rule evaluates against: all servers (the fleet), a chosen set, or the members of a fleet
+   tag (#3350). Tag scope stores the tag's STABLE id (scope.tagId), so a rename never re-scopes the rule; the
+   picker resolves name<->id from the /api/fleet tag forest. */
+function scopeSection(model, fleet, tags, onChange) {
   const list = el("div", { class: "scope-list" });
   const box = el("div", {});
 
   const modeSel = el("select", { class: "editor-select", "aria-label": "Scope" }, [
     el("option", { value: "all", text: "All servers (fleet)" }),
     el("option", { value: "servers", text: "Specific servers" }),
+    el("option", { value: "tag", text: "Servers with a tag" }),
   ]);
   modeSel.value = model.scopeMode;
   modeSel.addEventListener("change", () => {
-    model.scopeMode = modeSel.value === "servers" ? "servers" : "all";
+    model.scopeMode = modeSel.value === "servers" ? "servers" : modeSel.value === "tag" ? "tag" : "all";
     redraw();
     onChange();
   });
 
   function redraw() {
+    if (model.scopeMode === "tag") {
+      mount(box, tagScope());
+      return;
+    }
     if (model.scopeMode !== "servers") {
       mount(box, el("div", { class: "block-help", text: "This rule evaluates against every monitored server." }));
       return;
@@ -577,8 +601,41 @@ function scopeSection(model, fleet, onChange) {
     mount(box, [list, el("div", { class: "block-help", text: "The rule fires per server; pick the servers it applies to." })]);
   }
 
+  /* The tag picker: a single-select of the fleet tag forest, indented by depth. The rule evaluates the servers
+     DIRECTLY assigned the chosen tag, resolved fresh each sweep — so adding or removing a server from the tag
+     re-scopes the rule without editing it. */
+  function tagScope() {
+    if (!tags.length) {
+      return noticeStrip("No fleet tags are defined yet. Create and assign tags in the desktop viewer's fleet view, then scope a rule to one.");
+    }
+    const sel = el("select", { class: "editor-select", "aria-label": "Tag" });
+    sel.appendChild(el("option", { value: "", text: "— pick a tag —" }));
+    for (const t of tags) {
+      // Indent by depth (non-breaking spaces via textContent, never innerHTML) so the flat <select> shows the tree.
+      const prefix = t.depth > 0 ? "  ".repeat(t.depth) + "└ " : "";
+      sel.appendChild(el("option", { value: t.value, text: prefix + t.label }));
+    }
+    // A loaded rule may name a tag since deleted/renamed away; keep it selectable (like buildWindowSelect keeps a
+    // non-preset window) so the operator sees what is applied rather than a silent reset to "pick a tag".
+    if (model.scopeTagId != null && !tags.some((t) => t.value === String(model.scopeTagId))) {
+      sel.appendChild(el("option", { value: String(model.scopeTagId), text: "Tag " + model.scopeTagId + " (not in fleet — deleted?)" }));
+    }
+    sel.value = model.scopeTagId != null ? String(model.scopeTagId) : "";
+    sel.addEventListener("change", () => {
+      model.scopeTagId = sel.value ? Number(sel.value) : null;
+      onChange();
+    });
+    return el("div", {}, [
+      field("Tag", sel),
+      el("div", {
+        class: "block-help",
+        text: "The rule fires per server for every server DIRECTLY assigned this tag. Membership is resolved fresh each evaluation, so adding or removing a server from the tag re-scopes the rule automatically; an empty or deleted tag matches no server (the rule never fires).",
+      }),
+    ]);
+  }
+
   redraw();
-  return el("div", {}, [field("Servers", modeSel), box]);
+  return el("div", {}, [field("Scope", modeSel), box]);
 }
 
 function checkRow(label, checked, onToggle) {

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/editor.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/editor.js
@@ -123,6 +123,38 @@ export async function loadFleetOptions() {
     .sort((a, b) => a.label.localeCompare(b.label));
 }
 
+/* Fleet TAG options for the alert-rule scope picker (#3350): the /api/fleet tag forest flattened depth-first
+   (parents before their children) into { value: String(tag id), label, depth }. The value is the STABLE tag id
+   — a tag-scoped rule stores scope.tagId, not the name, so a rename never re-scopes it — and depth lets a flat
+   <select> render the hierarchy with indentation. Cycle- and dangling-parent-safe, the same projection the
+   fleet page groups with. Empty when no tags are defined. */
+export async function loadFleetTagOptions() {
+  const res = await apiGet("/api/fleet");
+  if (res.kind !== "data" || !res.data) return [];
+  const forest = Array.isArray(res.data.tags) ? res.data.tags : [];
+  const known = new Set(forest.map((t) => t.id));
+  const byParent = new Map();
+  for (const t of forest) {
+    const p = t.parent_id != null && known.has(t.parent_id) ? t.parent_id : 0; // dangling parent -> root
+    if (!byParent.has(p)) byParent.set(p, []);
+    byParent.get(p).push(t);
+  }
+  for (const list of byParent.values()) {
+    list.sort((a, b) => (a.sort_order || 0) - (b.sort_order || 0) || String(a.name).localeCompare(String(b.name)));
+  }
+  const out = [];
+  const visited = new Set();
+  const emit = (t, depth) => {
+    if (visited.has(t.id)) return; // cycle guard
+    visited.add(t.id);
+    out.push({ value: String(t.id), label: t.name || "Tag " + t.id, depth });
+    for (const child of byParent.get(t.id) || []) emit(child, depth + 1);
+  };
+  for (const t of byParent.get(0) || []) emit(t, 0);
+  for (const t of forest) if (!visited.has(t.id)) emit(t, 0); // cycle / disconnected -> surface as a root
+  return out;
+}
+
 /* ─────────────────────────── model <-> stored definition ─────────────────────────── */
 
 /** A new panel — a COMPOSED metric by default (the v2 headline); a read panel is the "advanced" alternative. */


### PR DESCRIPTION
Implements `scope.mode: "tag"` for custom alert rules — the capability deferred from the custom-alert feature (#3285). A rule can now be scoped to the servers carrying a fleet tag, resolved fresh each sweep, so adding or removing a server from the tag re-scopes the rule with no edit. No migration (the tag tables from #1640 already exist).

## Scope JSON shape
```json
"scope": { "mode": "tag", "tagId": 7 }
```
The tag is stored by its **stable integer id** (`tagId`), never its name — a rename never silently re-scopes the rule, consistent with the feature's immutable-id philosophy (`metric_name = "Custom:<rule_id>"`). The editor resolves name↔id from the fleet tag forest; display resolves id→name by lookup.

## How the evaluator resolves + tears down tag membership
- **Resolve once per cache refresh:** `CustomAlertEvaluator.GetEnabledRulesAsync` collects the tag-scoped rules' ids and resolves them in one round-trip via `CustomAlertRuleStore.ListTagMembersAsync` (`SELECT tag_id, server_id FROM server_tag_map WHERE tag_id = ANY($1)`, bare name resolved through the pool's `search_path`). The resolved `IReadOnlySet<int>` server-ids ride on the cached `ParsedRule`.
- **Gate:** one shared pure `RuleAppliesToServer(definition, tagServerIds, serverId, storageName)` — All/Servers delegate to the pure name-based `AppliesTo`; Tag is `tagServerIds.Contains(serverId)`. The sweep, the teardown, and the never-firing check all route through it.
- **Teardown (#3305):** when a server **leaves** the tag its id drops out of the resolved set, so `ClassifyStateTeardown` returns out-of-scope and the open incident is force-resolved — the exact idiom a server leaving a `servers` scope already used. No parallel mechanism.
- Membership is **directly-assigned only** in v1 (the tag tree is not traversed to include descendant tags' servers) — noted in a code comment as a possible follow-up.

## 0-server / deleted tag (integrity)
A missing/deleted/renamed-away/empty tag resolves to an **empty** server set → the rule matches no server → it never fires, and that flows through the **existing** #3304 never-firing self-health surface: `ClassifyNeverFiring` now flags a tag rule whose tag matches no monitored server (unit-tested).

## Test-now
`test_custom_alert_rule` (and the `/api/alerts/test` endpoint that wraps it) resolves the tag on the least-privilege mcp/viewer pool and evaluates **only** the tagged servers, via the same `RuleAppliesToServer` gate.

## UI
`alert-editor.js` gains a **"Servers with a tag"** scope mode with a single-select tag picker populated from the `/api/fleet` tag forest (indented by depth, deleted tag kept visible), mapped to/from `scope.mode: "tag"` + `tagId`. Between/outside operators stay out (that's #3351).

## Round-trip
MCP create/update/get and the `/api/alerts` CRUD carry `definition` verbatim, so tag scope rides through automatically (the web create route validates through the same `TryParse`).

## Tests
`dotnet build` of the service and test projects is **0 warnings / 0 errors**. Ran the touched classes (72 tests, all green): validator tag accept/reject, the `RuleAppliesToServer` gate (new `CustomAlertTagScopeTests`), tag teardown, tag never-firing, and the MCP validate surface. Added a **gated** live create→get tag round-trip (`DARLING_TEST_PG`, not run here). Did not run live/integration tests against real servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
