### PR TITLE
Add an optional Critical tier for between/outside range alert predicates (#3372)

### DIFF
--- a/Darling/Darling.Tests/CustomAlertRuleDefinitionTests.cs
+++ b/Darling/Darling.Tests/CustomAlertRuleDefinitionTests.cs
@@ -446,4 +446,167 @@ public class CustomAlertRuleDefinitionTests
         Assert.True(def!.IsBreaching(0));
         Assert.False(def.BreachesOnZero());
     }
+
+    // ─────────────────────────── #3372: the optional Critical tier for range ops ───────────────────────────
+
+    private static string Inv(double d) => d.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>A two-tier range predicate over the shared (non-count) metric: a warn band [lower, upper] plus a
+    /// crit band [critLower, critUpper] (the more-severe extension — wider for 'outside', narrower for 'between').</summary>
+    private static string CritRangePredicate(string op, double lower, double upper, double critLower, double critUpper) =>
+        "{" + Metric + ",\"predicate\":{\"op\":\"" + op + "\",\"lowerBound\":" + Inv(lower) + ",\"upperBound\":" + Inv(upper) +
+        ",\"criticalLowerBound\":" + Inv(critLower) + ",\"criticalUpperBound\":" + Inv(critUpper) + "}}";
+
+    [Theory]
+    [InlineData("outside", 5, 200)]  // WIDER crit band, containing the warn band
+    [InlineData("between", 40, 60)]  // NARROWER crit band, contained by the warn band
+    public void TwoTierRange_Parses_WithCriticalBand(string op, double critLower, double critUpper)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(CritRangePredicate(op, 10, 100, critLower, critUpper));
+
+        Assert.Null(error);
+        Assert.NotNull(def);
+        Assert.True(def!.IsRange);
+        Assert.Equal(10d, def.LowerBound);
+        Assert.Equal(100d, def.UpperBound);
+        Assert.Equal(critLower, def.CriticalLowerBound);
+        Assert.Equal(critUpper, def.CriticalUpperBound);
+    }
+
+    [Theory]
+    // outside, warn [10,100], crit [5,200] (WIDER, containing the warn band): further OUT is more severe.
+    [InlineData(50, false, AlertSeverityLevel.Warning)]   // inside the warn band -> no breach
+    [InlineData(7, true, AlertSeverityLevel.Warning)]     // below warn, still inside crit (low side) -> Warning
+    [InlineData(150, true, AlertSeverityLevel.Warning)]   // above warn, still inside crit (high side) -> Warning
+    [InlineData(3, true, AlertSeverityLevel.Critical)]    // beyond crit on the low side -> Critical
+    [InlineData(250, true, AlertSeverityLevel.Critical)]  // beyond crit on the high side -> Critical
+    public void Outside_TwoTier_SeverityByBand(double value, bool breaching, AlertSeverityLevel severity)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(CritRangePredicate("outside", 10, 100, 5, 200));
+        Assert.Null(error);
+        Assert.Equal(breaching, def!.IsBreaching(value));
+        if (breaching)
+        {
+            Assert.Equal(severity, def.SeverityFor(value));
+        }
+    }
+
+    [Theory]
+    // between, warn [10,100], crit [40,60] (NARROWER, contained by the warn band): DEEPER in is more severe.
+    [InlineData(5, false, AlertSeverityLevel.Warning)]    // outside the warn band -> no breach
+    [InlineData(20, true, AlertSeverityLevel.Warning)]    // inside warn, outside crit -> Warning
+    [InlineData(100, true, AlertSeverityLevel.Warning)]   // warn upper edge, outside crit -> Warning
+    [InlineData(50, true, AlertSeverityLevel.Critical)]   // inside the crit band -> Critical
+    [InlineData(40, true, AlertSeverityLevel.Critical)]   // crit lower edge (inclusive) -> Critical
+    [InlineData(60, true, AlertSeverityLevel.Critical)]   // crit upper edge (inclusive) -> Critical
+    [InlineData(150, false, AlertSeverityLevel.Warning)]  // outside the warn band -> no breach
+    public void Between_TwoTier_SeverityByBand(double value, bool breaching, AlertSeverityLevel severity)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(CritRangePredicate("between", 10, 100, 40, 60));
+        Assert.Null(error);
+        Assert.Equal(breaching, def!.IsBreaching(value));
+        if (breaching)
+        {
+            Assert.Equal(severity, def.SeverityFor(value));
+        }
+    }
+
+    [Fact]
+    public void OutsideCritBand_NarrowerThanWarn_IsError()
+    {
+        // 'outside' needs a WIDER crit band; a narrower one ([20,80] inside [10,100]) would make Critical unreachable.
+        var (def, error) = CustomAlertRuleDefinition.TryParse(CritRangePredicate("outside", 10, 100, 20, 80));
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void BetweenCritBand_WiderThanWarn_IsError()
+    {
+        // 'between' needs a NARROWER crit band; a wider one ([5,200] containing [10,100]) would make Critical fire
+        // before (outside) Warning.
+        var (def, error) = CustomAlertRuleDefinition.TryParse(CritRangePredicate("between", 10, 100, 5, 200));
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void BetweenCritBand_InvertedBounds_IsError()
+    {
+        // Even sitting inside the warn band, the crit bounds must be ordered (critLower <= critUpper); [60,40] fails.
+        var (def, error) = CustomAlertRuleDefinition.TryParse(CritRangePredicate("between", 10, 100, 60, 40));
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    // A lone crit bound is a half-specified band: the parser wants both or neither.
+    [InlineData("\"criticalLowerBound\":5")]
+    [InlineData("\"criticalUpperBound\":200")]
+    public void RangeCritBand_LoneBound_IsError(string critKey)
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"outside\",\"lowerBound\":10,\"upperBound\":100," + critKey + "}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void RangeCritBand_NonNumeric_IsError()
+    {
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + Metric + ",\"predicate\":{\"op\":\"outside\",\"lowerBound\":10,\"upperBound\":100," +
+            "\"criticalLowerBound\":\"x\",\"criticalUpperBound\":200}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TwoTier_FiredThreshold_Outside_ConveysBothBands()
+    {
+        // The delivered-alert render authority conveys BOTH bands, the crit band repeating the word for 'outside',
+        // with the plain " - " separator and no numeric twin (a band has no single threshold value).
+        var (def, _) = CustomAlertRuleDefinition.TryParse(CritRangePredicate("outside", 10, 100, 5, 200));
+        var (text, numeric) = def!.FiredThreshold(AlertSeverityLevel.Critical);
+        Assert.Equal("outside 10 - 100 (crit outside 5 - 200)", text);
+        Assert.Null(numeric);
+    }
+
+    [Fact]
+    public void TwoTier_FiredThreshold_Between_ConveysBothBands()
+    {
+        var (def, _) = CustomAlertRuleDefinition.TryParse(CritRangePredicate("between", 10, 100, 40, 60));
+        var (text, numeric) = def!.FiredThreshold(AlertSeverityLevel.Warning);
+        Assert.Equal("between 10 - 100 (crit 40 - 60)", text);
+        Assert.Null(numeric);
+    }
+
+    [Fact]
+    public void CountTwoTierRange_WarnBandFiresOnZero_IsError_EvenWithCritBand()
+    {
+        // The #3378 count guard still fires with a crit band present: the WARN band ('between' [0,100] fires on 0)
+        // is the outer firing envelope, so a valid crit band nested inside it cannot make the rule safe on a
+        // stalled-collector 0. (The crit band [40,60] nests correctly; the warn band is what trips the guard.)
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + CountMetric + ",\"predicate\":{\"op\":\"between\",\"lowerBound\":0,\"upperBound\":100," +
+            "\"criticalLowerBound\":40,\"criticalUpperBound\":60}}");
+        Assert.Null(def);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void CountTwoTierRange_WarnBandSafeOnZero_Parses_WithCritBand()
+    {
+        // WARN band safe on 0 ('between' [1,100] excludes 0) with a nested crit band [40,60] -> parses; and because
+        // the crit firing region is a subset of the warn firing region, the band is safe on a stalled 0 too.
+        var (def, error) = CustomAlertRuleDefinition.TryParse(
+            "{" + CountMetric + ",\"predicate\":{\"op\":\"between\",\"lowerBound\":1,\"upperBound\":100," +
+            "\"criticalLowerBound\":40,\"criticalUpperBound\":60}}");
+        Assert.Null(error);
+        Assert.NotNull(def);
+        Assert.True(def!.IsRange);
+        Assert.Equal(40d, def.CriticalLowerBound);
+        Assert.Equal(60d, def.CriticalUpperBound);
+        Assert.False(def.BreachesOnZero());
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleDefinition.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CustomAlertRuleDefinition.cs
@@ -64,6 +64,8 @@ public sealed record CustomAlertRuleDefinition(
     double? CriticalThreshold,
     double? LowerBound,
     double? UpperBound,
+    double? CriticalLowerBound,
+    double? CriticalUpperBound,
     int BreachSamples,
     int ClearSamples,
     CustomAlertScopeMode ScopeMode,
@@ -74,7 +76,9 @@ public sealed record CustomAlertRuleDefinition(
     /// <summary>Whether this rule's operator tests the value against a two-sided band
     /// (<see cref="LowerBound"/>/<see cref="UpperBound"/>) rather than a single scalar threshold (#3351). A
     /// range op carries both bounds and neither <see cref="WarnThreshold"/> nor <see cref="CriticalThreshold"/>;
-    /// a scalar op is the mirror image — the validator enforces that mutual exclusivity.</summary>
+    /// a scalar op is the mirror image — the validator enforces that mutual exclusivity. A range op may also carry
+    /// an OPTIONAL second, more-severe band (<see cref="CriticalLowerBound"/>/<see cref="CriticalUpperBound"/>,
+    /// #3372) for a Warning/Critical two-tier; absent, it fires Warning-only exactly as #3351/#3378.</summary>
     public bool IsRange => IsRangeOp(Op);
 
     /// <summary>Pure op-category test, usable by the validator before a definition is constructed.</summary>
@@ -132,14 +136,35 @@ public sealed record CustomAlertRuleDefinition(
     /// guard uses to reject such a rule, mirroring the scalar '&lt;'/'&lt;=' count rejection. Expressed as the
     /// band's own <see cref="IsBreaching"/> verdict at 0 so the band logic stays the single authority; meaningful
     /// only for a range op (a scalar op returns false here — its count trap is the separate '&lt;'/'&lt;=' rejection).
+    /// <para>This tests the WARN band, which is the OUTER firing envelope for both ops: under the #3372 nesting the
+    /// crit firing region is always a subset of the warn firing region ('outside' crit is wider so being outside it
+    /// implies outside warn; 'between' crit is narrower so being inside it implies inside warn). So a warn band that
+    /// does not fire on 0 guarantees the crit band does not either — the warn-band check is a complete 0-guard for
+    /// both bands, and needs no parallel crit-band test.</para>
     /// </summary>
     public bool BreachesOnZero() => IsRange && IsBreaching(0);
 
-    /// <summary>The tier a breaching value fires at: Critical when it also crosses the critical bar, else Warning.
-    /// A range op is Warning-only in v1 (a two-tier band would need a warn-band AND a crit-band = four bounds;
-    /// that escalation is a tracked follow-up, not this slice), so it always fires Warning.</summary>
-    public AlertSeverityLevel SeverityFor(double value) =>
-        !IsRange && CriticalThreshold is double c && Compare(value, c) ? AlertSeverityLevel.Critical : AlertSeverityLevel.Warning;
+    /// <summary>
+    /// The tier a breaching value fires at (called on an already-breaching value). A SCALAR op is Critical when it
+    /// also crosses the critical bar, else Warning. A RANGE op is Critical when it also breaches the OPTIONAL crit
+    /// band (#3372) — evaluated as just another (op, lower, upper) triple through the shared
+    /// <see cref="RangeBreaches"/> authority, so there is no parallel band math — else Warning; with no crit band it
+    /// stays Warning-only exactly as #3351/#3378. The crit band's firing region is a subset of the warn band's (the
+    /// validator enforces the op-specific nesting: 'outside' crit is WIDER/containing, 'between' crit is
+    /// NARROWER/contained), so a value that breaches the crit band necessarily breaches the warn band that
+    /// <see cref="IsBreaching"/> already confirmed.
+    /// </summary>
+    public AlertSeverityLevel SeverityFor(double value)
+    {
+        if (IsRange)
+        {
+            return CriticalLowerBound is double cl && CriticalUpperBound is double cu && RangeBreaches(Op, cl, cu, value)
+                ? AlertSeverityLevel.Critical
+                : AlertSeverityLevel.Warning;
+        }
+
+        return CriticalThreshold is double c && Compare(value, c) ? AlertSeverityLevel.Critical : AlertSeverityLevel.Warning;
+    }
 
     /// <summary>The scalar comparison — the single authority for a one-sided bar. Range ops go through the band
     /// logic in <see cref="IsBreaching"/> instead, never here.</summary>
@@ -167,16 +192,28 @@ public sealed record CustomAlertRuleDefinition(
     /// How the threshold reads in a fired alert body, plus the numeric twin persisted alongside it
     /// (<c>NumericThresholdValue</c>). A scalar op reports the crossed bar as "&lt;symbol&gt; &lt;value&gt;"
     /// (e.g. "&gt;= 25") with that bar as the numeric twin; a range op reports the band as "outside 10 - 100" /
-    /// "between 10 - 100" with a NULL numeric twin (a band has no single threshold value). The plain " - " band
-    /// separator keeps an em dash — a style tell — out of delivered text. Range ops are Warning-only, so the tier
-    /// only selects warn-vs-critical for a scalar op.
+    /// "between 10 - 100" with a NULL numeric twin (a band has no single threshold value), and — when a crit band is
+    /// set (#3372) — conveys BOTH bands as "outside 10 - 100 (crit outside 5 - 200)" / "between 10 - 100 (crit
+    /// 40 - 60)". The plain " - " band separator keeps an em dash — a style tell — out of delivered text. The range
+    /// band render is severity-independent (it always shows both bands when a crit tier exists); the tier only
+    /// selects warn-vs-critical for a scalar op's single bar.
     /// </summary>
     public (string Text, double? Numeric) FiredThreshold(AlertSeverityLevel severity)
     {
         if (IsRange)
         {
             var word = Op == CustomAlertOp.Between ? "between" : "outside";
-            return (string.Create(CultureInfo.InvariantCulture, $"{word} {LowerBound ?? 0:0.###} - {UpperBound ?? 0:0.###}"), null);
+            var band = string.Create(CultureInfo.InvariantCulture, $"{word} {LowerBound ?? 0:0.###} - {UpperBound ?? 0:0.###}");
+            if (CriticalLowerBound is double cl && CriticalUpperBound is double cu)
+            {
+                // The crit band is the more-severe extension of the warn band. For 'outside' it is a different
+                // (wider) outside test, so the word is repeated to read unambiguously; for 'between' the narrower
+                // inner band reads plainly under the leading "between". Same plain " - " separator as the warn band.
+                var critWord = Op == CustomAlertOp.Outside ? "outside " : string.Empty;
+                band += string.Create(CultureInfo.InvariantCulture, $" (crit {critWord}{cl:0.###} - {cu:0.###})");
+            }
+
+            return (band, null);
         }
 
         var bar = severity == AlertSeverityLevel.Critical && CriticalThreshold is double c ? c : WarnThreshold ?? 0;
@@ -272,6 +309,8 @@ public sealed record CustomAlertRuleDefinition(
         double? critical = null;
         double? lowerBound = null;
         double? upperBound = null;
+        double? criticalLowerBound = null;
+        double? criticalUpperBound = null;
 
         if (IsRangeOp(op))
         {
@@ -295,6 +334,56 @@ public sealed record CustomAlertRuleDefinition(
                 return (null, "'predicate.lowerBound' must be less than 'predicate.upperBound'.");
             }
 
+            // Optional Critical band (#3372): two more bounds that carve a MORE-SEVERE region out of the warn band,
+            // for a two-tier Warning/Critical range rule. All-or-nothing — both crit bounds or neither (a lone crit
+            // bound is a half-specified band, rejected). "More severe" means FURTHER from healthy, which flips the
+            // nesting between the two ops: 'outside' breaches further OUT, so its crit band is WIDER and CONTAINS the
+            // warn band (criticalLowerBound <= lowerBound < upperBound <= criticalUpperBound); 'between' breaches
+            // DEEPER in, so its crit band is NARROWER and is CONTAINED BY the warn band (lowerBound <=
+            // criticalLowerBound <= criticalUpperBound <= upperBound). In BOTH cases the crit firing region is a
+            // subset of the warn firing region, so IsBreaching (the warn band) stays the single "breaches at all"
+            // envelope and SeverityFor only asks whether the value ALSO breaches the crit band (the same
+            // RangeBreaches authority, given the crit triple). Absent -> Warning-only, exactly #3351/#3378.
+            var hasCritLower = predicate["criticalLowerBound"] is not null;
+            var hasCritUpper = predicate["criticalUpperBound"] is not null;
+            if (hasCritLower != hasCritUpper)
+            {
+                return (null, "a range predicate's critical band needs BOTH 'criticalLowerBound' and 'criticalUpperBound', or neither.");
+            }
+
+            if (hasCritLower)
+            {
+                if (predicate["criticalLowerBound"] is not JsonNode critLowerNode || !TryDouble(critLowerNode, out var critLower))
+                {
+                    return (null, "'predicate.criticalLowerBound' must be a number.");
+                }
+
+                if (predicate["criticalUpperBound"] is not JsonNode critUpperNode || !TryDouble(critUpperNode, out var critUpper))
+                {
+                    return (null, "'predicate.criticalUpperBound' must be a number.");
+                }
+
+                // Op-specific nesting (see above). 'outside': the crit band must be WIDER than (and contain) the warn
+                // band; because lower < upper is already established, criticalLowerBound <= lowerBound and upperBound
+                // <= criticalUpperBound gives the full criticalLowerBound <= lowerBound < upperBound <=
+                // criticalUpperBound chain. 'between': the crit band must be NARROWER than (and sit inside) the warn
+                // band, with its own bounds ordered — lowerBound <= criticalLowerBound <= criticalUpperBound <=
+                // upperBound. A band that does not nest would make Critical unreachable or fire before Warning.
+                var nested = op == CustomAlertOp.Outside
+                    ? critLower <= lower && upper <= critUpper
+                    : lower <= critLower && critLower <= critUpper && critUpper <= upper;
+                if (!nested)
+                {
+                    var nestingError = op == CustomAlertOp.Outside
+                        ? "for 'outside', the critical band must be WIDER than the warning band ('criticalLowerBound' <= 'lowerBound' and 'upperBound' <= 'criticalUpperBound') so a value further outside fires Critical."
+                        : "for 'between', the critical band must be NARROWER than the warning band ('lowerBound' <= 'criticalLowerBound' <= 'criticalUpperBound' <= 'upperBound') so a value deeper inside fires Critical.";
+                    return (null, nestingError);
+                }
+
+                criticalLowerBound = critLower;
+                criticalUpperBound = critUpper;
+            }
+
             // A range band that fires when the count is 0 has the SAME stalled-collector ambiguity as the scalar
             // '<'/'<=' count trap below: COUNT(*) over an empty window is 0 (never the NULL the evaluator's
             // no-data freeze catches), so a dead collector reads 0 and the band false-fires exactly when the true
@@ -302,6 +391,10 @@ public sealed record CustomAlertRuleDefinition(
             // through the same band authority (RangeBreaches) the live evaluation uses. 'outside' fires on 0 when
             // 0 < lower; 'between' when lower <= 0 <= upper; nudging the bounds so 0 falls outside the firing
             // region (outside -> lower 0, between -> lower above 0) makes the band safe on an empty window.
+            // This tests the WARN band, and that is a COMPLETE 0-guard for BOTH bands: the crit band was just
+            // validated to nest INSIDE the warn firing region (#3372), so if the warn band does not fire on 0 the
+            // crit band cannot either — no separate crit-band 0-check is needed (and a crit band that DID fire on 0
+            // could only do so with a warn band that also fires on 0, which is already rejected here).
             if (plan.Aggregate == ComposeAggregate.Count && RangeBreaches(op, lower, upper, 0))
             {
                 return (null, "a 'between'/'outside' alert on a count whose band fires when the count is 0 can't distinguish zero events from a stalled collector; set the bounds so a count of 0 does not fire.");
@@ -434,6 +527,7 @@ public sealed record CustomAlertRuleDefinition(
 
         var definition = new CustomAlertRuleDefinition(
             plan, plan.Measure.DisplayName, windowHours, op, warn, critical, lowerBound, upperBound,
+            criticalLowerBound, criticalUpperBound,
             breachSamples, clearSamples, scopeMode, scopeServers, scopeTagId, intervalSeconds);
         return (definition, null);
     }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpCustomAlertTools.cs
@@ -109,8 +109,11 @@ public sealed class DarlingMcpCustomAlertTools
         "must reduce to a single value), a 'predicate' (either a SCALAR comparison - 'op' one of gt/ge/lt/le, a " +
         "numeric 'warnThreshold', and an optional 'criticalThreshold' that must be more extreme than warn in the " +
         "operator's direction; or a RANGE band - 'op' 'between' or 'outside', with numeric 'lowerBound' and " +
-        "'upperBound' where lowerBound < upperBound, which fires Warning-only and carries no warn/critical - the " +
-        "two shapes being mutually exclusive), an " +
+        "'upperBound' where lowerBound < upperBound, which fires Warning and carries no warn/critical but MAY add " +
+        "an optional critical band via 'criticalLowerBound'/'criticalUpperBound' (both or neither) for a second, " +
+        "more-severe tier - WIDER than the warn band for 'outside' (criticalLowerBound <= lowerBound and " +
+        "upperBound <= criticalUpperBound), NARROWER for 'between' (lowerBound <= criticalLowerBound <= " +
+        "criticalUpperBound <= upperBound); the scalar and range shapes being mutually exclusive), an " +
         "optional 'hysteresis' ('breachSamples'/'clearSamples', each an integer >= 1), an optional 'scope' " +
         "('mode' 'all', or 'servers' with a non-empty 'servers' list, or 'tag' with an integer 'tagId' fleet-tag " +
         "id whose directly-assigned servers the rule then evaluates), and an " +

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/alert-editor.js
@@ -67,7 +67,8 @@ const WINDOW_OPTIONS = [
 
 /* The comparison operators an alert predicate offers — matching the CustomAlertOp enum the backend parses. The
    four scalar comparisons test the value against a single bar (a warning threshold + an optional critical); the
-   two range ops (#3351) test it against a two-sided band [lower, upper] and fire a single Warning tier. */
+   two range ops (#3351) test it against a two-sided band [lower, upper], firing Warning, with an optional second
+   critical band (#3372) for a Warning/Critical two-tier. */
 const OP_OPTIONS = [
   { value: "gt", label: "is greater than (>)" },
   { value: "ge", label: "is greater than or equal to (≥)" },
@@ -158,6 +159,8 @@ function blankModel() {
     critical: "",
     lower: "",
     upper: "",
+    critLower: "",
+    critUpper: "",
     breachSamples: 1,
     clearSamples: 1,
     scopeMode: "all",
@@ -201,6 +204,8 @@ function definitionToModel(def, name, description, enabled) {
     critical: pred.criticalThreshold != null ? String(pred.criticalThreshold) : "",
     lower: pred.lowerBound != null ? String(pred.lowerBound) : "",
     upper: pred.upperBound != null ? String(pred.upperBound) : "",
+    critLower: pred.criticalLowerBound != null ? String(pred.criticalLowerBound) : "",
+    critUpper: pred.criticalUpperBound != null ? String(pred.criticalUpperBound) : "",
     breachSamples: intOr(hyst.breachSamples, 1),
     clearSamples: intOr(hyst.clearSamples, 1),
     scopeMode: scope.mode === "servers" ? "servers" : scope.mode === "tag" ? "tag" : "all",
@@ -221,6 +226,14 @@ function modelToDefinition(model) {
   if (isRangeOp(model.op)) {
     /* Range op: a two-sided band, and NO warn/critical (the backend rejects a range predicate that carries them). */
     predicate = { op: model.op, lowerBound: parseNumOrNull(model.lower), upperBound: parseNumOrNull(model.upper) };
+    /* Optional critical band (#3372): emit BOTH crit bounds or neither. A lone bound is left off (so the backend
+       reads a warn-only rule) — the save-blocker reports the all-or-nothing rule inline before a save. */
+    const critLower = parseNumOrNull(model.critLower);
+    const critUpper = parseNumOrNull(model.critUpper);
+    if (critLower != null && critUpper != null) {
+      predicate.criticalLowerBound = critLower;
+      predicate.criticalUpperBound = critUpper;
+    }
   } else {
     predicate = { op: model.op, warnThreshold: parseNumOrNull(model.warn) };
     if (model.critical.trim() !== "") predicate.criticalThreshold = parseNumOrNull(model.critical);
@@ -279,6 +292,25 @@ function alertSaveBlocker(model) {
     if (metric.aggregate === "count" &&
         (model.op === "outside" ? (0 < lower || 0 > upper) : (lower <= 0 && 0 <= upper))) {
       return "A 'between' or 'outside' alert on a count whose band fires when the count is 0 can't tell zero events from a stalled collector — set the bounds so a count of 0 doesn't fire.";
+    }
+
+    /* Optional critical band (#3372): all-or-nothing, and nested per op — WIDER than the warning band for 'outside'
+       (fires Critical further out), NARROWER for 'between' (fires Critical deeper in). The backend re-validates. */
+    const hasCritLower = String(model.critLower).trim() !== "";
+    const hasCritUpper = String(model.critUpper).trim() !== "";
+    if (hasCritLower !== hasCritUpper) return "Enter BOTH a critical lower and upper bound, or leave both blank.";
+    if (hasCritLower) {
+      const critLower = parseNumOrNull(model.critLower);
+      const critUpper = parseNumOrNull(model.critUpper);
+      if (critLower == null) return "The critical lower bound must be a number.";
+      if (critUpper == null) return "The critical upper bound must be a number.";
+      if (model.op === "outside") {
+        if (!(critLower <= lower && upper <= critUpper)) {
+          return "For 'outside', the critical band must be wider than the warning band (critical lower ≤ lower, and upper ≤ critical upper).";
+        }
+      } else if (!(lower <= critLower && critLower <= critUpper && critUpper <= upper)) {
+        return "For 'between', the critical band must be narrower than the warning band (lower ≤ critical lower ≤ critical upper ≤ upper).";
+      }
     }
   } else {
     const warn = parseNumOrNull(model.warn);
@@ -489,8 +521,8 @@ function buildAlertEditor(main, ctx) {
 /* When the metric fires: the evaluation window, the comparison operator, and the threshold(s) — which DEPEND on
    the operator. A scalar op (gt/ge/lt/le) shows a Warning threshold + an optional (more-extreme) Critical, and the
    severity is those two thresholds (CustomAlertRuleDefinition.SeverityFor). A range op (between/outside, #3351)
-   shows a Lower/Upper bound instead and fires a single Warning tier, so the inputs — and the help text — swap in
-   place when the op category changes. */
+   shows a Lower/Upper bound instead, plus an OPTIONAL Critical Lower/Upper band (#3372) for a second, more-severe
+   tier; so the inputs — and the help text — swap in place when the op category changes. */
 function conditionSection(model, onChange) {
   const windowSel = buildWindowSelect(model, onChange);
 
@@ -516,11 +548,19 @@ function conditionSection(model, onChange) {
 
   function drawCondition() {
     if (isRangeOp(model.op)) {
-      mount(thresholdBox, [numField("Lower bound", "lower", "lower bound"), numField("Upper bound", "upper", "upper bound")]);
+      mount(thresholdBox, [
+        numField("Lower bound", "lower", "lower bound"),
+        numField("Upper bound", "upper", "upper bound"),
+        numField("Critical lower bound", "critLower", "optional"),
+        numField("Critical upper bound", "critUpper", "optional"),
+      ]);
       helpBox.textContent =
         "The metric is aggregated to one value over the window, then tested against the band. 'Is outside the range' " +
         "fires when the value is below the lower bound or above the upper bound; 'is within the range' fires when it " +
-        "falls inside (bounds inclusive). A range rule fires a single Warning tier.";
+        "falls inside (bounds inclusive). Leave the critical bounds blank for a single Warning tier, or set both for a " +
+        "second, more-severe Critical tier: for 'is outside the range' the critical band must be WIDER than the " +
+        "warning band (Critical fires when the value is even further outside); for 'is within the range' it must be " +
+        "NARROWER (Critical fires when the value is even deeper inside).";
     } else {
       mount(thresholdBox, [numField("Warning threshold", "warn", "warning value"), numField("Critical threshold", "critical", "critical value (optional)")]);
       helpBox.textContent =

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/alert-rules.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/alert-rules.js
@@ -175,15 +175,23 @@ function describeMetric(metric) {
   return agg + name;
 }
 
-/** A compact condition label — a scalar bar ("≥ 30000 / crit 120000") or a range band ("outside 10–100"), or null. */
+/** A compact condition label — a scalar bar ("≥ 30000 / crit 120000") or a range band ("outside 10–100", or
+ *  "outside 10–100 (crit outside 5–200)" / "between 10–100 (crit 40–60)" with a critical tier), or null. */
 function describeCondition(pred) {
   if (!pred || typeof pred !== "object") return null;
 
   /* Range op (#3351): a two-sided band, rendered "outside 10–100" / "between 10–100" with an en dash (–)
-     between the bounds — a range predicate carries lowerBound/upperBound and no warnThreshold. */
+     between the bounds — a range predicate carries lowerBound/upperBound and no warnThreshold. An optional
+     critical band (#3372) appends " (crit ...)" so the chip conveys both tiers: the crit band is the more-severe
+     extension (wider for 'outside', narrower for 'between'), the word repeated only for 'outside' to read clearly. */
   if (pred.op === "between" || pred.op === "outside") {
     if (pred.lowerBound == null || pred.upperBound == null) return null;
-    return pred.op + " " + pred.lowerBound + "–" + pred.upperBound;
+    let band = pred.op + " " + pred.lowerBound + "–" + pred.upperBound;
+    if (pred.criticalLowerBound != null && pred.criticalUpperBound != null) {
+      const critWord = pred.op === "outside" ? "outside " : "";
+      band += " (crit " + critWord + pred.criticalLowerBound + "–" + pred.criticalUpperBound + ")";
+    }
+    return band;
   }
 
   if (pred.warnThreshold == null) return null;


### PR DESCRIPTION
## What

Adds an **optional Critical tier** for the `between`/`outside` range custom-alert predicates (#3372, part of #3285). Range ops (#3351/#3378) were Warning-only; they can now carry a second, more-severe band via two new nullable predicate fields `criticalLowerBound` / `criticalUpperBound`. Absent → Warning-only (today's behavior, unchanged). Scalar ops (`gt`/`ge`/`lt`/`le`) are untouched.

## Predicate JSON shape (two-tier range rule)

```jsonc
// outside: crit band is WIDER and CONTAINS the warn band
{ "op": "outside", "lowerBound": 10, "upperBound": 100,
  "criticalLowerBound": 5, "criticalUpperBound": 200 }

// between: crit band is NARROWER and is CONTAINED BY the warn band
{ "op": "between", "lowerBound": 10, "upperBound": 100,
  "criticalLowerBound": 40, "criticalUpperBound": 60 }
```

The existing `lowerBound`/`upperBound` are the **Warning** band; the crit pair is the **Critical** band.

## How severity routes through `RangeBreaches`

"More severe" means further from healthy, so the nesting flips by op. The shared private `RangeBreaches(op, lower?, upper?, value)` stays the single band authority and is evaluated at **both** bands — the crit band is just another `(op, lower, upper)` triple:

- `IsBreaching(value)` tests the **warn** band → "breaches at all".
- `SeverityFor(value)` for a range op → **Critical** iff the crit band exists AND `RangeBreaches(Op, criticalLowerBound, criticalUpperBound, value)`, else **Warning**.

Because the validator enforces the nesting, the crit firing region is always a **subset** of the warn firing region, so the warn band is the outer envelope and `SeverityFor` only asks the incremental "also in crit?" question. No parallel band math. The #3341 open-incident severity-change path already calls `SeverityFor`, so a range rule now escalates Warning→Critical (and de-escalates) automatically.

## Op-specific nesting validation

- **`outside`**: `criticalLowerBound <= lowerBound < upperBound <= criticalUpperBound` (WIDER). A too-narrow crit band is rejected.
- **`between`**: `lowerBound <= criticalLowerBound <= criticalUpperBound <= upperBound` (NARROWER, and its own bounds ordered). A too-wide or inverted crit band is rejected.
- Crit bounds are **all-or-nothing** (both or neither) and numeric; a scalar op still rejects any range/crit bounds and a range op still rejects `warnThreshold`/`criticalThreshold`.

## #3378 COUNT-on-zero guard interaction

The guard tests the **warn** band (`RangeBreaches(op, lower, upper, 0)`), which is a **complete** 0-guard for both bands: the crit band was just validated to nest inside the warn firing region, so if the warn band doesn't fire on 0 the crit band can't either — and any crit band that would fire on 0 could only do so alongside a warn band that also fires on 0, which is already rejected. No separate crit-band 0-check is needed. The guard still fires with a crit band present (regression covered).

## Render + editor

- **Delivered alert (`FiredThreshold`) + rule-card chip** convey both bands: `outside 10 - 100 (crit outside 5 - 200)` / `between 10 - 100 (crit 40 - 60)` (card chip uses the existing en-dash style). Numeric threshold twin stays `null` for range, consistent with #3371.
- **Editor** (`wwwroot/js/alert-editor.js`): two optional `Critical lower bound` / `Critical upper bound` inputs appear for a range op, with help text stating the nesting; mapped to/from the new fields in `definitionToModel`/`modelToDefinition`, with an all-or-nothing + op-nesting client-side save-blocker. Backend `/api/alerts/validate` stays the authority.
- MCP `validate_custom_alert_rule` description updated to document the optional crit band.

## Tests

`Darling.Tests` build clean; `CustomAlertRuleDefinitionTests` (79) and the pure custom-alert classes (evaluate-now, severity-escalation, display, MCP tools, templates, teardown, health, tag-scope, cap — 70) all pass. New coverage: two-tier severity for both ops (low + high side for outside; warn-not-crit vs crit for between), op-specific nesting rejection (too-narrow outside / too-wide + inverted between), all-or-nothing + non-numeric crit bounds, both-band `FiredThreshold` render, and the COUNT-on-zero guard still firing with a crit band present. Warning-only range regression guards (#3371/#3378) unchanged.

Service builds `0 Warning(s) / 0 Error(s)`.

## Deferred

Nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5xoN5PzhzYfHHrfutyeEe
