### PR TITLE
Guard COUNT range-op alerts against a stalled-collector no-data 0 (#3373)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertRuleDefinitionTests.cs
+++ b/Darling/Darling.Tests/CustomAlertRuleDefinitionTests.cs
@@ -347,4 +347,103 @@ public class CustomAlertRuleDefinitionTests
         Assert.Equal(">= 40", critText);
         Assert.Equal(40d, critNum);
     }
+
+    // ─────────────── #3373: the no-data (stalled-collector) count guard — scalar AND range ───────────────
+
+    /// <summary>A COUNT-aggregate Scalar metric. deadlocks/deadlock_count is a count-only per-event measure, so
+    /// the metric compiles to <c>COUNT(*)</c>, which reads 0 over an empty (stalled) window — never the NULL the
+    /// evaluator's no-data freeze catches. A '&lt;'/'&lt;=' scalar, or a range band that fires at 0, therefore
+    /// cannot tell "no events happened" from "the collector is dead".</summary>
+    private const string CountMetric =
+        "\"metric\":{\"source\":\"deadlocks\",\"measure\":\"deadlock_count\",\"aggregate\":\"count\",\"hours\":1}";
+
+    /// <summary>A range predicate over the COUNT metric above.</summary>
+    private static string CountRangePredicate(string op, double lower, double upper) =>
+        "{" + CountMetric + ",\"predicate\":{\"op\":\"" + op + "\",\"lowerBound\":" +
+        lower.ToString(System.Globalization.CultureInfo.InvariantCulture) + ",\"upperBound\":" +
+        upper.ToString(System.Globalization.CultureInfo.InvariantCulture) + "}}";
+
+    /// <summary>A range predicate over the shared NON-count metric (wait_stats/wait_time_ms/SUM).</summary>
+    private static string SumRangePredicate(string op, double lower, double upper) =>
+        "{" + Metric + ",\"predicate\":{\"op\":\"" + op + "\",\"lowerBound\":" +
+        lower.ToString(System.Globalization.CultureInfo.InvariantCulture) + ",\"upperBound\":" +
+        upper.ToString(System.Globalization.CultureInfo.InvariantCulture) + "}}";
+
+    [Theory]
+    [InlineData("lt")]
+    [InlineData("le")]
+    public void ScalarCountWithLessThanOrEqual_IsError_StalledCollectorTrap(string op)
+    {
+        // The scalar half of the count no-data guard (the range half is below): a stalled collector reads COUNT 0,
+        // indistinguishable from zero events, so a '<'/'<=' count alert would false-fire on a data gap.
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + CountMetric + ",\"predicate\":{\"op\":\"" + op + "\",\"warnThreshold\":5}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    // A COUNT range band that FIRES on a stalled-collector 0 is rejected (the #3373 range half of the guard).
+    [InlineData("outside", 1, 100)] // 0 < lower  => outside fires on 0
+    [InlineData("between", 0, 100)] // lower <= 0 <= upper => between fires on 0
+    public void CountRangeBandThatFiresOnZero_IsError_StalledCollectorTrap(string op, double lower, double upper)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(CountRangePredicate(op, lower, upper));
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    // A COUNT range band that does NOT fire on 0 is fine: a stalled 0 simply does not breach, so there is no
+    // ambiguity to guard against and the rule parses normally.
+    [InlineData("outside", 0, 100)] // 0 is the inclusive lower edge => not outside => safe
+    [InlineData("between", 1, 100)] // 0 < lower => not between => safe
+    public void CountRangeBandThatDoesNotFireOnZero_Parses(string op, double lower, double upper)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(CountRangePredicate(op, lower, upper));
+        Assert.Null(error);
+        Assert.NotNull(def);
+        Assert.True(def!.IsRange);
+        Assert.False(def.BreachesOnZero()); // the guard's predicate agrees the band is safe on a stalled 0
+        Assert.False(def.IsBreaching(0));   // and a stalled 0 genuinely does not breach
+    }
+
+    [Theory]
+    // The guard is COUNT-specific: a non-count aggregate (SUM) whose band fires on 0 is NOT rejected, because a
+    // stalled collector returns NULL for SUM/AVG (caught by the evaluator's no-data freeze), not a real 0.
+    [InlineData("outside", 1, 100)]
+    [InlineData("between", 0, 100)]
+    public void NonCountRangeBandThatFiresOnZero_Parses(string op, double lower, double upper)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(SumRangePredicate(op, lower, upper));
+        Assert.Null(error);
+        Assert.NotNull(def);
+        Assert.True(def!.BreachesOnZero()); // the band WOULD fire on 0, but the metric is not a COUNT...
+        Assert.True(def.IsBreaching(0));    // ...so the guard leaves it alone.
+    }
+
+    [Theory]
+    // BreachesOnZero is the band-at-0 verdict for a range op, and it IS IsBreaching(0) — the single authority.
+    [InlineData("outside", 1, 100, true)]
+    [InlineData("outside", 0, 100, false)]
+    [InlineData("between", 0, 100, true)]
+    [InlineData("between", 1, 100, false)]
+    public void BreachesOnZero_EqualsIsBreachingAtZero_ForRangeOps(string op, double lower, double upper, bool expected)
+    {
+        // Use the non-count metric so a fires-on-0 band still PARSES (the count guard would reject it otherwise).
+        var (def, _) = CustomAlertRuleDefinition.TryParse(SumRangePredicate(op, lower, upper));
+        Assert.Equal(expected, def!.BreachesOnZero());
+        Assert.Equal(def.IsBreaching(0), def.BreachesOnZero());
+    }
+
+    [Fact]
+    public void BreachesOnZero_IsFalse_ForScalarOp_EvenWhenItBreachesAtZero()
+    {
+        // BreachesOnZero is a range-only concept; a scalar op's count trap is the separate '<'/'<=' rejection.
+        // 'le 0' on a SUM metric DOES breach at 0, yet BreachesOnZero is false because the op is not a range.
+        var (def, _) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"le\",\"warnThreshold\":0}}");
+        Assert.True(def!.IsBreaching(0));
+        Assert.False(def.BreachesOnZero());
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleDefinition.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleDefinition.cs
@@ -105,14 +105,35 @@ public sealed record CustomAlertRuleDefinition(
     /// Whether a value breaches the predicate. A scalar op crosses its warning bar (the <see cref="Compare"/>
     /// authority); a range op falls IN (<see cref="CustomAlertOp.Between"/>) or OUT
     /// (<see cref="CustomAlertOp.Outside"/>) of the INCLUSIVE band [<see cref="LowerBound"/>,
-    /// <see cref="UpperBound"/>] (#3351). Bounds are guaranteed present for a range op by the validator.
+    /// <see cref="UpperBound"/>] (#3351), through the shared <see cref="RangeBreaches"/> band authority. Bounds
+    /// are guaranteed present for a range op by the validator.
     /// </summary>
-    public bool IsBreaching(double value) => Op switch
+    public bool IsBreaching(double value) => IsRange
+        ? RangeBreaches(Op, LowerBound, UpperBound, value)
+        : WarnThreshold is double warn && Compare(value, warn);
+
+    /// <summary>The pure band-membership decision a range op breaches on (#3351): <see cref="CustomAlertOp.Between"/>
+    /// breaches INSIDE the inclusive band [lower, upper], <see cref="CustomAlertOp.Outside"/> beyond it. Factored
+    /// out of <see cref="IsBreaching"/> so the band math lives in ONE place, shared by the live evaluation, the
+    /// <see cref="BreachesOnZero"/> no-data guard, and the parse-time count guard (#3373). Returns false for a
+    /// scalar op (whose bar is <see cref="Compare"/>) and whenever a bound is absent.</summary>
+    private static bool RangeBreaches(CustomAlertOp op, double? lowerBound, double? upperBound, double value) => op switch
     {
-        CustomAlertOp.Between => LowerBound is double lo && UpperBound is double hi && value >= lo && value <= hi,
-        CustomAlertOp.Outside => LowerBound is double lo && UpperBound is double hi && (value < lo || value > hi),
-        _ => WarnThreshold is double warn && Compare(value, warn),
+        CustomAlertOp.Between => lowerBound is double lo && upperBound is double hi && value >= lo && value <= hi,
+        CustomAlertOp.Outside => lowerBound is double lo && upperBound is double hi && (value < lo || value > hi),
+        _ => false,
     };
+
+    /// <summary>
+    /// Whether this range predicate's band treats a no-data 0 as a breach (#3373). A COUNT metric cannot tell
+    /// "zero events happened" from "the collector stalled and wrote no rows" — both read as <c>COUNT(*)</c> 0, a
+    /// real value (never the NULL the evaluator's no-data freeze catches, unlike SUM/AVG over an empty window) —
+    /// so a band that fires on 0 would false-fire on a dead collector. This is the predicate the parse-time count
+    /// guard uses to reject such a rule, mirroring the scalar '&lt;'/'&lt;=' count rejection. Expressed as the
+    /// band's own <see cref="IsBreaching"/> verdict at 0 so the band logic stays the single authority; meaningful
+    /// only for a range op (a scalar op returns false here — its count trap is the separate '&lt;'/'&lt;=' rejection).
+    /// </summary>
+    public bool BreachesOnZero() => IsRange && IsBreaching(0);
 
     /// <summary>The tier a breaching value fires at: Critical when it also crosses the critical bar, else Warning.
     /// A range op is Warning-only in v1 (a two-tier band would need a warn-band AND a crit-band = four bounds;
@@ -272,6 +293,18 @@ public sealed record CustomAlertRuleDefinition(
             if (!(lower < upper))
             {
                 return (null, "'predicate.lowerBound' must be less than 'predicate.upperBound'.");
+            }
+
+            // A range band that fires when the count is 0 has the SAME stalled-collector ambiguity as the scalar
+            // '<'/'<=' count trap below: COUNT(*) over an empty window is 0 (never the NULL the evaluator's
+            // no-data freeze catches), so a dead collector reads 0 and the band false-fires exactly when the true
+            // signal is "no data". Guard it the same way, keyed on the same COUNT-aggregate archetype and routed
+            // through the same band authority (RangeBreaches) the live evaluation uses. 'outside' fires on 0 when
+            // 0 < lower; 'between' when lower <= 0 <= upper; nudging the bounds so 0 falls outside the firing
+            // region (outside -> lower 0, between -> lower above 0) makes the band safe on an empty window.
+            if (plan.Aggregate == ComposeAggregate.Count && RangeBreaches(op, lower, upper, 0))
+            {
+                return (null, "a 'between'/'outside' alert on a count whose band fires when the count is 0 can't distinguish zero events from a stalled collector; set the bounds so a count of 0 does not fire.");
             }
 
             lowerBound = lower;

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
@@ -115,8 +115,10 @@ public sealed class DarlingMcpCustomAlertTools
         "('mode' 'all', or 'servers' with a non-empty 'servers' list, or 'tag' with an integer 'tagId' fleet-tag " +
         "id whose directly-assigned servers the rule then evaluates), and an " +
         "optional 'evaluationIntervalSeconds' (>= 30). Build the metric panel from the compose catalog exposed " +
-        "by describe_custom_view_catalog. A '<'/'<=' predicate on a count aggregate is rejected because it " +
-        "cannot tell zero events from a stalled collector; use '>=' instead.")]
+        "by describe_custom_view_catalog. On a count aggregate, a predicate that fires when the count is 0 is " +
+        "rejected because it cannot tell zero events from a stalled collector: a scalar '<'/'<=' (use '>=' " +
+        "instead), or a 'between'/'outside' band whose firing region includes 0 (set the bounds so a count of 0 " +
+        "does not fire).")]
     public static Task<string> ValidateCustomAlertRule(
         [Description("The rule definition JSON to validate (NOT persisted).")] string definition)
     {

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
@@ -265,13 +265,21 @@ function alertSaveBlocker(model) {
   if (model.windowHours > MAX_WINDOW_HOURS) return "The evaluation window can be at most 24 hours (an alert window is recent).";
 
   if (isRangeOp(model.op)) {
-    /* Range op: both bounds required and ordered; no warn/critical and no count trap (the same rules the backend
-       enforces for a between/outside predicate). */
+    /* Range op: both bounds required and ordered; no warn/critical (the same rules the backend enforces for a
+       between/outside predicate). */
     const lower = parseNumOrNull(model.lower);
     const upper = parseNumOrNull(model.upper);
     if (lower == null) return "Enter a lower bound (a number).";
     if (upper == null) return "Enter an upper bound (a number).";
     if (!(lower < upper)) return "The lower bound must be less than the upper bound.";
+
+    /* A range band that fires when the count is 0 has the same stalled-collector ambiguity as the '<'/'<=' count
+       trap below (a dead collector reads COUNT 0, not "no data"), so the backend rejects it. 'outside' fires on 0
+       when 0 < lower; 'between' when lower <= 0 <= upper. Mirror that here so the operator gets the reason inline. */
+    if (metric.aggregate === "count" &&
+        (model.op === "outside" ? (0 < lower || 0 > upper) : (lower <= 0 && 0 <= upper))) {
+      return "A 'between' or 'outside' alert on a count whose band fires when the count is 0 can't tell zero events from a stalled collector — set the bounds so a count of 0 doesn't fire.";
+    }
   } else {
     const warn = parseNumOrNull(model.warn);
     if (warn == null) return "Enter a warning threshold (a number).";


### PR DESCRIPTION
## What

Extends the custom-alert **no-data (stalled-collector) guard** from the scalar `lt`/`le` COUNT case to the `between`/`outside` range ops (#3371), completing #3373 (part of #3285).

A COUNT metric compiles to `COUNT(*)`, which reads **0** over an empty window -- never the `NULL` the evaluator's no-data freeze catches -- so a stalled collector is indistinguishable from "zero events happened". A range band that treats that 0 as a breach therefore false-fires on a dead collector, exactly the ambiguity the scalar path already rejects.

## The rule

For a **COUNT** metric + range op, reject at parse time when the band fires on 0:

| band | fires on 0? | verdict |
|---|---|---|
| `outside [1, N]` | yes (`0 < 1`) | **rejected** |
| `between [0, N]` | yes (`0` in band) | **rejected** |
| `outside [0, N]` | no (`0` is the inclusive edge) | allowed |
| `between [1, N]` | no (`0 < 1`) | allowed |

Non-COUNT metrics are unaffected: `SUM`/`AVG` return `NULL` on an empty window, which the no-data freeze already handles.

## How it reuses the scalar guard (no parallel path)

- The parse-time rejection lives in `CustomAlertRuleDefinition.TryParse`, right beside the scalar `lt`/`le` count trap, keyed on the **same** `plan.Aggregate == ComposeAggregate.Count` archetype check.
- The band-membership math is factored into one private `RangeBreaches`; `IsBreaching`, the new public `BreachesOnZero()` predicate, and the guard all route through it -- `IsBreaching` stays the single evaluation authority (`BreachesOnZero() == IsBreaching(0)` for a range op).
- The rejection is mirrored in the two other places the scalar trap lives: the `alert-editor.js` save-blocker (which previously said range ops had "no count trap") and the `validate_custom_alert_rule` MCP tool description.

## Tests

`CustomAlertRuleDefinitionTests`: the four band/op combinations on a COUNT (two rejected, two allowed), a non-COUNT (SUM) band that fires on 0 staying allowed, `BreachesOnZero == IsBreaching(0)` across range ops and `false` for a scalar op, plus the previously-missing scalar COUNT `lt`/`le` rejection test alongside them.

## Verification

- `dotnet build Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj -c Debug` -> `0 Warning(s) / 0 Error(s)`; test project builds clean too.
- `CustomAlertRuleDefinitionTests` 55/55 pass; the related non-live evaluate-now / severity-escalation / templates / rule-health classes 36/36 pass (the `IsBreaching` refactor is behavior-preserving).

## Scope

No change to the range predicate JSON shape, the scalar path, or the severity model (no Critical tier -- that's #3372). CHANGELOG untouched (team lead folds it post-wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5xoN5PzhzYfHHrfutyeEe