### PR TITLE
Guard the hypothetical-index EXPLAIN to exactly one statement (#3385)

### DIFF
--- a/Darling/Darling.Tests/HypotheticalIndexSingleStatementGuardTests.cs
+++ b/Darling/Darling.Tests/HypotheticalIndexSingleStatementGuardTests.cs
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using PerformanceMonitor.Darling.Service.Targets;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3385: the deliberate single-statement guard under the one dynamic-SQL sink in this product that is
+/// handed text from a monitored server.
+///
+/// <para>
+/// <c>EXPLAIN (GENERIC_PLAN)</c> needs the <c>$1</c> placeholders in normalized text to stay placeholders,
+/// so the statement cannot travel as a bound parameter of the EXPLAIN. It is staged into a GUC and
+/// string-concatenated into a server-side <c>EXECUTE</c> instead. <c>EXPLAIN</c> without <c>ANALYZE</c>
+/// only PLANS, which is why that is not exploitable; this guard is the layer beneath that one.
+/// </para>
+///
+/// <para>
+/// <b>The whole difficulty is that a semicolon scan is the wrong check.</b> Real normalized
+/// <c>pg_stat_statements</c> text is full of comments, and ~5% of it carries a <c>;</c> inside one, so a
+/// <c>;</c> scan refuses legitimate index candidates while buying nothing. Every fixture in
+/// <see cref="EveryFormThatCanHideASemicolon_IsAccepted"/> therefore holds a <c>;</c> somewhere a
+/// <c>;</c> scan would find it, and <see cref="TheFixtureSetWouldFailAPlainSemicolonScan"/> asserts that
+/// rather than leaving a reader to take it on trust.
+/// </para>
+/// </summary>
+public sealed class HypotheticalIndexSingleStatementGuardTests
+{
+    /// <summary>
+    /// One statement each, every one carrying a <c>;</c> inside a construct PostgreSQL's lexer swallows:
+    /// a line comment, a block comment, a NESTED block comment with the <c>;</c> on either side of the
+    /// nesting, a block comment holding an unbalanced apostrophe, a plain string, a string with <c>''</c>
+    /// doubling, an <c>E'…'</c> string with a backslash-escaped quote and another with an escaped
+    /// backslash, a <c>$$</c> body, a <c>$tag$</c> body, a <c>$outer$</c> body holding both a <c>$$</c>
+    /// and a different <c>$tag$</c> that do not close it, a quoted identifier, a quoted identifier with
+    /// <c>""</c> doubling, and the shape real captured text arrives in.
+    /// </summary>
+    private static readonly string[] s_acceptedCarryingASemicolon =
+    {
+        /* -- to end of line. */
+        "SELECT a FROM t WHERE x = $1 -- ; not a separator",
+
+        /* A block comment: the case the whole issue turns on. */
+        "SELECT /* ; */ a FROM t WHERE x = $1",
+
+        /* Nested, with the ; in the INNER comment. PostgreSQL block comments nest, so closing at the
+           first terminator would read the rest of the outer comment as code. */
+        "SELECT /* outer /* ; */ still outer */ a FROM t WHERE x = $1",
+
+        /* Nested, with the ; in the OUTER comment after the inner one closes. */
+        "SELECT /* /* inner */ ; */ a FROM t WHERE x = $1",
+
+        /* A block comment whose apostrophe is unbalanced: a string-aware but comment-BLIND scan opens a
+           string here and then swallows a real separator later. */
+        "/* it's fine ; here */ SELECT a FROM t WHERE x = $1",
+
+        /* '…' with no backslash escape, which is what standard_conforming_strings means. */
+        "SELECT a FROM t WHERE note = 'a; b' AND x = $1",
+
+        /* '' is an embedded quote, not the end of the string. */
+        "SELECT a FROM t WHERE note = 'it''s a; b' AND x = $1",
+
+        /* E'…', where a backslash DOES escape, so the quote after it is data. */
+        """SELECT a FROM t WHERE note = E'a\'; b' AND x = $1""",
+
+        /* E'…' with an escaped backslash, so the ; after it is still inside the string. */
+        """SELECT a FROM t WHERE note = E'a\\; b' AND x = $1""",
+
+        /* $$ … $$, an empty tag. */
+        "SELECT $$a; b$$ AS note, a FROM t WHERE x = $1",
+
+        /* $tag$ … $tag$. */
+        "SELECT $body$a; b$body$ AS note, a FROM t WHERE x = $1",
+
+        /* Only the byte-identical tag closes a body: neither the $$ nor the $body$ inside this one
+           does. */
+        "SELECT $outer$ a; b $$ c $body$ d $outer$ AS note, a FROM t WHERE x = $1",
+
+        /* "…" quoted identifier. */
+        "SELECT a AS \"a; b\" FROM t WHERE x = $1",
+
+        /* "" is an embedded double quote. */
+        "SELECT a AS \"a\"\"b; c\" FROM t WHERE x = $1",
+
+        /* The shape captured text arrives in: a tracing header, prose mid-statement, and a run of
+           placeholders including multi-digit ones. */
+        """
+        /* service='agent' */ SELECT a, b, c
+          FROM t
+         WHERE x = $1 -- ; bounded above
+           AND y = $2 /* ; also bounded */
+           AND z = $12
+         LIMIT $35
+        """,
+    };
+
+    [Fact]
+    public void EveryFormThatCanHideASemicolon_IsAccepted()
+        => Assert.All(
+            s_acceptedCarryingASemicolon,
+            statement => Assert.True(
+                HypotheticalIndexExperiment.IsSingleStatement(statement),
+                $"refused a single statement: {statement}"));
+
+    /// <summary>
+    /// The discriminating assertion, and the reason this suite is not a semicolon scan wearing a better
+    /// name: every fixture above contains a <c>;</c>, so a guard reduced to <c>IndexOf(';')</c> refuses
+    /// all of them and <see cref="EveryFormThatCanHideASemicolon_IsAccepted"/> goes red on every case.
+    /// </summary>
+    [Fact]
+    public void TheFixtureSetWouldFailAPlainSemicolonScan()
+    {
+        Assert.NotEmpty(s_acceptedCarryingASemicolon);
+
+        Assert.All(
+            s_acceptedCarryingASemicolon,
+            statement => Assert.True(
+                statement.Contains(';', StringComparison.Ordinal),
+                $"fixture carries no ; so it discriminates nothing: {statement}"));
+    }
+
+    [Theory]
+    /* Nothing hiding anything: the baseline, so "accept everything" is not what passes above. */
+    [InlineData("SELECT a FROM t WHERE x = $1")]
+    /* Placeholders stay placeholders. A $ before a digit does not open a dollar-quoted body, and reading
+       one that way would swallow the rest of the statement and every ; in it. */
+    [InlineData("SELECT a FROM t WHERE x = $1 AND y = $2 AND z = $12 AND w = $35")]
+    /* A $ that opens nothing: it is legal inside an identifier, and a tag with no closing $ is not a
+       delimiter. */
+    [InlineData("SELECT a$b FROM t WHERE x = $1")]
+    /* An e that ENDS an identifier is not an E'…' prefix, so this is a plain string. */
+    [InlineData("SELECT ase'plain' FROM t WHERE x = $1")]
+    public void AnOrdinaryStatement_IsAccepted(string statement)
+        => Assert.True(HypotheticalIndexExperiment.IsSingleStatement(statement));
+
+    [Theory]
+    /* Two statements, plainly. The other half of the discriminating pair. */
+    [InlineData("SELECT $1; SELECT $2")]
+    /* Two statements where a block comment ALSO holds a ;. A comment-aware scan has to skip the decoy and
+       still find the real separator; a comment-blind one stops at the decoy. */
+    [InlineData("SELECT $1 /* ; */; SELECT $2")]
+    [InlineData("SELECT $1 /* /* ; */ */; SELECT $2")]
+    /* Same, with the decoy in a line comment, so the separator is on the next line. */
+    [InlineData("SELECT $1 -- ;\n; SELECT $2")]
+    /* Same, with the decoy in each string and quoting form. */
+    [InlineData("SELECT 'a; b'; SELECT $1")]
+    [InlineData("SELECT 'it''s a; b'; SELECT $1")]
+    [InlineData("""SELECT E'a\'; b'; SELECT $1""")]
+    [InlineData("SELECT $$a; b$$; SELECT $1")]
+    [InlineData("SELECT $body$a; b$body$; SELECT $1")]
+    [InlineData("SELECT a AS \"a; b\"; SELECT $2")]
+    /* A comment-blind but string-aware scan opens a string at this apostrophe and never sees the
+       separator. */
+    [InlineData("/* it's fine */ SELECT $1; SELECT $2")]
+    /* An e that ENDS an identifier is not an E'…' prefix, so the backslash is data, the quote closes the
+       string, and the ; is a real separator. Reading a plain string as an escape string is the one
+       direction that hides one, so the ambiguous case is scanned as plain. */
+    [InlineData("""SELECT ase'\'; x'""")]
+    /* Not stripped. A normalized pg_stat_statements entry carries no terminator, so a trailing ; is text
+       from somewhere else, and trimming it is the quiet transformation this guard exists to refuse. */
+    [InlineData("SELECT a FROM t WHERE x = $1;")]
+    [InlineData("SELECT a FROM t WHERE x = $1; /* done */")]
+    /* Unterminated, in every form. Refused rather than read to the end of the text: the tail of a
+       construct nobody can close is not a statement. */
+    [InlineData("SELECT $1 /* ;")]
+    [InlineData("SELECT $1 /* /* ; */")]
+    [InlineData("SELECT 'a; b")]
+    [InlineData("""SELECT E'a\'; b""")]
+    [InlineData("SELECT $tag$ a; b")]
+    [InlineData("SELECT $$ a; b")]
+    /* A tag closes only on itself: $aa$ is not $a$. */
+    [InlineData("SELECT $a$ x $aa$ y")]
+    [InlineData("SELECT a AS \"a; b")]
+    /* Zero statements is not one statement. */
+    [InlineData("/* just a comment ; */")]
+    [InlineData("-- nothing here ;")]
+    [InlineData("   \n\t ")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void AnythingThatIsNotExactlyOneStatement_IsRefused(string? statement)
+        => Assert.False(HypotheticalIndexExperiment.IsSingleStatement(statement));
+
+    /// <summary>
+    /// The guard is a PREDICATE, and that is the property that keeps the feature working. It returns a
+    /// verdict, never text, so there is no path by which it rewrites, escapes or trims the statement, and
+    /// the <c>$1</c> placeholders <c>GENERIC_PLAN</c> needs reach the EXPLAIN exactly as captured. The
+    /// staging bind is asserted alongside it, because that is the value the guard cleared.
+    /// </summary>
+    [Fact]
+    public void TheGuardIsAPredicate_SoTheTextItClearsIsNeverRewritten()
+    {
+        var source = ExperimentSource();
+
+        Assert.Contains("public static bool IsSingleStatement(string? statementText)", source, StringComparison.Ordinal);
+        Assert.Contains("stage.Parameters.AddWithValue(statementText)", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The guard runs at BOTH ends: the entry point, so a refused candidate costs the monitored server no
+    /// round trip at all, and the sink, so a second caller of the private EXPLAIN helper cannot reach the
+    /// concatenation without it.
+    /// </summary>
+    [Fact]
+    public void TheGuardRunsAtTheEntryPointAndAtTheSink()
+    {
+        var source = ExperimentSource();
+
+        Assert.Contains("if (!IsSingleStatement(normalizedStatementText))", source, StringComparison.Ordinal);
+        Assert.Contains("if (!IsSingleStatement(statementText))", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// And the barrier the guard sits UNDER rather than replaces: the EXPLAIN only PLANS. A refactor that
+    /// added <c>ANALYZE</c> would execute monitored-server text as the monitoring credential on the
+    /// monitored server, and no single-statement check makes that acceptable. Asserted against the SQL
+    /// itself, not the file, because the surrounding prose says the word too.
+    /// </summary>
+    [Fact]
+    public void TheExplainStillOnlyPlans()
+    {
+        var sql = ExplainSql();
+
+        Assert.Contains("EXPLAIN (GENERIC_PLAN, FORMAT JSON) ", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("ANALYZE", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The body of the <c>ExplainThroughGucSql</c> raw string literal, which is the SQL that actually
+    /// reaches the monitored server.
+    /// </summary>
+    private static string ExplainSql()
+    {
+        var source = ExperimentSource();
+        const string opening = "ExplainThroughGucSql = \"\"\"";
+
+        var start = source.IndexOf(opening, StringComparison.Ordinal);
+        Assert.True(start >= 0, "ExplainThroughGucSql is gone or renamed — this pin needs re-anchoring.");
+
+        start += opening.Length;
+        var end = source.IndexOf("\"\"\";", start, StringComparison.Ordinal);
+        Assert.True(end > start, "ExplainThroughGucSql is no longer a raw string literal.");
+
+        return source[start..end];
+    }
+
+    private static string ExperimentSource()
+        => File.ReadAllText(Path.Combine(RepoRoot(),
+            "Darling", "PerformanceMonitor.Darling.Service", "Targets", "HypotheticalIndexExperiment.cs"));
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new InvalidOperationException("PerformanceMonitor.sln not found above the test output directory.");
+    }
+}

--- a/Darling/Darling.Tests/HypotheticalIndexSingleStatementGuardTests.cs
+++ b/Darling/Darling.Tests/HypotheticalIndexSingleStatementGuardTests.cs
@@ -54,7 +54,7 @@ public sealed class HypotheticalIndexSingleStatementGuardTests
 
         /* Nested, with the ; in the INNER comment. PostgreSQL block comments nest, so closing at the
            first terminator would read the rest of the outer comment as code. */
-        "SELECT /* outer /* ; */ still outer */ a FROM t WHERE x = $1",
+        "SELECT /* outer /* ; */ ; still outer */ a FROM t WHERE x = $1",
 
         /* Nested, with the ; in the OUTER comment after the inner one closes. */
         "SELECT /* /* inner */ ; */ a FROM t WHERE x = $1",
@@ -179,6 +179,9 @@ public sealed class HypotheticalIndexSingleStatementGuardTests
     [InlineData("SELECT $$ a; b")]
     /* A tag closes only on itself: $aa$ is not $a$. */
     [InlineData("SELECT $a$ x $aa$ y")]
+    /* $1 is a PARAMETER, so the $ in front of the ; opens nothing and the ; is a real separator.
+       Reading a digit as a tag start turns all of this into one dollar-quoted body. */
+    [InlineData("SELECT $1$;$1$")]
     [InlineData("SELECT a AS \"a; b")]
     /* Zero statements is not one statement. */
     [InlineData("/* just a comment ; */")]

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/HypotheticalIndexExperiment.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/HypotheticalIndexExperiment.cs
@@ -183,6 +183,17 @@ public static class HypotheticalIndexExperiment
                 + "rather than guessed.");
         }
 
+        if (!IsSingleStatement(normalizedStatementText))
+        {
+            return new Result(
+                false, 0, 0, null, null, null,
+                "The stored text for this statement is not exactly one PostgreSQL statement, and the "
+                + "EXPLAIN concatenates it into a server-side EXECUTE. Refused rather than repaired: "
+                + "nothing was stripped, escaped or truncated, and no command reached the monitored "
+                + "server. A normalized pg_stat_statements entry is one statement and carries no "
+                + "terminator, so this is text that did not come from one.");
+        }
+
         /* ROLLED BACK unconditionally: the hypothetical index is session-local, but the session is pooled
            and would carry it into the next caller's work. */
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
@@ -301,6 +312,255 @@ public static class HypotheticalIndexExperiment
     }
 
     /// <summary>
+    /// Whether <paramref name="statementText"/> is EXACTLY ONE PostgreSQL statement — the deliberate
+    /// barrier under the concatenation at <see cref="ExplainThroughGucSql"/> (#3385).
+    ///
+    /// <para>
+    /// <b>It refuses; it never repairs.</b> Nothing is escaped, nothing is truncated at the first
+    /// statement, and a trailing <c>;</c> is not stripped. The text reaches the EXPLAIN byte-identical or
+    /// it does not reach it at all, which is also what keeps the <c>$1</c> placeholders
+    /// <c>GENERIC_PLAN</c> needs from being rewritten into something that is no longer a placeholder.
+    /// Sanitizing a value on its way into a dynamic-SQL sink converts a loud refusal into a quiet
+    /// transformation nobody reviews.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>A <c>;</c> scan is NOT this check.</b> Real normalized <c>pg_stat_statements</c> text is full of
+    /// comments — tracing headers from agents and ORMs, and prose inside this product's own queries — and
+    /// #3385 measured ~45% of real normalized queries carrying a block comment, ~5% of them with a
+    /// <c>;</c> inside one. A <c>;</c> scan refuses those, so it costs legitimate index candidates without
+    /// buying anything. PostgreSQL's lexical rules therefore run FIRST and the <c>;</c> is looked for only
+    /// in what they leave: <c>--</c> to end of line; <c>/* … */</c>, which NESTS in PostgreSQL, so depth is
+    /// counted rather than matched to the first <c>*/</c>; <c>'…'</c> with <c>''</c> doubling and no
+    /// backslash escape, which is what <c>standard_conforming_strings</c> means; <c>E'…'</c>, where a
+    /// backslash DOES escape, recognized only where the <c>E</c> does not continue an identifier;
+    /// <c>$tag$…$tag$</c> and <c>$$…$$</c>, closed only by the byte-identical tag and told apart from the
+    /// <c>$1</c> placeholders; <c>"…"</c> with <c>""</c> doubling. <c>U&amp;'…'</c>, <c>B'…'</c> and
+    /// <c>X'…'</c> need no case of their own — their prefixes lex as ordinary characters and their bodies
+    /// follow the <c>'…'</c> rule.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Every uncertainty resolves toward refusal.</b> An unterminated comment, string, quoted identifier
+    /// or dollar-quoted body is refused rather than read to the end of the text, and so is text holding no
+    /// statement at all. An <c>E</c> that might belong to an identifier is scanned as a plain quote,
+    /// because reading a plain string as an escape string is the one direction that can hide a <c>;</c>:
+    /// in <c>'\'; x'</c> the backslash is data, the <c>;</c> separates statements, and only the plain
+    /// reading sees it.
+    /// </para>
+    /// </summary>
+    public static bool IsSingleStatement(string? statementText)
+    {
+        if (string.IsNullOrWhiteSpace(statementText))
+        {
+            return false;
+        }
+
+        var text = statementText;
+        var index = 0;
+        var sawStatement = false;
+
+        while (index < text.Length)
+        {
+            var character = text[index];
+            int next;
+
+            if (character == '-' && index + 1 < text.Length && text[index + 1] == '-')
+            {
+                next = EndOfLineComment(text, index);
+            }
+            else if (character == '/' && index + 1 < text.Length && text[index + 1] == '*')
+            {
+                next = EndOfBlockComment(text, index);
+            }
+            else if (character == ';')
+            {
+                /* Top level, because every construct that could be holding one has been consumed above. */
+                return false;
+            }
+            else if (character is '\'' or '"')
+            {
+                sawStatement = true;
+                next = EndOfQuoted(text, index, character, backslashEscapes: false);
+            }
+            else if ((character is 'e' or 'E')
+                     && index + 1 < text.Length
+                     && text[index + 1] == '\''
+                     && (index == 0 || !IsIdentifierCharacter(text[index - 1])))
+            {
+                sawStatement = true;
+                next = EndOfQuoted(text, index + 1, '\'', backslashEscapes: true);
+            }
+            else if (character == '$')
+            {
+                sawStatement = true;
+                next = EndOfDollarQuoted(text, index);
+            }
+            else
+            {
+                sawStatement |= !char.IsWhiteSpace(character);
+                next = index + 1;
+            }
+
+            if (next < 0)
+            {
+                /* Unterminated. The tail of a construct nobody can close is not something to scan past. */
+                return false;
+            }
+
+            index = next;
+        }
+
+        /* Comments and whitespace alone are zero statements, not one. */
+        return sawStatement;
+    }
+
+    /// <summary>
+    /// Past a <c>--</c> comment. One that reaches the end of the text is COMPLETE rather than
+    /// unterminated, so this never returns a refusal.
+    /// </summary>
+    private static int EndOfLineComment(string text, int start)
+    {
+        for (var index = start + 2; index < text.Length; index++)
+        {
+            if (text[index] is '\n' or '\r')
+            {
+                return index;
+            }
+        }
+
+        return text.Length;
+    }
+
+    /// <summary>
+    /// Past a <c>/* … */</c> comment, or -1 when it never closes.
+    ///
+    /// <para>PostgreSQL block comments NEST, so this counts depth. Matching to the first <c>*/</c> would
+    /// leave the tail of a nested comment being read as code, and a <c>;</c> in that tail is exactly where
+    /// one hides from a scanner that looks like it handles comments.</para>
+    /// </summary>
+    private static int EndOfBlockComment(string text, int start)
+    {
+        var depth = 0;
+        var index = start;
+
+        while (index + 1 < text.Length)
+        {
+            if (text[index] == '/' && text[index + 1] == '*')
+            {
+                depth++;
+                index += 2;
+                continue;
+            }
+
+            if (text[index] == '*' && text[index + 1] == '/')
+            {
+                depth--;
+                index += 2;
+
+                if (depth == 0)
+                {
+                    return index;
+                }
+
+                continue;
+            }
+
+            index++;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Past a <c>'…'</c> string or a <c>"…"</c> quoted identifier, or -1 when it never closes. A doubled
+    /// delimiter is an embedded one in both forms.
+    ///
+    /// <para><paramref name="backslashEscapes"/> is true only for <c>E'…'</c>. A plain string honours no
+    /// backslash, which is what <c>standard_conforming_strings</c> means and has been the default since
+    /// PostgreSQL 9.1. With it OFF this reading refuses MORE rather than less: the <c>'</c> that an
+    /// ignored backslash exposes ends the string, and whatever follows is then read at top level.</para>
+    /// </summary>
+    private static int EndOfQuoted(string text, int start, char quote, bool backslashEscapes)
+    {
+        for (var index = start + 1; index < text.Length; index++)
+        {
+            if (backslashEscapes && text[index] == '\\')
+            {
+                index++;
+                continue;
+            }
+
+            if (text[index] != quote)
+            {
+                continue;
+            }
+
+            if (index + 1 < text.Length && text[index + 1] == quote)
+            {
+                index++;
+                continue;
+            }
+
+            return index + 1;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Past a <c>$tag$…$tag$</c> or <c>$$…$$</c> body, -1 when it never closes, or the next character when
+    /// this <c>$</c> opens nothing.
+    ///
+    /// <para><b>Telling those last two apart is the case this feature cannot afford to get wrong.</b>
+    /// Normalized text is built out of <c>$1</c>, <c>$2</c>, <c>$35</c> placeholders. A <c>$</c> before a
+    /// digit is a placeholder, a <c>$</c> at the end of the text is an ordinary character, and <c>$abc</c>
+    /// with no second <c>$</c> lexes as a <c>$</c> followed by an identifier. Reading any of them as an
+    /// opening delimiter would swallow the rest of the statement and every <c>;</c> in it.</para>
+    ///
+    /// <para>A tag follows the rules for an unquoted identifier except that it cannot hold a <c>$</c>, and
+    /// only the byte-identical tag closes the body — neither <c>$$</c> nor a different <c>$tag$</c> inside
+    /// a <c>$outer$</c> body ends it.</para>
+    /// </summary>
+    private static int EndOfDollarQuoted(string text, int start)
+    {
+        var tagEnd = start + 1;
+
+        if (tagEnd < text.Length && IsDollarTagStart(text[tagEnd]))
+        {
+            do
+            {
+                tagEnd++;
+            }
+            while (tagEnd < text.Length && IsDollarTagCharacter(text[tagEnd]));
+        }
+
+        if (tagEnd >= text.Length || text[tagEnd] != '$')
+        {
+            return start + 1;
+        }
+
+        var delimiter = text[start..(tagEnd + 1)];
+        var close = text.IndexOf(delimiter, tagEnd + 1, StringComparison.Ordinal);
+
+        return close < 0 ? -1 : close + delimiter.Length;
+    }
+
+    /// <summary>
+    /// Identifier characters as PostgreSQL's lexer reads them: ASCII letters and digits, <c>_</c>,
+    /// <c>$</c> (legal anywhere but the first character), and everything above ASCII.
+    /// </summary>
+    private static bool IsIdentifierCharacter(char character)
+        => char.IsAsciiLetterOrDigit(character) || character is '_' or '$' || character > '\u007f';
+
+    /// <summary>A dollar-quote tag's first character. A digit here makes it a placeholder instead.</summary>
+    private static bool IsDollarTagStart(char character)
+        => char.IsAsciiLetter(character) || character == '_' || character > '\u007f';
+
+    private static bool IsDollarTagCharacter(char character)
+        => IsDollarTagStart(character) || char.IsAsciiDigit(character);
+
+    /// <summary>
     /// The statement text is BOUND, never interpolated — and getting there took two failed designs worth
     /// recording, because both look correct.
     ///
@@ -332,9 +592,12 @@ public static class HypotheticalIndexExperiment
     /// rests, in order, on: (1) <c>EXPLAIN</c> WITHOUT <c>ANALYZE</c> only PLANS — a hostile statement is never
     /// executed; (2) the text is a single NORMALIZED <c>pg_stat_statements</c> entry, not a script;
     /// (3) <c>FOR line IN EXECUTE</c> rejects a multi-statement string outright; (4) the whole call runs in a
-    /// ROLLED-BACK transaction as a least-privilege role. Barriers (2) and (3) are today INCIDENTAL, not a
-    /// deliberate check — a real single-statement guard is tracked in #3385, and a naive semicolon scan is NOT
-    /// it (measured: ~5% of real normalized queries carry a <c>;</c> inside a block comment). So do NOT
+    /// ROLLED-BACK transaction as a least-privilege role. Barrier (1) is the strong one and stays first:
+    /// <see cref="IsSingleStatement"/> is defence in depth beneath it, never a replacement for it. That
+    /// guard is what makes barriers (2) and (3) DELIBERATE rather than incidental — it refuses anything
+    /// that is not exactly one statement, and it decides that with PostgreSQL's lexical rules rather than a
+    /// semicolon scan, which would refuse the ~5% of real normalized queries that carry a <c>;</c> inside a
+    /// block comment (#3385). So do NOT
     /// "simplify" this to a plain <c>EXECUTE</c> of a bound value, and do not drop the
     /// <c>GENERIC_PLAN</c>/no-<c>ANALYZE</c> shape, on the belief that the binding protects the concatenation:
     /// it does not.
@@ -355,6 +618,16 @@ public static class HypotheticalIndexExperiment
     private static async Task<string?> ExplainAsync(
         NpgsqlConnection connection, DbTransaction transaction, string statementText, CancellationToken cancellationToken)
     {
+        /* The guard sits AT the sink as well as at the entry point, so a second caller of this method
+           cannot reach the concatenation without it. RunAsync checks first and returns a Result carrying
+           the refusal, so the only caller today never reaches this throw. */
+        if (!IsSingleStatement(statementText))
+        {
+            throw new InvalidOperationException(
+                "Refused: the statement text is not exactly one PostgreSQL statement, and it is "
+                + "concatenated into a server-side EXECUTE.");
+        }
+
         /* is_local = true on both: the settings die with the transaction that is rolled back below, so
            nothing survives into the next caller of this pooled session. */
         await using (var stage = new NpgsqlCommand("SELECT set_config('pm.stmt', $1, true)", connection, (NpgsqlTransaction)transaction)


### PR DESCRIPTION
`HypotheticalIndexExperiment` stages monitored-server statement text into a transaction-local GUC and the `DO` block string-concatenates it back out into a server-side `EXECUTE`. `GENERIC_PLAN` needs the `$1` placeholders to stay placeholders, so the text cannot travel as a bound parameter of the EXPLAIN and the concatenation is inherent to the approach. #3385 asked for the single-statement property that concatenation leans on to be asserted rather than left incidental.

`IsSingleStatement` is that assertion. It refuses anything that is not exactly one statement, and it refuses rather than repairs: no trailing `;` is stripped, nothing is escaped, nothing is truncated at the first statement. A predicate is its whole API surface, so there is no path by which it rewrites the text on its way to the EXPLAIN. It runs at the entry point, where a refusal returns a `Result` carrying the reason and costs the monitored server no round trip at all, and again at the sink, so a future second caller of the private EXPLAIN helper cannot reach the concatenation without it.

## Why a semicolon scan is the wrong check

A `;` scan would be a regression rather than a guard, and that is measured. #3385 measured 40 real normalized queries on a production PostgreSQL 18 target: 18 carry a block comment and 2 carry a `;` inside one, this product's own collector queries among them. A `;` scan refuses those legitimate index candidates while buying nothing, because the text is not a script to begin with.

Two further observations from this change. Of 12 top entries read from a production PostgreSQL target, every one opens with a `/* … */` tracing comment, one carries a `--` comment mid-statement, and none carries a trailing `;` — consistent with `pg_stat_statements` storing the statement without its terminator, and it is why refusing a trailing `;` costs nothing real. And extracting the PostgreSQL statements embedded in this repository's own source finds 38 carrying a block comment, half of which hold a `;` inside it.

So PostgreSQL's lexical rules run first and the `;` is looked for only in what they leave: `--` to end of line; `/* … */`, which nests, so depth is counted rather than matched to the first terminator; `'…'` with `''` doubling and no backslash escape, which is what `standard_conforming_strings` means; `E'…'`, where a backslash does escape, recognized only where the `E` does not continue an identifier; `$tag$…$tag$` and `$$…$$`, closed only by the byte-identical tag and told apart from the `$1` placeholders; `"…"` with `""` doubling. `U&'…'`, `B'…'` and `X'…'` need no case of their own, because their prefixes lex as ordinary characters and their bodies follow the `'…'` rule.

Every ambiguity resolves toward refusal. An unterminated construct is refused rather than read to the end of the text, text holding no statement at all is refused, and an `E` that might belong to an identifier is scanned as a plain quote, because a plain string read as an escape string is the one direction that can hide a separator.

## Why client-side tokenization rather than server-side verification

The issue offered either. Server-side verification would cost a second dynamic-SQL sink to guard the first: core PostgreSQL exposes no function that parses a string without executing or preparing it, so handing the text to the server's own parser means concatenating it into another `EXECUTE` or `PREPARE`. `PREPARE` would also refuse legitimate candidates on a second, unrelated axis, since it accepts only a subset of statement kinds. Beyond that it would cost a round trip to a monitored production server per experiment, and it would be unpinnable here, because no PostgreSQL instance exists in CI. The scan costs a pass over a short string and is deterministic on every platform the suite runs on.

No existing tokenizer was reusable. The one comment-aware SQL span classifier in the repository is a private member of a test class, is T-SQL-only, and handles neither dollar-quoting, `E'…'` strings, nor double-quoted identifiers; `CSharpSourceWalker` reads C#. The scan therefore lives next to the sink it guards rather than arriving as a new shared utility, because it has exactly one consumer.

## What this does not change

`EXPLAIN` without `ANALYZE` only PLANS, and that is the barrier this sits underneath rather than replaces. The GUC staging, the no-`ANALYZE` shape and the rolled-back transaction are untouched, and `TheExplainStillOnlyPlans` pins the first of those against the SQL literal itself rather than the file, because the surrounding prose says the word too.

## Tests

`HypotheticalIndexSingleStatementGuardTests` holds 15 accepted single statements, each carrying a `;` inside one of the forms above: a line comment, a block comment, a nested block comment with a `;` on either side of the nesting, a block comment holding an unbalanced apostrophe, a plain string, a string with `''` doubling, two `E'…'` strings, a `$$` body, a `$tag$` body, a `$outer$` body holding both a `$$` and a different `$tag$` that do not close it, two quoted identifiers, and the shape captured text arrives in. Refusals cover genuine two-statement text carrying the same decoys, a trailing `;`, every unterminated form, a tag that closes only on itself, a `$` immediately preceding a separator, and text that is nothing but a comment.

`TheFixtureSetWouldFailAPlainSemicolonScan` asserts the corpus discriminates rather than asking a reader to take it on trust: every accepted fixture contains a `;`, so reducing the guard to `IndexOf(';')` turns all 15 red.
