### PR TITLE
Derive the nightly stamp once per run instead of per job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,11 +65,37 @@ jobs:
     timeout-minutes: 10
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
+      stamp: ${{ steps.stamp.outputs.stamp }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'dev' }}
           fetch-depth: 0
+
+      # The nightly prerelease stamp, derived ONCE for the whole run and consumed by every job
+      # that names an artifact (#3390). Two properties matter and a per-job `date` has neither.
+      #
+      # Stable across jobs: `linux` needs `build`, which takes ~8.5 minutes, so the two jobs read
+      # their clocks ~8.5 minutes apart. Each deriving its own date means a run whose two stamp
+      # steps straddle midnight UTC ships a Windows zip dated one day and a Linux tarball dated
+      # the next, from one commit.
+      #
+      # Unique per build: the date alone is not. Multiple dispatches a day are normal here - over
+      # 2026-08-24..09-12, 13 of 20 days published two or more distinct source trees under one
+      # version string, peaking at five - and nothing in the artifact then distinguishes them.
+      # `FileVersion` / `ProductVersion` / `InformationalVersion` and the asset names all carry
+      # this string, and the apphost exe is byte-identical across builds, so with a colliding
+      # stamp there is no read that answers "which nightly is this".
+      #
+      # run_number is monotonic and numeric, so SemVer 2.0 compares these prereleases in build
+      # order; the date stays leftmost and human-readable. A short sha would identify the tree
+      # but sorts as an alphanumeric identifier, which outranks every numeric one.
+      - name: Derive the nightly stamp
+        id: stamp
+        run: |
+          stamp="$(date -u +%Y%m%d).${{ github.run_number }}"
+          echo "stamp=${stamp}" >> "$GITHUB_OUTPUT"
+          echo "Nightly stamp: ${stamp}"
 
       - name: Check for new commits in last 24 hours
         id: check
@@ -110,11 +136,13 @@ jobs:
       - name: Set nightly version
         id: version
         shell: pwsh
+        env:
+          NIGHTLY_STAMP: ${{ needs.check.outputs.stamp }}
         run: |
           $base = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }
           if ([string]::IsNullOrWhiteSpace($base)) { throw "Read no version from Directory.Build.props." }
-          $date = Get-Date -Format "yyyyMMdd"
-          $nightly = "$base-nightly.$date"
+          if ([string]::IsNullOrWhiteSpace($env:NIGHTLY_STAMP)) { throw "Read no stamp from the check job." }
+          $nightly = "$base-nightly.$env:NIGHTLY_STAMP"
           echo "VERSION=$nightly" >> $env:GITHUB_OUTPUT
           echo "Nightly version: $nightly"
 
@@ -450,7 +478,9 @@ jobs:
   # The bundled pg-runtime is deliberately absent from the linux artifact — the compose distribution
   # pairs the service with the official timescale/timescaledb image, and managed mode stays Windows.
   linux:
-    needs: build
+    # check as well as build: build already depends on check, so this adds no ordering, only
+    # access to the one stamp both jobs name their artifacts with (#3390).
+    needs: [check, build]
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -469,13 +499,15 @@ jobs:
       - name: Set nightly version
         id: version
         shell: bash
+        env:
+          NIGHTLY_STAMP: ${{ needs.check.outputs.stamp }}
         run: |
           set -euo pipefail
           base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)
           [ -n "${base}" ] || { echo "::error::Read no version from Directory.Build.props."; exit 1; }
-          date=$(date +%Y%m%d)
-          echo "VERSION=${base}-nightly.${date}" >> "$GITHUB_OUTPUT"
-          echo "Nightly version: ${base}-nightly.${date}"
+          [ -n "${NIGHTLY_STAMP}" ] || { echo "::error::Read no stamp from the check job."; exit 1; }
+          echo "VERSION=${base}-nightly.${NIGHTLY_STAMP}" >> "$GITHUB_OUTPUT"
+          echo "Nightly version: ${base}-nightly.${NIGHTLY_STAMP}"
 
       - name: Publish service (linux-x64)
         run: dotnet publish Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj -c Release -r linux-x64 --self-contained false -o publish/DarlingService-linux

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,8 +92,17 @@ jobs:
       # but sorts as an alphanumeric identifier, which outranks every numeric one.
       - name: Derive the nightly stamp
         id: stamp
+        shell: bash
         run: |
+          set -euo pipefail
           stamp="$(date -u +%Y%m%d).${{ github.run_number }}"
