### PR TITLE
Add between/outside range predicate operators for custom alert rules (#3351)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertEvaluateNowTests.cs
+++ b/Darling/Darling.Tests/CustomAlertEvaluateNowTests.cs
@@ -35,6 +35,15 @@ public class CustomAlertEvaluateNowTests
         "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
         "\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1000}}");
 
+    /// <summary>Range ops (#3351): a two-sided band [10, 100]. between = fire inside, outside = fire beyond; both Warning-only.</summary>
+    private static CustomAlertRuleDefinition BetweenRule() => Parse(
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
+        "\"predicate\":{\"op\":\"between\",\"lowerBound\":10,\"upperBound\":100}}");
+
+    private static CustomAlertRuleDefinition OutsideRule() => Parse(
+        "{\"metric\":{\"source\":\"wait_stats\",\"measure\":\"wait_time_ms\",\"aggregate\":\"sum\",\"hours\":1}," +
+        "\"predicate\":{\"op\":\"outside\",\"lowerBound\":10,\"upperBound\":100}}");
+
     private static CustomAlertRuleDefinition Parse(string json)
     {
         var (def, error) = CustomAlertRuleDefinition.TryParse(json);
@@ -81,6 +90,48 @@ public class CustomAlertEvaluateNowTests
     public void NoData_IsNeverABreach()
     {
         var (breaching, severity) = CustomAlertEvaluator.ClassifyTestValue(TieredRule(), null);
+        Assert.False(breaching);
+        Assert.Null(severity);
+    }
+
+    // ─────────────────────────── range ops (#3351): between / outside would-fire ───────────────────────────
+
+    [Fact]
+    public void Between_InsideBand_WouldFire_Warning()
+    {
+        var (breaching, severity) = CustomAlertEvaluator.ClassifyTestValue(BetweenRule(), 55);
+        Assert.True(breaching);
+        Assert.Equal(AlertSeverityLevel.Warning, severity); // a range op has no critical tier in v1
+    }
+
+    [Fact]
+    public void Between_OutsideBand_WouldNotFire()
+    {
+        var (breaching, severity) = CustomAlertEvaluator.ClassifyTestValue(BetweenRule(), 500);
+        Assert.False(breaching);
+        Assert.Null(severity);
+    }
+
+    [Fact]
+    public void Outside_BeyondBand_WouldFire_Warning()
+    {
+        var (breaching, severity) = CustomAlertEvaluator.ClassifyTestValue(OutsideRule(), 500);
+        Assert.True(breaching);
+        Assert.Equal(AlertSeverityLevel.Warning, severity);
+    }
+
+    [Fact]
+    public void Outside_InsideBand_WouldNotFire()
+    {
+        var (breaching, severity) = CustomAlertEvaluator.ClassifyTestValue(OutsideRule(), 55);
+        Assert.False(breaching);
+        Assert.Null(severity);
+    }
+
+    [Fact]
+    public void Range_NoData_IsNeverABreach()
+    {
+        var (breaching, severity) = CustomAlertEvaluator.ClassifyTestValue(OutsideRule(), null);
         Assert.False(breaching);
         Assert.Null(severity);
     }

--- a/Darling/Darling.Tests/CustomAlertRuleDefinitionTests.cs
+++ b/Darling/Darling.Tests/CustomAlertRuleDefinitionTests.cs
@@ -31,8 +31,11 @@ public class CustomAlertRuleDefinitionTests
         Assert.Null(error);
         Assert.NotNull(def);
         Assert.Equal(CustomAlertOp.GreaterOrEqual, def!.Op);
-        Assert.Equal(1000, def.WarnThreshold);
+        Assert.Equal(1000d, def.WarnThreshold);
         Assert.Null(def.CriticalThreshold);
+        Assert.Null(def.LowerBound);   // a scalar rule carries no band
+        Assert.Null(def.UpperBound);
+        Assert.False(def.IsRange);
         Assert.Equal(1, def.BreachSamples);
         Assert.Equal(1, def.ClearSamples);
         Assert.Equal(CustomAlertScopeMode.All, def.ScopeMode);
@@ -102,8 +105,9 @@ public class CustomAlertRuleDefinitionTests
     [Fact]
     public void UnknownOp_IsError()
     {
+        // 'between'/'outside' are now real range ops (#3351), so an unknown op is a genuinely unrecognized token.
         var (def, error) = CustomAlertRuleDefinition.TryParse(
-            "{" + Metric + ",\"predicate\":{\"op\":\"between\",\"warnThreshold\":1}}");
+            "{" + Metric + ",\"predicate\":{\"op\":\"nope\",\"warnThreshold\":1}}");
         Assert.Null(def);
         Assert.NotNull(error);
     }
@@ -202,5 +206,145 @@ public class CustomAlertRuleDefinitionTests
             "{" + Metric + ",\"predicate\":{\"op\":\"ge\",\"warnThreshold\":1},\"scope\":{\"mode\":\"servers\",\"servers\":[]}}");
         Assert.Null(def);
         Assert.NotNull(error);
