### PR TITLE
Refuse a non-finite min_duration_ms (#3287)

### DIFF
--- a/Darling/Darling.Tests/DarlingCollectionLogReadTests.cs
+++ b/Darling/Darling.Tests/DarlingCollectionLogReadTests.cs
@@ -359,6 +359,22 @@ public sealed class DarlingCollectionLogReadTests
                full page with nothing to say the filter did not apply. */
             Assert.DoesNotContain("\"runs\"", negative, StringComparison.Ordinal);
 
+            /* ── 8. a floor that is not a real number is refused on the same terms ── */
+            foreach (var notANumber in new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity })
+            {
+                var refused = await DarlingMcpDataTools.GetCollectionLog(
+                    dataSource, FilterServerName, 24, 200, min_duration_ms: notANumber);
+
+                Assert.Contains("real number of milliseconds", refused, StringComparison.Ordinal);
+                Assert.DoesNotContain("\"runs\"", refused, StringComparison.Ordinal);
+
+                /* The assertion that discriminates. Before the finite test, NaN and +Infinity passed
+                   validation and then matched nothing, so the caller got the filtered-no-matches status —
+                   which NAMES the floor it applied and reads as a true negative about the window. Asserting
+                   only the absence of a payload would have been green on that. */
+                Assert.DoesNotContain("matched min_duration_ms", refused, StringComparison.Ordinal);
+            }
+
             bodySucceeded = true;
         }
         finally

--- a/Darling/Darling.Tests/DarlingCollectionLogReadTests.cs
+++ b/Darling/Darling.Tests/DarlingCollectionLogReadTests.cs
@@ -359,21 +359,37 @@ public sealed class DarlingCollectionLogReadTests
                full page with nothing to say the filter did not apply. */
             Assert.DoesNotContain("\"runs\"", negative, StringComparison.Ordinal);
 
-            /* ── 8. a floor that is not a real number is refused on the same terms ── */
-            foreach (var notANumber in new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity })
+            /* ── 8. a NON-FINITE floor is refused too, and a negative test cannot see one ── */
+            /*
+                Every comparison against NaN is false and +Infinity < 0 is false, so both passed the
+                original range check and came back as an empty, duration-RANKED page reporting
+                "matched min_duration_ms NaN". All of them are reachable through /api/read: TryParse under
+                NumberStyles.Float accepts the named literals AND accepts an oversized number like 1e400,
+                which overflows to +Infinity rather than failing. Review found this after the lane had
+                reasoned -- wrongly -- that no real surface could deliver one.
+            */
+            foreach (var unusable in new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity })
             {
                 var refused = await DarlingMcpDataTools.GetCollectionLog(
-                    dataSource, FilterServerName, 24, 200, min_duration_ms: notANumber);
+                    dataSource, FilterServerName, 24, 200, min_duration_ms: unusable);
 
-                Assert.Contains("real number of milliseconds", refused, StringComparison.Ordinal);
+                Assert.Contains("must be a finite number", refused, StringComparison.Ordinal);
                 Assert.DoesNotContain("\"runs\"", refused, StringComparison.Ordinal);
 
-                /* The assertion that discriminates. Before the finite test, NaN and +Infinity passed
-                   validation and then matched nothing, so the caller got the filtered-no-matches status —
-                   which NAMES the floor it applied and reads as a true negative about the window. Asserting
-                   only the absence of a payload would have been green on that. */
+                /* And NOT the empty status: an unusable floor is a refusal, not a miss. */
+                Assert.DoesNotContain("\"empty\"", refused, StringComparison.Ordinal);
+
+                /* And not the no-matches MESSAGE either, which names the floor it applied and so reads as a
+                   fact about the window. Asserted beside the status token because the two can drift: the
+                   status is the branch, this sentence is what the caller actually reads. */
                 Assert.DoesNotContain("matched min_duration_ms", refused, StringComparison.Ordinal);
             }
+
+            /* Positive control for those negatives: a FINITE floor on the same read still returns a page,
+               so the three assertions above are not passing against a read that refuses everything. */
+            var finite = await DarlingMcpDataTools.GetCollectionLog(
+                dataSource, FilterServerName, 24, 200, min_duration_ms: 20_000);
+            Assert.Contains("\"runs\"", finite, StringComparison.Ordinal);
 
             bodySucceeded = true;
         }

--- a/Lite.Tests/CollectionLogToolTests.cs
+++ b/Lite.Tests/CollectionLogToolTests.cs
@@ -273,6 +273,20 @@ public sealed class CollectionLogToolTests : IClassFixture<SharedDuckDbFixture>,
             service, _serverManager, ServerName, 24, 200, min_duration_ms: -1);
         Assert.Contains("cannot be negative", negative, StringComparison.Ordinal);
         Assert.DoesNotContain("\"runs\"", negative, StringComparison.Ordinal);
