### PR TITLE
Resolve custom-alert tag scope to the tag's whole subtree (#3367)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertTagSubtreeLiveTests.cs
+++ b/Darling/Darling.Tests/CustomAlertTagSubtreeLiveTests.cs
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3367 gated live round-trips (DARLING_TEST_PG) for tag-SUBTREE scope resolution
+/// (<see cref="CustomAlertRuleStore.ListTagMembersAsync"/>). The recursive-CTE walk cannot be exercised without a
+/// real Postgres tag tree (the <c>parent_id</c> self-join, the per-root keying, and the cycle/self-parent depth
+/// bound), so these pin: a parent tag with servers only under its children resolves to the whole subtree; a
+/// mid-tree tag resolves to itself + its descendants but NOT its siblings or ancestors; a leaf tag resolves to
+/// exactly its direct members (the pre-#3367 behavior); the walk de-dups a server reachable under several
+/// descendant tags; several requested roots resolve in one call each keyed on the tag the RULE names; and a
+/// malformed tree (a cycle A→B→A, a self-parent A→A) resolves safely without hanging or crashing. The pure
+/// gate <see cref="CustomAlertEvaluator.RuleAppliesToServer"/> is pinned in <c>CustomAlertTagScopeTests</c>.
+///
+/// <para>All tags are named with a per-run prefix and deleted in cleanup (which cascades their
+/// <c>server_tag_map</c> rows away), so the shared store is left as it was found. Server ids are synthetic and
+/// never touch <c>config_monitored_servers</c> (the map carries no FK to it).</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class CustomAlertTagSubtreeLiveTests
+{
+    private static string RequireLivePostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string (owner/superuser) to run the tag-subtree live tests.");
+        return connectionString!;
+    }
+
+    private static async Task<NpgsqlDataSource> MigrateAndOpenAsync(string connectionString, CancellationToken ct)
+    {
+        await using (var migrate = new NpgsqlConnection(connectionString))
+        {
+            await migrate.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(migrate, ct);
+        }
+
+        var dataSourceConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            SearchPath = "collect,config,public",
+        }.ConnectionString;
+
+        return NpgsqlDataSource.Create(dataSourceConnectionString);
+    }
+
+    /// <summary>Inserts one tag (name = <paramref name="prefix"/> + <paramref name="suffix"/>) under
+    /// <paramref name="parentId"/> (NULL = a root) and returns its generated id.</summary>
+    private static async Task<int> InsertTagAsync(
+        NpgsqlDataSource dataSource, string prefix, string suffix, int? parentId, CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand(
+            "INSERT INTO server_tags (name, parent_id) VALUES ($1, $2) RETURNING id");
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = prefix + suffix });
+        command.Parameters.Add(new NpgsqlParameter { Value = (object?)parentId ?? DBNull.Value });
+        return Convert.ToInt32(await command.ExecuteScalarAsync(ct));
+    }
+
+    /// <summary>Points <paramref name="tagId"/>'s parent at <paramref name="parentId"/> — used to bend a tree
+    /// into a cycle or a self-parent AFTER both rows exist (the FK needs the parent present).</summary>
+    private static async Task SetParentAsync(
+        NpgsqlDataSource dataSource, int tagId, int parentId, CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand("UPDATE server_tags SET parent_id = $2 WHERE id = $1");
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = tagId });
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = parentId });
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task AssignAsync(
+        NpgsqlDataSource dataSource, int serverId, int tagId, CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand(
+            "INSERT INTO server_tag_map (server_id, tag_id) VALUES ($1, $2)");
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = tagId });
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>Breaks any cycle first (null the parents, so a cyclic cascade cannot surprise), then deletes the
+    /// run's tags — their <c>server_tag_map</c> rows cascade away with them.</summary>
+    private static async Task DeleteByPrefixAsync(NpgsqlConnection cleanup, string prefix, CancellationToken ct)
+    {
+        using (var unparent = new NpgsqlCommand("UPDATE config.server_tags SET parent_id = NULL WHERE name LIKE $1", cleanup))
+        {
+            unparent.Parameters.Add(new NpgsqlParameter<string> { TypedValue = prefix + "%" });
+            await unparent.ExecuteNonQueryAsync(ct);
+        }
+
+        using var delete = new NpgsqlCommand("DELETE FROM config.server_tags WHERE name LIKE $1", cleanup);
+        delete.Parameters.Add(new NpgsqlParameter<string> { TypedValue = prefix + "%" });
+        await delete.ExecuteNonQueryAsync(ct);
+    }
+
+    private static void AssertResolvesTo(
+        IReadOnlyDictionary<int, IReadOnlySet<int>> result, int tagId, params int[] expected)
+    {
+        Assert.True(result.TryGetValue(tagId, out var actual), $"Tag {tagId} was not in the resolved map.");
+        Assert.Equal(expected.OrderBy(x => x), actual!.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task Subtree_ResolvesParentToDescendants_ExcludesSiblings_AndDeDups()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = await MigrateAndOpenAsync(connectionString, ct);
+
+        var store = new CustomAlertRuleStore(dataSource);
+        var prefix = "tsub_" + Guid.NewGuid().ToString("N") + "_";
+
+        // Synthetic server ids (never real): the assertions compare exactly these sets.
+        const int SvrA = 970001, SvrG = 970002, SvrB = 970003, SvrSib = 970004, SvrDup = 970005;
+
+        var bodySucceeded = false;
+        try
+        {
+            /* Tree:  root(R) [no direct servers] ── childA(A) ── grandchild(G)
+                                                  └─ childB(B)
+                      sibling(SIB) [separate root]
+               Assignments: A={SvrA,SvrDup}  G={SvrG,SvrDup}  B={SvrB}  SIB={SvrSib}
+               R carries NO direct server — its members come only from the subtree (the #3367 point). SvrDup sits
+               under both A and G so the walk must return it once per requested root. */
+            var r = await InsertTagAsync(dataSource, prefix, "R", null, ct);
+            var a = await InsertTagAsync(dataSource, prefix, "A", r, ct);
+            var g = await InsertTagAsync(dataSource, prefix, "G", a, ct);
+            var b = await InsertTagAsync(dataSource, prefix, "B", r, ct);
+            var sib = await InsertTagAsync(dataSource, prefix, "SIB", null, ct);
+
+            await AssignAsync(dataSource, SvrA, a, ct);
+            await AssignAsync(dataSource, SvrDup, a, ct);
+            await AssignAsync(dataSource, SvrG, g, ct);
+            await AssignAsync(dataSource, SvrDup, g, ct);
+            await AssignAsync(dataSource, SvrB, b, ct);
+            await AssignAsync(dataSource, SvrSib, sib, ct);
+
+            // One round-trip for every requested root, plus a never-created id that must be absent from the map.
+            const int MissingTagId = -12345;
+            var result = await store.ListTagMembersAsync(new[] { r, a, g, b, sib, MissingTagId }, ct);
+
+            // Parent with servers only under its children -> the whole subtree, SvrDup de-duped to one entry.
+            AssertResolvesTo(result, r, SvrA, SvrDup, SvrG, SvrB);
+
+            // Mid-tree tag -> itself + descendants (A's own + G's), never its sibling B or the other root SIB.
+            AssertResolvesTo(result, a, SvrA, SvrDup, SvrG);
+
+            // Leaf tags -> exactly their direct members (byte-for-byte the pre-#3367 lookup).
+            AssertResolvesTo(result, g, SvrG, SvrDup);
+            AssertResolvesTo(result, b, SvrB);
+
+            // A separate root is isolated: no ancestor/sibling bleed from R's subtree.
+            AssertResolvesTo(result, sib, SvrSib);
+
+            // A tag id that does not exist resolves to nothing -> absent from the map (rule never fires).
+            Assert.False(result.ContainsKey(MissingTagId));
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DeleteByPrefixAsync(cleanup, prefix, cleanupCt);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task Subtree_MalformedTree_ResolvesSafely_NoHangNoCrash()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = await MigrateAndOpenAsync(connectionString, ct);
+
+        var store = new CustomAlertRuleStore(dataSource);
+        var prefix = "tsubcyc_" + Guid.NewGuid().ToString("N") + "_";
+
+        const int SvrCycle = 980001, SvrSelf = 980002;
+
+        var bodySucceeded = false;
+        try
+        {
+            /* Two malformed shapes the depth bound must tame:
+                 - a 2-node cycle  cycA.parent = cycB, cycB.parent = cycA  (server on cycB)
+                 - a self-parent   self.parent = self                       (server on self)
+               A UNION-ALL walk with no bound would spin forever on either; the `depth < 64` guard stops it. */
+            var cycA = await InsertTagAsync(dataSource, prefix, "cycA", null, ct);
+            var cycB = await InsertTagAsync(dataSource, prefix, "cycB", cycA, ct);
+            await SetParentAsync(dataSource, cycA, cycB, ct); // close the cycle: cycA.parent = cycB
+            await AssignAsync(dataSource, SvrCycle, cycB, ct);
+
+            var self = await InsertTagAsync(dataSource, prefix, "self", null, ct);
+            await SetParentAsync(dataSource, self, self, ct); // self-parent
+            await AssignAsync(dataSource, SvrSelf, self, ct);
+
+            // Both calls must RETURN (the assertion running at all proves no hang) with the correct member set.
+            var cycleResult = await store.ListTagMembersAsync(new[] { cycA }, ct);
+            AssertResolvesTo(cycleResult, cycA, SvrCycle); // reachable through the cycle, still resolved
+
+            var selfResult = await store.ListTagMembersAsync(new[] { self }, ct);
+            AssertResolvesTo(selfResult, self, SvrSelf);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DeleteByPrefixAsync(cleanup, prefix, cleanupCt);
+            });
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleStore.cs
@@ -105,19 +105,53 @@ WHERE enabled
 ORDER BY id
 LIMIT $1";
 
-    /// <summary>Resolves each given fleet-tag id to the set of server ids DIRECTLY assigned to it (#3350 tag
-    /// scope) — one round-trip for every tag via <c>= ANY($1)</c>. Reads <c>config.server_tag_map</c> (bare
-    /// name; the pool's search_path resolves it, the same as <c>custom_alert_rules</c> above). $1 the tag ids.
+    /// <summary>Resolves each requested fleet-tag id to the set of server ids under its WHOLE SUBTREE (#3367 —
+    /// the tag itself plus every descendant tag's directly-assigned servers), in ONE round-trip for the full set
+    /// of requested roots via <c>= ANY($1)</c>. A recursive CTE walks <c>server_tags</c> from each requested id
+    /// down through <c>parent_id</c> (a child references its parent), carrying the REQUESTED ROOT id so the rows
+    /// it returns are still <c>(requested_root_tag_id, server_id)</c> — the caller's per-rule map keys on the tag
+    /// the RULE names, never a descendant. Reads <c>server_tags</c> / <c>server_tag_map</c> (bare names; the
+    /// pool's search_path resolves them, the same as <c>custom_alert_rules</c> above). $1 the tag ids.
     ///
-    /// <para>A tag with no rows — never assigned, or deleted so the map rows cascaded away — is simply absent
-    /// from the result, which the caller treats as "resolves to no server", so a tag-scoped rule on it never
-    /// fires (the #3350 integrity requirement; the 0-server case then flows to the #3304 never-firing surface).
-    /// Membership is DIRECT only: descendant tags' servers are NOT pulled in (a v1 decision — the tree is not
-    /// traversed here; that is a possible later slice).</para></summary>
+    /// <para><b>Leaf tags are unchanged.</b> A tag with no children resolves to exactly its direct members — the
+    /// recursive term finds no child, so the walk is only the anchor row, byte-for-byte the pre-#3367 direct
+    /// lookup. A parent tag that carries servers only under its children now resolves to those children's servers
+    /// (the point of #3367). A tag absent from <c>server_tags</c> (never created, or deleted so its rows cascaded
+    /// away) produces no anchor row and is simply absent from the result, which the caller treats as "resolves to
+    /// no server" so a tag-scoped rule on it never fires (the #3350 integrity requirement; the 0-server case flows
+    /// to the #3304 never-firing surface). The final <c>DISTINCT</c> collapses a server reachable under several
+    /// descendant tags of the same requested root to one row.</para>
+    ///
+    /// <para><b>Cycle- and dangling-parent-safe</b>, mirroring the frontend fleet-forest projection
+    /// (<c>wwwroot/js/pages/fleet.js</c>, which guards with a <c>visited</c> set and re-roots a dangling parent).
+    /// A well-formed tree terminates on its own — leaf tags have no children, so the recursion frontier empties
+    /// (long before the cap). The guaranteed terminator for a MALFORMED tree is <c>depth &lt; 64</c>: a cycle
+    /// (A→B→A, or a self-parent A→A) keeps the frontier non-empty forever, and the depth predicate stops it after
+    /// at most 64 iterations rather than looping or crashing. 64 is far above the 4-level nesting the Viewer
+    /// enforces app-side, so a legitimate subtree is never truncated; the cap only ever bites a malformed cycle.
+    /// A <c>parent_id</c> pointing at a missing or unrelated row needs no special handling — the child-join finds
+    /// no match, so that branch ends. <c>UNION</c> (not <c>UNION ALL</c>) collapses duplicate walk rows.</para></summary>
     public const string ListTagMembersSql = @"
-SELECT tag_id, server_id
-FROM server_tag_map
-WHERE tag_id = ANY($1)";
+WITH RECURSIVE tag_subtree (root_id, tag_id, depth) AS
+(
+    SELECT t.id, t.id, 1
+    FROM server_tags AS t
+    WHERE t.id = ANY($1)
+
+    UNION
+
+    SELECT s.root_id, c.id, s.depth + 1
+    FROM tag_subtree AS s
+    JOIN server_tags AS c
+      ON c.parent_id = s.tag_id
+    WHERE s.depth < 64
+)
+SELECT DISTINCT
+    s.root_id AS tag_id,
+    m.server_id
+FROM tag_subtree AS s
+JOIN server_tag_map AS m
+  ON m.tag_id = s.tag_id";
 
     /// <summary>Inserts a new rule at version 1. $1 name, $2 definition (jsonb), $3 description, $4 enabled, $5 updated_by.</summary>
     public const string InsertSql = @"
@@ -260,12 +294,16 @@ RETURNING id, name, definition, description, enabled, version, created_at, updat
     }
 
     /// <summary>
-    /// Resolves each fleet-tag id to the set of server ids directly assigned to it (#3350 tag scope), in ONE
-    /// round-trip. The single shared tag-membership read: the evaluator calls it on the owner pool each cache
-    /// refresh, and the evaluate-now test tool calls it on the least-privilege mcp/viewer pool — both of which
-    /// carry <c>SELECT</c> on <c>config.server_tag_map</c> (it holds no secret column). A tag with no assigned
-    /// servers is absent from the returned map (the caller reads that as an empty set → the rule matches no
-    /// server). Returns an empty map for an empty input without touching the store.
+    /// Resolves each fleet-tag id to the set of server ids under its whole subtree — the tag plus every
+    /// descendant tag's directly-assigned servers (#3367; #3350 introduced the direct-only form) — in ONE
+    /// round-trip via <see cref="ListTagMembersSql"/>. The single shared tag-membership read: the evaluator
+    /// calls it on the owner pool each cache refresh, and the evaluate-now test tool calls it on the
+    /// least-privilege mcp/viewer pool — both of which carry <c>SELECT</c> on <c>config.server_tags</c> and
+    /// <c>config.server_tag_map</c> (neither holds a secret column, so both are covered by the blanket
+    /// <c>GRANT … ON ALL TABLES IN SCHEMA config</c> provisioning re-runs on every start). A tag that resolves
+    /// to no servers (an empty subtree, or a tag absent from <c>server_tags</c>) is absent from the returned map
+    /// (the caller reads that as an empty set → the rule matches no server). Returns an empty map for an empty
+    /// input without touching the store.
     /// </summary>
     public async Task<IReadOnlyDictionary<int, IReadOnlySet<int>>> ListTagMembersAsync(
         IReadOnlyCollection<int> tagIds, CancellationToken cancellationToken = default)

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
@@ -651,9 +651,9 @@ function scopeSection(model, fleet, tags, onChange) {
     mount(box, [list, el("div", { class: "block-help", text: "The rule fires per server; pick the servers it applies to." })]);
   }
 
-  /* The tag picker: a single-select of the fleet tag forest, indented by depth. The rule evaluates the servers
-     DIRECTLY assigned the chosen tag, resolved fresh each sweep — so adding or removing a server from the tag
-     re-scopes the rule without editing it. */
+  /* The tag picker: a single-select of the fleet tag forest, indented by depth. The rule evaluates every server
+     under the chosen tag's whole subtree (the tag plus its descendant tags' servers), resolved fresh each sweep
+     — so adding or removing a server, or a sub-tag, re-scopes the rule without editing it. */
   function tagScope() {
     if (!tags.length) {
       return noticeStrip("No fleet tags are defined yet. Create and assign tags in the desktop viewer's fleet view, then scope a rule to one.");
@@ -679,7 +679,7 @@ function scopeSection(model, fleet, tags, onChange) {
       field("Tag", sel),
       el("div", {
         class: "block-help",
-        text: "The rule fires per server for every server DIRECTLY assigned this tag. Membership is resolved fresh each evaluation, so adding or removing a server from the tag re-scopes the rule automatically; an empty or deleted tag matches no server (the rule never fires).",
+        text: "The rule fires per server for every server assigned this tag OR any tag beneath it (the whole subtree). Membership is resolved fresh each evaluation, so adding or removing a server — or a sub-tag — re-scopes the rule automatically; a tag whose subtree has no servers matches nothing (the rule never fires).",
       }),
     ]);
   }


### PR DESCRIPTION
## What

A custom-alert rule scoped to a fleet tag now evaluates every server under that tag's **whole subtree** (the tag itself plus all descendant tags' servers), not only servers assigned directly to it (#3367, part of #3285). Organizational parent tags — where servers are assigned only to child tags — previously resolved to nothing, so a rule scoped to them never fired.

## How (store-only)

`CustomAlertRuleStore.ListTagMembersSql` changes from a direct `server_tag_map` lookup to a recursive CTE:

```sql
WITH RECURSIVE tag_subtree (root_id, tag_id, depth) AS
(
    SELECT t.id, t.id, 1
    FROM server_tags AS t
    WHERE t.id = ANY($1)

    UNION

    SELECT s.root_id, c.id, s.depth + 1
    FROM tag_subtree AS s
    JOIN server_tags AS c
      ON c.parent_id = s.tag_id
    WHERE s.depth < 64
)
SELECT DISTINCT
    s.root_id AS tag_id,
    m.server_id
FROM tag_subtree AS s
JOIN server_tag_map AS m
  ON m.tag_id = s.tag_id
```

- **One round-trip** for the full set of requested roots — the anchor keeps `= ANY($1)`, and each root's `id` is carried down as `root_id`, so the returned `(requested_root_tag_id, server_id)` rows still key the caller's per-rule map on the tag the *rule* names, never a descendant.
- **Leaf tags are unchanged**: a tag with no children produces only the anchor row, so it resolves to exactly its direct members — byte-for-byte the pre-#3367 behavior.
- **De-dup**: the final `DISTINCT` collapses a server reachable under several descendant tags of the same requested root to one row.
- **Cycle- and dangling-parent-safe**, mirroring the frontend fleet-forest projection (`wwwroot/js/pages/fleet.js`, which guards with a `visited` set and re-roots a dangling parent). A well-formed tree terminates on its own — leaf tags have no children, so the recursion frontier empties. The guaranteed terminator for a malformed tree is `depth < 64`: a cycle (A→B→A) or a self-parent (A→A) keeps the frontier non-empty forever, and the depth predicate stops it after at most 64 iterations. 64 is far above the 4-level nesting the Viewer enforces app-side, so a legitimate subtree is never truncated; the cap only ever bites a malformed cycle. A `parent_id` pointing at a missing or unrelated row needs no special handling — the child-join finds no match, so that branch ends. `UNION` (not `UNION ALL`) collapses duplicate walk rows.

The downstream evaluator gate (`RuleAppliesToServer`) and the resolved `IReadOnlySet<int>` are server-id based and untouched; the scope JSON shape is unchanged.

## Editor

The alert editor's tag-picker help text (and its docstring) now says a tag scope covers the whole subtree: *"…every server assigned this tag OR any tag beneath it (the whole subtree)…"*. Trivial reword of the existing help string — no new UI.

## Tests

New `CustomAlertTagSubtreeLiveTests` (`DARLING_TEST_PG`-gated, following the existing custom-alert live-store pattern, per-run tag prefix + cascade cleanup):
- a parent with servers only under children resolves to the whole subtree;
- a mid-tree tag resolves to itself + its descendants but **not** its siblings/ancestors or a separate root;
- leaf tags resolve to their direct members only;
- a server under multiple descendant tags is de-duped;
- several requested roots resolve in one call, each keyed on its own tag, and a non-existent tag id is absent;
- a cycle and a self-parent both resolve safely (no hang, no crash).

Verified green on a throwaway PostgreSQL 18.4 + TimescaleDB rig (full migration ladder): the two new live tests pass, and the 6 pure-gate `CustomAlertTagScopeTests` still pass (8/8). Service build is `0 Warning(s) / 0 Error(s)`. CHANGELOG deliberately untouched (folded post-wave).

Closes #3367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5xoN5PzhzYfHHrfutyeEe