+          # Shape, not emptiness. A `date` that exited 0 having printed nothing yields
+          # ".<run_number>" - non-empty, so it passes every downstream `-n` /
+          # IsNullOrWhiteSpace guard and stamps both artifacts with a malformed version instead
+          # of failing here. Asserting the shape at the one place the stamp is produced makes
+          # those guards a backstop against broken output wiring rather than the only check.
+          shape='^[0-9]{8}\.[0-9]+$'
+          [[ "${stamp}" =~ ${shape} ]] || { echo "::error::Derived a malformed nightly stamp: '${stamp}'"; exit 1; }
           echo "stamp=${stamp}" >> "$GITHUB_OUTPUT"
           echo "Nightly stamp: ${stamp}"
 

--- a/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
+++ b/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
@@ -472,6 +472,10 @@ public class ProductVersionDeclarationTests
     [InlineData("base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)", false)]
     // An emptiness test that fails nothing is not a guard, and this spelling is already in the workflows.
     [InlineData("base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)\nif [ -n \"$base\" ]; then echo found; fi", false)]
+    // A real guard that fails the step, for a DIFFERENT variable. Both spellings occur in nightly.yml's
+    // version steps, which guard the version and the run stamp separately (#3390).
+    [InlineData("base=$(grep -oPm1 '(?<=<Version>)[^<]+' Directory.Build.props)\n[ -n \"${STAMP}\" ] || { echo x; exit 1; }", false)]
+    [InlineData("$v = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version\nif ([string]::IsNullOrWhiteSpace($env:STAMP)) { throw \"no\" }", false)]
     public void TheGuardDetector_CreditsOnlyAGuardThatFailsTheStep(string snippet, bool expected) =>
         Assert.Equal(expected, Assert.Single(VersionReads(snippet)).Guarded);
 
@@ -529,7 +533,8 @@ public class ProductVersionDeclarationTests
             found.Add(new VersionRead(
                 line,
                 sources.Count == 0 ? new[] { "(unresolved)" } : sources,
-                lines.Skip(index + 1).Take(GuardWindowLines).Any(IsGuardLine)));
+                lines.Skip(index + 1).Take(GuardWindowLines)
+                 .Any(candidate => IsGuardLine(candidate, AssignedVariable(line)))));
         }
 
         return found;
@@ -549,11 +554,47 @@ public class ProductVersionDeclarationTests
     /// <para>The bash arm requires the exit as well as the test. <c>[ -n "</c> on its own is not a
     /// guard — the workflows already use that spelling for unrelated conditions, and one sitting
     /// near a read would otherwise be credited as protecting it.</para>
+    ///
+    /// <para>It must also guard THIS read's variable. A step may legitimately hold more than one
+    /// emptiness guard — <c>nightly.yml</c>'s version steps guard the version they read and the
+    /// run stamp they interpolate — and a shape-only match credits either one for the other. That
+    /// is not hypothetical: adding the stamp guard made removing the version guard undetectable
+    /// here until this check became variable-aware.</para>
     /// </summary>
-    private static bool IsGuardLine(string line) =>
-        line.Contains("IsNullOrWhiteSpace", StringComparison.Ordinal)
-        || (line.Contains("[ -n \"", StringComparison.Ordinal) && line.Contains("exit 1", StringComparison.Ordinal))
-        || line.Contains("==\"\" (", StringComparison.Ordinal);
+    private static bool IsGuardLine(string line, string? variable)
+    {
+        var fails =
+            line.Contains("IsNullOrWhiteSpace", StringComparison.Ordinal)
+            || (line.Contains("[ -n \"", StringComparison.Ordinal) && line.Contains("exit 1", StringComparison.Ordinal))
+            || line.Contains("==\"\" (", StringComparison.Ordinal);
+
+        if (!fails)
+        {
+            return false;
+        }
+
+        /* A read whose assigned name could not be determined falls back to shape alone, so an
+           unrecognised assignment spelling cannot silently mark every read unguarded. */
+        return variable is null
+            || Regex.IsMatch(line, $@"\b{Regex.Escape(variable)}\b", RegexOptions.IgnoreCase);
+    }
+
+    /// <summary>
+    /// The variable a version read assigns to, across the three spellings the reads use:
+    /// <c>base=$(...)</c> and <c>version="$(...)"</c> in bash, <c>$base = ([xml]...)</c> in pwsh, and
+    /// <c>... do set VERSION=%%a</c> in cmd. Null when no assignment is recognisable.
+    /// </summary>
+    private static string? AssignedVariable(string line)
+    {
+        var cmd = Regex.Match(line, @"\bset\s+([A-Za-z_][A-Za-z0-9_]*)\s*=");
+        if (cmd.Success)
+        {
+            return cmd.Groups[1].Value;
+        }
+
+        var assignment = Regex.Match(line, @"^\s*\$?([A-Za-z_][A-Za-z0-9_]*)\s*=");
+        return assignment.Success ? assignment.Groups[1].Value : null;
+    }
 
     /// <summary>The MSBuild file paths named on one line, separators normalised to forward slashes.</summary>
     private static List<string> MsBuildPathsIn(string line) =>