+
+        /* ── and a floor that is not a real number, in the same words again ── */
+        foreach (var notANumber in new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity })
+        {
+            var refused = await McpHealthTools.GetCollectionLog(
+                service, _serverManager, ServerName, 24, 200, min_duration_ms: notANumber);
+
+            Assert.Contains("real number of milliseconds", refused, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"runs\"", refused, StringComparison.Ordinal);
+
+            /* The discriminating one: these used to pass validation and fall into the no-matches status,
+               which names the floor and reads as a fact about the window. See Darling's twin. */
+            Assert.DoesNotContain("matched min_duration_ms", refused, StringComparison.Ordinal);
+        }
     }
 
     /// <summary>

--- a/Lite.Tests/CollectionLogToolTests.cs
+++ b/Lite.Tests/CollectionLogToolTests.cs
@@ -274,19 +274,27 @@ public sealed class CollectionLogToolTests : IClassFixture<SharedDuckDbFixture>,
         Assert.Contains("cannot be negative", negative, StringComparison.Ordinal);
         Assert.DoesNotContain("\"runs\"", negative, StringComparison.Ordinal);
 
-        /* ── and a floor that is not a real number, in the same words again ── */
-        foreach (var notANumber in new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity })
+        /*
+            And a NON-FINITE floor, which a negative test cannot see: every comparison against NaN is false
+            and +Infinity < 0 is false, so both passed the original range check and came back as an empty,
+            duration-ranked page. Same refusal words as Darling's twin.
+        */
+        foreach (var unusable in new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity })
         {
             var refused = await McpHealthTools.GetCollectionLog(
-                service, _serverManager, ServerName, 24, 200, min_duration_ms: notANumber);
+                service, _serverManager, ServerName, 24, 200, min_duration_ms: unusable);
 
-            Assert.Contains("real number of milliseconds", refused, StringComparison.Ordinal);
+            Assert.Contains("must be a finite number", refused, StringComparison.Ordinal);
             Assert.DoesNotContain("\"runs\"", refused, StringComparison.Ordinal);
-
-            /* The discriminating one: these used to pass validation and fall into the no-matches status,
-               which names the floor and reads as a fact about the window. See Darling's twin. */
+            Assert.DoesNotContain("\"empty\"", refused, StringComparison.Ordinal);
             Assert.DoesNotContain("matched min_duration_ms", refused, StringComparison.Ordinal);
         }