+    }
+
+    // ─────────────────────────── range ops (#3351): between / outside ───────────────────────────
+
+    /// <summary>A valid range predicate over the shared metric: op + a two-sided band [lower, upper].</summary>
+    private static string RangePredicate(string op, double lower, double upper) =>
+        "{" + Metric + ",\"predicate\":{\"op\":\"" + op + "\",\"lowerBound\":" +
+        lower.ToString(System.Globalization.CultureInfo.InvariantCulture) + ",\"upperBound\":" +
+        upper.ToString(System.Globalization.CultureInfo.InvariantCulture) + "}}";
+
+    [Theory]
+    [InlineData("between", CustomAlertOp.Between)]
+    [InlineData("outside", CustomAlertOp.Outside)]
+    public void RangeRule_Parses_WithBounds_AndNoScalarThresholds(string op, CustomAlertOp expected)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(RangePredicate(op, 10, 100));
+
+        Assert.Null(error);
+        Assert.NotNull(def);
+        Assert.Equal(expected, def!.Op);
+        Assert.True(def.IsRange);
+        Assert.Equal(10d, def.LowerBound);
+        Assert.Equal(100d, def.UpperBound);
+        // A range op carries the band ONLY — never the scalar warn/critical bars (mutual exclusivity).
+        Assert.Null(def.WarnThreshold);
+        Assert.Null(def.CriticalThreshold);
+    }
+
+    [Theory]
+    [InlineData("between")]
+    [InlineData("outside")]
+    public void RangeOp_MissingLowerBound_IsError(string op)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"" + op + "\",\"upperBound\":100}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("between")]
+    [InlineData("outside")]
+    public void RangeOp_MissingUpperBound_IsError(string op)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"" + op + "\",\"lowerBound\":10}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData(100, 100)] // equal bounds are not a band
+    [InlineData(100, 10)]  // inverted bounds
+    public void RangeOp_LowerNotLessThanUpper_IsError(double lower, double upper)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(RangePredicate("outside", lower, upper));
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("\"warnThreshold\":50")]
+    [InlineData("\"criticalThreshold\":50")]
+    public void RangeOp_CarryingScalarThreshold_IsError(string scalarKey)
+    {
+        // Mutual exclusivity: a between/outside predicate must NOT carry warn/critical.
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"outside\",\"lowerBound\":10,\"upperBound\":100," + scalarKey + "}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("\"lowerBound\":10")]
+    [InlineData("\"upperBound\":100")]
+    public void ScalarOp_CarryingBound_IsError(string boundKey)
+    {
+        // Mutual exclusivity: a gt/ge/lt/le predicate must NOT carry lowerBound/upperBound.
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"ge\",\"warnThreshold\":25," + boundKey + "}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData(5, false)]   // below the band
+    [InlineData(10, true)]   // on the lower bound (inclusive)
+    [InlineData(55, true)]   // inside
+    [InlineData(100, true)]  // on the upper bound (inclusive)
+    [InlineData(150, false)] // above the band
+    public void Between_BreachesInsideTheInclusiveBand(double value, bool breaching)
+    {
+        var (def, _) = CustomAlertRuleDefinition.TryParse(RangePredicate("between", 10, 100));
+        Assert.Equal(breaching, def!.IsBreaching(value));
+        if (breaching)
+        {
+            // A range op is Warning-only in v1 — no critical tier.
+            Assert.Equal(AlertSeverityLevel.Warning, def.SeverityFor(value));
+        }
+    }
+
+    [Theory]
+    [InlineData(5, true)]    // below the band
+    [InlineData(10, false)]  // on the lower bound (inclusive band => not outside)
+    [InlineData(55, false)]  // inside
+    [InlineData(100, false)] // on the upper bound (inclusive band => not outside)
+    [InlineData(150, true)]  // above the band
+    public void Outside_BreachesBeyondTheInclusiveBand(double value, bool breaching)
+    {
+        var (def, _) = CustomAlertRuleDefinition.TryParse(RangePredicate("outside", 10, 100));
+        Assert.Equal(breaching, def!.IsBreaching(value));
+        if (breaching)
+        {
+            Assert.Equal(AlertSeverityLevel.Warning, def.SeverityFor(value));
+        }
+    }
+
+    [Fact]
+    public void FiredThreshold_RendersBand_ForRangeOp_WithNoNumericTwin()
+    {
+        // Round-trip through the delivered-alert render authority: a range op renders its band as ASCII
+        // "outside <lo> - <hi>" and has no single numeric threshold value (NumericThresholdValue is null).
+        var (def, _) = CustomAlertRuleDefinition.TryParse(RangePredicate("outside", 10, 100));
+        var (text, numeric) = def!.FiredThreshold(AlertSeverityLevel.Warning);
+        Assert.Equal("outside 10 - 100", text);
+        Assert.Null(numeric);
+    }
+
+    [Fact]
+    public void FiredThreshold_RendersScalarBar_ForScalarOp_WithTheCrossedValue()
+    {
+        var (def, _) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"ge\",\"warnThreshold\":25,\"criticalThreshold\":40}}");
+        var (warnText, warnNum) = def!.FiredThreshold(AlertSeverityLevel.Warning);
+        Assert.Equal(">= 25", warnText);
+        Assert.Equal(25d, warnNum);
+
+        var (critText, critNum) = def.FiredThreshold(AlertSeverityLevel.Critical);
+        Assert.Equal(">= 40", critText);
+        Assert.Equal(40d, critNum);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertEvaluator.cs
@@ -459,10 +459,9 @@ public sealed class CustomAlertEvaluator
     {
         var metricName = MetricNameFor(row.Id);
         var currentText = value.ToString("0.###", CultureInfo.InvariantCulture);
-        var thresholdValue = severity == AlertSeverityLevel.Critical && def.CriticalThreshold is double critical
-            ? critical
-            : def.WarnThreshold;
-        var thresholdText = string.Create(CultureInfo.InvariantCulture, $"{def.OpSymbol} {thresholdValue:0.###}");
+        // Scalar ops render "<symbol> <bar>" with the crossed bar as the numeric twin; a range op renders its
+        // band ("outside 10 - 100") with a null numeric twin. The definition is the single authority (#3351).
+        var (thresholdText, thresholdValue) = def.FiredThreshold(severity);
 
         /* Sanitize the user-authored name/description before they enter any rendered string or the persisted
            detail_text: strip every line break + control char and cap the length so a crafted name cannot

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleDefinition.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleDefinition.cs
@@ -15,13 +15,21 @@ using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitor.Darling.Service;
 
-/// <summary>The scalar comparison a rule's value is tested against.</summary>
+/// <summary>The comparison a rule's value is tested against: a one-sided scalar bar
+/// (<see cref="GreaterThan"/>..<see cref="LessOrEqual"/>) or a two-sided range band
+/// (<see cref="Between"/>/<see cref="Outside"/>, #3351).</summary>
 public enum CustomAlertOp
 {
     GreaterThan,
     GreaterOrEqual,
     LessThan,
     LessOrEqual,
+
+    /// <summary>Breaches when the value is INSIDE the inclusive band [lowerBound, upperBound] (#3351).</summary>
+    Between,
+
+    /// <summary>Breaches when the value is OUTSIDE the inclusive band [lowerBound, upperBound] (#3351).</summary>
+    Outside,
 }
 
 /// <summary>Which servers a rule evaluates against: every monitored server (<see cref="All"/>), an explicit
@@ -52,8 +60,10 @@ public sealed record CustomAlertRuleDefinition(
     string MeasureDisplayName,
     double WindowHours,
     CustomAlertOp Op,
-    double WarnThreshold,
+    double? WarnThreshold,
     double? CriticalThreshold,
+    double? LowerBound,
+    double? UpperBound,
     int BreachSamples,
     int ClearSamples,
     CustomAlertScopeMode ScopeMode,
@@ -61,6 +71,15 @@ public sealed record CustomAlertRuleDefinition(
     int? ScopeTagId,
     int? EvaluationIntervalSeconds)
 {
+    /// <summary>Whether this rule's operator tests the value against a two-sided band
+    /// (<see cref="LowerBound"/>/<see cref="UpperBound"/>) rather than a single scalar threshold (#3351). A
+    /// range op carries both bounds and neither <see cref="WarnThreshold"/> nor <see cref="CriticalThreshold"/>;
+    /// a scalar op is the mirror image — the validator enforces that mutual exclusivity.</summary>
+    public bool IsRange => IsRangeOp(Op);
+
+    /// <summary>Pure op-category test, usable by the validator before a definition is constructed.</summary>
+    private static bool IsRangeOp(CustomAlertOp op) => op is CustomAlertOp.Between or CustomAlertOp.Outside;
+
     /// <summary>Alert windows are recent (hours), never the 90-day compose chart ceiling — R2 hardening.</summary>
     public const double MaxWindowHours = 24.0;
 
@@ -82,13 +101,27 @@ public sealed record CustomAlertRuleDefinition(
         ScopeMode == CustomAlertScopeMode.All
         || ScopeServers.Any(s => string.Equals(s, storageName, StringComparison.OrdinalIgnoreCase));
 
-    /// <summary>Whether a value breaches the warning bar (the predicate).</summary>
-    public bool IsBreaching(double value) => Compare(value, WarnThreshold);
+    /// <summary>
+    /// Whether a value breaches the predicate. A scalar op crosses its warning bar (the <see cref="Compare"/>
+    /// authority); a range op falls IN (<see cref="CustomAlertOp.Between"/>) or OUT
+    /// (<see cref="CustomAlertOp.Outside"/>) of the INCLUSIVE band [<see cref="LowerBound"/>,
+    /// <see cref="UpperBound"/>] (#3351). Bounds are guaranteed present for a range op by the validator.
+    /// </summary>
+    public bool IsBreaching(double value) => Op switch
+    {
+        CustomAlertOp.Between => LowerBound is double lo && UpperBound is double hi && value >= lo && value <= hi,
+        CustomAlertOp.Outside => LowerBound is double lo && UpperBound is double hi && (value < lo || value > hi),
+        _ => WarnThreshold is double warn && Compare(value, warn),
+    };
 
-    /// <summary>The tier a breaching value fires at: Critical when it also crosses the critical bar, else Warning.</summary>
+    /// <summary>The tier a breaching value fires at: Critical when it also crosses the critical bar, else Warning.
+    /// A range op is Warning-only in v1 (a two-tier band would need a warn-band AND a crit-band = four bounds;
+    /// that escalation is a tracked follow-up, not this slice), so it always fires Warning.</summary>
     public AlertSeverityLevel SeverityFor(double value) =>
-        CriticalThreshold is double c && Compare(value, c) ? AlertSeverityLevel.Critical : AlertSeverityLevel.Warning;
+        !IsRange && CriticalThreshold is double c && Compare(value, c) ? AlertSeverityLevel.Critical : AlertSeverityLevel.Warning;
 
+    /// <summary>The scalar comparison — the single authority for a one-sided bar. Range ops go through the band
+    /// logic in <see cref="IsBreaching"/> instead, never here.</summary>
     private bool Compare(double value, double threshold) => Op switch
     {
         CustomAlertOp.GreaterThan => value > threshold,
@@ -98,7 +131,8 @@ public sealed record CustomAlertRuleDefinition(
         _ => false,
     };
 
-    /// <summary>The operator's human symbol, for rendering the threshold in an alert body.</summary>
+    /// <summary>The scalar operator's human symbol, for rendering a one-sided threshold in an alert body. A range
+    /// op has no single symbol — its band renders through <see cref="FiredThreshold"/> — so this is "?" for one.</summary>
     public string OpSymbol => Op switch
     {
         CustomAlertOp.GreaterThan => ">",
@@ -107,6 +141,26 @@ public sealed record CustomAlertRuleDefinition(
         CustomAlertOp.LessOrEqual => "<=",
         _ => "?",
     };
+
+    /// <summary>
+    /// How the threshold reads in a fired alert body, plus the numeric twin persisted alongside it
+    /// (<c>NumericThresholdValue</c>). A scalar op reports the crossed bar as "&lt;symbol&gt; &lt;value&gt;"
+    /// (e.g. "&gt;= 25") with that bar as the numeric twin; a range op reports the band as "outside 10 - 100" /
+    /// "between 10 - 100" with a NULL numeric twin (a band has no single threshold value). The plain " - " band
+    /// separator keeps an em dash — a style tell — out of delivered text. Range ops are Warning-only, so the tier
+    /// only selects warn-vs-critical for a scalar op.
+    /// </summary>
+    public (string Text, double? Numeric) FiredThreshold(AlertSeverityLevel severity)
+    {
+        if (IsRange)
+        {
+            var word = Op == CustomAlertOp.Between ? "between" : "outside";
+            return (string.Create(CultureInfo.InvariantCulture, $"{word} {LowerBound ?? 0:0.###} - {UpperBound ?? 0:0.###}"), null);
+        }
+
+        var bar = severity == AlertSeverityLevel.Critical && CriticalThreshold is double c ? c : WarnThreshold ?? 0;
+        return (string.Create(CultureInfo.InvariantCulture, $"{OpSymbol} {bar:0.###}"), bar);
+    }
 
     /// <summary>
     /// Parses and validates a rule definition JSON. Returns the typed definition, or a human-readable error
@@ -185,37 +239,81 @@ public sealed record CustomAlertRuleDefinition(
 
         if (predicate["op"] is not JsonValue opValue || !TryParseOp(opValue.ToString(), out var op))
         {
-            return (null, "'predicate.op' must be one of: gt, ge, lt, le.");
+            return (null, "'predicate.op' must be one of: gt, ge, lt, le, between, outside.");
         }
 
-        // A '<'/'<=' alert on a COUNT cannot tell zero matching events from a stalled collector reading zero
-        // rows, so it would false-fire exactly when the true signal is "no data". Deferred; use a >= count.
-        if (plan.Aggregate == ComposeAggregate.Count && op is CustomAlertOp.LessThan or CustomAlertOp.LessOrEqual)
-        {
-            return (null, "a '<'/'<=' alert on a count can't distinguish zero events from a stalled collector; use '>=' instead.");
-        }
-
-        if (predicate["warnThreshold"] is not JsonNode warnNode || !TryDouble(warnNode, out var warn))
-        {
-            return (null, "'predicate.warnThreshold' (a number) is required.");
-        }
-
+        // Scalar ops carry a warning bar (+ optional more-extreme critical); range ops carry a two-sided band.
+        // The two shapes are MUTUALLY EXCLUSIVE (#3351): a scalar predicate MUST NOT carry bounds, and a range
+        // predicate MUST NOT carry warn/critical. Overloading warn/critical as the band would break the "crossed
+        // the warning threshold" wording and the two-tier severity model, so the band lives in its own
+        // lowerBound/upperBound and only one shape is populated on any given rule.
+        double? warn = null;
         double? critical = null;
-        if (predicate["criticalThreshold"] is JsonNode critNode)
+        double? lowerBound = null;
+        double? upperBound = null;
+
+        if (IsRangeOp(op))
         {
-            if (!TryDouble(critNode, out var c))
+            if (predicate["warnThreshold"] is not null || predicate["criticalThreshold"] is not null)
             {
-                return (null, "'predicate.criticalThreshold' must be a number.");
+                return (null, "a range predicate ('between'/'outside') uses 'lowerBound'/'upperBound', not 'warnThreshold'/'criticalThreshold'.");
             }
 
-            // Critical must be MORE extreme than warning in the operator's direction.
-            var ordered = op is CustomAlertOp.GreaterThan or CustomAlertOp.GreaterOrEqual ? c >= warn : c <= warn;
-            if (!ordered)
+            if (predicate["lowerBound"] is not JsonNode lowerNode || !TryDouble(lowerNode, out var lower))
             {
-                return (null, "'predicate.criticalThreshold' must be more extreme than 'warnThreshold' in the operator's direction.");
+                return (null, "'predicate.lowerBound' (a number) is required for a range predicate ('between'/'outside').");
             }
 
-            critical = c;
+            if (predicate["upperBound"] is not JsonNode upperNode || !TryDouble(upperNode, out var upper))
+            {
+                return (null, "'predicate.upperBound' (a number) is required for a range predicate ('between'/'outside').");
+            }
+
+            if (!(lower < upper))
+            {
+                return (null, "'predicate.lowerBound' must be less than 'predicate.upperBound'.");
+            }
+
+            lowerBound = lower;
+            upperBound = upper;
+        }
+        else
+        {
+            if (predicate["lowerBound"] is not null || predicate["upperBound"] is not null)
+            {
+                return (null, "a scalar predicate ('gt'/'ge'/'lt'/'le') uses 'warnThreshold' (+ an optional 'criticalThreshold'), not 'lowerBound'/'upperBound'.");
+            }
+
+            // A '<'/'<=' alert on a COUNT cannot tell zero matching events from a stalled collector reading zero
+            // rows, so it would false-fire exactly when the true signal is "no data". Deferred; use a >= count.
+            if (plan.Aggregate == ComposeAggregate.Count && op is CustomAlertOp.LessThan or CustomAlertOp.LessOrEqual)
+            {
+                return (null, "a '<'/'<=' alert on a count can't distinguish zero events from a stalled collector; use '>=' instead.");
+            }
+
+            if (predicate["warnThreshold"] is not JsonNode warnNode || !TryDouble(warnNode, out var w))
+            {
+                return (null, "'predicate.warnThreshold' (a number) is required.");
+            }
+
+            warn = w;
+
+            if (predicate["criticalThreshold"] is JsonNode critNode)
+            {
+                if (!TryDouble(critNode, out var c))
+                {
+                    return (null, "'predicate.criticalThreshold' must be a number.");
+                }
+
+                // Critical must be MORE extreme than warning in the operator's direction.
+                var ordered = op is CustomAlertOp.GreaterThan or CustomAlertOp.GreaterOrEqual ? c >= w : c <= w;
+                if (!ordered)
+                {
+                    return (null, "'predicate.criticalThreshold' must be more extreme than 'warnThreshold' in the operator's direction.");
+                }
+
+                critical = c;
+            }
         }
 
         // ---- hysteresis ----
@@ -302,7 +400,7 @@ public sealed record CustomAlertRuleDefinition(
         }
 
         var definition = new CustomAlertRuleDefinition(
-            plan, plan.Measure.DisplayName, windowHours, op, warn, critical,
+            plan, plan.Measure.DisplayName, windowHours, op, warn, critical, lowerBound, upperBound,
             breachSamples, clearSamples, scopeMode, scopeServers, scopeTagId, intervalSeconds);
         return (definition, null);
     }
@@ -327,6 +425,12 @@ public sealed record CustomAlertRuleDefinition(
             case "le":
             case "<=":
                 op = CustomAlertOp.LessOrEqual;
+                return true;
+            case "between":
+                op = CustomAlertOp.Between;
+                return true;
+            case "outside":
+                op = CustomAlertOp.Outside;
                 return true;
             default:
                 return false;

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
@@ -106,8 +106,11 @@ public sealed class DarlingMcpCustomAlertTools
         "it loads a rule, so use it to iterate on a generated definition until it is valid. The definition is a " +
         "JSON object: a 'metric' (a compose SCALAR panel - a 'source' + 'measure'|'ratio' + 'aggregate', plus " +
         "an optional 'hours' window between one minute and 24 hours; no 'timeBucket'/'topN', since the metric " +
-        "must reduce to a single value), a 'predicate' ('op' one of gt/ge/lt/le, a numeric 'warnThreshold', and " +
-        "an optional 'criticalThreshold' that must be more extreme than warn in the operator's direction), an " +
+        "must reduce to a single value), a 'predicate' (either a SCALAR comparison - 'op' one of gt/ge/lt/le, a " +
+        "numeric 'warnThreshold', and an optional 'criticalThreshold' that must be more extreme than warn in the " +
+        "operator's direction; or a RANGE band - 'op' 'between' or 'outside', with numeric 'lowerBound' and " +
+        "'upperBound' where lowerBound < upperBound, which fires Warning-only and carries no warn/critical - the " +
+        "two shapes being mutually exclusive), an " +
         "optional 'hysteresis' ('breachSamples'/'clearSamples', each an integer >= 1), an optional 'scope' " +
         "('mode' 'all', or 'servers' with a non-empty 'servers' list, or 'tag' with an integer 'tagId' fleet-tag " +
         "id whose directly-assigned servers the rule then evaluates), and an " +

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
@@ -65,14 +65,23 @@ const WINDOW_OPTIONS = [
   { hours: 24, label: "Last 24 hours" },
 ];
 
-/* The comparison operators an alert predicate offers. Between / outside are deferred (#3351), so only the four
-   scalar comparisons appear — matching the CustomAlertOp enum the backend parses. */
+/* The comparison operators an alert predicate offers — matching the CustomAlertOp enum the backend parses. The
+   four scalar comparisons test the value against a single bar (a warning threshold + an optional critical); the
+   two range ops (#3351) test it against a two-sided band [lower, upper] and fire a single Warning tier. */
 const OP_OPTIONS = [
   { value: "gt", label: "is greater than (>)" },
   { value: "ge", label: "is greater than or equal to (≥)" },
   { value: "lt", label: "is less than (<)" },
   { value: "le", label: "is less than or equal to (≤)" },
+  { value: "outside", label: "is outside the range" },
+  { value: "between", label: "is within the range" },
 ];
+
+/* Range ops compare the value to a band [lower, upper] rather than a single threshold, so the editor swaps the
+   Warning/Critical inputs for Lower/Upper-bound inputs when one is chosen (and maps them to lowerBound/upperBound
+   instead of warnThreshold/criticalThreshold). */
+const RANGE_OPS = new Set(["between", "outside"]);
+const isRangeOp = (op) => RANGE_OPS.has(op);
 
 /* ─────────────────────────── entry ─────────────────────────── */
 
@@ -147,6 +156,8 @@ function blankModel() {
     op: "gt",
     warn: "",
     critical: "",
+    lower: "",
+    upper: "",
     breachSamples: 1,
     clearSamples: 1,
     scopeMode: "all",
@@ -188,6 +199,8 @@ function definitionToModel(def, name, description, enabled) {
     op: normalizeOp(pred.op),
     warn: pred.warnThreshold != null ? String(pred.warnThreshold) : "",
     critical: pred.criticalThreshold != null ? String(pred.criticalThreshold) : "",
+    lower: pred.lowerBound != null ? String(pred.lowerBound) : "",
+    upper: pred.upperBound != null ? String(pred.upperBound) : "",
     breachSamples: intOr(hyst.breachSamples, 1),
     clearSamples: intOr(hyst.clearSamples, 1),
     scopeMode: scope.mode === "servers" ? "servers" : scope.mode === "tag" ? "tag" : "all",
@@ -204,8 +217,14 @@ function modelToDefinition(model) {
   const metric = metricSpecFromDesc(composedPanelToDesc(model.metric));
   metric.hours = model.windowHours;
 
-  const predicate = { op: model.op, warnThreshold: parseNumOrNull(model.warn) };
-  if (model.critical.trim() !== "") predicate.criticalThreshold = parseNumOrNull(model.critical);
+  let predicate;
+  if (isRangeOp(model.op)) {
+    /* Range op: a two-sided band, and NO warn/critical (the backend rejects a range predicate that carries them). */
+    predicate = { op: model.op, lowerBound: parseNumOrNull(model.lower), upperBound: parseNumOrNull(model.upper) };
+  } else {
+    predicate = { op: model.op, warnThreshold: parseNumOrNull(model.warn) };
+    if (model.critical.trim() !== "") predicate.criticalThreshold = parseNumOrNull(model.critical);
+  }
 
   const def = {
     metric,
@@ -245,20 +264,30 @@ function alertSaveBlocker(model) {
   if (!(model.windowHours >= MIN_WINDOW_HOURS)) return "Choose an evaluation window.";
   if (model.windowHours > MAX_WINDOW_HOURS) return "The evaluation window can be at most 24 hours (an alert window is recent).";
 
-  const warn = parseNumOrNull(model.warn);
-  if (warn == null) return "Enter a warning threshold (a number).";
+  if (isRangeOp(model.op)) {
+    /* Range op: both bounds required and ordered; no warn/critical and no count trap (the same rules the backend
+       enforces for a between/outside predicate). */
+    const lower = parseNumOrNull(model.lower);
+    const upper = parseNumOrNull(model.upper);
+    if (lower == null) return "Enter a lower bound (a number).";
+    if (upper == null) return "Enter an upper bound (a number).";
+    if (!(lower < upper)) return "The lower bound must be less than the upper bound.";
+  } else {
+    const warn = parseNumOrNull(model.warn);
+    if (warn == null) return "Enter a warning threshold (a number).";
 
-  /* A '<'/'<=' alert on a COUNT can't tell zero matching events from a stalled collector reading zero rows, so it
-     would false-fire exactly when the true signal is "no data" — the same rule the backend enforces. */
-  if (metric.aggregate === "count" && (model.op === "lt" || model.op === "le")) {
-    return "A '<' or '≤' alert on a count can't tell zero events from a stalled collector — use '≥' instead.";
-  }
+    /* A '<'/'<=' alert on a COUNT can't tell zero matching events from a stalled collector reading zero rows, so it
+       would false-fire exactly when the true signal is "no data" — the same rule the backend enforces. */
+    if (metric.aggregate === "count" && (model.op === "lt" || model.op === "le")) {
+      return "A '<' or '≤' alert on a count can't tell zero events from a stalled collector — use '≥' instead.";
+    }
 
-  if (model.critical.trim() !== "") {
-    const critical = parseNumOrNull(model.critical);
-    if (critical == null) return "The critical threshold must be a number (or leave it blank).";
-    const ordered = model.op === "gt" || model.op === "ge" ? critical >= warn : critical <= warn;
-    if (!ordered) return "The critical threshold must be more extreme than the warning threshold, in the operator's direction.";
+    if (model.critical.trim() !== "") {
+      const critical = parseNumOrNull(model.critical);
+      if (critical == null) return "The critical threshold must be a number (or leave it blank).";
+      const ordered = model.op === "gt" || model.op === "ge" ? critical >= warn : critical <= warn;
+      if (!ordered) return "The critical threshold must be more extreme than the warning threshold, in the operator's direction.";
+    }
   }
 
   if (!(model.breachSamples >= 1)) return "Breach samples must be at least 1.";
@@ -287,6 +316,7 @@ function readyToCheck(model) {
   const metric = model.metric;
   if (!metric.measure && !metric.ratio) return false;
   if (metric.measure && !metric.aggregate) return false;
+  if (isRangeOp(model.op)) return parseNumOrNull(model.lower) != null && parseNumOrNull(model.upper) != null;
   return parseNumOrNull(model.warn) != null;
 }
 
@@ -448,45 +478,65 @@ function buildAlertEditor(main, ctx) {
 
 /* ─────────────────────────── condition (window + predicate) ─────────────────────────── */
 
-/* When the metric fires: the evaluation window, the comparison operator, and the warning / critical thresholds.
-   Warn = the Warning tier; adding a (more-extreme) critical threshold arms the Critical tier — the severity is the
-   two thresholds, not a separate control (CustomAlertRuleDefinition.SeverityFor). */
+/* When the metric fires: the evaluation window, the comparison operator, and the threshold(s) — which DEPEND on
+   the operator. A scalar op (gt/ge/lt/le) shows a Warning threshold + an optional (more-extreme) Critical, and the
+   severity is those two thresholds (CustomAlertRuleDefinition.SeverityFor). A range op (between/outside, #3351)
+   shows a Lower/Upper bound instead and fires a single Warning tier, so the inputs — and the help text — swap in
+   place when the op category changes. */
 function conditionSection(model, onChange) {
   const windowSel = buildWindowSelect(model, onChange);
 
   const opSel = el("select", { class: "editor-select", "aria-label": "Comparison" });
   for (const o of OP_OPTIONS) opSel.appendChild(el("option", { value: o.value, text: o.label }));
   opSel.value = model.op;
+
+  /* The threshold inputs + help live in redrawn sub-containers so switching between a scalar and a range op swaps
+     Warning/Critical <-> Lower/Upper in place; modelToDefinition maps them to the right predicate keys. */
+  const thresholdBox = el("div", { class: "composed-fields" });
+  const helpBox = el("div", { class: "block-help" });
+
+  /** A numeric input bound to model[key], re-checking save state + preview on every edit (like the old warn/crit). */
+  function numField(label, key, placeholder) {
+    const input = el("input", { class: "editor-input", type: "number", step: "any", placeholder, "aria-label": label });
+    input.value = model[key];
+    input.addEventListener("input", () => {
+      model[key] = input.value;
+      onChange();
+    });
+    return field(label, input);
+  }
+
+  function drawCondition() {
+    if (isRangeOp(model.op)) {
+      mount(thresholdBox, [numField("Lower bound", "lower", "lower bound"), numField("Upper bound", "upper", "upper bound")]);
+      helpBox.textContent =
+        "The metric is aggregated to one value over the window, then tested against the band. 'Is outside the range' " +
+        "fires when the value is below the lower bound or above the upper bound; 'is within the range' fires when it " +
+        "falls inside (bounds inclusive). A range rule fires a single Warning tier.";
+    } else {
+      mount(thresholdBox, [numField("Warning threshold", "warn", "warning value"), numField("Critical threshold", "critical", "critical value (optional)")]);
+      helpBox.textContent =
+        "The metric is aggregated to one value over the window, then compared. Crossing the warning threshold fires " +
+        "a Warning; crossing the (more-extreme) critical threshold fires a Critical. Leave critical blank for a " +
+        "single Warning tier.";
+    }
+  }
+
   opSel.addEventListener("change", () => {
+    const wasRange = isRangeOp(model.op);
     model.op = opSel.value;
+    /* Only redraw the inputs when the op crosses the scalar<->range boundary (a scalar->scalar change keeps the
+       same warn/crit inputs, so their in-progress values are preserved). */
+    if (isRangeOp(model.op) !== wasRange) drawCondition();
     onChange();
   });
 
-  const warnInput = el("input", { class: "editor-input", type: "number", step: "any", placeholder: "warning value", "aria-label": "Warning threshold" });
-  warnInput.value = model.warn;
-  warnInput.addEventListener("input", () => {
-    model.warn = warnInput.value;
-    onChange();
-  });
-
-  const critInput = el("input", { class: "editor-input", type: "number", step: "any", placeholder: "critical value (optional)", "aria-label": "Critical threshold" });
-  critInput.value = model.critical;
-  critInput.addEventListener("input", () => {
-    model.critical = critInput.value;
-    onChange();
-  });
+  drawCondition();
 
   return el("div", {}, [
-    el("div", { class: "composed-fields" }, [
-      field("Evaluate over", windowSel),
-      field("When the value", opSel),
-      field("Warning threshold", warnInput),
-      field("Critical threshold", critInput),
-    ]),
-    el("div", {
-      class: "block-help",
-      text: "The metric is aggregated to one value over the window, then compared. Crossing the warning threshold fires a Warning; crossing the (more-extreme) critical threshold fires a Critical. Leave critical blank for a single Warning tier.",
-    }),
+    el("div", { class: "composed-fields" }, [field("Evaluate over", windowSel), field("When the value", opSel)]),
+    thresholdBox,
+    helpBox,
   ]);
 }
 
@@ -772,6 +822,10 @@ function normalizeOp(raw) {
     case "le":
     case "<=":
       return "le";
+    case "between":
+      return "between";
+    case "outside":
+      return "outside";
     default:
       return "gt";
   }

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/alert-rules.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/alert-rules.js
@@ -22,7 +22,8 @@
 import { el, mount, loadingStrip, errorStrip, emptyStrip, relTime } from "../util.js";
 import * as api from "../alerts-api.js";
 
-/** The operator's human symbol for a condition chip (mirrors CustomAlertRuleDefinition.OpSymbol). */
+/** The scalar operator's human symbol for a condition chip (mirrors CustomAlertRuleDefinition.OpSymbol); the range
+ *  ops (between/outside, #3351) render their band instead — see describeCondition. */
 const OP_SYMBOLS = { gt: ">", ge: "≥", lt: "<", le: "≤" };
 
 /* ─────────────────────────── list page ─────────────────────────── */
@@ -174,9 +175,18 @@ function describeMetric(metric) {
   return agg + name;
 }
 
-/** A compact condition label ("> 25" or "≥ 30000 / crit 120000"), or null. */
+/** A compact condition label — a scalar bar ("≥ 30000 / crit 120000") or a range band ("outside 10–100"), or null. */
 function describeCondition(pred) {
-  if (!pred || typeof pred !== "object" || pred.warnThreshold == null) return null;
+  if (!pred || typeof pred !== "object") return null;
+
+  /* Range op (#3351): a two-sided band, rendered "outside 10–100" / "between 10–100" with an en dash (–)
+     between the bounds — a range predicate carries lowerBound/upperBound and no warnThreshold. */
+  if (pred.op === "between" || pred.op === "outside") {
+    if (pred.lowerBound == null || pred.upperBound == null) return null;
+    return pred.op + " " + pred.lowerBound + "–" + pred.upperBound;
+  }
+
+  if (pred.warnThreshold == null) return null;
   const sym = OP_SYMBOLS[pred.op] || pred.op || "?";
   let text = sym + " " + pred.warnThreshold;
   if (pred.criticalThreshold != null) text += " / crit " + pred.criticalThreshold;


### PR DESCRIPTION
## What

Implements the `between` / `outside` range predicate operators for custom alert rules (#3351) — the range comparisons deferred from #3285.

A rule's predicate can now test a metric against a two-sided band `[lowerBound, upperBound]` in addition to the existing scalar bars (`gt`/`ge`/`lt`/`le`):

- **`outside`** breaches when `value < lowerBound OR value > upperBound`
- **`between`** breaches when `lowerBound <= value <= upperBound` (inclusive bounds)

## Design

- The band lives in **new `predicate` fields** `lowerBound` / `upperBound` (nullable), never by overloading `warnThreshold` / `criticalThreshold` — overloading would break the "crossed the warning threshold" notification wording and the two-tier severity model.
- **Mutually exclusive shapes**, enforced in the validator (`CustomAlertRuleDefinition.TryParse`): a scalar op requires `warnThreshold` (+ an optional more-extreme `criticalThreshold`) and rejects bounds; a range op requires both numeric bounds with `lowerBound < upperBound` and rejects warn/critical.
- **Warning-only in v1** for range ops: a two-tier band would need a warn-band *and* a crit-band (four bounds). `SeverityFor` returns Warning for a breaching range op; a code comment marks the escalation follow-up.
- `Compare` / `SeverityFor` / `IsBreaching` remain the single breach authority. The delivered-alert body renders the band as `outside 10 - 100` (ASCII, with a null numeric threshold twin) via a new `FiredThreshold` helper the evaluator calls.

## Predicate JSON (range rule)

```json
{
  "metric": { "source": "wait_stats", "measure": "wait_time_ms", "aggregate": "sum", "hours": 1 },
  "predicate": { "op": "outside", "lowerBound": 10, "upperBound": 100 }
}
```

## Frontend

- Editor: `outside` / `between` added to the operator dropdown; the Warning/Critical inputs (and the help text) swap for Lower/Upper-bound inputs when a range op is chosen, mapped to `lowerBound`/`upperBound` in `modelToDefinition`/`definitionToModel`. The live `/api/alerts/test` preview evaluates the serialized definition, so it works unchanged.
- Rule card chip renders range rules as `outside 10–100` / `between 10–100`.

## Tests

`Darling.Tests.exe` for `CustomAlertRuleDefinitionTests` + `CustomAlertEvaluateNowTests` + `CustomAlertSeverityEscalationTests` + `CustomAlertTemplatesTests` → 65 passing, plus `DarlingMcpCustomAlertToolsSurfaceTests` → 18 passing. Added: parser accepts between/outside; bounds required + numeric; `lower < upper`; scalar-vs-range mutual exclusion (both directions); breach logic at/inside/outside the band for both ops; `SeverityFor` = Warning; `FiredThreshold` round-trip (band text + null numeric twin, and the scalar bar); and `ClassifyTestValue` would-fire for range ops.

Service + tests build `0 Warning(s) / 0 Error(s)`.

## Deferred

- **Range-op Critical tier** (escalation over a warn-band + crit-band, four bounds) — Warning-only in v1, code comment left in `SeverityFor`. Recommend a tracked issue.
- **Count-with-`<` trap for range ops** — the scalar `<`/`<=`-on-a-count guard (zero events vs stalled collector) is not mirrored to range ops; whether a given band is ambiguous depends on the specific bounds, so it needs a design decision rather than a mechanical mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WejwpgWF5Xfm3fAmoEbFz4