--- a/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
+++ b/Darling/Darling.Tests/ProductVersionDeclarationTests.cs
@@ -534,7 +534,7 @@ public class ProductVersionDeclarationTests
                 line,
                 sources.Count == 0 ? new[] { "(unresolved)" } : sources,
                 lines.Skip(index + 1).Take(GuardWindowLines)
-                 .Any(candidate => IsGuardLine(candidate, AssignedVariable(line)))));
+                    .Any(candidate => IsGuardLine(candidate, AssignedVariable(line)))));
         }
 
         return found;


### PR DESCRIPTION
Closes #3390.

The nightly prerelease stamp was `yyyyMMdd`, built independently in two places — the `build` job in pwsh and the `linux` job in bash. That is wrong on two axes, and the second one I only found while sizing the fix for the first.

**It is not unique per build.** Multiple dispatches a day are normal here. Over 2026-08-24..09-12, **13 of 20 days published two or more distinct source trees under one version string**, peaking at five on 09-03. `FileVersion`, `ProductVersion`, `InformationalVersion` and every asset name carry this string, and the root `.exe` is the apphost stub whose bytes are a function of the app name and target framework rather than of any code — it came back byte-identical across two nightlies 31 commits apart. So a colliding stamp leaves no read that answers which nightly a machine is running.

**It is not stable across jobs.** `linux` needs `build`, which takes ~8.5 minutes; on run 34722502741 the two stamp steps ran 8m37s apart. A run whose steps straddle midnight UTC ships a Windows zip dated one day and a Linux tarball dated the next, from one commit. That is the inverse of the first symptom and worse in kind: two builds sharing a version is ambiguous, one build emitting two versions is inconsistent.

`check` now derives `<date>.<run_number>` once and exposes it as a job output both jobs consume. `run_number` is monotonic and numeric, so SemVer 2.0 orders these prereleases in build order; the date stays leftmost and readable. A short sha would identify the source tree but sorts as an alphanumeric identifier, which outranks every numeric one. `linux` gains `check` in its `needs` purely for access to the output — it already depended on `check` transitively through `build`, so nothing about ordering changes.

Both jobs keep their own `Directory.Build.props` read. `ProductVersionDeclarationTests` pins that two text-scraping reads exist in the tree, so collapsing them into one would have failed that guard rather than tidied anything.

## The guard detector had to become variable-aware, because this change weakened it

`IsGuardLine` credited an emptiness-guard **shape** appearing anywhere within six lines of a version read, without checking which variable it tested. Each version step now holds two guards — one for the version it reads, one for the stamp it interpolates — so the stamp guard was credited in the version guard's place, and **removing the version guard entirely left the pin green**.

That is not a pre-existing gap I inherited. I ran the same mutation against `origin/dev`'s unmodified workflow and the pin failed there as it should, which locates the weakening in this change.

A guard must now also name the variable the read assigned. Two red-first rows cover the shape that caused it — a real guard, one that does fail its step, for a different variable — in bash and in pwsh. When an assignment spelling is not recognisable the check falls back to shape alone and says so, so an unfamiliar shape cannot silently mark every read unguarded and empty the pin from the other direction.

Verified by mutation rather than by the green run: with the detector variable-aware, deleting the version guard from either the bash or the pwsh step fails `EveryVersionRead_FailsItsStepOnAnEmptyResult`; before it, neither did. The clean tree passes 26 of 26.

## The stamp asserts its own shape

The stamp step runs under an explicit `shell: bash` with `set -euo pipefail`, and asserts `^[0-9]{8}\.[0-9]+$` before publishing the output.

Emptiness is not the property the consumers need. A `date` that exits 0 having printed nothing yields `".<run_number>"` — non-empty, so it passes every `-n` and `IsNullOrWhiteSpace` guard this PR adds and stamps both artifacts with a malformed version rather than failing in the step that produced it. `set -e`, which is already GitHub's default for a Linux `run` step, only covers `date` exiting non-zero.

Exercised against the real logic in bash rather than reasoned about: accepts `20260912.42`, refuses `.42`, `20260912.`, the empty string, a seven-digit date, a trailing non-digit and a non-numeric date. The pattern is held in a variable so `{8}` cannot be reached by brace expansion.

The consumer guards stay, but as a backstop against broken output wiring rather than as the only check — which is what they were implicitly being relied on for.

## Not a user-facing change

No shipped release is affected — release builds use `Directory.Build.props`'s version directly, with no date suffix, so nothing installed from a release ever carried a colliding version. The cost was confined to identifying which nightly a machine is running during a fleet install.