+
+        /* Positive control: a FINITE floor on the same read still returns a page, so the negatives above are
+           not passing against a read that refuses everything. */
+        var finite = await McpHealthTools.GetCollectionLog(
+            service, _serverManager, ServerName, 24, 200, min_duration_ms: 20_000);
+        Assert.Contains("\"runs\"", finite, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/PerformanceMonitor.Common/Mcp/McpHelpers.cs
+++ b/PerformanceMonitor.Common/Mcp/McpHelpers.cs
@@ -243,8 +243,22 @@ internal static class McpHelpers
     /// </summary>
     public static string? ValidateMinMs(double? minMs, string paramName)
     {
-        if (minMs is < 0)
-            return $"Invalid {paramName} value '{Ms(minMs)}'. A duration floor cannot be negative — use 0 to admit every row, or omit it entirely.";
+        if (minMs is not { } floor)
+            return null;
+
+        /* Non-finite is tested BEFORE the sign, and both tests are needed. NaN fails every comparison it
+           is given, including `< 0`; +Infinity is not negative either; and an overflowing literal such as
+           1e400 PARSES, to +Infinity, rather than failing to bind. So all three arrived as accepted floors,
+           matched no row, and came back as the filtered-no-matches status naming a floor that was never a
+           number — a refusal rendered as an answer, in the one validator whose job is refusing. -Infinity
+           was already caught by the sign test and is caught here instead, because "not a real number of
+           milliseconds" is the accurate reason for it rather than its sign. */
+        if (!double.IsFinite(floor))
+            return $"Invalid {paramName} value '{Ms(floor)}'. A duration floor has to be a real number of milliseconds — use 0 to admit every row, or omit it entirely.";
+
+        if (floor < 0)
+            return $"Invalid {paramName} value '{Ms(floor)}'. A duration floor cannot be negative — use 0 to admit every row, or omit it entirely.";
+
         return null;
     }
 

--- a/PerformanceMonitor.Common/Mcp/McpHelpers.cs
+++ b/PerformanceMonitor.Common/Mcp/McpHelpers.cs
@@ -240,25 +240,22 @@ internal static class McpHelpers
     /// <para>ZERO is accepted and is NOT the same as omitting the parameter: it is the floor that admits every
     /// row, which on an ordering-switching read is how a caller asks to rank the whole window by duration
     /// rather than by time. Callers must therefore test for <c>null</c>, never for falsiness.</para>
+    ///
+    /// <para>NON-FINITE is refused, and checked FIRST because a negative test cannot see it: every comparison
+    /// against <c>NaN</c> is false, and <c>+Infinity &lt; 0</c> is false too. All three are reachable from the
+    /// web surface — <c>double.TryParse</c> under <c>NumberStyles.Float</c> accepts the literal
+    /// <c>NaN</c> and <c>Infinity</c> regardless of the style flags, and it also accepts a merely OVERSIZED
+    /// number like <c>1e400</c>, which silently overflows to <c>+Infinity</c> (measured, all four). None can
+    /// ever match a run, so accepting one returns an empty, duration-RANKED page with nothing to say the
+    /// floor was unusable: the silently-dropped-parameter failure this validator exists to remove, wearing a
+    /// number instead of a typo.</para>
     /// </summary>
     public static string? ValidateMinMs(double? minMs, string paramName)
     {
-        if (minMs is not { } floor)
-            return null;
-
-        /* Non-finite is tested BEFORE the sign, and both tests are needed. NaN fails every comparison it
-           is given, including `< 0`; +Infinity is not negative either; and an overflowing literal such as
-           1e400 PARSES, to +Infinity, rather than failing to bind. So all three arrived as accepted floors,
-           matched no row, and came back as the filtered-no-matches status naming a floor that was never a
-           number — a refusal rendered as an answer, in the one validator whose job is refusing. -Infinity
-           was already caught by the sign test and is caught here instead, because "not a real number of
-           milliseconds" is the accurate reason for it rather than its sign. */
-        if (!double.IsFinite(floor))
-            return $"Invalid {paramName} value '{Ms(floor)}'. A duration floor has to be a real number of milliseconds — use 0 to admit every row, or omit it entirely.";
-
-        if (floor < 0)
-            return $"Invalid {paramName} value '{Ms(floor)}'. A duration floor cannot be negative — use 0 to admit every row, or omit it entirely.";
-
+        if (minMs is { } value && !double.IsFinite(value))
+            return $"Invalid {paramName} value '{Ms(minMs)}'. A duration floor must be a finite number — NaN and Infinity parse but can never match a run, so the read would come back empty and duration-ranked with nothing to say the floor was unusable. Note that an oversized number overflows to Infinity rather than being rejected as too large.";
+        if (minMs is < 0)
+            return $"Invalid {paramName} value '{Ms(minMs)}'. A duration floor cannot be negative — use 0 to admit every row, or omit it entirely.";
         return null;
     }
 


### PR DESCRIPTION
`ValidateMinMs` tested only `minMs is < 0`. NaN fails that like it fails every comparison, `+Infinity` is not negative, and an oversized literal such as `1e400` **parses**, to `+Infinity`, rather than being rejected as too large — so all four spellings arrived as accepted floors. None can ever match a run, so the read then returned the filtered-no-matches status, which names the floor it applied and reads as a true negative about the window. A refusal rendered as an answer, in the one validator whose whole job is refusing values that cannot mean what they say.

All of them are reachable from the web surface: `double.TryParse` under `NumberStyles.Float` accepts the named literals regardless of the style flags, and the overflow case parses rather than failing. Measured, all four.

`!double.IsFinite` is tested ahead of the sign so `-Infinity` is refused for what it is rather than for its sign. `0` remains a real value — it admits every row and ranks the page by duration — and the negative message keeps its wording, which pins on both SKUs assert on.

## Two lanes reached this independently, and this carries the better-instrumented half of each

The #3287 lane found it from the same review comment and had already written a fix on its own branch. Its version is better in two ways and both are taken here rather than defended against:

- **A positive control on both SKUs** — a finite floor on the same read still returns a page, so the refusal assertions are not passing against a read that refuses everything.
- **The mechanism documented in the `<summary>`**, where a caller reading the API sees it, rather than in a comment inside the method body.

What is kept from the other version is one extra assertion: the refusal must not contain the no-matches **message** either, asserted beside the status-token check. The status is the branch taken and the sentence is what the caller actually reads, and the two can drift.

Pinned end-to-end on both SKUs over NaN, `+Infinity` and `-Infinity`, with the finite positive control. The assertions that discriminate are the two absences: before this, the value passed validation and fell into the no-matches branch, so asserting only the lack of a payload would have been green on the defect.

Found by the review bot on #3363 and merged past — this is that finding, repaired.
